### PR TITLE
perf(route_handler): simplify queries on the shoulder lanelets

### DIFF
--- a/planning/behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_goal_planner_module/src/util.cpp
@@ -55,12 +55,11 @@ lanelet::ConstLanelets getPullOverLanes(
   // todo(kosuek55): automatically calculates this distance.
   const double backward_distance_with_buffer = backward_distance + 100;
 
-  lanelet::ConstLanelet target_shoulder_lane{};
-  if (route_handler::RouteHandler::getPullOverTarget(
-        route_handler.getShoulderLanelets(), goal_pose, &target_shoulder_lane)) {
+  const auto target_shoulder_lane = route_handler.getPullOverTarget(goal_pose);
+  if (target_shoulder_lane) {
     // pull over on shoulder lane
     return route_handler.getShoulderLaneletSequence(
-      target_shoulder_lane, goal_pose, backward_distance_with_buffer, forward_distance);
+      *target_shoulder_lane, goal_pose, backward_distance_with_buffer, forward_distance);
   }
 
   lanelet::ConstLanelet closest_lane{};

--- a/planning/behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -341,11 +341,9 @@ TargetObjectsOnLane createTargetObjectsOnLane(
   };
 
   const auto update_left_shoulder_lanelet = [&](const lanelet::ConstLanelet & target_lane) {
-    lanelet::ConstLanelet neighbor_shoulder_lane{};
-    const bool shoulder_lane_is_found =
-      route_handler->getLeftShoulderLanelet(target_lane, &neighbor_shoulder_lane);
-    if (shoulder_lane_is_found) {
-      all_left_shoulder_lanelets.insert(all_left_shoulder_lanelets.end(), neighbor_shoulder_lane);
+    const auto neighbor_shoulder_lane = route_handler->getLeftShoulderLanelet(target_lane);
+    if (neighbor_shoulder_lane) {
+      all_left_shoulder_lanelets.insert(all_left_shoulder_lanelets.end(), *neighbor_shoulder_lane);
     }
   };
 

--- a/planning/behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner_common/src/utils/path_utils.cpp
@@ -643,15 +643,12 @@ BehaviorModuleOutput createGoalAroundPath(const std::shared_ptr<const PlannerDat
   const auto & modified_goal = planner_data->prev_modified_goal;
 
   const Pose goal_pose = modified_goal ? modified_goal->pose : route_handler->getGoalPose();
-  const auto shoulder_lanes = route_handler->getShoulderLanelets();
 
   lanelet::ConstLanelet goal_lane;
-  const bool is_failed_getting_lanelet = std::invoke([&]() {
-    if (isInLanelets(goal_pose, shoulder_lanes)) {
-      return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
-    }
-    return !route_handler->getGoalLanelet(&goal_lane);
-  });
+  const auto shoulder_goal_lane = route_handler->getShoulderLaneletAtPose(goal_pose);
+  if (shoulder_goal_lane) goal_lane = *shoulder_goal_lane;
+  const auto is_failed_getting_lanelet =
+    !shoulder_goal_lane && !route_handler->getGoalLanelet(&goal_lane);
   if (is_failed_getting_lanelet) {
     return output;
   }

--- a/planning/behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner_common/src/utils/utils.cpp
@@ -496,15 +496,12 @@ bool isEgoOutOfRoute(
   const Pose & goal_pose = (modified_goal && modified_goal->uuid == route_handler->getRouteUuid())
                              ? modified_goal->pose
                              : route_handler->getGoalPose();
-  const auto shoulder_lanes = route_handler->getShoulderLanelets();
 
   lanelet::ConstLanelet goal_lane;
-  const bool is_failed_getting_lanelet = std::invoke([&]() {
-    if (utils::isInLanelets(goal_pose, shoulder_lanes)) {
-      return !lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &goal_lane);
-    }
-    return !route_handler->getGoalLanelet(&goal_lane);
-  });
+  const auto shoulder_goal_lane = route_handler->getShoulderLaneletAtPose(goal_pose);
+  if (shoulder_goal_lane) goal_lane = *shoulder_goal_lane;
+  const auto is_failed_getting_lanelet =
+    !shoulder_goal_lane && !route_handler->getGoalLanelet(&goal_lane);
   if (is_failed_getting_lanelet) {
     RCLCPP_WARN_STREAM(
       rclcpp::get_logger("behavior_path_planner").get_child("util"), "cannot find goal lanelet");
@@ -527,14 +524,7 @@ bool isEgoOutOfRoute(
 
   // If ego vehicle is out of the closest lanelet, return true
   // Check if ego vehicle is in shoulder lane
-  const bool is_in_shoulder_lane = std::invoke([&]() {
-    lanelet::Lanelet closest_shoulder_lanelet;
-    if (!lanelet::utils::query::getClosestLanelet(
-          shoulder_lanes, self_pose, &closest_shoulder_lanelet)) {
-      return false;
-    }
-    return lanelet::utils::isInLanelet(self_pose, closest_shoulder_lanelet);
-  });
+  const bool is_in_shoulder_lane = route_handler->getShoulderLaneletAtPose(self_pose).has_value();
   // Check if ego vehicle is in road lane
   const bool is_in_road_lane = std::invoke([&]() {
     lanelet::ConstLanelet closest_road_lane;
@@ -1660,13 +1650,6 @@ bool isAllowedGoalModification(const std::shared_ptr<RouteHandler> & route_handl
 bool checkOriginalGoalIsInShoulder(const std::shared_ptr<RouteHandler> & route_handler)
 {
   const Pose & goal_pose = route_handler->getOriginalGoalPose();
-  const auto shoulder_lanes = route_handler->getShoulderLanelets();
-
-  lanelet::ConstLanelet closest_shoulder_lane{};
-  if (lanelet::utils::query::getClosestLanelet(shoulder_lanes, goal_pose, &closest_shoulder_lane)) {
-    return lanelet::utils::isInLanelet(goal_pose, closest_shoulder_lane, 0.1);
-  }
-
-  return false;
+  return route_handler->getShoulderLaneletAtPose(goal_pose).has_value();
 }
 }  // namespace behavior_path_planner::utils

--- a/planning/behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_start_planner_module/src/util.cpp
@@ -90,11 +90,10 @@ lanelet::ConstLanelets getPullOutLanes(
   const auto & route_handler = planner_data->route_handler;
   const auto start_pose = planner_data->route_handler->getOriginalStartPose();
 
-  lanelet::ConstLanelet current_shoulder_lane;
-  if (route_handler->getPullOutStartLane(
-        route_handler->getShoulderLanelets(), start_pose, vehicle_width, &current_shoulder_lane)) {
+  const auto current_shoulder_lane = route_handler->getPullOutStartLane(start_pose, vehicle_width);
+  if (current_shoulder_lane) {
     // pull out from shoulder lane
-    return route_handler->getShoulderLaneletSequence(current_shoulder_lane, start_pose);
+    return route_handler->getShoulderLaneletSequence(*current_shoulder_lane, start_pose);
   }
 
   // pull out from road lane

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -348,10 +348,10 @@ public:
     const lanelet::ConstLanelets & lanelets, const Pose & pose, const double vehicle_width,
     lanelet::ConstLanelet * target_lanelet);
   double getLaneChangeableDistance(const Pose & current_pose, const Direction & direction) const;
-  bool getLeftShoulderLanelet(
-    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * left_lanelet) const;
-  bool getRightShoulderLanelet(
-    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * right_lanelet) const;
+  std::optional<lanelet::ConstLanelet> getLeftShoulderLanelet(
+    const lanelet::ConstLanelet & lanelet) const;
+  std::optional<lanelet::ConstLanelet> getRightShoulderLanelet(
+    const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstPolygon3d getIntersectionAreaById(const lanelet::Id id) const;
   bool isPreferredLane(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getClosestLanelets(const geometry_msgs::msg::Pose & target_pose) const;

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -414,8 +414,8 @@ private:
   lanelet::ConstLanelets getShoulderLaneletSequenceAfter(
     const lanelet::ConstLanelet & lanelet,
     const double min_length = std::numeric_limits<double>::max()) const;
-  bool getPreviousShoulderLanelet(
-    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * prev_lanelet) const;
+  std::optional<lanelet::ConstLanelet> getPreviousShoulderLanelet(
+    const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getShoulderLaneletSequenceUpTo(
     const lanelet::ConstLanelet & lanelet,
     const double min_length = std::numeric_limits<double>::max()) const;

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -324,7 +324,6 @@ public:
     const double check_length) const;
   lanelet::routing::RelationType getRelation(
     const lanelet::ConstLanelet & prev_lane, const lanelet::ConstLanelet & next_lane) const;
-  lanelet::ConstLanelets getShoulderLanelets() const;
   bool isShoulderLanelet(const lanelet::ConstLanelet & lanelet) const;
   bool isRouteLanelet(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getPreferredLanelets() const;
@@ -349,6 +348,8 @@ public:
     const lanelet::ConstLanelet & lanelet) const;
   std::optional<lanelet::ConstLanelet> getRightShoulderLanelet(
     const lanelet::ConstLanelet & lanelet) const;
+  /// @warning if the pose is inside multiple shoulder lanelets, the selection is random
+  std::optional<lanelet::ConstLanelet> getShoulderLaneletAtPose(const Pose & pose) const;
   lanelet::ConstPolygon3d getIntersectionAreaById(const lanelet::Id id) const;
   bool isPreferredLane(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getClosestLanelets(const geometry_msgs::msg::Pose & target_pose) const;
@@ -364,7 +365,6 @@ private:
   lanelet::ConstLanelets preferred_lanelets_;
   lanelet::ConstLanelets start_lanelets_;
   lanelet::ConstLanelets goal_lanelets_;
-  lanelet::ConstLanelets shoulder_lanelets_;
   std::shared_ptr<LaneletRoute> route_ptr_{nullptr};
 
   rclcpp::Logger logger_{rclcpp::get_logger("route_handler")};

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -409,8 +409,8 @@ private:
     const lanelet::ConstLanelet & lanelet,
     const double min_length = std::numeric_limits<double>::max(),
     const bool only_route_lanes = true) const;
-  bool getFollowingShoulderLanelet(
-    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * following_lanelet) const;
+  std::optional<lanelet::ConstLanelet> getFollowingShoulderLanelet(
+    const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getShoulderLaneletSequenceAfter(
     const lanelet::ConstLanelet & lanelet,
     const double min_length = std::numeric_limits<double>::max()) const;

--- a/planning/route_handler/include/route_handler/route_handler.hpp
+++ b/planning/route_handler/include/route_handler/route_handler.hpp
@@ -341,12 +341,9 @@ public:
     const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const;
   bool getLeftLaneChangeTargetExceptPreferredLane(
     const lanelet::ConstLanelets & lanelets, lanelet::ConstLanelet * target_lanelet) const;
-  static bool getPullOverTarget(
-    const lanelet::ConstLanelets & lanelets, const Pose & goal_pose,
-    lanelet::ConstLanelet * target_lanelet);
-  static bool getPullOutStartLane(
-    const lanelet::ConstLanelets & lanelets, const Pose & pose, const double vehicle_width,
-    lanelet::ConstLanelet * target_lanelet);
+  std::optional<lanelet::ConstLanelet> getPullOverTarget(const Pose & goal_pose) const;
+  std::optional<lanelet::ConstLanelet> getPullOutStartLane(
+    const Pose & pose, const double vehicle_width) const;
   double getLaneChangeableDistance(const Pose & current_pose, const Direction & direction) const;
   std::optional<lanelet::ConstLanelet> getLeftShoulderLanelet(
     const lanelet::ConstLanelet & lanelet) const;

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -724,28 +724,26 @@ bool RouteHandler::getFollowingShoulderLanelet(
   return false;
 }
 
-bool RouteHandler::getLeftShoulderLanelet(
-  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * left_lanelet) const
+std::optional<lanelet::ConstLanelet> RouteHandler::getLeftShoulderLanelet(
+  const lanelet::ConstLanelet & lanelet) const
 {
   for (const auto & shoulder_lanelet : shoulder_lanelets_) {
     if (lanelet::geometry::leftOf(shoulder_lanelet, lanelet)) {
-      *left_lanelet = shoulder_lanelet;
-      return true;
+      return shoulder_lanelet;
     }
   }
-  return false;
+  return std::nullopt;
 }
 
-bool RouteHandler::getRightShoulderLanelet(
-  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelet * right_lanelet) const
+std::optional<lanelet::ConstLanelet> RouteHandler::getRightShoulderLanelet(
+  const lanelet::ConstLanelet & lanelet) const
 {
   for (const auto & shoulder_lanelet : shoulder_lanelets_) {
     if (lanelet::geometry::rightOf(shoulder_lanelet, lanelet)) {
-      *right_lanelet = shoulder_lanelet;
-      return true;
+      return shoulder_lanelet;
     }
   }
-  return false;
+  return std::nullopt;
 }
 
 lanelet::ConstLanelets RouteHandler::getShoulderLaneletSequenceAfter(
@@ -1019,10 +1017,8 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getRightLanelet(
 
   // right shoulder lanelet
   if (get_shoulder_lane) {
-    lanelet::ConstLanelet right_shoulder_lanelet;
-    if (getRightShoulderLanelet(lanelet, &right_shoulder_lanelet)) {
-      return right_shoulder_lanelet;
-    }
+    const auto right_shoulder_lanelet = getRightShoulderLanelet(lanelet);
+    if (right_shoulder_lanelet) return *right_shoulder_lanelet;
   }
 
   // routable lane
@@ -1100,10 +1096,8 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getLeftLanelet(
 
   // left shoulder lanelet
   if (get_shoulder_lane) {
-    lanelet::ConstLanelet left_shoulder_lanelet;
-    if (getLeftShoulderLanelet(lanelet, &left_shoulder_lanelet)) {
-      return left_shoulder_lanelet;
-    }
+    const auto left_shoulder_lanelet = getLeftShoulderLanelet(lanelet);
+    if (left_shoulder_lanelet) return *left_shoulder_lanelet;
   }
 
   // routable lane

--- a/planning/route_handler/src/route_handler.cpp
+++ b/planning/route_handler/src/route_handler.cpp
@@ -724,13 +724,19 @@ bool RouteHandler::getFollowingShoulderLanelet(
   return false;
 }
 
+bool is_road_shoulder(const lanelet::ConstLanelet & ll)
+{
+  const lanelet::Attribute & attr = ll.attributeOr(lanelet::AttributeName::Subtype, "");
+  return attr.value() == "road_shoulder";
+}
+
 std::optional<lanelet::ConstLanelet> RouteHandler::getLeftShoulderLanelet(
   const lanelet::ConstLanelet & lanelet) const
 {
-  for (const auto & shoulder_lanelet : shoulder_lanelets_) {
-    if (lanelet::geometry::leftOf(shoulder_lanelet, lanelet)) {
-      return shoulder_lanelet;
-    }
+  for (const auto & other_lanelet :
+       lanelet_map_ptr_->laneletLayer.findUsages(lanelet.leftBound())) {
+    if (other_lanelet.rightBound() == lanelet.leftBound() && is_road_shoulder(other_lanelet))
+      return other_lanelet;
   }
   return std::nullopt;
 }
@@ -738,10 +744,10 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getLeftShoulderLanelet(
 std::optional<lanelet::ConstLanelet> RouteHandler::getRightShoulderLanelet(
   const lanelet::ConstLanelet & lanelet) const
 {
-  for (const auto & shoulder_lanelet : shoulder_lanelets_) {
-    if (lanelet::geometry::rightOf(shoulder_lanelet, lanelet)) {
-      return shoulder_lanelet;
-    }
+  for (const auto & other_lanelet :
+       lanelet_map_ptr_->laneletLayer.findUsages(lanelet.rightBound())) {
+    if (other_lanelet.leftBound() == lanelet.rightBound() && is_road_shoulder(other_lanelet))
+      return other_lanelet;
   }
   return std::nullopt;
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Currently, some functions are performing queries on ALL shoulder lanelets of the map.
With very large maps, this leads to performance issues which are solved by this PR.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim: starting and setting goal at should lanelets.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
