### PR TITLE
feat(autoware_pid_longitudinal_controller): switch to emergency when the reference is not properly assigned

### DIFF
--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -722,6 +722,10 @@ double calcSignedArcLength(const T & points, const size_t src_idx, const size_t 
     return -calcSignedArcLength(points, dst_idx, src_idx);
   }
 
+  if (src_idx == dst_idx) {
+    return 0.0;
+  }
+
   double dist_sum = 0.0;
   for (size_t i = src_idx; i < dst_idx; ++i) {
     dist_sum += autoware::universe_utils::calcDistance2d(points.at(i), points.at(i + 1));

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -65,7 +65,7 @@ double calcStopDistance(
     traj.points, current_pose, max_dist, max_yaw);
   const double signed_length_on_traj = autoware::motion_utils::calcSignedArcLength(
     traj.points, current_pose.position, seg_idx, traj.points.at(end_idx).pose.position,
-    std::min(end_idx, std::max(traj.points.size() - 2, 0)));
+    std::min(end_idx, std::max(traj.points.size() - 2, static_cast<size_t>(0))));
 
   return signed_length_on_traj;
 }

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -65,7 +65,7 @@ double calcStopDistance(
     traj.points, current_pose, max_dist, max_yaw);
   const double signed_length_on_traj = autoware::motion_utils::calcSignedArcLength(
     traj.points, current_pose.position, seg_idx, traj.points.at(end_idx).pose.position,
-    std::min(end_idx, traj.points.size() - 2));
+    std::min(end_idx, std::max(traj.points.size() - 2, 0)));
 
   return signed_length_on_traj;
 }

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -67,9 +67,6 @@ double calcStopDistance(
     traj.points, current_pose.position, seg_idx, traj.points.at(end_idx).pose.position,
     std::min(end_idx, traj.points.size() - 2));
 
-  if (std::isnan(signed_length_on_traj)) {
-    return 0.0;
-  }
   return signed_length_on_traj;
 }
 

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -637,9 +637,11 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
   // ==========================================================================================
   const double current_vel_cmd = std::fabs(
     control_data.interpolated_traj.points.at(control_data.nearest_idx).longitudinal_velocity_mps);
+  const bool missing_reference = std::isnan(stop_dist);
   const bool emergency_condition = m_enable_overshoot_emergency &&
                                    stop_dist < -p.emergency_state_overshoot_stop_dist &&
-                                   current_vel_cmd < vel_epsilon;
+                                   current_vel_cmd < vel_epsilon ||
+                                   missing_reference;
   const bool has_nonzero_target_vel = std::abs(current_vel_cmd) > 1.0e-5;
 
   const auto changeState = [this](const auto s) {

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -638,9 +638,9 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
   const double current_vel_cmd = std::fabs(
     control_data.interpolated_traj.points.at(control_data.nearest_idx).longitudinal_velocity_mps);
   const bool missing_reference = std::isnan(stop_dist);
-  const bool emergency_condition = m_enable_overshoot_emergency &&
+  const bool emergency_condition = (m_enable_overshoot_emergency &&
                                    stop_dist < -p.emergency_state_overshoot_stop_dist &&
-                                   current_vel_cmd < vel_epsilon ||
+                                   current_vel_cmd < vel_epsilon) ||
                                    missing_reference;
   const bool has_nonzero_target_vel = std::abs(current_vel_cmd) > 1.0e-5;
 

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -638,10 +638,10 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
   const double current_vel_cmd = std::fabs(
     control_data.interpolated_traj.points.at(control_data.nearest_idx).longitudinal_velocity_mps);
   const bool missing_reference = std::isnan(stop_dist);
-  const bool emergency_condition = (m_enable_overshoot_emergency &&
-                                   stop_dist < -p.emergency_state_overshoot_stop_dist &&
-                                   current_vel_cmd < vel_epsilon) ||
-                                   missing_reference;
+  const bool emergency_condition =
+    (m_enable_overshoot_emergency && stop_dist < -p.emergency_state_overshoot_stop_dist &&
+     current_vel_cmd < vel_epsilon) ||
+    missing_reference;
   const bool has_nonzero_target_vel = std::abs(current_vel_cmd) > 1.0e-5;
 
   const auto changeState = [this](const auto s) {

--- a/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -71,8 +71,7 @@ TEST(TestLongitudinalControllerUtils, calcStopDistance)
   point.pose.position.y = 0.0;
   point.longitudinal_velocity_mps = 0.0;
   traj.points.push_back(point);
-  EXPECT_DOUBLE_EQ(
-    longitudinal_utils::calcStopDistance(current_pose, traj, max_dist, max_yaw), 0.0);
+  EXPECT_TRUE(std::isnan(longitudinal_utils::calcStopDistance(current_pose, traj, max_dist, max_yaw)));
   traj.points.clear();
   // non stopping trajectory: stop distance = trajectory length
   point.pose.position.x = 0.0;

--- a/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -71,7 +71,8 @@ TEST(TestLongitudinalControllerUtils, calcStopDistance)
   point.pose.position.y = 0.0;
   point.longitudinal_velocity_mps = 0.0;
   traj.points.push_back(point);
-  EXPECT_TRUE(std::isnan(longitudinal_utils::calcStopDistance(current_pose, traj, max_dist, max_yaw)));
+  EXPECT_TRUE(
+    std::isnan(longitudinal_utils::calcStopDistance(current_pose, traj, max_dist, max_yaw)));
   traj.points.clear();
   // non stopping trajectory: stop distance = trajectory length
   point.pose.position.x = 0.0;


### PR DESCRIPTION
## Description

The car sometimes cannot stop after reaching the goal.
Instead, it drives beyond the desired goal without stopping.

[Screencast from 08-13-2024 11:11:26 AM.webm](https://github.com/user-attachments/assets/f6e3b75a-f263-44e7-a146-ae13b6d2ffe8)

---
**Cause:**
The corresponding indices of the reference/current position will return a `nan` sometimes.
This result (`nan`) is deemed a missing reference.

A missing reference can result in an unexpected behavior of the system.
A modification on the missing reference, e.g., assigning it to `0.0`, without a sound stability proof, cannot stabilize the car. 
 
---
**In this PR:**
When the reference is `nan`, enter the EMERGENCY mode directly.
In plain words, the car will endeavor to stop immediately when the reference is not properly assigned. 

---
**Further potential modifications (not fixed in this PR):**
1. stop_time is not correctly calculated.
2. Strong stop and weak stop did not help if the reference is not given properly.
3. The stability proof of the smooth stop is missing. A document/tutorial can be helpful.
4. `STOPPING` mode is not a conventional controller. Further extensions can be made.
5. Mismatch between the feedforward-acceleration and the desired velocity.
6. The reference point, sometimes, is not taken in correctly.

## Tests performed



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
