### PR TITLE
test(autoware_simple_object_merger): add node test

### DIFF
--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -601,6 +601,11 @@ public:
     pub_clock_->publish(clock);
   }
 
+  void spin()
+  {
+    rclcpp::spin_some(test_node_);
+  }
+
 protected:
   // Publisher
   std::unordered_map<std::string, std::shared_ptr<rclcpp::PublisherBase>> publishers_;

--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -601,10 +601,7 @@ public:
     pub_clock_->publish(clock);
   }
 
-  void spin()
-  {
-    rclcpp::spin_some(test_node_);
-  }
+  void spin() { rclcpp::spin_some(test_node_); }
 
 protected:
   // Publisher

--- a/perception/autoware_simple_object_merger/CMakeLists.txt
+++ b/perception/autoware_simple_object_merger/CMakeLists.txt
@@ -22,8 +22,8 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
   # node test
   ament_auto_add_gtest(simple_object_merger_node_test
-  test/test_simple_object_merger_node.cpp
-)
+    test/test_simple_object_merger_node.cpp
+  )
 endif()
 
 # Package

--- a/perception/autoware_simple_object_merger/CMakeLists.txt
+++ b/perception/autoware_simple_object_merger/CMakeLists.txt
@@ -20,6 +20,10 @@ if(BUILD_TESTING)
   list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  # node test
+  ament_auto_add_gtest(simple_object_merger_node_test
+  test/test_simple_object_merger_node.cpp
+)
 endif()
 
 # Package

--- a/perception/autoware_simple_object_merger/package.xml
+++ b/perception/autoware_simple_object_merger/package.xml
@@ -14,6 +14,7 @@
 
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_universe_utils</depend>
+    <depend>autoware_test_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/autoware_simple_object_merger/package.xml
+++ b/perception/autoware_simple_object_merger/package.xml
@@ -14,14 +14,15 @@
 
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_universe_utils</depend>
-    <depend>autoware_test_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <build_depend>autoware_cmake</build_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>autoware_test_utils</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/perception/autoware_simple_object_merger/src/simple_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/src/simple_object_merger_node.cpp
@@ -20,6 +20,14 @@
 #include <string>
 #include <vector>
 
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
+#endif
+
 namespace
 {
 template <class T>

--- a/perception/autoware_simple_object_merger/test/test_simple_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/test/test_simple_object_merger_node.cpp
@@ -86,13 +86,10 @@ TEST(SimpleObjectMergerTest, testSimpleObjectMergerTwoTopics)
   // set the subscriber
   test_manager->set_subscriber<DetectedObjects>("/output/objects", callback);
 
-  // Set the clock and initialize the node
+  // Time-wise simulation
   rclcpp::Time current_time(0);
-
-  // time-wise simulation
   auto time_interval = rclcpp::Duration(0, 0);
   time_interval = time_interval.from_seconds(0.010);
-
   for (int i = 0; i < 20; i++) {
     current_time = current_time + time_interval;
     test_manager->jump_clock(current_time);

--- a/perception/autoware_simple_object_merger/test/test_simple_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/test/test_simple_object_merger_node.cpp
@@ -14,9 +14,16 @@
 
 #include "../src/simple_object_merger_node.hpp"
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
 #include <gtest/gtest.h>
+
+#include <vector>
+
+using autoware::simple_object_merger::SimpleObjectMergerNode;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
 
 std::shared_ptr<autoware::test_utils::AutowareTestManager> generateTestManager()
 {
@@ -24,3 +31,72 @@ std::shared_ptr<autoware::test_utils::AutowareTestManager> generateTestManager()
   return test_manager;
 }
 
+std::shared_ptr<SimpleObjectMergerNode> generateNode()
+{
+  auto node_options = rclcpp::NodeOptions{};
+  const auto package_dir =
+    ament_index_cpp::get_package_share_directory("autoware_simple_object_merger");
+  node_options.arguments(
+    {"--ros-args", "--params-file", package_dir + "/config/simple_object_merger.param.yaml"});
+
+  std::vector<std::string> input_topics;
+  input_topics.push_back("/input/object0");
+  input_topics.push_back("/input/object1");
+  node_options.append_parameter_override("input_topics", input_topics);
+
+  return std::make_shared<SimpleObjectMergerNode>(node_options);
+}
+
+std::shared_ptr<DetectedObjects> generateDetectedObjects(const rclcpp::Time stamp)
+{
+  auto detected_objects = std::make_shared<DetectedObjects>();
+  detected_objects->header.frame_id = "base_link";
+  detected_objects->header.stamp = stamp;
+
+  DetectedObject object;
+
+  object.kinematics.pose_with_covariance.pose.position.x = 1.0;
+  object.kinematics.pose_with_covariance.pose.position.y = 2.0;
+  object.kinematics.pose_with_covariance.pose.position.z = 3.0;
+  object.kinematics.pose_with_covariance.pose.orientation.x = 0.0;
+  object.kinematics.pose_with_covariance.pose.orientation.y = 0.0;
+  object.kinematics.pose_with_covariance.pose.orientation.z = 0.0;
+  object.kinematics.pose_with_covariance.pose.orientation.w = 1.0;
+
+  detected_objects->objects.push_back(object);
+
+  return detected_objects;
+}
+
+TEST(SimpleObjectMergerTest, testSimpleObjectMergerTwoTopics)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = generateTestManager();
+  auto test_target_node = generateNode();
+
+  // Check output topic
+  int counter = 0;
+  auto callback = [&counter](const DetectedObjects::ConstSharedPtr msg) {
+    (void)msg;
+    ++counter;
+  };
+
+  // Create a DetectedObjects message
+  rclcpp::Time stamp(0);
+  DetectedObjects msg = *generateDetectedObjects(stamp);
+
+  // Publish the message to the input topics
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "/input/object0", msg);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "/input/object1", msg);
+
+  // Check if the message is published to the output topic
+  test_manager->set_subscriber<DetectedObjects>("/output/object", callback);
+
+  // Wait for the message to be published
+  // test_manager->spin(test_target_node, 1s);
+
+  // Check if the message is published to the output topic
+  EXPECT_GE(counter, 1);
+
+  rclcpp::shutdown();
+}

--- a/perception/autoware_simple_object_merger/test/test_simple_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/test/test_simple_object_merger_node.cpp
@@ -1,0 +1,26 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/simple_object_merger_node.hpp"
+
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <gtest/gtest.h>
+
+std::shared_ptr<autoware::test_utils::AutowareTestManager> generateTestManager()
+{
+  auto test_manager = std::make_shared<autoware::test_utils::AutowareTestManager>();
+  return test_manager;
+}
+

--- a/perception/autoware_simple_object_merger/test/test_simple_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/test/test_simple_object_merger_node.cpp
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <thread>
 #include <vector>
 
 using autoware::simple_object_merger::SimpleObjectMergerNode;
@@ -99,14 +101,13 @@ TEST(SimpleObjectMergerTest, testSimpleObjectMergerTwoTopics)
   test_manager->test_pub_msg<DetectedObjects>(target_node, "/input/object1", msg);
 
   // Spin the test target node
-  auto time_interval = rclcpp::Duration(0, 1e8);
-  // time_interval = time_interval.from_seconds(
-  //   0.1);  // longer than the update rate, so the timer callback should be called
+  auto time_interval = rclcpp::Duration(
+    0, 1e8);  // longer than the update rate, so the timer callback should be called
   test_manager->jump_clock(current_time + time_interval);
-  rclcpp::spin_some(target_node);
-
-  // spin the test manager to subscribe the output topic
-  test_manager->spin();
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));  // thread switch
+  rclcpp::spin_some(target_node);                              // spin the test target node
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));  // thread switch
+  test_manager->spin();  // spin the test manager node for the subscriber callback
 
   // Check if the message is published to the output topic
   EXPECT_GE(counter, 1);


### PR DESCRIPTION
## Description

A spin method is needed when the node test is done under ROS sim time.
By triggering the spin, the test manager can subscribe.

## Related links

The test manager need to be updated by https://github.com/autowarefoundation/autoware.universe/pull/8727

## How was this PR tested?
```
# build
colcon build --packages-select autoware_simple_object_merger

# run the test
colcon test --packages-select autoware_simple_object_merger

# print the result
cat log/latest_test/autoware_simple_object_merger/stdout.log
```


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
