### PR TITLE
refactor(static_centerline_optimizer): rework parameter

### DIFF
--- a/planning/autoware_static_centerline_generator/README.md
+++ b/planning/autoware_static_centerline_generator/README.md
@@ -81,3 +81,17 @@ By default, footprints' color is
 - when the distance is less than 0.1 [m] : red
 - when the distance is less than 0.2 [m] : green
 - when the distance is less than 0.3 [m] : blue
+
+## Parameters
+
+### Common Parameters
+{{ json_to_markdown("planning/autoware_static_centerline_generator/schema/common.schema.json") }}
+
+### Nearest Search
+{{ json_to_markdown("planning/autoware_static_centerline_generator/schema/nearest_search.schema.json") }}
+
+### Static Centerline Generator
+{{ json_to_markdown("planning/autoware_static_centerline_generator/schema/static_centerline_generator.schema.json") }}
+
+### Vehicle Info
+{{ json_to_markdown("planning/autoware_static_centerline_generator/schema/vehicle_info.schema.json") }}

--- a/planning/autoware_static_centerline_generator/README.md
+++ b/planning/autoware_static_centerline_generator/README.md
@@ -85,13 +85,17 @@ By default, footprints' color is
 ## Parameters
 
 ### Common Parameters
+
 {{ json_to_markdown("planning/autoware_static_centerline_generator/schema/common.schema.json") }}
 
 ### Nearest Search
+
 {{ json_to_markdown("planning/autoware_static_centerline_generator/schema/nearest_search.schema.json") }}
 
 ### Static Centerline Generator
+
 {{ json_to_markdown("planning/autoware_static_centerline_generator/schema/static_centerline_generator.schema.json") }}
 
 ### Vehicle Info
+
 {{ json_to_markdown("planning/autoware_static_centerline_generator/schema/vehicle_info.schema.json") }}

--- a/planning/autoware_static_centerline_generator/schema/common.schema.json
+++ b/planning/autoware_static_centerline_generator/schema/common.schema.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Common Parameters",
+    "type": "object",
+    "definitions": {
+        "common_params": {
+        "type": "object",
+        "properties": {
+            "max_vel": {
+            "type": "number",
+            "description": "max velocity limit [m/s]",
+            "default": 11.1
+            },
+            "normal": {
+            "type": "object",
+            "properties": {
+                "min_acc": {
+                "type": "number",
+                "description": "min deceleration [m/ss]",
+                "default": -1.0
+                },
+                "max_acc": {
+                "type": "number",
+                "description": "max acceleration [m/ss]",
+                "default": 1.0
+                },
+                "min_jerk": {
+                "type": "number",
+                "description": "min jerk [m/sss]",
+                "default": -1.0
+                },
+                "max_jerk": {
+                "type": "number",
+                "description": "max jerk [m/sss]",
+                "default": 1.0
+                }
+            },
+            "required": ["min_acc", "max_acc", "min_jerk", "max_jerk"]
+            },
+            "limit": {
+            "type": "object",
+            "properties": {
+                "min_acc": {
+                "type": "number",
+                "description": "min deceleration limit [m/ss]",
+                "default": -2.5
+                },
+                "max_acc": {
+                "type": "number",
+                "description": "max acceleration limit [m/ss]",
+                "default": 1.0
+                },
+                "min_jerk": {
+                "type": "number",
+                "description": "min jerk limit [m/sss]",
+                "default": -1.5
+                },
+                "max_jerk": {
+                "type": "number",
+                "description": "max jerk limit [m/sss]",
+                "default": 1.5
+                }
+            },
+            "required": ["min_acc", "max_acc", "min_jerk", "max_jerk"]
+            }
+        },
+        "required": ["max_vel", "normal", "limit"],
+        "additionalProperties": false
+        }
+    },
+    "properties": {
+        "/**": {
+        "type": "object",
+        "properties": {
+            "ros__parameters": {
+            "$ref": "#/definitions/common_params"
+            }
+        },
+        "required": ["ros__parameters"],
+        "additionalProperties": false
+        }
+    },
+    "required": ["/**"],
+    "additionalProperties": false
+}

--- a/planning/autoware_static_centerline_generator/schema/common.schema.json
+++ b/planning/autoware_static_centerline_generator/schema/common.schema.json
@@ -1,85 +1,85 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Common Parameters",
-    "type": "object",
-    "definitions": {
-        "common_params": {
-        "type": "object",
-        "properties": {
-            "max_vel": {
-            "type": "number",
-            "description": "max velocity limit [m/s]",
-            "default": 11.1
-            },
-            "normal": {
-            "type": "object",
-            "properties": {
-                "min_acc": {
-                "type": "number",
-                "description": "min deceleration [m/ss]",
-                "default": -1.0
-                },
-                "max_acc": {
-                "type": "number",
-                "description": "max acceleration [m/ss]",
-                "default": 1.0
-                },
-                "min_jerk": {
-                "type": "number",
-                "description": "min jerk [m/sss]",
-                "default": -1.0
-                },
-                "max_jerk": {
-                "type": "number",
-                "description": "max jerk [m/sss]",
-                "default": 1.0
-                }
-            },
-            "required": ["min_acc", "max_acc", "min_jerk", "max_jerk"]
-            },
-            "limit": {
-            "type": "object",
-            "properties": {
-                "min_acc": {
-                "type": "number",
-                "description": "min deceleration limit [m/ss]",
-                "default": -2.5
-                },
-                "max_acc": {
-                "type": "number",
-                "description": "max acceleration limit [m/ss]",
-                "default": 1.0
-                },
-                "min_jerk": {
-                "type": "number",
-                "description": "min jerk limit [m/sss]",
-                "default": -1.5
-                },
-                "max_jerk": {
-                "type": "number",
-                "description": "max jerk limit [m/sss]",
-                "default": 1.5
-                }
-            },
-            "required": ["min_acc", "max_acc", "min_jerk", "max_jerk"]
-            }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Common Parameters",
+  "type": "object",
+  "definitions": {
+    "common_params": {
+      "type": "object",
+      "properties": {
+        "max_vel": {
+          "type": "number",
+          "description": "max velocity limit [m/s]",
+          "default": 11.1
         },
-        "required": ["max_vel", "normal", "limit"],
-        "additionalProperties": false
-        }
-    },
-    "properties": {
-        "/**": {
-        "type": "object",
-        "properties": {
-            "ros__parameters": {
-            "$ref": "#/definitions/common_params"
+        "normal": {
+          "type": "object",
+          "properties": {
+            "min_acc": {
+              "type": "number",
+              "description": "min deceleration [m/ss]",
+              "default": -1.0
+            },
+            "max_acc": {
+              "type": "number",
+              "description": "max acceleration [m/ss]",
+              "default": 1.0
+            },
+            "min_jerk": {
+              "type": "number",
+              "description": "min jerk [m/sss]",
+              "default": -1.0
+            },
+            "max_jerk": {
+              "type": "number",
+              "description": "max jerk [m/sss]",
+              "default": 1.0
             }
+          },
+          "required": ["min_acc", "max_acc", "min_jerk", "max_jerk"]
         },
-        "required": ["ros__parameters"],
-        "additionalProperties": false
+        "limit": {
+          "type": "object",
+          "properties": {
+            "min_acc": {
+              "type": "number",
+              "description": "min deceleration limit [m/ss]",
+              "default": -2.5
+            },
+            "max_acc": {
+              "type": "number",
+              "description": "max acceleration limit [m/ss]",
+              "default": 1.0
+            },
+            "min_jerk": {
+              "type": "number",
+              "description": "min jerk limit [m/sss]",
+              "default": -1.5
+            },
+            "max_jerk": {
+              "type": "number",
+              "description": "max jerk limit [m/sss]",
+              "default": 1.5
+            }
+          },
+          "required": ["min_acc", "max_acc", "min_jerk", "max_jerk"]
         }
-    },
-    "required": ["/**"],
-    "additionalProperties": false
+      },
+      "required": ["max_vel", "normal", "limit"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/common_params"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
 }

--- a/planning/autoware_static_centerline_generator/schema/nearest_search.schema.json
+++ b/planning/autoware_static_centerline_generator/schema/nearest_search.schema.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Nearest Search Params",
+    "type": "object",
+    "definitions": {
+        "nearest_search": {
+        "type": "object",
+        "properties": {
+            "ego_nearest_dist_threshold": {
+            "type": "number",
+            "description": "Threshold for nearest distance to the ego vehicle [m]",
+            "default": 3.0
+            },
+            "ego_nearest_yaw_threshold": {
+            "type": "number",
+            "description": "Threshold for nearest yaw angle to the ego vehicle [rad]",
+            "default": 1.046
+            }
+        },
+        "required": ["ego_nearest_dist_threshold", "ego_nearest_yaw_threshold"],
+        "additionalProperties": false
+        }
+    },
+    "properties": {
+        "/**": {
+        "type": "object",
+        "properties": {
+            "ros__parameters": {
+            "$ref": "#/definitions/nearest_search"
+            }
+        },
+        "required": ["ros__parameters"],
+        "additionalProperties": false
+        }
+    },
+    "required": ["/**"],
+    "additionalProperties": false
+}

--- a/planning/autoware_static_centerline_generator/schema/nearest_search.schema.json
+++ b/planning/autoware_static_centerline_generator/schema/nearest_search.schema.json
@@ -1,38 +1,38 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Nearest Search Params",
-    "type": "object",
-    "definitions": {
-        "nearest_search": {
-        "type": "object",
-        "properties": {
-            "ego_nearest_dist_threshold": {
-            "type": "number",
-            "description": "Threshold for nearest distance to the ego vehicle [m]",
-            "default": 3.0
-            },
-            "ego_nearest_yaw_threshold": {
-            "type": "number",
-            "description": "Threshold for nearest yaw angle to the ego vehicle [rad]",
-            "default": 1.046
-            }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Nearest Search Params",
+  "type": "object",
+  "definitions": {
+    "nearest_search": {
+      "type": "object",
+      "properties": {
+        "ego_nearest_dist_threshold": {
+          "type": "number",
+          "description": "Threshold for nearest distance to the ego vehicle [m]",
+          "default": 3.0
         },
-        "required": ["ego_nearest_dist_threshold", "ego_nearest_yaw_threshold"],
-        "additionalProperties": false
+        "ego_nearest_yaw_threshold": {
+          "type": "number",
+          "description": "Threshold for nearest yaw angle to the ego vehicle [rad]",
+          "default": 1.046
         }
-    },
-    "properties": {
-        "/**": {
-        "type": "object",
-        "properties": {
-            "ros__parameters": {
-            "$ref": "#/definitions/nearest_search"
-            }
-        },
-        "required": ["ros__parameters"],
-        "additionalProperties": false
+      },
+      "required": ["ego_nearest_dist_threshold", "ego_nearest_yaw_threshold"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/nearest_search"
         }
-    },
-    "required": ["/**"],
-    "additionalProperties": false
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
 }

--- a/planning/autoware_static_centerline_generator/schema/static_centerline_generator.schema.json
+++ b/planning/autoware_static_centerline_generator/schema/static_centerline_generator.schema.json
@@ -1,65 +1,70 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Static Centerline Generator Params",
-    "type": "object",
-    "definitions": {
-        "static_centerline_generator": {
-        "type": "object",
-        "properties": {
-            "marker_color": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "description": "Marker colors in hexadecimal format",
-            "default": ["FF0000", "FF5A00", "FFFF00"]
-            },
-            "marker_color_dist_thresh": {
-            "type": "array",
-            "items": {
-                "type": "number"
-            },
-            "description": "Threshold values for marker color distance",
-            "default": [0.1, 0.2, 0.3]
-            },
-            "output_trajectory_interval": {
-            "type": "number",
-            "description": "Interval for output trajectory [s]",
-            "default": 1.0
-            },
-            "validation": {
-            "type": "object",
-            "properties": {
-                "dist_threshold_to_road_border": {
-                "type": "number",
-                "description": "Distance threshold to road border [m]",
-                "default": 0.0
-                },
-                "max_steer_angle_margin": {
-                "type": "number",
-                "description": "Max steer angle margin [rad] (Positive value decreases the max steer angle threshold)",
-                "default": 0.0
-                }
-            },
-            "required": ["dist_threshold_to_road_border", "max_steer_angle_margin"]
-            }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Static Centerline Generator Params",
+  "type": "object",
+  "definitions": {
+    "static_centerline_generator": {
+      "type": "object",
+      "properties": {
+        "marker_color": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Marker colors in hexadecimal format",
+          "default": ["FF0000", "FF5A00", "FFFF00"]
         },
-        "required": ["marker_color", "marker_color_dist_thresh", "output_trajectory_interval", "validation"],
-        "additionalProperties": false
-        }
-    },
-    "properties": {
-        "/**": {
-        "type": "object",
-        "properties": {
-            "ros__parameters": {
-            "$ref": "#/definitions/static_centerline_generator"
-            }
+        "marker_color_dist_thresh": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Threshold values for marker color distance",
+          "default": [0.1, 0.2, 0.3]
         },
-        "required": ["ros__parameters"],
-        "additionalProperties": false
+        "output_trajectory_interval": {
+          "type": "number",
+          "description": "Interval for output trajectory [s]",
+          "default": 1.0
+        },
+        "validation": {
+          "type": "object",
+          "properties": {
+            "dist_threshold_to_road_border": {
+              "type": "number",
+              "description": "Distance threshold to road border [m]",
+              "default": 0.0
+            },
+            "max_steer_angle_margin": {
+              "type": "number",
+              "description": "Max steer angle margin [rad] (Positive value decreases the max steer angle threshold)",
+              "default": 0.0
+            }
+          },
+          "required": ["dist_threshold_to_road_border", "max_steer_angle_margin"]
         }
-    },
-    "required": ["/**"],
-    "additionalProperties": false
+      },
+      "required": [
+        "marker_color",
+        "marker_color_dist_thresh",
+        "output_trajectory_interval",
+        "validation"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/static_centerline_generator"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
 }

--- a/planning/autoware_static_centerline_generator/schema/static_centerline_generator.schema.json
+++ b/planning/autoware_static_centerline_generator/schema/static_centerline_generator.schema.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Static Centerline Generator Params",
+    "type": "object",
+    "definitions": {
+        "static_centerline_generator": {
+        "type": "object",
+        "properties": {
+            "marker_color": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "Marker colors in hexadecimal format",
+            "default": ["FF0000", "FF5A00", "FFFF00"]
+            },
+            "marker_color_dist_thresh": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "description": "Threshold values for marker color distance",
+            "default": [0.1, 0.2, 0.3]
+            },
+            "output_trajectory_interval": {
+            "type": "number",
+            "description": "Interval for output trajectory [s]",
+            "default": 1.0
+            },
+            "validation": {
+            "type": "object",
+            "properties": {
+                "dist_threshold_to_road_border": {
+                "type": "number",
+                "description": "Distance threshold to road border [m]",
+                "default": 0.0
+                },
+                "max_steer_angle_margin": {
+                "type": "number",
+                "description": "Max steer angle margin [rad] (Positive value decreases the max steer angle threshold)",
+                "default": 0.0
+                }
+            },
+            "required": ["dist_threshold_to_road_border", "max_steer_angle_margin"]
+            }
+        },
+        "required": ["marker_color", "marker_color_dist_thresh", "output_trajectory_interval", "validation"],
+        "additionalProperties": false
+        }
+    },
+    "properties": {
+        "/**": {
+        "type": "object",
+        "properties": {
+            "ros__parameters": {
+            "$ref": "#/definitions/static_centerline_generator"
+            }
+        },
+        "required": ["ros__parameters"],
+        "additionalProperties": false
+        }
+    },
+    "required": ["/**"],
+    "additionalProperties": false
+}

--- a/planning/autoware_static_centerline_generator/schema/vehicle_info.schema.json
+++ b/planning/autoware_static_centerline_generator/schema/vehicle_info.schema.json
@@ -1,89 +1,89 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Vehicle Info Params",
-    "type": "object",
-    "definitions": {
-        "vehicle_info": {
-        "type": "object",
-        "properties": {
-            "wheel_radius": {
-            "type": "number",
-            "description": "radius of the vehicle's wheels",
-            "default": 0.39
-            },
-            "wheel_width": {
-            "type": "number",
-            "description": "width of the vehicle's wheels",
-            "default": 0.42
-            },
-            "wheel_base": {
-            "type": "number",
-            "description": "distance between front and rear wheel centers",
-            "default": 2.74
-            },
-            "wheel_tread": {
-            "type": "number",
-            "description": "distance between left and right wheel centers",
-            "default": 1.63
-            },
-            "front_overhang": {
-            "type": "number",
-            "description": "distance between front wheel center and vehicle front",
-            "default": 1.0
-            },
-            "rear_overhang": {
-            "type": "number",
-            "description": "distance between rear wheel center and vehicle rear",
-            "default": 1.03
-            },
-            "left_overhang": {
-            "type": "number",
-            "description": "distance between left wheel center and vehicle left",
-            "default": 0.1
-            },
-            "right_overhang": {
-            "type": "number",
-            "description": "distance between right wheel center and vehicle right",
-            "default": 0.1
-            },
-            "vehicle_height": {
-            "type": "number",
-            "description": "height of the vehicle",
-            "default": 2.5
-            },
-            "max_steer_angle": {
-            "type": "number",
-            "description": "maximum steering angle in radians",
-            "default": 0.70
-            }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Vehicle Info Params",
+  "type": "object",
+  "definitions": {
+    "vehicle_info": {
+      "type": "object",
+      "properties": {
+        "wheel_radius": {
+          "type": "number",
+          "description": "radius of the vehicle's wheels",
+          "default": 0.39
         },
-        "required": [
-            "wheel_radius",
-            "wheel_width",
-            "wheel_base",
-            "wheel_tread",
-            "front_overhang",
-            "rear_overhang",
-            "left_overhang",
-            "right_overhang",
-            "vehicle_height",
-            "max_steer_angle"
-        ],
-        "additionalProperties": false
-        }
-    },
-    "properties": {
-        "/**": {
-        "type": "object",
-        "properties": {
-            "ros__parameters": {
-            "$ref": "#/definitions/vehicle_info"
-            }
+        "wheel_width": {
+          "type": "number",
+          "description": "width of the vehicle's wheels",
+          "default": 0.42
         },
-        "required": ["ros__parameters"],
-        "additionalProperties": false
+        "wheel_base": {
+          "type": "number",
+          "description": "distance between front and rear wheel centers",
+          "default": 2.74
+        },
+        "wheel_tread": {
+          "type": "number",
+          "description": "distance between left and right wheel centers",
+          "default": 1.63
+        },
+        "front_overhang": {
+          "type": "number",
+          "description": "distance between front wheel center and vehicle front",
+          "default": 1.0
+        },
+        "rear_overhang": {
+          "type": "number",
+          "description": "distance between rear wheel center and vehicle rear",
+          "default": 1.03
+        },
+        "left_overhang": {
+          "type": "number",
+          "description": "distance between left wheel center and vehicle left",
+          "default": 0.1
+        },
+        "right_overhang": {
+          "type": "number",
+          "description": "distance between right wheel center and vehicle right",
+          "default": 0.1
+        },
+        "vehicle_height": {
+          "type": "number",
+          "description": "height of the vehicle",
+          "default": 2.5
+        },
+        "max_steer_angle": {
+          "type": "number",
+          "description": "maximum steering angle in radians",
+          "default": 0.7
         }
-    },
-    "required": ["/**"],
-    "additionalProperties": false
+      },
+      "required": [
+        "wheel_radius",
+        "wheel_width",
+        "wheel_base",
+        "wheel_tread",
+        "front_overhang",
+        "rear_overhang",
+        "left_overhang",
+        "right_overhang",
+        "vehicle_height",
+        "max_steer_angle"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/vehicle_info"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
 }

--- a/planning/autoware_static_centerline_generator/schema/vehicle_info.schema.json
+++ b/planning/autoware_static_centerline_generator/schema/vehicle_info.schema.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Vehicle Info Params",
+    "type": "object",
+    "definitions": {
+        "vehicle_info": {
+        "type": "object",
+        "properties": {
+            "wheel_radius": {
+            "type": "number",
+            "description": "radius of the vehicle's wheels",
+            "default": 0.39
+            },
+            "wheel_width": {
+            "type": "number",
+            "description": "width of the vehicle's wheels",
+            "default": 0.42
+            },
+            "wheel_base": {
+            "type": "number",
+            "description": "distance between front and rear wheel centers",
+            "default": 2.74
+            },
+            "wheel_tread": {
+            "type": "number",
+            "description": "distance between left and right wheel centers",
+            "default": 1.63
+            },
+            "front_overhang": {
+            "type": "number",
+            "description": "distance between front wheel center and vehicle front",
+            "default": 1.0
+            },
+            "rear_overhang": {
+            "type": "number",
+            "description": "distance between rear wheel center and vehicle rear",
+            "default": 1.03
+            },
+            "left_overhang": {
+            "type": "number",
+            "description": "distance between left wheel center and vehicle left",
+            "default": 0.1
+            },
+            "right_overhang": {
+            "type": "number",
+            "description": "distance between right wheel center and vehicle right",
+            "default": 0.1
+            },
+            "vehicle_height": {
+            "type": "number",
+            "description": "height of the vehicle",
+            "default": 2.5
+            },
+            "max_steer_angle": {
+            "type": "number",
+            "description": "maximum steering angle in radians",
+            "default": 0.70
+            }
+        },
+        "required": [
+            "wheel_radius",
+            "wheel_width",
+            "wheel_base",
+            "wheel_tread",
+            "front_overhang",
+            "rear_overhang",
+            "left_overhang",
+            "right_overhang",
+            "vehicle_height",
+            "max_steer_angle"
+        ],
+        "additionalProperties": false
+        }
+    },
+    "properties": {
+        "/**": {
+        "type": "object",
+        "properties": {
+            "ros__parameters": {
+            "$ref": "#/definitions/vehicle_info"
+            }
+        },
+        "required": ["ros__parameters"],
+        "additionalProperties": false
+        }
+    },
+    "required": ["/**"],
+    "additionalProperties": false
+}


### PR DESCRIPTION
### Description
----------------------------------------------
Implement the ROS Node configuration layout described in [Autoware Foundation Discussion #3371](https://github.com/orgs/autowarefoundation/discussions/3371) for the `static_centerline_optimizer` package.

- Remove duplication of parameter declaration between the source code and the parameter file.
- Remove the default value from the source code to ensure all parameter values are passed from the parameter files.
- Use types that match those returned from declare_parameter() to prevent confusion and potential coding errors.
- Move the default parameter file to a standardized location. Use the JSON Schema for that.

### Tests performed
----------------------------------------------
No.

### Pre-review checklist for the PR author
----------------------------------------------
The PR author must check the checkboxes below when creating the PR.

- [ ]  I've confirmed the [contribution guideline](https://autowarefoundation.github.io/autoware-documentation/main/contributing/).
- [ ]  The PR follows the pull [request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).

### In-review checklist for the PR reviewers
----------------------------------------------
The PR reviewers must check the checkboxes below before approval.

- [ ]  The PR follows the pull [request guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/).
- [ ]  The PR has been properly tested.
- [ ]  The PR has been reviewed by the code owners.

### Post-review checklist for the PR author
----------------------------------------------
The PR author must check the checkboxes below before merging.

- [ ]  There are no open discussions or they are tracked via tickets.
- [ ]  The PR is ready for merge.

After all checkboxes are checked, anyone with write access can merge the PR.
