### PR TITLE
fix(autoware_behavior_path_planner_common): modify geometric parallel parking path planning

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
@@ -398,10 +398,20 @@ std::vector<PathWithLaneId> GeometricParallelParking::planOneTrial(
   const Point C_far_goal_coords = inverse_transform_point(C_far.position, arc_end_pose);
   const Point self_point_goal_coords = inverse_transform_point(start_pose.position, arc_end_pose);
 
-  const double alpha =
-    left_side_parking
-      ? M_PI_2 - psi + std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit)
-      : M_PI_2 + psi - std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit);
+  double alpha;
+  if (is_forward) {
+    alpha =
+      left_side_parking
+        ? M_PI_2 + psi + std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit)
+        : M_PI_2 - psi -
+            std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit);
+  } else {
+    alpha =
+      left_side_parking
+        ? M_PI_2 - psi + std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit)
+        : M_PI_2 + psi -
+            std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit);
+  }
 
   const double R_E_near = (std::pow(d_C_far_Einit, 2) - std::pow(R_E_far, 2)) /
                           (2 * (R_E_far + d_C_far_Einit * std::cos(alpha)));
@@ -424,7 +434,7 @@ std::vector<PathWithLaneId> GeometricParallelParking::planOneTrial(
 
   // If start_pose is parallel to goal_pose, we can know lateral deviation of edges of vehicle,
   // and detect lane departure.
-  if (is_forward) {  // Check near bound
+  if (is_forward) {  // Check near front corner
     const double R_front_near =
       std::hypot(R_E_far + common_params.vehicle_width / 2, common_params.base_link2front);
     const double distance_to_near_bound =
@@ -433,13 +443,13 @@ std::vector<PathWithLaneId> GeometricParallelParking::planOneTrial(
     if (std::abs(distance_to_near_bound) - near_deviation < lane_departure_margin) {
       return std::vector<PathWithLaneId>{};
     }
-  } else {  // Check far bound
-    const double R_front_far =
-      std::hypot(R_E_near + common_params.vehicle_width / 2, common_params.base_link2front);
-    const double far_deviation = R_front_far - R_E_near;
-    const double distance_to_far_bound =
-      utils::getSignedDistanceFromBoundary(lanes, start_pose, !left_side_parking);
-    if (std::abs(distance_to_far_bound) - far_deviation < lane_departure_margin) {
+  } else {  // Check near back corner
+    const double R_front_near =
+      std::hypot(R_E_far + common_params.vehicle_width / 2, common_params.base_link2rear);
+    const double distance_to_near_bound =
+      utils::getSignedDistanceFromBoundary(pull_over_lanes, arc_end_pose, left_side_parking);
+    const double near_deviation = R_front_near - R_E_far;
+    if (std::abs(distance_to_near_bound) - near_deviation < lane_departure_margin) {
       return std::vector<PathWithLaneId>{};
     }
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
@@ -398,20 +398,10 @@ std::vector<PathWithLaneId> GeometricParallelParking::planOneTrial(
   const Point C_far_goal_coords = inverse_transform_point(C_far.position, arc_end_pose);
   const Point self_point_goal_coords = inverse_transform_point(start_pose.position, arc_end_pose);
 
-  double alpha;
-  if (is_forward) {
-    alpha =
-      left_side_parking
-        ? M_PI_2 + psi + std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit)
-        : M_PI_2 - psi -
-            std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit);
-  } else {
-    alpha =
-      left_side_parking
-        ? M_PI_2 - psi + std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit)
-        : M_PI_2 + psi -
-            std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit);
-  }
+  const double angle_offset =
+    std::asin((self_point_goal_coords.y - C_far_goal_coords.y) / d_C_far_Einit);
+  const double alpha = M_PI_2 + (left_side_parking ? 1.0 : -1.0) *
+                                  (is_forward ? psi + angle_offset : -psi + angle_offset);
 
   const double R_E_near = (std::pow(d_C_far_Einit, 2) - std::pow(R_E_far, 2)) /
                           (2 * (R_E_far + d_C_far_Einit * std::cos(alpha)));


### PR DESCRIPTION
## Description
Modify the weird path generation of geometric parallel parking. The alpha calculation was wrong and must be computed according to forward or backward parking.
Moreover, this PR includes modification of a useless boundary check (check for the opposite side of the shoulder). 

Before
![Screenshot from 2024-12-11 12-46-34](https://github.com/user-attachments/assets/77032c1e-f776-47d0-abbc-d6bbfaf5701a)

After
![Screenshot from 2024-12-11 12-47-40](https://github.com/user-attachments/assets/49b8dfbb-0b32-40ac-b578-822c0ae4c6f5)


 
## Related links

**Parent Issue:**

- N/A

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- [plot_map](https://github.com/tier4/autoware.universe/blob/tier4/main/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp) as shown in above Pictures. 
- Evaluator: https://evaluation.tier4.jp/evaluation/reports/33c8c0c1-e59c-52b0-8a71-5325f4f7cc07?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
