### PR TITLE
feat(tier4_state_rviz_plugin): save & load config of VelocitySteeringFactorsPanel

### DIFF
--- a/visualization/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
+++ b/visualization/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
@@ -77,6 +77,9 @@ protected:
 
   void onVelocityFactors(const VelocityFactorArray::ConstSharedPtr msg);
   void onSteeringFactors(const SteeringFactorArray::ConstSharedPtr msg);
+
+  void save(rviz_common::Config config) const override;
+  void load(const rviz_common::Config & config) override;
 };
 }  // namespace rviz_plugins
 

--- a/visualization/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
@@ -303,6 +303,24 @@ void VelocitySteeringFactorsPanel::onSteeringFactors(const SteeringFactorArray::
   }
   steering_factors_table_->update();
 }
+
+void VelocitySteeringFactorsPanel::save(rviz_common::Config config) const
+{
+  rviz_common::Panel::save(config);
+  config.mapSetValue("jerk", jerk_input_->value());
+  config.mapSetValue("decel_limit", decel_limit_input_->value());
+}
+
+void VelocitySteeringFactorsPanel::load(const rviz_common::Config & config)
+{
+  rviz_common::Panel::load(config);
+  if (float jerk; config.mapGetFloat("jerk", &jerk)) {
+    jerk_input_->setValue(static_cast<double>(jerk));
+  }
+  if (float decel_limit; config.mapGetFloat("decel_limit", &decel_limit)) {
+    decel_limit_input_->setValue(static_cast<double>(decel_limit));
+  }
+}
 }  // namespace rviz_plugins
 
 #include <pluginlib/class_list_macros.hpp>


### PR DESCRIPTION
## Description

This PR enables to save and load the configuration of `VelocitySteeringFactorsPanel`.
Currently the jerk and the deceleration limit for abrupt deceleration checking feature are covered.

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
