### PR TITLE
feat(map_based_prediction): add diagnostic handler to warn the processing time excess

### DIFF
--- a/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
@@ -56,3 +56,4 @@
     publish_processing_time_detail: false
     publish_debug_markers: false
     processing_time_tolerance_ms: 500.0 #[ms]
+    consecutive_delay_tolerance_ms: 1000.0 #[ms]

--- a/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
@@ -55,5 +55,5 @@
     publish_processing_time: false
     publish_processing_time_detail: false
     publish_debug_markers: false
-    processing_time_tolerance_ms: 500.0 #[ms]
-    consecutive_delay_tolerance_ms: 1000.0 #[ms]
+    processing_time_tolerance: 0.5 #[s]
+    processing_time_consecutive_excess_tolerance: 1.0 #[s]

--- a/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
@@ -55,3 +55,4 @@
     publish_processing_time: false
     publish_processing_time_detail: false
     publish_debug_markers: false
+    processing_time_tolerance_ms: 500.0 #[ms]

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -170,7 +170,7 @@ private:
   void trafficSignalsCallback(const TrafficLightGroupArray::ConstSharedPtr msg);
   void objectsCallback(const TrackedObjects::ConstSharedPtr in_objects);
 
-  // Diagnostics procses
+  // Diagnostics proccess
   void updateDiagnostics(const rclcpp::Time & timestamp, double processing_time_ms);
 
   // Map process

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -46,7 +46,6 @@
 #include <deque>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -119,11 +118,9 @@ private:
 
   // Diagnostics
   std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
-  rclcpp::TimerBase::SharedPtr diagnostics_timer_;
   double processing_time_tolerance_ms_;
-  double consecutive_delay_tolerance_ms_;
-  std::optional<rclcpp::Time> last_intime_processing_timestamp_;
-  std::mutex diagnostics_mtx_;
+  double processing_time_consecutive_excess_tolerance_ms_;
+  std::optional<rclcpp::Time> last_in_time_processing_timestamp_;
 
   ////// Parameters
 
@@ -173,8 +170,8 @@ private:
   void trafficSignalsCallback(const TrafficLightGroupArray::ConstSharedPtr msg);
   void objectsCallback(const TrackedObjects::ConstSharedPtr in_objects);
 
-  // Diagnostics callback
-  void diagnosticsTimerCallback();
+  // Diagnostics procses
+  void updateDiagnostics(const rclcpp::Time & timestamp, double processing_time_ms);
 
   // Map process
   bool doesPathCrossFence(

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -21,6 +21,7 @@
 
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/debug_publisher.hpp>
+#include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
 #include <autoware_utils/ros/transform_listener.hpp>
@@ -114,6 +115,10 @@ private:
 
   // Predictor
   std::shared_ptr<PredictorVru> predictor_vru_;
+
+  // Diagnostics
+  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
+  double processing_time_tolerance_ms_;
 
   ////// Parameters
 

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -46,6 +46,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -118,7 +119,11 @@ private:
 
   // Diagnostics
   std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
+  rclcpp::TimerBase::SharedPtr diagnostics_timer_;
   double processing_time_tolerance_ms_;
+  double consecutive_delay_tolerance_ms_;
+  std::optional<rclcpp::Time> last_intime_processing_timestamp_;
+  std::mutex diagnostics_mtx_;
 
   ////// Parameters
 
@@ -167,6 +172,9 @@ private:
   void mapCallback(const LaneletMapBin::ConstSharedPtr msg);
   void trafficSignalsCallback(const TrafficLightGroupArray::ConstSharedPtr msg);
   void objectsCallback(const TrackedObjects::ConstSharedPtr in_objects);
+
+  // Diagnostics callback
+  void diagnosticsTimerCallback();
 
   // Map process
   bool doesPathCrossFence(


### PR DESCRIPTION
## Description

This PR introduces diagnostics handler to warn when the processing time exceed a threshold value.

## Related links

- Parameter update in `autoware_launch`: https://github.com/autowarefoundation/autoware_launch/pull/1362

## How was this PR tested?

[Screencast from 03-18-2025 04:30:02 PM.webm](https://github.com/user-attachments/assets/66c25dd8-77c7-46b1-966f-6b843e9cbb6f)

[TIER IV INTERNAL LINK](https://evaluation.ci.tier4.jp/evaluation/reports/17102d51-5559-59b2-b142-9d0a0ad25eac?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `processing_time_tolerance_ms`   | `double` | `500.0`         | If the processing exceeds this value, diagnostics publishes  warning.|

## Effects on system behavior

None.
