### PR TITLE
fix(start_planner): use waypoints as centerline if available

### DIFF
--- a/build_depends_humble.repos
+++ b/build_depends_humble.repos
@@ -11,7 +11,7 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.6.2
+    version: 0.7.0
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
@@ -230,7 +230,7 @@ private:
   bool receivedNewRoute() const;
 
   bool isModuleRunning() const;
-  bool isCurrentPoseOnMiddleOfTheRoad() const;
+  bool isCurrentPoseOnCenterline() const;
 
   /**
    * @brief Check if the ego vehicle is preventing the rear vehicle from passing through.

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
@@ -230,7 +230,7 @@ private:
   bool receivedNewRoute() const;
 
   bool isModuleRunning() const;
-  bool isCurrentPoseOnCenterline() const;
+  bool isCurrentPoseOnEgoCenterline() const;
 
   /**
    * @brief Check if the ego vehicle is preventing the rear vehicle from passing through.

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -347,7 +347,7 @@ bool StartPlannerModule::isExecutionRequested() const
   // - The vehicle has reached the goal position.
   // - The vehicle is still moving.
   if (
-    isCurrentPoseOnCenterline() || isCloseToOriginalStartPose() || hasArrivedAtGoal() ||
+    isCurrentPoseOnEgoCenterline() || isCloseToOriginalStartPose() || hasArrivedAtGoal() ||
     isMoving()) {
     return false;
   }
@@ -367,7 +367,7 @@ bool StartPlannerModule::isModuleRunning() const
   return getCurrentStatus() == ModuleStatus::RUNNING;
 }
 
-bool StartPlannerModule::isCurrentPoseOnCenterline() const
+bool StartPlannerModule::isCurrentPoseOnEgoCenterline() const
 {
   const auto & lanelet_map_ptr = planner_data_->route_handler->getLaneletMapPtr();
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -373,8 +373,7 @@ bool StartPlannerModule::isCurrentPoseOnCenterline() const
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;
   const lanelet::ConstLanelets current_lanes = utils::getCurrentLanes(planner_data_);
   const double lateral_distance_to_center_lane =
-    lanelet::utils::getArcCoordinatesConsideringWaypoints(
-      current_lanes, current_pose, lanelet_map_ptr)
+    lanelet::utils::getArcCoordinatesOnEgoCenterline(current_lanes, current_pose, lanelet_map_ptr)
       .distance;
 
   return std::abs(lateral_distance_to_center_lane) < parameters_->th_distance_to_middle_of_the_road;


### PR DESCRIPTION
## Description

closes https://github.com/autowarefoundation/autoware.universe/issues/10237

:exclamation: **Should be merged after** https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/49 **is merged**

:question: What this PR changes:

- `start_planner` does not consider "waypoints" attribute (custom centerline)  assigned to the lanelet but calculated centerline when it judges whether ego is in the middle of the road or not
 Instead I propose it is more convenient to query if ego is on the centerline (custom or calculated) whether [use_waypoints](https://github.com/autowarefoundation/autoware_launch/blob/c97fd6203be0b81b8cc4f4548161eca4418a6d66/autoware_launch/config/map/lanelet2_map_loader.param.yaml#L5) : `true` or [use_waypoints](https://github.com/autowarefoundation/autoware_launch/blob/c97fd6203be0b81b8cc4f4548161eca4418a6d66/autoware_launch/config/map/lanelet2_map_loader.param.yaml#L5) : `false` since "waypoints" is supposed to be used for ego path judgement.

**Before:** 
![start_planner_activates](https://github.com/user-attachments/assets/9d39c34c-2bba-4dc7-8987-3a3156cdfd40)

**After:**

https://github.com/user-attachments/assets/35b717d8-7156-4d69-b2ea-bfca5f27d870

## Related links

**Parent Issue:**

[- Link](https://github.com/autowarefoundation/autoware.universe/issues/10237)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Download the map & scenario: [map and scenario.zip](https://github.com/user-attachments/files/19109765/map.and.scenario.zip)
- Run the scenario

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
