### PR TITLE
fix(autoware_multi_object_tracker): stabilize bicycle model slip

### DIFF
--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -326,7 +326,9 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
     X_t(IDX::Y) + vel * sin_yaw * dt + 0.5 * vel * cos_slip * w_dtdt;  // dy = v * sin(yaw) * dt
   X_next_t(IDX::YAW) = X_t(IDX::YAW) + w * dt;                         // d(yaw) = w * dt
   X_next_t(IDX::VEL) = X_t(IDX::VEL);
-  X_next_t(IDX::SLIP) = X_t(IDX::SLIP);  // slip_angle = asin(lr * w / v)
+  // Apply exponential decay to slip angle over time, with a half-life of 2 seconds
+  const double decay_rate = std::exp(-dt * 0.69314718056 / 2.0);
+  X_next_t(IDX::SLIP) = X_t(IDX::SLIP) * decay_rate;  // slip_angle = asin(lr * w / v)
 
   // State transition matrix A
   Eigen::MatrixXd A = Eigen::MatrixXd::Identity(DIM, DIM);


### PR DESCRIPTION
## Description

Apply exponential decay to slip angle over time, with a half-life (2 seconds).

The current bicycle motion model assumes constant turn rate. However, it can cause slip angle instability, oscillation or divergence. Especially, the oscillation or divergence occurs with high turn-rate object and newly spawned object, normally has high covariance of yaw.

Therefore, the decay is introduced to mitigate this system instability.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/41daf875-a09b-51d3-8368-1407effee592?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
