### PR TITLE
fix(autoware_crosswalk_traffic_light_estimator): add process that guard access to empty elements

### DIFF
--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -303,7 +303,11 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
         output_traffic_signal_element.color = color;
         output_traffic_signal_element.shape = TrafficSignalElement::CIRCLE;
         output_traffic_signal_element.confidence = 1.0;
-        output.traffic_light_groups[idx].elements[0] = output_traffic_signal_element;
+        if (output.traffic_light_groups[idx].elements.empty()) {
+          output.traffic_light_groups[idx].elements.push_back(output_traffic_signal_element);
+        } else {
+          output.traffic_light_groups[idx].elements[0] = output_traffic_signal_element;
+        }
         continue;
       }
       updateFlashingState(signal);  // check if it is flashing
@@ -325,6 +329,10 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
 bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(
   const TrafficSignal & signal) const
 {
+   // invalid if elements is empty
+  if (signal.elements.empty()) {
+    return true;
+  }
   // check occlusion, backlight(shape is unknown) and no detection(shape is circle)
   if (
     signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
@@ -347,6 +355,7 @@ void CrosswalkTrafficLightEstimatorNode::updateFlashingState(const TrafficSignal
 
   // flashing green
   if (
+    !signal.elements.empty() &&
     signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
     signal.elements.front().confidence != 0 &&  // not due to occlusion
     current_color_state_.at(id) != TrafficSignalElement::UNKNOWN) {

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -329,7 +329,7 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
 bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(
   const TrafficSignal & signal) const
 {
-   // invalid if elements is empty
+  // invalid if elements is empty
   if (signal.elements.empty()) {
     return true;
   }
@@ -355,8 +355,7 @@ void CrosswalkTrafficLightEstimatorNode::updateFlashingState(const TrafficSignal
 
   // flashing green
   if (
-    !signal.elements.empty() &&
-    signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
+    !signal.elements.empty() && signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
     signal.elements.front().confidence != 0 &&  // not due to occlusion
     current_color_state_.at(id) != TrafficSignalElement::UNKNOWN) {
     is_flashing_.at(id) = true;


### PR DESCRIPTION
## Description
There is a problem that the crosswalk traffic light estimator drops out when a pedestrian signal is received with V2I signal coordination.

This problem is caused by a process in crosswalk_traffic_light_estimator that accesses elements without checking for the presence of signal recognition results.
Accessing an element without checking its value even when it is empty causes a segmentation fault.

This PR solves the problem by adding a process that prevents the result of signal recognition from being referenced in an empty state.

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-34969) 
- [Evaluator](https://evaluation.ci.tier4.jp/evaluation/reports/c913655e-2855-5a2b-ae65-8a983ce3cde3?project_id=prd_jt)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    |
![psim_cross_walk_signal_node_dead](https://github.com/user-attachments/assets/64f22dfe-d821-4016-a805-b21f63c8a776)
![psim_cross_walk_signal_node_dead](https://github.com/user-attachments/assets/fe2f39ea-1eb0-4005-9077-da64f2695dbe)
 Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
