### PR TITLE
feat(multi_object_tracker): add diagnostics warning when extrapolation time exceeds limit with latency guarantee enabled

### DIFF
--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -36,5 +36,5 @@
     publish_debug_markers: false
     diagnostics_warn_delay: 0.5      # [sec]
     diagnostics_error_delay: 1.0     # [sec]
-    diagnostics_warn_extrapolation_: 0.5      # [sec]
-    diagnostics_error_extrapolation_: 1.0      # [sec]
+    diagnostics_warn_extrapolation: 0.5      # [sec]
+    diagnostics_error_extrapolation: 1.0      # [sec]

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -36,3 +36,5 @@
     publish_debug_markers: false
     diagnostics_warn_delay: 0.5      # [sec]
     diagnostics_error_delay: 1.0     # [sec]
+    diagnostics_warn_extrapolation_: 0.5      # [sec]
+    diagnostics_error_extrapolation_: 1.0      # [sec]

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -151,12 +151,12 @@
           "description": "Delay threshold for error diagnostics in seconds.",
           "default": 1.0
         },
-        "diagnostics_warn_extrapolation_": {
+        "diagnostics_warn_extrapolation": {
           "type": "number",
           "description": "Delay extrapolation threshold for warning diagnostics in seconds.",
           "default": 0.5
         },
-        "diagnostics_error_extrapolation_": {
+        "diagnostics_error_extrapolation": {
           "type": "number",
           "description": "Delay extrapolation threshold for error diagnostics in seconds.",
           "default": 1.0

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -150,6 +150,16 @@
           "type": "number",
           "description": "Delay threshold for error diagnostics in seconds.",
           "default": 1.0
+        },
+        "diagnostics_warn_extrapolation_": {
+          "type": "number",
+          "description": "Delay extrapolation threshold for warning diagnostics in seconds.",
+          "default": 0.5
+        },
+        "diagnostics_error_extrapolation_": {
+          "type": "number",
+          "description": "Delay extrapolation threshold for error diagnostics in seconds.",
+          "default": 1.0
         }
       },
       "required": [

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -14,12 +14,12 @@
 
 #include "debugger.hpp"
 
+#include <algorithm>
 #include <list>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <algorithm>
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -70,9 +70,9 @@ void TrackerDebugger::loadParameters()
       node_.declare_parameter<double>("diagnostics_warn_delay");
     debug_settings_.diagnostics_error_delay =
       node_.declare_parameter<double>("diagnostics_error_delay");
-    debug_settings_.diagnostics_warn_extrapolation_ =
+    debug_settings_.diagnostics_warn_extrapolation =
       node_.declare_parameter<double>("diagnostics_warn_extrapolation_");
-    debug_settings_.diagnostics_error_extrapolation_ =
+    debug_settings_.diagnostics_error_extrapolation =
       node_.declare_parameter<double>("diagnostics_error_extrapolation_");
   } catch (const std::exception & e) {
     RCLCPP_WARN(node_.get_logger(), "Failed to declare parameter: %s", e.what());
@@ -122,14 +122,31 @@ TrackerDebugger::TimingCheckResult TrackerDebugger::checkDelayTiming(double dela
 }
 
 TrackerDebugger::TimingCheckResult TrackerDebugger::checkExtrapolationTiming(
-  double extrapolation_time) const
+  double extrapolation_time, const rclcpp::Time &timestamp)
 {
-  if (extrapolation_time <= debug_settings_.diagnostics_warn_extrapolation_) {
+  if (extrapolation_time <= debug_settings_.diagnostics_warn_extrapolation) {
+    last_non_warning_timestamp_ = timestamp;
     return {"Within limits", diagnostic_msgs::msg::DiagnosticStatus::OK};
   }
-  if (extrapolation_time <= debug_settings_.diagnostics_error_extrapolation_) {
-    return {"Exceeded warn threshold", diagnostic_msgs::msg::DiagnosticStatus::WARN};
+
+  // If this is the first time a warning occurs, initialize the timestamp
+  if (last_non_warning_timestamp_.nanoseconds() == 0) {
+    last_non_warning_timestamp_ = timestamp;
   }
+
+  // Calculate consecutive warning duration
+  const double consecutive_warning_duration_ms =
+    std::chrono::duration<double, std::milli>(
+      std::chrono::nanoseconds(
+        (timestamp - last_non_warning_timestamp_).nanoseconds()))
+      .count();
+
+
+  // Check if warnings have persisted beyond the allowed duration
+  if (consecutive_warning_duration_ms > debug_settings_.diagnostics_error_extrapolation) {
+    return {"Warnings persisted for too long", diagnostic_msgs::msg::DiagnosticStatus::ERROR};
+  }
+
   return {"Exceeded error threshold", diagnostic_msgs::msg::DiagnosticStatus::ERROR};
 }
 
@@ -175,7 +192,7 @@ void TrackerDebugger::checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper
   // Check individual timing components
   const auto delay_result = checkDelayTiming(delay);
   const auto extrapolation_result =
-    checkExtrapolationTiming(diagnostic_values_.min_extrapolation_time);
+    checkExtrapolationTiming(diagnostic_values_.min_extrapolation_time,node_.now());
   // Determine overall status
   const auto overall_result =
     determineOverallTimingStatus(no_published_trackers, delay_result, extrapolation_result);

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -122,7 +122,7 @@ TrackerDebugger::TimingCheckResult TrackerDebugger::checkDelayTiming(double dela
 }
 
 TrackerDebugger::TimingCheckResult TrackerDebugger::checkExtrapolationTiming(
-  double extrapolation_time, const rclcpp::Time &timestamp)
+  double extrapolation_time, const rclcpp::Time & timestamp)
 {
   if (extrapolation_time <= debug_settings_.diagnostics_warn_extrapolation) {
     last_non_warning_timestamp_ = timestamp;
@@ -137,10 +137,8 @@ TrackerDebugger::TimingCheckResult TrackerDebugger::checkExtrapolationTiming(
   // Calculate consecutive warning duration
   const double consecutive_warning_duration_ms =
     std::chrono::duration<double, std::milli>(
-      std::chrono::nanoseconds(
-        (timestamp - last_non_warning_timestamp_).nanoseconds()))
+      std::chrono::nanoseconds((timestamp - last_non_warning_timestamp_).nanoseconds()))
       .count();
-
 
   // Check if warnings have persisted beyond the allowed duration
   if (consecutive_warning_duration_ms > debug_settings_.diagnostics_error_extrapolation) {
@@ -192,7 +190,7 @@ void TrackerDebugger::checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper
   // Check individual timing components
   const auto delay_result = checkDelayTiming(delay);
   const auto extrapolation_result =
-    checkExtrapolationTiming(diagnostic_values_.min_extrapolation_time,node_.now());
+    checkExtrapolationTiming(diagnostic_values_.min_extrapolation_time, node_.now());
   // Determine overall status
   const auto overall_result =
     determineOverallTimingStatus(no_published_trackers, delay_result, extrapolation_result);

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -146,8 +146,8 @@ TrackerDebugger::TimingCheckResult TrackerDebugger::checkExtrapolationTiming(
   // Check if warnings have persisted beyond the allowed duration
   if (consecutive_warning_duration_s > debug_settings_.diagnostics_error_extrapolation) {
     return {
-      "[ERROR] Extrapolation time exceeded warning threshold " +
-        std::to_string(debug_settings_.diagnostics_warn_extrapolation) + " too long for " +
+      "[ERROR] Extrapolation time exceeded the warning threshold of " +
+        std::to_string(debug_settings_.diagnostics_warn_extrapolation) + " for " +
         std::to_string(consecutive_warning_duration_s) + " seconds (Threshold " +
         std::to_string(debug_settings_.diagnostics_error_extrapolation) + ")",
       diagnostic_msgs::msg::DiagnosticStatus::ERROR};

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -103,7 +103,7 @@ void TrackerDebugger::publishTentativeObjects(
 void TrackerDebugger::checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   if (!is_initialized_) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Measurement time is not set.");
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Measurement time is not set.");
     return;
   }
   const double & delay = pipeline_latency_ms_ / 1e3;  // [s]

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -107,57 +107,55 @@ void TrackerDebugger::publishTentativeObjects(
   }
 }
 
-TrackerDebugger::TimingCheckResult 
-TrackerDebugger::checkDelayTiming(double delay) const
+TrackerDebugger::TimingCheckResult TrackerDebugger::checkDelayTiming(double delay) const
 {
-    if (delay == 0.0) {
-        return {"Not calculated", diagnostic_msgs::msg::DiagnosticStatus::OK};
-    }
-    if (delay < debug_settings_.diagnostics_warn_delay) {
-        return {"Within limits", diagnostic_msgs::msg::DiagnosticStatus::OK};
-    }
-    if (delay < debug_settings_.diagnostics_error_delay) {
-        return {"Exceeded warn threshold", diagnostic_msgs::msg::DiagnosticStatus::WARN};
-    }
-    return {"Exceeded error threshold", diagnostic_msgs::msg::DiagnosticStatus::ERROR};
+  if (delay == 0.0) {
+    return {"Not calculated", diagnostic_msgs::msg::DiagnosticStatus::OK};
+  }
+  if (delay < debug_settings_.diagnostics_warn_delay) {
+    return {"Within limits", diagnostic_msgs::msg::DiagnosticStatus::OK};
+  }
+  if (delay < debug_settings_.diagnostics_error_delay) {
+    return {"Exceeded warn threshold", diagnostic_msgs::msg::DiagnosticStatus::WARN};
+  }
+  return {"Exceeded error threshold", diagnostic_msgs::msg::DiagnosticStatus::ERROR};
 }
 
-TrackerDebugger::TimingCheckResult 
-TrackerDebugger::checkExtrapolationTiming(double extrapolation_time) const
+TrackerDebugger::TimingCheckResult TrackerDebugger::checkExtrapolationTiming(
+  double extrapolation_time) const
 {
-    if (extrapolation_time <= debug_settings_.diagnostics_warn_extrapolation_) {
-        return {"Within limits", diagnostic_msgs::msg::DiagnosticStatus::OK};
-    }
-    if (extrapolation_time <= debug_settings_.diagnostics_error_extrapolation_) {
-        return {"Exceeded warn threshold", diagnostic_msgs::msg::DiagnosticStatus::WARN};
-    }
-    return {"Exceeded error threshold", diagnostic_msgs::msg::DiagnosticStatus::ERROR};
+  if (extrapolation_time <= debug_settings_.diagnostics_warn_extrapolation_) {
+    return {"Within limits", diagnostic_msgs::msg::DiagnosticStatus::OK};
+  }
+  if (extrapolation_time <= debug_settings_.diagnostics_error_extrapolation_) {
+    return {"Exceeded warn threshold", diagnostic_msgs::msg::DiagnosticStatus::WARN};
+  }
+  return {"Exceeded error threshold", diagnostic_msgs::msg::DiagnosticStatus::ERROR};
 }
 
-TrackerDebugger::TimingCheckResult 
-TrackerDebugger::determineOverallTimingStatus(bool no_published_trackers,
-                                            const TimingCheckResult& delay_result,
-                                            const TimingCheckResult& extrapolation_result) const
+TrackerDebugger::TimingCheckResult TrackerDebugger::determineOverallTimingStatus(
+  bool no_published_trackers, const TimingCheckResult & delay_result,
+  const TimingCheckResult & extrapolation_result) const
 {
-    if (no_published_trackers) {
-        return {"No objects being tracked (normal if no detections)", 
-                diagnostic_msgs::msg::DiagnosticStatus::OK};
-    }
+  if (no_published_trackers) {
+    return {
+      "No objects being tracked (normal if no detections)",
+      diagnostic_msgs::msg::DiagnosticStatus::OK};
+  }
 
-    if (delay_result.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR ||
-        extrapolation_result.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
-        return {"Critical timing thresholds exceeded", 
-                diagnostic_msgs::msg::DiagnosticStatus::ERROR};
-    }
+  if (
+    delay_result.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR ||
+    extrapolation_result.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
+    return {"Critical timing thresholds exceeded", diagnostic_msgs::msg::DiagnosticStatus::ERROR};
+  }
 
-    if (delay_result.level == diagnostic_msgs::msg::DiagnosticStatus::WARN ||
-        extrapolation_result.level == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
-        return {"Warning timing thresholds exceeded", 
-                diagnostic_msgs::msg::DiagnosticStatus::WARN};
-    }
+  if (
+    delay_result.level == diagnostic_msgs::msg::DiagnosticStatus::WARN ||
+    extrapolation_result.level == diagnostic_msgs::msg::DiagnosticStatus::WARN) {
+    return {"Warning timing thresholds exceeded", diagnostic_msgs::msg::DiagnosticStatus::WARN};
+  }
 
-    return {"All timings within normal limits", 
-            diagnostic_msgs::msg::DiagnosticStatus::OK};
+  return {"All timings within normal limits", diagnostic_msgs::msg::DiagnosticStatus::OK};
 }
 
 // Time measurement functions
@@ -176,11 +174,11 @@ void TrackerDebugger::checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper
 
   // Check individual timing components
   const auto delay_result = checkDelayTiming(delay);
-  const auto extrapolation_result = checkExtrapolationTiming(diagnostic_values_.min_extrapolation_time);
+  const auto extrapolation_result =
+    checkExtrapolationTiming(diagnostic_values_.min_extrapolation_time);
   // Determine overall status
-  const auto overall_result = determineOverallTimingStatus(no_published_trackers, 
-                                                          delay_result, 
-                                                           extrapolation_result);
+  const auto overall_result =
+    determineOverallTimingStatus(no_published_trackers, delay_result, extrapolation_result);
 
   stat.add("Detection delay (s)", delay);
   stat.add("Detection status", delay_result.message);

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -91,7 +91,8 @@ void TrackerDebugger::setupDiagnostics()
   diagnostic_updater_.setPeriod(0.1);
 }
 
-void TrackerDebugger::updateDiagnosticValues(double min_extrapolation_time, size_t published_count) {
+void TrackerDebugger::updateDiagnosticValues(double min_extrapolation_time, size_t published_count)
+{
   diagnostic_values_.min_extrapolation_time = min_extrapolation_time;
   diagnostic_values_.published_trackers_count = published_count;
   // Force update diagnostic values
@@ -138,11 +139,11 @@ void TrackerDebugger::checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper
 
   // Initialize with OK status
   int8_t overall_level = diagnostic_msgs::msg::DiagnosticStatus::OK;
-  std::string overall_message = no_published_trackers ? 
-    "No objects being tracked (normal if no detections)" : 
-    "All timings within normal limits";
+  std::string overall_message = no_published_trackers
+                                  ? "No objects being tracked (normal if no detections)"
+                                  : "All timings within normal limits";
   // Determine overall status
-    // Only check extrapolation if we have published trackers
+  // Only check extrapolation if we have published trackers
   if (!no_published_trackers) {
     if (
       delay >= settings.diagnostics_error_delay ||

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.cpp
@@ -87,14 +87,13 @@ void TrackerDebugger::loadParameters()
 void TrackerDebugger::setupDiagnostics()
 {
   diagnostic_updater_.setHardwareID(node_.get_name());
-  diagnostic_updater_.add(
-    "Tracker Timing Diagnostics", this, &TrackerDebugger::checkAllTiming);
+  diagnostic_updater_.add("Tracker Timing Diagnostics", this, &TrackerDebugger::checkAllTiming);
   diagnostic_updater_.setPeriod(0.1);
 }
 
 void TrackerDebugger::updateMinExtrapolationTime(double min_extrapolation_time)
 {
-    diagnostic_values_.min_extrapolation_time = min_extrapolation_time;
+  diagnostic_values_.min_extrapolation_time = min_extrapolation_time;
 }
 
 void TrackerDebugger::publishTentativeObjects(
@@ -106,7 +105,7 @@ void TrackerDebugger::publishTentativeObjects(
 }
 
 // Time measurement functions
-void TrackerDebugger::checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper &stat)
+void TrackerDebugger::checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   // Check initialization status
   if (!is_initialized_) {
@@ -117,33 +116,36 @@ void TrackerDebugger::checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper
 
   const double delay = pipeline_latency_ms_ / 1e3;  // [s]
   // Alias for cleaner code
-  const auto& settings = debug_settings_;  
-  const auto& values = diagnostic_values_; 
+  const auto & settings = debug_settings_;
+  const auto & values = diagnostic_values_;
 
   // Detection delay thresholds
-  const std::string delay_status = 
-  (delay == 0.0) ? "Not calculated" :
-  (delay < settings.diagnostics_warn_delay) ? "Within limits" :
-  (delay < settings.diagnostics_error_delay) ? "Exceeded warn threshold" :
-  "Exceeded error threshold";
+  const std::string delay_status = (delay == 0.0)                              ? "Not calculated"
+                                   : (delay < settings.diagnostics_warn_delay) ? "Within limits"
+                                   : (delay < settings.diagnostics_error_delay)
+                                     ? "Exceeded warn threshold"
+                                     : "Exceeded error threshold";
   // Extrapolation time thresholds
   const std::string extrapolation_status =
-  (values.min_extrapolation_time <= settings.diagnostics_warn_extrapolation_) ? "Within limits" :
-  (values.min_extrapolation_time <= settings.diagnostics_error_extrapolation_) ? "Exceeded warn threshold" :
-  "Exceeded error threshold";
+    (values.min_extrapolation_time <= settings.diagnostics_warn_extrapolation_) ? "Within limits"
+    : (values.min_extrapolation_time <= settings.diagnostics_error_extrapolation_)
+      ? "Exceeded warn threshold"
+      : "Exceeded error threshold";
 
   // Initialize with OK status
   int8_t overall_level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   std::string overall_message = "All timings within normal limits";
   // Determine overall status
-  if (delay >= settings.diagnostics_error_delay || 
+  if (
+    delay >= settings.diagnostics_error_delay ||
     values.min_extrapolation_time > settings.diagnostics_error_extrapolation_) {
-      overall_level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
-      overall_message = "Critical timing thresholds exceeded";
-  } else if (delay >= settings.diagnostics_warn_delay || 
+    overall_level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    overall_message = "Critical timing thresholds exceeded";
+  } else if (
+    delay >= settings.diagnostics_warn_delay ||
     values.min_extrapolation_time > settings.diagnostics_warn_extrapolation_) {
-      overall_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-      overall_message = "Warning timing thresholds exceeded";
+    overall_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    overall_message = "Warning timing thresholds exceeded";
   }
   stat.add("Detection delay (s)", delay);
   stat.add("Detection status", delay_status);

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -58,9 +58,9 @@ private:
   TimingCheckResult checkDelayTiming(double delay) const;
   TimingCheckResult checkExtrapolationTiming(
     double extrapolation_time, const rclcpp::Time & timestamp);
-  TimingCheckResult determineOverallTimingStatus(
+  static TimingCheckResult determineOverallTimingStatus(
     bool no_published_trackers, const TimingCheckResult & delay_result,
-    const TimingCheckResult & extrapolation_result) const;
+    const TimingCheckResult & extrapolation_result);
   // Debug settings
   struct DEBUG_SETTINGS
   {

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -47,7 +47,15 @@ public:
   TrackerDebugger(
     rclcpp::Node & node, const std::string & frame_id,
     const std::vector<types::InputChannel> & channels_config);
+    struct DiagnosticValues {
+      double pipeline_latency = 0.0;
+      double min_extrapolation_time = 0.0;
+      double processing_time = 0.0;
+      double cycle_time = 0.0;
+    } diagnostic_values_;
 
+    //void updateDiagnosticValues(const rclcpp::Time & current_time);
+    void updateMinExtrapolationTime(double min_extrapolation_time);
 private:
   struct DEBUG_SETTINGS
   {
@@ -56,6 +64,8 @@ private:
     bool publish_debug_markers;
     double diagnostics_warn_delay;
     double diagnostics_error_delay;
+    double diagnostics_warn_extrapolation_;
+    double diagnostics_error_extrapolation_;
   } debug_settings_;
 
   // ROS node, publishers
@@ -68,7 +78,6 @@ private:
   diagnostic_updater::Updater diagnostic_updater_;
   // Object debugger
   TrackerObjectDebugger object_debugger_;
-
   // Time measurement
   bool is_initialized_ = false;
   double pipeline_latency_ms_ = 0.0;
@@ -95,8 +104,7 @@ public:
   void startPublishTime(const rclcpp::Time & now);
   void endPublishTime(const rclcpp::Time & now, const rclcpp::Time & object_time);
   // cppcheck-suppress functionConst
-  void checkDelay(diagnostic_updater::DiagnosticStatusWrapper & stat);
-
+  void checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper &stat);
   // Debug object
   void collectObjectInfo(
     const rclcpp::Time & message_time, const std::list<std::shared_ptr<Tracker>> & list_tracker,

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -56,11 +56,10 @@ private:
     diagnostic_msgs::msg::DiagnosticStatus::_level_type level;
   };
   TimingCheckResult checkDelayTiming(double delay) const;
-  TimingCheckResult checkExtrapolationTiming(double extrapolation_time) const;
+  TimingCheckResult checkExtrapolationTiming(double extrapolation_time, const rclcpp::Time &timestamp);
   TimingCheckResult determineOverallTimingStatus(
     bool no_published_trackers, const TimingCheckResult & delay_result,
     const TimingCheckResult & extrapolation_result) const;
-
   // Debug settings
   struct DEBUG_SETTINGS
   {
@@ -69,8 +68,8 @@ private:
     bool publish_debug_markers;
     double diagnostics_warn_delay;
     double diagnostics_error_delay;
-    double diagnostics_warn_extrapolation_;
-    double diagnostics_error_extrapolation_;
+    double diagnostics_warn_extrapolation;
+    double diagnostics_error_extrapolation;
   } debug_settings_;
 
   // Diagnostic values
@@ -98,6 +97,7 @@ private:
   rclcpp::Time stamp_process_end_;
   rclcpp::Time stamp_publish_start_;
   rclcpp::Time stamp_publish_output_;
+  rclcpp::Time last_non_warning_timestamp_;
 
   // Configuration
   void setupDiagnostics();

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -50,7 +50,8 @@ public:
 
 private:
   // Timing check utilities
-  struct TimingCheckResult {
+  struct TimingCheckResult
+  {
     std::string message;
     diagnostic_msgs::msg::DiagnosticStatus::_level_type level;
   };
@@ -59,7 +60,7 @@ private:
   TimingCheckResult determineOverallTimingStatus(
     bool no_published_trackers, const TimingCheckResult & delay_result,
     const TimingCheckResult & extrapolation_result) const;
-  
+
   // Debug settings
   struct DEBUG_SETTINGS
   {
@@ -78,7 +79,7 @@ private:
     double min_extrapolation_time = 0.0;
     size_t published_trackers_count = 0;
   } diagnostic_values_;
-                                             
+
   // ROS node, publishers
   rclcpp::Node & node_;
   rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -54,6 +54,7 @@ public:
   } diagnostic_values_;
   // Single update method for all diagnostic values
   void updateDiagnosticValues(double min_extrapolation_time, size_t published_count);
+
 private:
   struct DEBUG_SETTINGS
   {

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -56,7 +56,8 @@ private:
     diagnostic_msgs::msg::DiagnosticStatus::_level_type level;
   };
   TimingCheckResult checkDelayTiming(double delay) const;
-  TimingCheckResult checkExtrapolationTiming(double extrapolation_time, const rclcpp::Time &timestamp);
+  TimingCheckResult checkExtrapolationTiming(
+    double extrapolation_time, const rclcpp::Time & timestamp);
   TimingCheckResult determineOverallTimingStatus(
     bool no_published_trackers, const TimingCheckResult & delay_result,
     const TimingCheckResult & extrapolation_result) const;

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -49,15 +49,11 @@ public:
     const std::vector<types::InputChannel> & channels_config);
   struct DiagnosticValues
   {
-    double pipeline_latency = 0.0;
     double min_extrapolation_time = 0.0;
-    double processing_time = 0.0;
-    double cycle_time = 0.0;
+    size_t published_trackers_count = 0;
   } diagnostic_values_;
-
-  // void updateDiagnosticValues(const rclcpp::Time & current_time);
-  void updateMinExtrapolationTime(double min_extrapolation_time);
-
+  // Single update method for all diagnostic values
+  void updateDiagnosticValues(double min_extrapolation_time, size_t published_count);
 private:
   struct DEBUG_SETTINGS
   {

--- a/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_multi_object_tracker/src/debugger/debugger.hpp
@@ -47,15 +47,17 @@ public:
   TrackerDebugger(
     rclcpp::Node & node, const std::string & frame_id,
     const std::vector<types::InputChannel> & channels_config);
-    struct DiagnosticValues {
-      double pipeline_latency = 0.0;
-      double min_extrapolation_time = 0.0;
-      double processing_time = 0.0;
-      double cycle_time = 0.0;
-    } diagnostic_values_;
+  struct DiagnosticValues
+  {
+    double pipeline_latency = 0.0;
+    double min_extrapolation_time = 0.0;
+    double processing_time = 0.0;
+    double cycle_time = 0.0;
+  } diagnostic_values_;
 
-    //void updateDiagnosticValues(const rclcpp::Time & current_time);
-    void updateMinExtrapolationTime(double min_extrapolation_time);
+  // void updateDiagnosticValues(const rclcpp::Time & current_time);
+  void updateMinExtrapolationTime(double min_extrapolation_time);
+
 private:
   struct DEBUG_SETTINGS
   {
@@ -104,7 +106,7 @@ public:
   void startPublishTime(const rclcpp::Time & now);
   void endPublishTime(const rclcpp::Time & now, const rclcpp::Time & object_time);
   // cppcheck-suppress functionConst
-  void checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper &stat);
+  void checkAllTiming(diagnostic_updater::DiagnosticStatusWrapper & stat);
   // Debug object
   void collectObjectInfo(
     const rclcpp::Time & message_time, const std::list<std::shared_ptr<Tracker>> & list_tracker,

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -256,7 +256,6 @@ void MultiObjectTracker::onTimer()
   // in this case, it will perform extrapolate/remove old objects
   const double maximum_publish_interval = publisher_period_ * maximum_publish_interval_ratio;
   should_publish = should_publish || elapsed_time > maximum_publish_interval;
-  // debugger_->updateDiagnosticValues(current_time);
 
   // Publish with delay compensation to the current time
   if (should_publish) checkAndPublish(current_time);

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -60,6 +60,10 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   bool enable_delay_compensation{declare_parameter<bool>("enable_delay_compensation")};
   bool enable_odometry_uncertainty = declare_parameter<bool>("consider_odometry_uncertainty");
 
+  // Add new parameters for extrapolation thresholds
+  diagnostics_warn_extrapolation_ = declare_parameter<double>("diagnostics_warn_extrapolation_");
+  diagnostics_error_extrapolation_ = declare_parameter<double>("diagnostics_error_extrapolation_");
+
   declare_parameter("selected_input_channels", std::vector<std::string>());
   std::vector<std::string> selected_input_channels =
     get_parameter("selected_input_channels").as_string_array();
@@ -206,7 +210,11 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
 
   // Debugger
   debugger_ = std::make_unique<TrackerDebugger>(*this, world_frame_id_, input_channels_config_);
+
   published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  // Diagnostics
+  diagnostics_interface_ptr_ = std::make_unique<autoware_utils::DiagnosticsInterface>(
+    this, "multi_object_tracker_delay_compensation");
 }
 
 void MultiObjectTracker::onTrigger()
@@ -238,7 +246,8 @@ void MultiObjectTracker::onTrigger()
 void MultiObjectTracker::onTimer()
 {
   const rclcpp::Time current_time = this->now();
-
+  // Get minimum prediction time delta from all trackers
+  const double min_extrapolation_time = (current_time - last_updated_time_).seconds();
   // ensure minimum interval: room for the next process(prediction)
   const double minimum_publish_interval = publisher_period_ * minimum_publish_interval_ratio;
   const auto elapsed_time = (current_time - last_published_time_).seconds();
@@ -253,6 +262,27 @@ void MultiObjectTracker::onTimer()
   // in this case, it will perform extrapolate/remove old objects
   const double maximum_publish_interval = publisher_period_ * maximum_publish_interval_ratio;
   should_publish = should_publish || elapsed_time > maximum_publish_interval;
+
+  diagnostics_interface_ptr_->clear();
+  diagnostics_interface_ptr_->add_key_value("min_extrapolation_time", min_extrapolation_time);
+
+  if (min_extrapolation_time > diagnostics_error_extrapolation_) {
+    std::stringstream message;
+    message << "min_extrapolation_time exceeds error threshold ("
+            << diagnostics_error_extrapolation_ << "), current value: " << min_extrapolation_time;
+    diagnostics_interface_ptr_->update_level_and_message(
+      diagnostic_msgs::msg::DiagnosticStatus::ERROR, message.str());
+  } else if (min_extrapolation_time > diagnostics_warn_extrapolation_) {
+    std::stringstream message;
+    message << "min_extrapolation_time exceeds warning threshold ("
+            << diagnostics_warn_extrapolation_ << "), current value: " << min_extrapolation_time;
+    diagnostics_interface_ptr_->update_level_and_message(
+      diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
+  } else {
+    diagnostics_interface_ptr_->update_level_and_message(
+      diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
+  }
+  diagnostics_interface_ptr_->publish(current_time);
 
   // Publish with delay compensation to the current time
   if (should_publish) checkAndPublish(current_time);

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -259,7 +259,7 @@ void MultiObjectTracker::onTimer()
   // Get minimum prediction time delta from all trackers
   const double min_extrapolation_time = (current_time - last_updated_time_).seconds();
   debugger_->updateMinExtrapolationTime(min_extrapolation_time);
-  //debugger_->updateDiagnosticValues(current_time);
+  // debugger_->updateDiagnosticValues(current_time);
 
   // Publish with delay compensation to the current time
   if (should_publish) checkAndPublish(current_time);

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -256,9 +256,6 @@ void MultiObjectTracker::onTimer()
   // in this case, it will perform extrapolate/remove old objects
   const double maximum_publish_interval = publisher_period_ * maximum_publish_interval_ratio;
   should_publish = should_publish || elapsed_time > maximum_publish_interval;
-  // Get minimum prediction time delta from all trackers
-  const double min_extrapolation_time = (current_time - last_updated_time_).seconds();
-  debugger_->updateMinExtrapolationTime(min_extrapolation_time);
   // debugger_->updateDiagnosticValues(current_time);
 
   // Publish with delay compensation to the current time
@@ -324,6 +321,10 @@ void MultiObjectTracker::publish(const rclcpp::Time & time) const
 
   // Publish debugger information if enabled
   debugger_->endPublishTime(this->now(), time);
+
+  // Update the diagnostic values
+  const double min_extrapolation_time = (time - last_updated_time_).seconds();
+  debugger_->updateDiagnosticValues(min_extrapolation_time, output_msg.objects.size());
 
   if (debugger_->shouldPublishTentativeObjects()) {
     autoware_perception_msgs::msg::TrackedObjects tentative_output_msg;

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -246,6 +246,10 @@ void MultiObjectTracker::onTrigger()
 void MultiObjectTracker::onTimer()
 {
   const rclcpp::Time current_time = this->now();
+  if (last_updated_time_.nanoseconds() == 0) {
+    // If the last updated time is not set, set it to the current time
+    last_updated_time_ = current_time;
+  }
   // Get minimum prediction time delta from all trackers
   const double min_extrapolation_time = (current_time - last_updated_time_).seconds();
   // ensure minimum interval: room for the next process(prediction)

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -26,7 +26,6 @@
 #include "processor/input_manager.hpp"
 #include "processor/processor.hpp"
 
-#include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
@@ -69,8 +68,6 @@ private:
   // debugger
   std::unique_ptr<TrackerDebugger> debugger_;
   std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
-  // diagnostics
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
 
   // publish timer
   rclcpp::TimerBase::SharedPtr publish_timer_;
@@ -79,8 +76,6 @@ private:
   double publisher_period_;
   static constexpr double minimum_publish_interval_ratio = 0.85;
   static constexpr double maximum_publish_interval_ratio = 1.05;
-  double diagnostics_warn_extrapolation_;
-  double diagnostics_error_extrapolation_;
 
   // internal states
   std::string world_frame_id_;  // tracking frame

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -26,6 +26,7 @@
 #include "processor/input_manager.hpp"
 #include "processor/processor.hpp"
 
+#include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
@@ -68,6 +69,8 @@ private:
   // debugger
   std::unique_ptr<TrackerDebugger> debugger_;
   std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  // diagnostics
+  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
 
   // publish timer
   rclcpp::TimerBase::SharedPtr publish_timer_;
@@ -76,6 +79,8 @@ private:
   double publisher_period_;
   static constexpr double minimum_publish_interval_ratio = 0.85;
   static constexpr double maximum_publish_interval_ratio = 1.05;
+  double diagnostics_warn_extrapolation_;
+  double diagnostics_error_extrapolation_;
 
   // internal states
   std::string world_frame_id_;  // tracking frame


### PR DESCRIPTION
## Description
Launcher PR
https://github.com/autowarefoundation/autoware_launch/pull/1378
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested by running logging simulator

OK:
![image](https://github.com/user-attachments/assets/df79a37a-3fd5-4feb-afc7-b2359c07ebc3)

Warning &Error:

https://github.com/user-attachments/assets/10af0573-4cb9-4806-876e-77699ee27fa1



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
