### PR TITLE
fix(autoware_behavior_path_static_obstacle_avoidance_module): blinker bug in static obstacle avoidance

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -988,18 +988,6 @@ auto StaticObstacleAvoidanceModule::getTurnSignal(
     return getPreviousModuleOutput().turn_signal_info;
   }
 
-  const auto itr =
-    std::remove_if(shift_lines.begin(), shift_lines.end(), [&, this](const auto & s) {
-      const auto threshold = planner_data_->parameters.turn_signal_shift_length_threshold;
-      return std::abs(s.start_shift_length - s.end_shift_length) < threshold ||
-             is_ignore_signal(s.id);
-    });
-  shift_lines.erase(itr, shift_lines.end());
-
-  if (shift_lines.empty()) {
-    return getPreviousModuleOutput().turn_signal_info;
-  }
-
   const auto target_shift_line = [&]() {
     const auto & s1 = shift_lines.front();
 
@@ -1041,6 +1029,10 @@ auto StaticObstacleAvoidanceModule::getTurnSignal(
 
     return s1;
   }();
+
+  if (is_ignore_signal(target_shift_line.id)) {
+    return getPreviousModuleOutput().turn_signal_info;
+  }
 
   const auto original_signal = getPreviousModuleOutput().turn_signal_info;
 


### PR DESCRIPTION
## Description

1. The error occurred because unnecessary shift lines were excluded before target_shift_line was selected.
2. There were duplicate processes excluding small shifts in scene.cpp and turn_signal_decider.cpp.

## Related links

- [Slack Link](https://star4.slack.com/archives/C04HK9T2E0N/p1742176350312149?thread_ts=1742155919.679659&cid=C04HK9T2E0N)

## How was this PR tested?

- [Evaluator](https://evaluation.tier4.jp/evaluation/reports/0db01e96-59e4-5103-a1a0-d42fb25a4f5a?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
