### PR TITLE
fix(safety_check): set safety condition properly

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -881,6 +881,8 @@ autoware_internal_planning_msgs::msg::SafetyFactorArray to_safety_factor_array(
   const CollisionCheckDebugMap & debug_map)
 {
   autoware_internal_planning_msgs::msg::SafetyFactorArray safety_factors;
+  safety_factors.is_safe = std::all_of(
+    debug_map.begin(), debug_map.end(), [](const auto & result) { return result.second.is_safe; });
   for (const auto & [uuid, data] : debug_map) {
     autoware_internal_planning_msgs::msg::SafetyFactor safety_factor;
     safety_factor.type = autoware_internal_planning_msgs::msg::SafetyFactor::OBJECT;


### PR DESCRIPTION
## Description

Set safety condition properly in safety check utils.

## Related links

**Parent Issue:**

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I confirmed the flag is_safe became false when I put dummy vehicle near the lane change path in Psim.

![image](https://github.com/user-attachments/assets/265a19a4-f7c5-413e-b12a-d43c11ddd769)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
