### PR TITLE
feat(autoware_overlay_rviz_plugin)!: add static blinking option for turn_signal

### DIFF
--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/signal_display.hpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/signal_display.hpp
@@ -27,6 +27,7 @@
 #include <QString>
 #include <rviz_common/display.hpp>
 #include <rviz_common/properties/color_property.hpp>
+#include <rviz_common/properties/enum_property.hpp>
 #include <rviz_common/properties/float_property.hpp>
 #include <rviz_common/properties/int_property.hpp>
 #include <rviz_common/properties/ros_topic_property.hpp>
@@ -60,6 +61,7 @@ private Q_SLOTS:
   void updateSmallOverlaySize();
   void updateOverlayPosition();
   void updateOverlayColor();
+  void updateTurnSignalBlinkingMode();
   void topic_updated_gear();
   void topic_updated_steering();
   void topic_updated_speed();
@@ -82,6 +84,8 @@ private:
   rviz_common::properties::ColorProperty * property_primary_color_;
   rviz_common::properties::ColorProperty * property_light_limit_color_;
   rviz_common::properties::ColorProperty * property_dark_limit_color_;
+
+  rviz_common::properties::EnumProperty * property_turn_signal_blinking_mode_;
 
   std::unique_ptr<rviz_common::properties::RosTopicProperty> steering_topic_property_;
   std::unique_ptr<rviz_common::properties::RosTopicProperty> gear_topic_property_;

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/turn_signals_display.hpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/turn_signals_display.hpp
@@ -30,7 +30,8 @@
 #include <OgreMaterial.h>
 #include <OgreTexture.h>
 
-#include <chrono>
+#include <string>
+#include <string_view>
 
 namespace autoware_overlay_rviz_plugin
 {
@@ -44,10 +45,13 @@ public:
     const autoware_vehicle_msgs::msg::TurnIndicatorsReport::ConstSharedPtr & msg);
   void updateHazardLightsData(
     const autoware_vehicle_msgs::msg::HazardLightsReport::ConstSharedPtr & msg);
+  void setBlinkingMode(std::string_view mode);
 
 private:
   QImage arrowImage;
   QColor gray = QColor(79, 79, 79);
+
+  std::string blinking_mode_ = "Static";
 
   int current_turn_signal_;    // Internal variable to store turn signal state
   int current_hazard_lights_;  // Internal variable to store hazard lights state

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/turn_signals_display.hpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/turn_signals_display.hpp
@@ -52,10 +52,6 @@ private:
   int current_turn_signal_;    // Internal variable to store turn signal state
   int current_hazard_lights_;  // Internal variable to store hazard lights state
   QImage coloredImage(const QImage & source, const QColor & color);
-
-  std::chrono::steady_clock::time_point last_toggle_time_;
-  bool blink_on_ = false;
-  const std::chrono::milliseconds blink_interval_{500};  // Blink interval in milliseconds
 };
 
 }  // namespace autoware_overlay_rviz_plugin

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/signal_display.cpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/signal_display.cpp
@@ -17,6 +17,7 @@
 #include <QFontDatabase>
 #include <QPainter>
 #include <rclcpp/rclcpp.hpp>
+#include <rviz_common/properties/enum_property.hpp>
 #include <rviz_common/properties/ros_topic_property.hpp>
 #include <rviz_rendering/render_system.hpp>
 
@@ -66,6 +67,11 @@ SignalDisplay::SignalDisplay()
   property_dark_limit_color_ = new rviz_common::properties::ColorProperty(
     "Dark Traffic Color", QColor(255, 51, 51), "Color of the signal arrows", this,
     SLOT(updateOverlayColor()));
+  property_turn_signal_blinking_mode_ = new rviz_common::properties::EnumProperty(
+    "Signal Blinking Mode", "Static", "State of the signal blinking", this,
+    SLOT(updateTurnSignalBlinkingMode()));
+  property_turn_signal_blinking_mode_->addOption("Static", 0);
+  property_turn_signal_blinking_mode_->addOption("Blinking", 1);
 
   // Initialize the component displays
   steering_wheel_display_ = std::make_unique<SteeringWheelDisplay>();
@@ -389,6 +395,15 @@ void SignalDisplay::updateOverlayPosition()
 void SignalDisplay::updateOverlayColor()
 {
   std::lock_guard<std::mutex> lock(mutex_);
+  queueRender();
+}
+
+void SignalDisplay::updateTurnSignalBlinkingMode()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (turn_signals_display_) {
+    turn_signals_display_->setBlinkingMode(property_turn_signal_blinking_mode_->getStdString());
+  }
   queueRender();
 }
 

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/turn_signals_display.cpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/turn_signals_display.cpp
@@ -26,6 +26,7 @@
 #include <OgreTextureManager.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
@@ -68,6 +69,11 @@ void TurnSignalsDisplay::updateHazardLightsData(
   }
 }
 
+void TurnSignalsDisplay::setBlinkingMode(std::string_view mode)
+{
+  blinking_mode_ = mode;
+}
+
 void TurnSignalsDisplay::drawArrows(
   QPainter & painter, const QRectF & backgroundRect, const QColor & color)
 {
@@ -85,10 +91,14 @@ void TurnSignalsDisplay::drawArrows(
     (current_turn_signal_ == autoware_vehicle_msgs::msg::TurnIndicatorsReport::ENABLE_RIGHT ||
      current_hazard_lights_ == autoware_vehicle_msgs::msg::HazardLightsReport::ENABLE);
 
-  if (leftActive) {
+  auto now = std::chrono::steady_clock::now().time_since_epoch();
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+
+  bool blink_off = blinking_mode_ == "Blinking" && (elapsed / 333) % 2 == 0;
+  if (leftActive && !blink_off) {
     scaledLeftArrow = coloredImage(scaledLeftArrow, color);
   }
-  if (rightActive) {
+  if (rightActive && !blink_off) {
     scaledRightArrow = coloredImage(scaledRightArrow, color);
   }
 

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/turn_signals_display.cpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/turn_signals_display.cpp
@@ -37,8 +37,6 @@ namespace autoware_overlay_rviz_plugin
 
 TurnSignalsDisplay::TurnSignalsDisplay() : current_turn_signal_(0)
 {
-  last_toggle_time_ = std::chrono::steady_clock::now();
-
   // Load the arrow image
   std::string package_path =
     ament_index_cpp::get_package_share_directory("autoware_overlay_rviz_plugin");
@@ -87,28 +85,16 @@ void TurnSignalsDisplay::drawArrows(
     (current_turn_signal_ == autoware_vehicle_msgs::msg::TurnIndicatorsReport::ENABLE_RIGHT ||
      current_hazard_lights_ == autoware_vehicle_msgs::msg::HazardLightsReport::ENABLE);
 
-  // Color the arrows based on the state of the turn signals and hazard lights by having them blink
-  // on and off
-  if (this->blink_on_) {
-    if (leftActive) {
-      scaledLeftArrow = coloredImage(scaledLeftArrow, color);
-    }
-    if (rightActive) {
-      scaledRightArrow = coloredImage(scaledRightArrow, color);
-    }
+  if (leftActive) {
+    scaledLeftArrow = coloredImage(scaledLeftArrow, color);
+  }
+  if (rightActive) {
+    scaledRightArrow = coloredImage(scaledRightArrow, color);
   }
 
   // Draw the arrows
   painter.drawImage(QPointF(leftArrowXPos, arrowYPos), scaledLeftArrow);
   painter.drawImage(QPointF(rightArrowXPos, arrowYPos), scaledRightArrow);
-
-  auto now = std::chrono::steady_clock::now();
-  if (
-    std::chrono::duration_cast<std::chrono::milliseconds>(now - last_toggle_time_) >=
-    blink_interval_) {
-    blink_on_ = !blink_on_;  // Toggle the blink state
-    last_toggle_time_ = now;
-  }
 }
 
 QImage TurnSignalsDisplay::coloredImage(const QImage & source, const QColor & color)


### PR DESCRIPTION
## Description

Currently, the display of turn_signal is blinking. However the blinking feature makes difficult to debug planning modules.  This PR removes the blinking feature.

**before** (x3)

https://github.com/user-attachments/assets/f3f774f7-02b2-4e6a-8755-e01e4ab2208f

**after** (x3)

https://github.com/user-attachments/assets/c1093eda-58c0-4a59-8b25-ba7f33b0329c

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
