### PR TITLE
feat(autoware_tenssort_common): validate TensorRT engine version for cached engine

### DIFF
--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -322,7 +322,7 @@ private:
   bool buildEngineFromOnnx();
 
   /**
-   * @brief Validate TensorRT engine.
+   * @brief Validate the TensorRT engine.
    *
    * @return Whether TensorRT version used for building engine is compatible.
    */

--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -46,6 +46,8 @@ using ProfileDimsPtr = std::unique_ptr<std::vector<ProfileDims>>;
 using TensorsVec = std::vector<std::pair<void *, nvinfer1::Dims>>;
 using TensorsMap = std::unordered_map<const char *, std::pair<void *, nvinfer1::Dims>>;
 
+// TensorRT version, written in serialized engine file (source:
+// https://github.com/NVIDIA/TensorRT/issues/3073#issuecomment-1599934548)
 constexpr int TRT_MAJOR_IDX = 24;
 constexpr int TRT_MINOR_IDX = 25;
 constexpr int TRT_PATCH_IDX = 26;

--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -324,7 +324,7 @@ private:
   /**
    * @brief Validate the TensorRT engine.
    *
-   * @return Whether TensorRT version used for building engine is compatible.
+   * @return Whether the TensorRT version used for building engine is compatible.
    */
   bool validateEngine();
 

--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -46,6 +46,10 @@ using ProfileDimsPtr = std::unique_ptr<std::vector<ProfileDims>>;
 using TensorsVec = std::vector<std::pair<void *, nvinfer1::Dims>>;
 using TensorsMap = std::unordered_map<const char *, std::pair<void *, nvinfer1::Dims>>;
 
+constexpr int TRT_MAJOR_IDX = 24;
+constexpr int TRT_MINOR_IDX = 25;
+constexpr int TRT_PATCH_IDX = 26;
+
 /**
  * @class TrtCommon
  * @brief TensorRT common library.
@@ -316,6 +320,13 @@ private:
    * @return Whether building engine is successful.
    */
   bool buildEngineFromOnnx();
+
+  /**
+   * @brief Validate TensorRT engine.
+   *
+   * @return Whether TensorRT version used for building engine is compatible.
+   */
+  bool validateEngine();
 
   /**
    * @brief Load TensorRT engine.

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -118,7 +118,7 @@ bool TrtCommon::setup(ProfileDimsPtr profile_dims, NetworkIOPtr network_io)
     if (!validateEngine()) {
       logger_->log(
         nvinfer1::ILogger::Severity::kWARNING,
-        "Engine validation failed for loaded engine from file. Rebuilding engine");
+        "Validation failed for the existing engine file. Rebuilding");
       // Rebuild engine if version mismatch occurred
       if (!build_engine_with_log()) {
         return false;


### PR DESCRIPTION
## Description

Rebuilds engine if cached engine file was build with different version of TensorRT.
TensorRT does not expose API for checking engine before deserialization (at least I couldn't find).
Source of implementation: https://github.com/NVIDIA/TensorRT/issues/3073#issuecomment-1599934548

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
