### PR TITLE
feat(start/goal_planner): use common max steer angle parameter from vehicle_info

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
@@ -310,7 +310,7 @@ Generate two backward arc paths.
 
 If the vehicle gets stuck with `LaneParkingPlanning`, `FreespaceParkingPlanner` is triggered.
 
-To run this feature, you need to set `parking_lot` to the map, `activate_by_scenario` of [costmap_generator](../costmap_generator/README.md) to `false` and `enable_freespace_parking` to `true`
+To run this feature, you need to set `parking_lot` to the map, `activate_by_scenario` of [costmap_generator](../../autoware_costmap_generator/README.md) to `false` and `enable_freespace_parking` to `true`
 
 ![pull_over_freespace_parking_flowchart](./images/pull_over_freespace_parking_flowchart.drawio.svg)
 
@@ -324,7 +324,7 @@ Simultaneous execution with `avoidance_module` in the flowchart is under develop
 | :----------------------- | :--- | :--- | :------------------------------------------------------------------------------------------------------------------- | :------------ |
 | enable_freespace_parking | [-]  | bool | This flag enables freespace parking, which runs when the vehicle is stuck due to e.g. obstacles in the parking area. | true          |
 
-See [freespace_planner](../autoware_freespace_planner/README.md) for other parameters.
+See [freespace_planner](../../autoware_freespace_planner/README.md) for other parameters.
 
 ### bezier parking
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
@@ -267,10 +267,10 @@ See also [[1]](https://www.sciencedirect.com/science/article/pii/S14746670153474
 
 #### Parameters geometric parallel parking
 
-| Name                    | Unit  | Type   | Description                                                                                                                         | Default value |
-| :---------------------- | :---- | :----- | :---------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| arc_path_interval       | [m]   | double | interval between arc path points                                                                                                    | 1.0           |
-| pull_over_max_steer_rad | [rad] | double | maximum steer angle for path generation. it may not be possible to control steer up to max_steer_angle in vehicle_info when stopped | 0.35          |
+| Name                         | Unit  | Type   | Description                                                                                              | Default value |
+| :--------------------------- | :---- | :----- | :------------------------------------------------------------------------------------------------------- | :------------ |
+| arc_path_interval            | [m]   | double | interval between arc path points                                                                         | 1.0           |
+| max_steer_angle_margin_scale | [rad] | double | scaling factor applied to the maximum steering angle (max_steer_angle) defined in vehicle_info parameter | 0.72          |
 
 #### arc forward parking
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
@@ -267,10 +267,10 @@ See also [[1]](https://www.sciencedirect.com/science/article/pii/S14746670153474
 
 #### Parameters geometric parallel parking
 
-| Name                         | Unit  | Type   | Description                                                                                              | Default value |
-| :--------------------------- | :---- | :----- | :------------------------------------------------------------------------------------------------------- | :------------ |
-| arc_path_interval            | [m]   | double | interval between arc path points                                                                         | 1.0           |
-| max_steer_angle_margin_scale | [rad] | double | scaling factor applied to the maximum steering angle (max_steer_angle) defined in vehicle_info parameter | 0.72          |
+| Name                         | Unit | Type   | Description                                                                                              | Default value |
+| :--------------------------- | :--- | :----- | :------------------------------------------------------------------------------------------------------- | :------------ |
+| arc_path_interval            | [m]  | double | interval between arc path points                                                                         | 1.0           |
+| max_steer_angle_margin_scale | [-]  | double | scaling factor applied to the maximum steering angle (max_steer_angle) defined in vehicle_info parameter | 0.72          |
 
 #### arc forward parking
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
@@ -73,22 +73,19 @@
 
         # parallel parking path
         parallel_parking:
-          path_interval: 1.0
-          max_steer_angle: 0.4 #22.9deg
+          max_steer_angle_margin_scale: 0.72
           forward:
             enable_arc_forward_parking: true
             after_forward_parking_straight_distance: 2.0
             forward_parking_velocity: 1.38
             forward_parking_lane_departure_margin: 0.0
             forward_parking_path_interval: 1.0
-            forward_parking_max_steer_angle: 0.4  # 22.9deg
           backward:
             enable_arc_backward_parking: true
             after_backward_parking_straight_distance: 2.0
             backward_parking_velocity: -1.38
             backward_parking_lane_departure_margin: 0.0
             backward_parking_path_interval: 1.0
-            backward_parking_max_steer_angle: 0.4  # 22.9deg
 
         # freespace parking
         freespace_parking:

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
@@ -168,8 +168,11 @@ GoalPlannerParameters GoalPlannerModuleManager::initGoalPlannerParameters(
 
   // parallel parking common
   {
+    const std::string ns = base_ns + "pull_over.parallel_parking.";
     p.parallel_parking_parameters.center_line_path_interval =
       p.center_line_path_interval;  // for geometric parallel parking
+    p.parallel_parking_parameters.max_steer_angle_margin_scale =
+      node->declare_parameter<double>(ns + "max_steer_angle_margin_scale");
   }
 
   // forward parallel parking forward
@@ -184,8 +187,6 @@ GoalPlannerParameters GoalPlannerModuleManager::initGoalPlannerParameters(
       node->declare_parameter<double>(ns + "forward_parking_lane_departure_margin");
     p.parallel_parking_parameters.forward_parking_path_interval =
       node->declare_parameter<double>(ns + "forward_parking_path_interval");
-    p.parallel_parking_parameters.forward_parking_max_steer_angle =
-      node->declare_parameter<double>(ns + "forward_parking_max_steer_angle");  // 20deg
   }
 
   // forward parallel parking backward
@@ -201,8 +202,6 @@ GoalPlannerParameters GoalPlannerModuleManager::initGoalPlannerParameters(
       node->declare_parameter<double>(ns + "backward_parking_lane_departure_margin");
     p.parallel_parking_parameters.backward_parking_path_interval =
       node->declare_parameter<double>(ns + "backward_parking_path_interval");
-    p.parallel_parking_parameters.backward_parking_max_steer_angle =
-      node->declare_parameter<double>(ns + "backward_parking_max_steer_angle");  // 20deg
   }
 
   // freespace parking general params
@@ -559,8 +558,12 @@ void GoalPlannerModuleManager::updateModuleParams(
 
   // parallel parking common
   {
+    const std::string ns = base_ns + "pull_over.parallel_parking.";
     p->parallel_parking_parameters.center_line_path_interval =
       p->center_line_path_interval;  // for geometric parallel parking
+    update_param<double>(
+      parameters, ns + "max_steer_angle_margin_scale",
+      p->parallel_parking_parameters.max_steer_angle_margin_scale);
   }
 
   // forward parallel parking forward
@@ -580,9 +583,6 @@ void GoalPlannerModuleManager::updateModuleParams(
     update_param<double>(
       parameters, ns + "forward_parking_path_interval",
       p->parallel_parking_parameters.forward_parking_path_interval);
-    update_param<double>(
-      parameters, ns + "forward_parking_max_steer_angle",
-      p->parallel_parking_parameters.forward_parking_max_steer_angle);
   }
 
   // forward parallel parking backward
@@ -602,9 +602,6 @@ void GoalPlannerModuleManager::updateModuleParams(
     update_param<double>(
       parameters, ns + "backward_parking_path_interval",
       p->parallel_parking_parameters.backward_parking_path_interval);
-    update_param<double>(
-      parameters, ns + "backward_parking_max_steer_angle",
-      p->parallel_parking_parameters.backward_parking_max_steer_angle);
   }
 
   // freespace parking general params

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -62,13 +62,12 @@ std::optional<PullOverPath> GeometricPullOver::plan(
   }
 
   const auto & p = parallel_parking_parameters_;
-  const double max_steer_angle =
-    is_forward_ ? p.forward_parking_max_steer_angle : p.backward_parking_max_steer_angle;
+  const double max_steer_angle = vehicle_info_.max_steer_angle_rad * p.max_steer_angle_margin_scale;
   planner_.setTurningRadius(planner_data->parameters, max_steer_angle);
   planner_.setPlannerData(planner_data);
 
-  const bool found_valid_path =
-    planner_.planPullOver(goal_pose, road_lanes, pull_over_lanes, is_forward_, left_side_parking_);
+  const bool found_valid_path = planner_.planPullOver(
+    goal_pose, road_lanes, pull_over_lanes, max_steer_angle, is_forward_, left_side_parking_);
   if (!found_valid_path) {
     return {};
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
@@ -42,20 +42,19 @@ struct ParallelParkingParameters
 {
   // common
   double center_line_path_interval{0.0};
+  double max_steer_angle_margin_scale{0.0};
 
   // forward parking
   double after_forward_parking_straight_distance{0.0};
   double forward_parking_velocity{0.0};
   double forward_parking_lane_departure_margin{0.0};
   double forward_parking_path_interval{0.0};
-  double forward_parking_max_steer_angle{0.0};
 
   // backward parking
   double after_backward_parking_straight_distance{0.0};
   double backward_parking_velocity{0.0};
   double backward_parking_lane_departure_margin{0.0};
   double backward_parking_path_interval{0.0};
-  double backward_parking_max_steer_angle{0.0};
 
   // pull_out
   double pull_out_velocity{0.0};
@@ -70,8 +69,8 @@ public:
   bool isParking() const;
   bool planPullOver(
     const Pose & goal_pose, const lanelet::ConstLanelets & road_lanes,
-    const lanelet::ConstLanelets & pull_over_lanes, const bool is_forward,
-    const bool left_side_parking);
+    const lanelet::ConstLanelets & pull_over_lanes, const double max_steer_angle,
+    const bool is_forward, const bool left_side_parking);
   bool planPullOut(
     const Pose & start_pose, const Pose & goal_pose, const lanelet::ConstLanelets & road_lanes,
     const lanelet::ConstLanelets & pull_over_lanes, const bool left_side_start,

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/parking_departure/geometric_parallel_parking.hpp
@@ -61,7 +61,7 @@ struct ParallelParkingParameters
   double pull_out_velocity{0.0};
   double pull_out_lane_departure_margin{0.0};
   double pull_out_arc_path_interval{0.0};
-  double pull_out_max_steer_angle{0.0};
+  double geometric_pull_out_max_steer_angle_margin_scale{0.0};
 };
 
 class GeometricParallelParking

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
@@ -159,8 +159,8 @@ void GeometricParallelParking::clearPaths()
 
 bool GeometricParallelParking::planPullOver(
   const Pose & goal_pose, const lanelet::ConstLanelets & road_lanes,
-  const lanelet::ConstLanelets & pull_over_lanes, const bool is_forward,
-  const bool left_side_parking)
+  const lanelet::ConstLanelets & pull_over_lanes, const double max_steer_angle,
+  const bool is_forward, const bool left_side_parking)
 {
   const auto & common_params = planner_data_->parameters;
   const double end_pose_offset = is_forward ? -parameters_.after_forward_parking_straight_distance
@@ -175,12 +175,10 @@ bool GeometricParallelParking::planPullOver(
   if (is_forward) {
     // When turning forward to the right, the front left goes out,
     // so reduce the steer angle at that time for seach no lane departure path.
-    // TODO(Sugahara): define in the config
     constexpr double start_pose_offset = 0.0;
     constexpr double min_steer_rad = 0.05;
     constexpr double steer_interval = 0.1;
-    for (double steer = parameters_.forward_parking_max_steer_angle; steer > min_steer_rad;
-         steer -= steer_interval) {
+    for (double steer = max_steer_angle; steer > min_steer_rad; steer -= steer_interval) {
       const double R_E_far = common_params.wheel_base / std::tan(steer);
       const auto start_pose = calcStartPose(
         arc_end_pose, road_lanes, start_pose_offset, R_E_far, is_forward, left_side_parking);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
@@ -525,7 +525,7 @@ If a safe path cannot be generated from the current position, search backwards f
 ### **freespace pull out**
 
 If the vehicle gets stuck with pull out along lanes, execute freespace pull out.
-To run this feature, you need to set `parking_lot` to the map, `activate_by_scenario` of [costmap_generator](../autoware_costmap_generator/README.md) to `false` and `enable_freespace_planner` to `true`
+To run this feature, you need to set `parking_lot` to the map, `activate_by_scenario` of [costmap_generator](../../autoware_costmap_generator/README.md) to `false` and `enable_freespace_planner` to `true`
 
 <img src="https://user-images.githubusercontent.com/39142679/270964106-ae688bca-1709-4e06-98c4-90f671bb8246.png" width="600">
 
@@ -544,4 +544,4 @@ To run this feature, you need to set `parking_lot` to the map, `activate_by_scen
 | end_pose_search_end_distance   | [m]  | double | distance from ego to the end point of the search for the end point in the freespace_pull_out driving lane                                | 30.0          |
 | end_pose_search_interval       | [m]  | bool   | interval to search for the end point in the freespace_pull_out driving lane                                                              | 2.0           |
 
-See [freespace_planner](../autoware_freespace_planner/README.md) for other parameters.
+See [freespace_planner](../../autoware_freespace_planner/README.md) for other parameters.

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
@@ -494,14 +494,14 @@ See also [[1]](https://www.sciencedirect.com/science/article/pii/S14746670153474
 
 #### parameters for geometric pull out
 
-| Name                                  | Unit  | Type   | Description                                                                                                                                               | Default value |
-| :------------------------------------ | :---- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
-| enable_geometric_pull_out             | [-]   | bool   | flag whether to enable geometric pull out                                                                                                                 | true          |
-| divide_pull_out_path                  | [-]   | bool   | flag whether to divide arc paths. The path is assumed to be divided because the curvature is not continuous. But it requires a stop during the departure. | false         |
-| geometric_pull_out_velocity           | [m/s] | double | velocity of geometric pull out                                                                                                                            | 1.0           |
-| lane_departure_margin                 | [m]   | double | margin of deviation to lane right                                                                                                                         | 0.2           |
-| lane_departure_check_expansion_margin | [m]   | double | margin to expand the ego vehicle footprint when doing lane departure checks                                                                               | 0.0           |
-| pull_out_max_steer_angle              | [rad] | double | maximum steer angle for path generation                                                                                                                   | 0.26          |
+| Name                                            | Unit  | Type   | Description                                                                                                                                               | Default value |
+| :---------------------------------------------- | :---- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| enable_geometric_pull_out                       | [-]   | bool   | flag whether to enable geometric pull out                                                                                                                 | true          |
+| divide_pull_out_path                            | [-]   | bool   | flag whether to divide arc paths. The path is assumed to be divided because the curvature is not continuous. But it requires a stop during the departure. | false         |
+| geometric_pull_out_velocity                     | [m/s] | double | velocity of geometric pull out                                                                                                                            | 1.0           |
+| lane_departure_margin                           | [m]   | double | margin of deviation to lane right                                                                                                                         | 0.2           |
+| lane_departure_check_expansion_margin           | [m]   | double | margin to expand the ego vehicle footprint when doing lane departure checks                                                                               | 0.0           |
+| geometric_pull_out_max_steer_angle_margin_scale | [-]   | double | scaling factor applied to the maximum steering angle (max_steer_angle) defined in vehicle_info parameter                                                  | 0.72          |
 
 ## **backward pull out start point search**
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -43,7 +43,7 @@
       lane_departure_margin: 0.2
       lane_departure_check_expansion_margin: 0.0
       backward_velocity: -1.0
-      pull_out_max_steer_angle: 0.26  # 15deg
+      geometric_pull_out_max_steer_angle_margin_scale: 0.72
       # search start pose backward
       enable_back: true
       search_priority: "efficient_path"  # "efficient_path" or "short_back_distance"

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/data_structs.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/data_structs.cpp
@@ -84,8 +84,9 @@ StartPlannerParameters StartPlannerParameters::init(rclcpp::Node & node)
       get_or_declare_parameter<double>(node, ns + "lane_departure_margin");
     p.lane_departure_check_expansion_margin =
       get_or_declare_parameter<double>(node, ns + "lane_departure_check_expansion_margin");
-    p.parallel_parking_parameters.pull_out_max_steer_angle =
-      get_or_declare_parameter<double>(node, ns + "pull_out_max_steer_angle");  // 15deg
+    p.parallel_parking_parameters.geometric_pull_out_max_steer_angle_margin_scale =
+      get_or_declare_parameter<double>(
+        node, ns + "geometric_pull_out_max_steer_angle_margin_scale");
     p.parallel_parking_parameters.center_line_path_interval =
       p.center_line_path_interval;  // for geometric parallel parking
     // search start pose backward

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -66,8 +66,7 @@ std::optional<PullOutPath> GeometricPullOut::plan(
   // check if the ego is at left or right side of road lane center
   const bool left_side_start = 0 < getArcCoordinates(road_lanes, start_pose).distance;
   const double max_steer_angle =
-    vehicle_info_.max_steer_angle *
-    parallel_parking_parameters_.geometric_pull_out_max_steer_angle_margin_scale;
+    vehicle_info_.max_steer_angle_rad * parallel_parking_parameters_.max_steer_angle_margin_scale;
 
   planner_.setTurningRadius(planner_data->parameters, max_steer_angle);
   planner_.setPlannerData(planner_data);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -66,7 +66,8 @@ std::optional<PullOutPath> GeometricPullOut::plan(
   // check if the ego is at left or right side of road lane center
   const bool left_side_start = 0 < getArcCoordinates(road_lanes, start_pose).distance;
   const double max_steer_angle =
-    vehicle_info_.max_steer_angle_rad * parallel_parking_parameters_.max_steer_angle_margin_scale;
+    vehicle_info_.max_steer_angle_rad *
+    parallel_parking_parameters_.geometric_pull_out_max_steer_angle_margin_scale;
 
   planner_.setTurningRadius(planner_data->parameters, max_steer_angle);
   planner_.setPlannerData(planner_data);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -65,9 +65,11 @@ std::optional<PullOutPath> GeometricPullOut::plan(
 
   // check if the ego is at left or right side of road lane center
   const bool left_side_start = 0 < getArcCoordinates(road_lanes, start_pose).distance;
+  const double max_steer_angle =
+    vehicle_info_.max_steer_angle *
+    parallel_parking_parameters_.geometric_pull_out_max_steer_angle_margin_scale;
 
-  planner_.setTurningRadius(
-    planner_data->parameters, parallel_parking_parameters_.pull_out_max_steer_angle);
+  planner_.setTurningRadius(planner_data->parameters, max_steer_angle);
   planner_.setPlannerData(planner_data);
   const bool found_valid_path = planner_.planPullOut(
     start_pose, goal_pose, road_lanes, pull_out_lanes, left_side_start, lane_departure_checker_);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/manager.cpp
@@ -127,8 +127,8 @@ void StartPlannerModuleManager::updateModuleParams(
       parameters, ns + "lane_departure_check_expansion_margin",
       p->lane_departure_check_expansion_margin);
     update_param<double>(
-      parameters, ns + "pull_out_max_steer_angle",
-      p->parallel_parking_parameters.pull_out_max_steer_angle);
+      parameters, ns + "geometric_pull_out_max_steer_angle_margin_scale",
+      p->parallel_parking_parameters.geometric_pull_out_max_steer_angle_margin_scale);
     update_param<bool>(parameters, ns + "enable_back", p->enable_back);
     update_param<double>(parameters, ns + "backward_velocity", p->backward_velocity);
     update_param<double>(


### PR DESCRIPTION
## Description

**https://github.com/autowarefoundation/autoware_launch/pull/1368 should be merged first.**

The maximum steering angle of the vehicle is defined in vehicle_info, and the planning/control modules reference this value. However, the start/goal planner defines its own parameters, so when the vehicle is changed, these parameters need to be modified individually.

Since it's difficult to consistently remember to implement these changes, and parameters may not be properly tuned, modify the system to reference the values from vehicle_info.

Based on past experience, the maximum steering angle is often not fully achieved, so a margin is necessary. manage this margin by introducing a coefficient parameter.

---

Additionally, though unrelated to this PR, there is unnecessary parameters that exist, which will be removed as part of this PR.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [PASSED TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/e24d2f8f-0426-5bc6-9286-505cd0b1fdd3?project_id=prd_jt)
- [x] run psim
- [x] update parameter from terminal and confirmed path curvature changes

first, disable shift pull out path with following command
```
ros2 param set /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner start_planner.enable_shift_pull_out false
```

And confirmed path curvaturte changes as expected

```
ros2 param set /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner start_planner.geometric_pull_out_max_steer_angle_margin_scale 0.9
```
![Screenshot from 2025-03-21 22-01-20](https://github.com/user-attachments/assets/5b4b89f8-c0d5-46d5-8365-faeb6b8f990f)


```
ros2 param set /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner start_planner.geometric_pull_out_max_steer_angle_margin_scale 0.1
```
![Screenshot from 2025-03-21 22-01-00](https://github.com/user-attachments/assets/688304af-8649-458d-b8fd-4bd14c597ed0)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |


#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Removed | `path_interval`   | `double` | `1.0`         | path points interval in geometric path |
| Removed | `max_steer_angle`   | `double` | `0.4`         | max steering angle [rad] in the path |
| Removed | `forward_parking_max_steer_angle`   | `double` | `0.4`         | max steering angle [rad] in the forward direction path |
| Removed | `backward_parking_max_steer_angle`   | `double` | `0.4`         | max steering angle [rad] in the backward direction path |
| Removed | `pull_out_max_steer_angle`   | `double` | `0.4`         | max steering angle [rad] in the pull out path |
| Added | `max_steer_angle_margin_scale`   | `double` | `0.72`         | scaling factor applied to the maximum steering angle (max_steer_angle) defined in vehicle_info parameter |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Removed | `path_interval`   | `double` | `1.0`         | path points interval in geometric path |
| Removed | `max_steer_angle`   | `double` | `0.4`         | max steering angle [rad] in the path |
| Removed | `forward_parking_max_steer_angle`   | `double` | `0.4`         | max steering angle [rad] in the forward direction path |
| Removed | `backward_parking_max_steer_angle`   | `double` | `0.4`         | max steering angle [rad] in the backward direction path |
| Removed | `pull_out_max_steer_angle`   | `double` | `0.4`         | max steering angle [rad] in the pull out path |
| Added | `max_steer_angle_margin_scale`   | `double` | `0.72`         | scaling factor applied to the maximum steering angle (max_steer_angle) defined in vehicle_info parameter |
| Added | `geometric_pull_out_max_steer_angle_margin_scale`   | `double` | `0.72`         | scaling factor applied to the maximum steering angle (max_steer_angle) defined in vehicle_info parameter |

## Effects on system behavior

None.
