### PR TITLE
feat(autoware_velocity_smoother): porting from universe to core

### DIFF
--- a/planning/autoware_velocity_smoother/README.ja.md
+++ b/planning/autoware_velocity_smoother/README.ja.md
@@ -1,12 +1,12 @@
 # Velocity Smoother
 
-## Purpose
+## Overview
 
 `autoware_velocity_smoother`は目標軌道上の各点における望ましい車速を計画して出力するモジュールである。
 このモジュールは、速度の最大化と乗り心地の良さを両立するために、事前に指定された制限速度、制限加速度および制限躍度の範囲で車速を計画する。
 加速度や躍度の制限を与えることは車速の変化を滑らかにすることに対応するため、このモジュールを`autoware_velocity_smoother`と呼んでいる。
 
-## Inner-workings / Algorithms
+## Design
 
 ### Flow chart
 
@@ -237,14 +237,8 @@ Example:
 - 参照経路に設定されている制限速度を指定した減速度やジャークで達成不可能な場合、可能な範囲で速度、加速度、ジャークの逸脱量を抑えながら減速
 - 各逸脱量の重視の度合いはパラメータにより指定
 
-## (Optional) Error detection and handling
-
-## (Optional) Performance characterization
-
-## (Optional) References/External links
+## References/External links
 
 [1] B. Stellato, et al., "OSQP: an operator splitting solver for quadratic programs", Mathematical Programming Computation, 2020, [10.1007/s12532-020-00179-2](https://link.springer.com/article/10.1007/s12532-020-00179-2).
 
 [2] Y. Zhang, et al., "Toward a More Complete, Flexible, and Safer Speed Planning for Autonomous Driving via Convex Optimization", Sensors, vol. 18, no. 7, p. 2185, 2018, [10.3390/s18072185](https://doi.org/10.3390/s18072185)
-
-## (Optional) Future extensions / Unimplemented parts

--- a/planning/autoware_velocity_smoother/README.md
+++ b/planning/autoware_velocity_smoother/README.md
@@ -1,12 +1,12 @@
 # Velocity Smoother
 
-## Purpose
+## Overview
 
 `autoware_velocity_smoother` outputs a desired velocity profile on a reference trajectory.
 This module plans a velocity profile within the limitations of the velocity, the acceleration and the jerk to realize both the maximization of velocity and the ride quality.
 We call this module `autoware_velocity_smoother` because the limitations of the acceleration and the jerk means the smoothness of the velocity profile.
 
-## Inner-workings / Algorithms
+## Design
 
 ### Flow chart
 
@@ -262,14 +262,8 @@ Example:
 - If the velocity limit set in the reference path cannot be achieved by the designated constraints of the deceleration and the jerk, decelerate while suppressing the velocity, the acceleration and the jerk deviation as much as possible
 - The importance of the deviations is set in the config file
 
-## (Optional) Error detection and handling
-
-## (Optional) Performance characterization
-
-## (Optional) References/External links
+## References/External links
 
 [1] B. Stellato, et al., "OSQP: an operator splitting solver for quadratic programs", Mathematical Programming Computation, 2020, [10.1007/s12532-020-00179-2](https://link.springer.com/article/10.1007/s12532-020-00179-2).
 
 [2] Y. Zhang, et al., "Toward a More Complete, Flexible, and Safer Speed Planning for Autonomous Driving via Convex Optimization", Sensors, vol. 18, no. 7, p. 2185, 2018, [10.3390/s18072185](https://doi.org/10.3390/s18072185)
-
-## (Optional) Future extensions / Unimplemented parts

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -187,72 +187,71 @@ private:
 
   mutable rclcpp::Clock::SharedPtr clock_;
 
-  void setupSmoother(const double wheelbase);
-
+  void setup_smoother(const double wheelbase);
   // parameter update
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;
-  rcl_interfaces::msg::SetParametersResult onParameter(
+  rcl_interfaces::msg::SetParametersResult on_parameter(
     const std::vector<rclcpp::Parameter> & parameters);
 
   // topic callback
-  void onCurrentTrajectory(const Trajectory::ConstSharedPtr msg);
+  void on_current_trajectory(const Trajectory::ConstSharedPtr msg);
 
-  void calcExternalVelocityLimit();
+  void calc_external_velocity_limit();
 
   // publish methods
-  void publishTrajectory(const TrajectoryPoints & traj) const;
+  void publish_trajectory(const TrajectoryPoints & traj) const;
 
-  void publishStopDistance(const TrajectoryPoints & trajectory) const;
+  void publish_stop_distance(const TrajectoryPoints & trajectory) const;
 
   // non-const methods
-  void publishClosestState(const TrajectoryPoints & trajectory);
+  void publish_closest_state(const TrajectoryPoints & trajectory);
 
-  void updatePrevValues(const TrajectoryPoints & final_result);
+  void update_prev_values(const TrajectoryPoints & final_result);
 
   // const methods
-  bool checkData() const;
+  bool check_data() const;
 
-  void updateDataForExternalVelocityLimit();
+  void update_data_for_external_velocity_limit();
 
-  AlgorithmType getAlgorithmType(const std::string & algorithm_name) const;
+  AlgorithmType get_algorithm_type(const std::string & algorithm_name) const;
 
-  TrajectoryPoints calcTrajectoryVelocity(const TrajectoryPoints & traj_input) const;
+  TrajectoryPoints calc_trajectory_velocity(const TrajectoryPoints & traj_input) const;
 
-  bool smoothVelocity(
+  bool smooth_velocity(
     const TrajectoryPoints & input, const size_t input_closest,
     TrajectoryPoints & traj_smoothed) const;
 
-  std::pair<Motion, InitializeType> calcInitialMotion(
+  std::pair<Motion, InitializeType> calc_initial_motion(
     const TrajectoryPoints & input_traj, const size_t input_closest) const;
 
-  void applyExternalVelocityLimit(TrajectoryPoints & traj) const;
+  void apply_external_velocity_limit(TrajectoryPoints & traj) const;
 
-  void insertBehindVelocity(
+  void insert_behind_velocity(
     const size_t output_closest, const InitializeType type, TrajectoryPoints & output) const;
 
-  void applyStopApproachingVelocity(TrajectoryPoints & traj) const;
+  void apply_stop_approaching_velocity(TrajectoryPoints & traj) const;
 
-  void overwriteStopPoint(const TrajectoryPoints & input, TrajectoryPoints & output) const;
+  void overwrite_stop_point(const TrajectoryPoints & input, TrajectoryPoints & output) const;
 
-  double calcTravelDistance() const;
+  double calc_travel_distance() const;
 
-  bool isEngageStatus(const double target_vel) const;
+  bool is_engage_status(const double target_velocity) const;
 
-  void publishDebugTrajectories(const std::vector<TrajectoryPoints> & debug_trajectories) const;
+  void publish_debug_trajectories(const std::vector<TrajectoryPoints> & debug_trajectories) const;
 
-  void publishClosestVelocity(
+  void publish_closest_velocity(
     const TrajectoryPoints & trajectory, const Pose & current_pose,
     const rclcpp::Publisher<Float32Stamped>::SharedPtr pub) const;
 
-  Trajectory toTrajectoryMsg(
+  Trajectory to_trajectory_msg(
     const TrajectoryPoints & points, const std_msgs::msg::Header * header = nullptr) const;
 
-  TrajectoryPoint calcProjectedTrajectoryPoint(
+  TrajectoryPoint calc_projected_trajectory_point(
     const TrajectoryPoints & trajectory, const Pose & pose) const;
-  TrajectoryPoint calcProjectedTrajectoryPointFromEgo(const TrajectoryPoints & trajectory) const;
+  TrajectoryPoint calc_projected_trajectory_point_from_ego(const TrajectoryPoints & trajectory) const;
 
   // parameter handling
-  void initCommonParam();
+  void init_common_param();
 
   // debug
   autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
@@ -279,10 +278,10 @@ private:
   rclcpp::Publisher<Float32Stamped>::SharedPtr pub_closest_merged_velocity_;
 
   // helper functions
-  size_t findNearestIndexFromEgo(const TrajectoryPoints & points) const;
-  bool isReverse(const TrajectoryPoints & points) const;
-  void flipVelocity(TrajectoryPoints & points) const;
-  void publishStopWatchTime();
+  size_t find_nearest_index_from_ego(const TrajectoryPoints & points) const;
+  bool is_reverse(const TrajectoryPoints & points) const;
+  void flip_velocity(TrajectoryPoints & points) const;
+  void publish_stop_watch_time();
 
   std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
   std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -248,7 +248,8 @@ private:
 
   TrajectoryPoint calc_projected_trajectory_point(
     const TrajectoryPoints & trajectory, const Pose & pose) const;
-  TrajectoryPoint calc_projected_trajectory_point_from_ego(const TrajectoryPoints & trajectory) const;
+  TrajectoryPoint calc_projected_trajectory_point_from_ego(
+    const TrajectoryPoints & trajectory) const;
 
   // parameter handling
   void init_common_param();

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/resample.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/resample.hpp
@@ -38,12 +38,12 @@ struct ResampleParam
   double sparse_min_interval_distance;  // minimum points-interval length for sparse sampling [m]
 };
 
-TrajectoryPoints resampleTrajectory(
+TrajectoryPoints resample_trajectory(
   const TrajectoryPoints & input, const double v_current,
   const geometry_msgs::msg::Pose & current_pose, const double nearest_dist_threshold,
   const double nearest_yaw_threshold, const ResampleParam & param, const bool use_zoh_for_v = true);
 
-TrajectoryPoints resampleTrajectory(
+TrajectoryPoints resample_trajectory(
   const TrajectoryPoints & input, const geometry_msgs::msg::Pose & current_pose,
   const double nearest_dist_threshold, const double nearest_yaw_threshold,
   const ResampleParam & param, const double nominal_ds, const bool use_zoh_for_v = true);

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -76,47 +76,47 @@ public:
     TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories,
     const bool publish_debug_trajs) override;
 
-  TrajectoryPoints resampleTrajectory(
+  TrajectoryPoints resample_trajectory(
     const TrajectoryPoints & input, [[maybe_unused]] const double v0,
     [[maybe_unused]] const geometry_msgs::msg::Pose & current_pose,
     [[maybe_unused]] const double nearest_dist_threshold,
     [[maybe_unused]] const double nearest_yaw_threshold) const override;
 
-  TrajectoryPoints applyLateralAccelerationFilter(
+  TrajectoryPoints apply_lateral_acceleration_filter(
     const TrajectoryPoints & input, [[maybe_unused]] const double v0,
     [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit,
     const bool use_resampling = true, const double input_points_interval = 1.0) const override;
 
-  void setParam(const Param & param);
-  Param getParam() const;
+  void set_param(const Param & param);
+  Param get_param() const;
 
 private:
   Param smoother_param_;
   rclcpp::Logger logger_{
     rclcpp::get_logger("smoother").get_child("analytical_jerk_constrained_smoother")};
 
-  bool searchDecelTargetIndices(
+  bool search_decel_target_indices(
     const TrajectoryPoints & trajectory, const size_t closest_index,
     std::vector<std::pair<size_t, double>> & decel_target_indices) const;
-  bool applyForwardJerkFilter(
+  bool apply_forward_jerk_filter(
     const TrajectoryPoints & base_trajectory, const size_t start_index, const double initial_vel,
     const double initial_acc, const Param & params, TrajectoryPoints & output_trajectory) const;
-  bool applyBackwardDecelFilter(
+  bool apply_backward_decel_filter(
     const std::vector<size_t> & start_indices, const size_t decel_target_index,
     const double decel_target_vel, const Param & params,
     TrajectoryPoints & output_trajectory) const;
-  bool calcEnoughDistForDecel(
+  bool calc_enough_dist_for_decel(
     const TrajectoryPoints & trajectory, const size_t start_index, const double decel_target_vel,
     const double planning_jerk, const Param & params, const std::vector<double> & dist_to_target,
     bool & is_enough_dist, int & type, std::vector<double> & times, double & stop_dist) const;
-  bool applyDecelVelocityFilter(
+  bool apply_decel_velocity_filter(
     const size_t decel_start_index, const double decel_target_vel, const double planning_jerk,
     const Param & params, const int type, const std::vector<double> & times,
     TrajectoryPoints & output_trajectory) const;
 
   // debug
-  std::string strTimes(const std::vector<double> & times) const;
-  std::string strStartIndices(const std::vector<size_t> & start_indices) const;
+  std::string str_times(const std::vector<double> & times) const;
+  std::string str_start_indices(const std::vector<size_t> & start_indices) const;
 };
 }  // namespace autoware::velocity_smoother
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp
@@ -32,19 +32,19 @@ namespace analytical_velocity_planning_utils
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
 
-bool calcStopDistWithJerkAndAccConstraints(
+bool calc_stop_dist_with_jerk_and_acc_constraints(
   const double v0, const double a0, const double jerk_acc, const double jerk_dec,
   const double min_acc, const double target_vel, int & type, std::vector<double> & times,
   double & stop_dist);
-bool validCheckCalcStopDist(
+bool valid_check_calc_stop_dist(
   const double v_end, const double a_end, const double v_target, const double a_target,
   const double v_margin, const double a_margin);
-bool calcStopVelocityWithConstantJerkAccLimit(
+bool calc_stop_velocity_with_constant_jerk_acc_limit(
   const double v0, const double a0, const double jerk_acc, const double jerk_dec,
   const double min_acc, const double decel_target_vel, const int type,
   const std::vector<double> & times, const size_t start_index,
   TrajectoryPoints & output_trajectory);
-void updateStopVelocityStatus(
+void update_stop_velocity_status(
   double v0, double a0, double jerk_acc, double jerk_dec, int type,
   const std::vector<double> & times, double t, double & x, double & v, double & a, double & j);
 double integ_x(double x0, double v0, double a0, double j0, double t);

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -50,26 +50,26 @@ public:
     TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories,
     const bool publish_debug_trajs) override;
 
-  TrajectoryPoints resampleTrajectory(
+  TrajectoryPoints resample_trajectory(
     const TrajectoryPoints & input, [[maybe_unused]] const double v0,
     const geometry_msgs::msg::Pose & current_pose, const double nearest_dist_threshold,
     const double nearest_yaw_threshold) const override;
 
-  void setParam(const Param & param);
-  Param getParam() const;
+  void set_param(const Param & param);
+  Param get_param() const;
 
 private:
   Param smoother_param_;
   std::shared_ptr<autoware::qp_interface::QPInterface> qp_interface_;
   rclcpp::Logger logger_{rclcpp::get_logger("smoother").get_child("jerk_filtered_smoother")};
 
-  TrajectoryPoints forwardJerkFilter(
+  TrajectoryPoints forward_jerk_filter(
     const double v0, const double a0, const double a_max, const double a_stop, const double j_max,
     const TrajectoryPoints & input) const;
-  TrajectoryPoints backwardJerkFilter(
+  TrajectoryPoints backward_jerk_filter(
     const double v0, const double a0, const double a_min, const double a_stop, const double j_min,
     const TrajectoryPoints & input) const;
-  TrajectoryPoints mergeFilteredTrajectory(
+  TrajectoryPoints merge_filtered_trajectory(
     const double v0, const double a0, const double a_min, const double j_min,
     const TrajectoryPoints & forward_filtered, const TrajectoryPoints & backward_filtered) const;
 };

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -48,12 +48,12 @@ public:
     TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories,
     const bool publish_debug_trajs) override;
 
-  TrajectoryPoints resampleTrajectory(
+  TrajectoryPoints resample_trajectory(
     const TrajectoryPoints & input, const double v0, const geometry_msgs::msg::Pose & current_pose,
     const double nearest_dist_threshold, const double nearest_yaw_threshold) const override;
 
-  void setParam(const Param & smoother_param);
-  Param getParam() const;
+  void set_param(const Param & smoother_param);
+  Param get_param() const;
 
 private:
   Param smoother_param_;

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -48,12 +48,12 @@ public:
     TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories,
     const bool publish_debug_trajs) override;
 
-  TrajectoryPoints resampleTrajectory(
+  TrajectoryPoints resample_trajectory(
     const TrajectoryPoints & input, const double v0, const geometry_msgs::msg::Pose & current_pose,
     const double nearest_dist_threshold, const double nearest_yaw_threshold) const override;
 
-  void setParam(const Param & smoother_param);
-  Param getParam() const;
+  void set_param(const Param & smoother_param);
+  Param get_param() const;
 
 private:
   Param smoother_param_;

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
@@ -64,30 +64,30 @@ public:
     TrajectoryPoints & output, std::vector<TrajectoryPoints> & debug_trajectories,
     const bool publish_debug_trajs) = 0;
 
-  virtual TrajectoryPoints resampleTrajectory(
+  virtual TrajectoryPoints resample_trajectory(
     const TrajectoryPoints & input, const double v0, const geometry_msgs::msg::Pose & current_pose,
     const double nearest_dist_threshold, const double nearest_yaw_threshold) const = 0;
 
-  virtual TrajectoryPoints applyLateralAccelerationFilter(
+  virtual TrajectoryPoints apply_lateral_acceleration_filter(
     const TrajectoryPoints & input, [[maybe_unused]] const double v0 = 0.0,
     [[maybe_unused]] const double a0 = 0.0, [[maybe_unused]] const bool enable_smooth_limit = false,
     const bool use_resampling = true, const double input_points_interval = 1.0) const;
 
-  TrajectoryPoints applySteeringRateLimit(
+  TrajectoryPoints apply_steering_rate_limit(
     const TrajectoryPoints & input, const bool use_resampling = true,
     const double input_points_interval = 1.0) const;
 
-  double getMaxAccel() const;
-  double getMinDecel() const;
-  double getMaxJerk() const;
-  double getMinJerk() const;
+  double get_max_accel() const;
+  double get_min_decel() const;
+  double get_max_jerk() const;
+  double get_min_jerk() const;
 
-  void setWheelBase(const double wheel_base);
-  void setMaxAccel(const double max_acceleration);
-  void setMaxJerk(const double max_jerk);
+  void set_wheel_base(const double wheel_base);
+  void set_max_accel(const double max_acceleration);
+  void set_max_jerk(const double max_jerk);
 
-  void setParam(const BaseParam & param);
-  BaseParam getBaseParam() const;
+  void set_param(const BaseParam & param);
+  BaseParam get_base_param() const;
 
 protected:
   BaseParam base_param_;

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/trajectory_utils.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/trajectory_utils.hpp
@@ -29,42 +29,42 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using geometry_msgs::msg::Pose;
 
-TrajectoryPoint calcInterpolatedTrajectoryPoint(
+TrajectoryPoint calc_interpolated_trajectory_point(
   const TrajectoryPoints & trajectory, const Pose & target_pose, const size_t seg_idx);
 
-TrajectoryPoints extractPathAroundIndex(
+TrajectoryPoints extract_path_around_index(
   const TrajectoryPoints & trajectory, const size_t index, const double & ahead_length,
   const double & behind_length);
 
-std::vector<double> calcArclengthArray(const TrajectoryPoints & trajectory);
+std::vector<double> calc_arclength_array(const TrajectoryPoints & trajectory);
 
-std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & trajectory);
+std::vector<double> calc_trajectory_interval_distance(const TrajectoryPoints & trajectory);
 
-std::vector<double> calcTrajectoryCurvatureFrom3Points(
+std::vector<double> calc_trajectory_curvature_from_3_points(
   const TrajectoryPoints & trajectory, size_t idx_dist);
 
-void applyMaximumVelocityLimit(
+void apply_maximum_velocity_limit(
   const size_t from, const size_t to, const double max_vel, TrajectoryPoints & trajectory);
 
-std::optional<size_t> searchZeroVelocityIdx(const TrajectoryPoints & trajectory);
+// std::optional<size_t> search_zero_velocity_idx(const TrajectoryPoints & trajectory);
 
-bool calcStopDistWithJerkConstraints(
+bool calc_stop_dist_with_jerk_constraints(
   const double v0, const double a0, const double jerk_acc, const double jerk_dec,
   const double min_acc, const double target_vel, std::map<double, double> & jerk_profile,
   double & stop_dist);
 
-bool isValidStopDist(
+bool is_valid_stop_dist(
   const double v_end, const double a_end, const double v_target, const double a_target,
   const double v_margin, const double a_margin);
 
-std::optional<std::tuple<double, double, double, double>> updateStateWithJerkConstraint(
+std::optional<std::tuple<double, double, double, double>> update_state_with_jerk_constraint(
   const double v0, const double a0, const std::map<double, double> & jerk_profile, const double t);
 
-std::vector<double> calcVelocityProfileWithConstantJerkAndAccelerationLimit(
+std::vector<double> calc_velocity_profile_with_constant_jerk_and_acceleration_limit(
   const TrajectoryPoints & trajectory, const double v0, const double a0, const double jerk,
   const double acc_max, const double acc_min);
 
-double calcStopDistance(const TrajectoryPoints & trajectory, const size_t closest);
+double calc_stop_distance(const TrajectoryPoints & trajectory, const size_t closest);
 
 }  // namespace autoware::velocity_smoother::trajectory_utils
 

--- a/planning/autoware_velocity_smoother/media/motion_velocity_smoother_flow.drawio.svg
+++ b/planning/autoware_velocity_smoother/media/motion_velocity_smoother_flow.drawio.svg
@@ -321,12 +321,12 @@
         <xhtml:div style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 50px; margin-left: 17px;">
           <xhtml:div style="box-sizing: border-box; font-size: 0; text-align: center; ">
             <xhtml:div style="display: inline-block; font-size: 14px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
-              onCurrentTrajectory
+              on_current_trajectory
             </xhtml:div>
           </xhtml:div>
         </xhtml:div>
       </foreignObject>
-      <text x="96" y="54" fill="#000000" font-family="Helvetica" font-size="14px" text-anchor="middle" id="text1082">onCurrentTrajectory</text>
+      <text x="96" y="54" fill="#000000" font-family="Helvetica" font-size="14px" text-anchor="middle" id="text1082">on_current_trajectory</text>
     </switch>
   </g>
   <path d="m 220.00026,140.00002 v 33.62997" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" id="path1088" style="stroke-width:0.999953"/>

--- a/planning/autoware_velocity_smoother/src/node.cpp
+++ b/planning/autoware_velocity_smoother/src/node.cpp
@@ -474,7 +474,8 @@ void VelocitySmootherNode::on_current_trajectory(const Trajectory::ConstSharedPt
 
   // calculate prev closest point
   if (!prev_output_.empty()) {
-    current_closest_point_from_prev_output_ = calc_projected_trajectory_point_from_ego(prev_output_);
+    current_closest_point_from_prev_output_ =
+      calc_projected_trajectory_point_from_ego(prev_output_);
   }
 
   // calculate distance to insert external velocity limit
@@ -750,8 +751,8 @@ void VelocitySmootherNode::insert_behind_velocity(
         return autoware::motion_utils::findNearestSegmentIndex(
           prev_output_, output.at(i).pose.position);
       }();
-      const auto prev_output_point =
-        trajectory_utils::calc_interpolated_trajectory_point(prev_output_, output.at(i).pose, seg_idx);
+      const auto prev_output_point = trajectory_utils::calc_interpolated_trajectory_point(
+        prev_output_, output.at(i).pose, seg_idx);
 
       // output should be always positive: TODO(Horibe) think better way
       output.at(i).longitudinal_velocity_mps =
@@ -819,7 +820,8 @@ std::pair<Motion, VelocitySmootherNode::InitializeType> VelocitySmootherNode::ca
       if (stop_dist > node_param_.stop_dist_to_prohibit_engage) {
         RCLCPP_DEBUG(
           get_logger(),
-          "calc_initial_motion : vehicle speed is low (%.3f), and desired speed is high (%.3f). Use "
+          "calc_initial_motion : vehicle speed is low (%.3f), and desired speed is high (%.3f). "
+          "Use "
           "engage speed (%.3f) until vehicle speed reaches engage_vel_thr (%.3f). stop_dist = %.3f",
           vehicle_speed, target_vel, node_param_.engage_velocity, engage_vel_thr, stop_dist);
         const double engage_acceleration =
@@ -834,7 +836,8 @@ std::pair<Motion, VelocitySmootherNode::InitializeType> VelocitySmootherNode::ca
     } else if (target_vel > 0.0) {
       RCLCPP_WARN_THROTTLE(
         get_logger(), *clock_, 3000,
-        "calc_initial_motion : target velocity(%.3f[m/s]) is lower than engage velocity(%.3f[m/s]). ",
+        "calc_initial_motion : target velocity(%.3f[m/s]) is lower than engage "
+        "velocity(%.3f[m/s]). ",
         target_vel, node_param_.engage_velocity);
     }
   }

--- a/planning/autoware_velocity_smoother/src/resample.cpp
+++ b/planning/autoware_velocity_smoother/src/resample.cpp
@@ -27,7 +27,7 @@ namespace autoware::velocity_smoother
 {
 namespace resampling
 {
-TrajectoryPoints resampleTrajectory(
+TrajectoryPoints resample_trajectory(
   const TrajectoryPoints & input, const double v_current,
   const geometry_msgs::msg::Pose & current_pose, const double nearest_dist_threshold,
   const double nearest_yaw_threshold, const ResampleParam & param, const bool use_zoh_for_v)
@@ -146,7 +146,7 @@ TrajectoryPoints resampleTrajectory(
   return output;
 }
 
-TrajectoryPoints resampleTrajectory(
+TrajectoryPoints resample_trajectory(
   const TrajectoryPoints & input, const geometry_msgs::msg::Pose & current_pose,
   const double nearest_dist_threshold, const double nearest_yaw_threshold,
   const ResampleParam & param, const double nominal_ds, const bool use_zoh_for_v)

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -315,7 +315,8 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::apply_lateral_acceleration_f
     static_cast<size_t>(std::max(static_cast<int>((curvature_calc_dist) / points_interval), 1));
 
   // Calculate curvature assuming the trajectory points interval is constant
-  const auto curvature_v = trajectory_utils::calc_trajectory_curvature_from_3_points(output, idx_dist);
+  const auto curvature_v =
+    trajectory_utils::calc_trajectory_curvature_from_3_points(output, idx_dist);
 
   // Decrease speed according to lateral G
   const size_t before_decel_index =

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -24,7 +24,7 @@ namespace autoware::velocity_smoother
 {
 namespace analytical_velocity_planning_utils
 {
-bool calcStopDistWithJerkAndAccConstraints(
+bool calc_stop_dist_with_jerk_and_acc_constraints(
   const double v0, const double a0, const double jerk_acc, const double jerk_dec,
   const double min_acc, const double target_vel, int & type, std::vector<double> & times,
   double & stop_dist)
@@ -65,7 +65,7 @@ bool calcStopDistWithJerkAndAccConstraints(
     const double a_target = 0.0;
     const double v_margin = 0.3;  // [m/s]
     const double a_margin = 0.1;  // [m/s^2]
-    if (!validCheckCalcStopDist(v3, a3, target_vel, a_target, v_margin, a_margin)) {
+    if (!valid_check_calc_stop_dist(v3, a3, target_vel, a_target, v_margin, a_margin)) {
       RCLCPP_DEBUG(rclcpp::get_logger("velocity_planning_utils"), "Valid check error. type = 1");
       return false;
     }
@@ -102,7 +102,7 @@ bool calcStopDistWithJerkAndAccConstraints(
       const double a_target = 0.0;
       const double v_margin = 0.3;
       const double a_margin = 0.1;
-      if (!validCheckCalcStopDist(v2, a2, target_vel, a_target, v_margin, a_margin)) {
+      if (!valid_check_calc_stop_dist(v2, a2, target_vel, a_target, v_margin, a_margin)) {
         RCLCPP_DEBUG(rclcpp::get_logger("velocity_planning_utils"), "Valid check error. type = 2");
         return false;
       }
@@ -129,7 +129,7 @@ bool calcStopDistWithJerkAndAccConstraints(
       const double a_target = 0.0;
       const double v_margin = 0.3;
       const double a_margin = 0.1;
-      if (!validCheckCalcStopDist(v1, a1, target_vel, a_target, v_margin, a_margin)) {
+      if (!valid_check_calc_stop_dist(v1, a1, target_vel, a_target, v_margin, a_margin)) {
         RCLCPP_DEBUG(rclcpp::get_logger("velocity_planning_utils"), "Valid check error. type = 3");
         return false;
       }
@@ -142,7 +142,7 @@ bool calcStopDistWithJerkAndAccConstraints(
   return true;
 }
 
-bool validCheckCalcStopDist(
+bool valid_check_calc_stop_dist(
   const double v_end, const double a_end, const double v_target, const double a_target,
   const double v_margin, const double a_margin)
 {
@@ -165,7 +165,7 @@ bool validCheckCalcStopDist(
   return true;
 }
 
-bool calcStopVelocityWithConstantJerkAccLimit(
+bool calc_stop_velocity_with_constant_jerk_acc_limit(
   const double v0, const double a0, const double jerk_acc, const double jerk_dec,
   const double min_acc, const double decel_target_vel, const int type,
   const std::vector<double> & times, const size_t start_index, TrajectoryPoints & output_trajectory)
@@ -179,7 +179,7 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   double j = 0.0;
 
   for (double t = 0.0; t < t_total; t += dt) {
-    updateStopVelocityStatus(v0, a0, jerk_acc, jerk_dec, type, times, t, x, v, a, j);
+    update_stop_velocity_status(v0, a0, jerk_acc, jerk_dec, type, times, t, x, v, a, j);
     if (v > 0.0) {
       a = std::max(a, min_acc);
       ts.push_back(t);
@@ -189,7 +189,7 @@ bool calcStopVelocityWithConstantJerkAccLimit(
       js.push_back(j);
     }
   }
-  updateStopVelocityStatus(v0, a0, jerk_acc, jerk_dec, type, times, t_total, x, v, a, j);
+  update_stop_velocity_status(v0, a0, jerk_acc, jerk_dec, type, times, t_total, x, v, a, j);
   if (v > 0.0 && !xs.empty() && xs.back() < x) {
     a = std::max(a, min_acc);
     ts.push_back(t_total);
@@ -210,7 +210,7 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   const double a_target = 0.0;
   const double v_margin = 0.3;
   const double a_margin = 0.1;
-  if (!validCheckCalcStopDist(v, a, decel_target_vel, a_target, v_margin, a_margin)) {
+  if (!valid_check_calc_stop_dist(v, a, decel_target_vel, a_target, v_margin, a_margin)) {
     return false;
   }
 
@@ -264,7 +264,7 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   return true;
 }
 
-void updateStopVelocityStatus(
+void update_stop_velocity_status(
   double v0, double a0, double jerk_acc, double jerk_dec, int type,
   const std::vector<double> & times, double t, double & x, double & v, double & a, double & j)
 {

--- a/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -42,12 +42,12 @@ L2PseudoJerkSmoother::L2PseudoJerkSmoother(
   qp_solver_.updateVerbose(false);
 }
 
-void L2PseudoJerkSmoother::setParam(const Param & smoother_param)
+void L2PseudoJerkSmoother::set_param(const Param & smoother_param)
 {
   smoother_param_ = smoother_param;
 }
 
-L2PseudoJerkSmoother::Param L2PseudoJerkSmoother::getParam() const
+L2PseudoJerkSmoother::Param L2PseudoJerkSmoother::get_param() const
 {
   return smoother_param_;
 }
@@ -76,7 +76,7 @@ bool L2PseudoJerkSmoother::apply(
   }
 
   const std::vector<double> interval_dist_arr =
-    trajectory_utils::calcTrajectoryIntervalDistance(input);
+    trajectory_utils::calc_trajectory_interval_distance(input);
 
   std::vector<double> v_max(N, 0.0);
   for (unsigned int i = 0; i < N; ++i) {
@@ -237,11 +237,11 @@ bool L2PseudoJerkSmoother::apply(
   return true;
 }
 
-TrajectoryPoints L2PseudoJerkSmoother::resampleTrajectory(
+TrajectoryPoints L2PseudoJerkSmoother::resample_trajectory(
   const TrajectoryPoints & input, const double v0, const geometry_msgs::msg::Pose & current_pose,
   const double nearest_dist_threshold, const double nearest_yaw_threshold) const
 {
-  return resampling::resampleTrajectory(
+  return resampling::resample_trajectory(
     input, v0, current_pose, nearest_dist_threshold, nearest_yaw_threshold,
     base_param_.resample_param);
 }

--- a/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -42,12 +42,12 @@ LinfPseudoJerkSmoother::LinfPseudoJerkSmoother(
   qp_solver_.updateVerbose(false);
 }
 
-void LinfPseudoJerkSmoother::setParam(const Param & smoother_param)
+void LinfPseudoJerkSmoother::set_param(const Param & smoother_param)
 {
   smoother_param_ = smoother_param;
 }
 
-LinfPseudoJerkSmoother::Param LinfPseudoJerkSmoother::getParam() const
+LinfPseudoJerkSmoother::Param LinfPseudoJerkSmoother::get_param() const
 {
   return smoother_param_;
 }
@@ -77,7 +77,7 @@ bool LinfPseudoJerkSmoother::apply(
     return false;
   }
 
-  std::vector<double> interval_dist_arr = trajectory_utils::calcTrajectoryIntervalDistance(input);
+  std::vector<double> interval_dist_arr = trajectory_utils::calc_trajectory_interval_distance(input);
 
   std::vector<double> v_max(N, 0.0);
   for (size_t i = 0; i < N; ++i) {
@@ -249,11 +249,11 @@ bool LinfPseudoJerkSmoother::apply(
   return true;
 }
 
-TrajectoryPoints LinfPseudoJerkSmoother::resampleTrajectory(
+TrajectoryPoints LinfPseudoJerkSmoother::resample_trajectory(
   const TrajectoryPoints & input, const double v0, const geometry_msgs::msg::Pose & current_pose,
   const double nearest_dist_threshold, const double nearest_yaw_threshold) const
 {
-  return resampling::resampleTrajectory(
+  return resampling::resample_trajectory(
     input, v0, current_pose, nearest_dist_threshold, nearest_yaw_threshold,
     base_param_.resample_param);
 }

--- a/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -77,7 +77,8 @@ bool LinfPseudoJerkSmoother::apply(
     return false;
   }
 
-  std::vector<double> interval_dist_arr = trajectory_utils::calc_trajectory_interval_distance(input);
+  std::vector<double> interval_dist_arr =
+    trajectory_utils::calc_trajectory_interval_distance(input);
 
   std::vector<double> v_max(N, 0.0);
   for (size_t i = 0; i < N; ++i) {

--- a/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
@@ -54,7 +54,8 @@ TrajectoryPoints applyPreProcess(
     arc_length.push_back(s);
   }
 
-  const auto points = autoware::motion_utils::resampleTrajectory(convertToTrajectory(input), arc_length);
+  const auto points =
+    autoware::motion_utils::resampleTrajectory(convertToTrajectory(input), arc_length);
   output = convertToTrajectoryPointArray(points);
   output.back() = input.back();  // keep the final speed.
 
@@ -173,7 +174,8 @@ TrajectoryPoints SmootherBase::apply_lateral_acceleration_filter(
     std::max(static_cast<int>((base_param_.curvature_calculation_distance) / points_interval), 1));
 
   // Calculate curvature assuming the trajectory points interval is constant
-  const auto curvature_v = trajectory_utils::calc_trajectory_curvature_from_3_points(output, idx_dist);
+  const auto curvature_v =
+    trajectory_utils::calc_trajectory_curvature_from_3_points(output, idx_dist);
 
   //  Decrease speed according to lateral G
   const size_t before_decel_index =
@@ -183,10 +185,11 @@ TrajectoryPoints SmootherBase::apply_lateral_acceleration_filter(
   const double max_lateral_accel_abs = std::fabs(base_param_.max_lateral_accel);
 
   const auto latacc_min_vel_arr =
-    enable_smooth_limit ? trajectory_utils::calc_velocity_profile_with_constant_jerk_and_acceleration_limit(
-                            output, v0, a0, base_param_.min_jerk, base_param_.max_accel,
-                            base_param_.min_decel_for_lateral_acc_lim_filter)
-                        : std::vector<double>{};
+    enable_smooth_limit
+      ? trajectory_utils::calc_velocity_profile_with_constant_jerk_and_acceleration_limit(
+          output, v0, a0, base_param_.min_jerk, base_param_.max_accel,
+          base_param_.min_decel_for_lateral_acc_lim_filter)
+      : std::vector<double>{};
 
   for (size_t i = 0; i < output.size(); ++i) {
     double curvature = 0.0;
@@ -229,7 +232,8 @@ TrajectoryPoints SmootherBase::apply_steering_rate_limit(
     std::max(static_cast<int>((base_param_.curvature_calculation_distance) / points_interval), 1));
 
   // Step1. Calculate curvature assuming the trajectory points interval is constant.
-  const auto curvature_v = trajectory_utils::calc_trajectory_curvature_from_3_points(output, idx_dist);
+  const auto curvature_v =
+    trajectory_utils::calc_trajectory_curvature_from_3_points(output, idx_dist);
 
   // Step2. Calculate steer rate for each trajectory point.
   std::vector<double> steer_rate_arr(output.size(), 0.0);

--- a/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
@@ -54,7 +54,7 @@ TrajectoryPoints applyPreProcess(
     arc_length.push_back(s);
   }
 
-  const auto points = resampleTrajectory(convertToTrajectory(input), arc_length);
+  const auto points = autoware::motion_utils::resampleTrajectory(convertToTrajectory(input), arc_length);
   output = convertToTrajectoryPointArray(points);
   output.back() = input.back();  // keep the final speed.
 
@@ -94,52 +94,52 @@ SmootherBase::SmootherBase(
     node.declare_parameter<double>("sparse_min_interval_distance");
 }
 
-void SmootherBase::setWheelBase(const double wheel_base)
+void SmootherBase::set_wheel_base(const double wheel_base)
 {
   base_param_.wheel_base = wheel_base;
 }
 
-void SmootherBase::setMaxAccel(const double max_acceleration)
+void SmootherBase::set_max_accel(const double max_acceleration)
 {
   base_param_.max_accel = max_acceleration;
 }
 
-void SmootherBase::setMaxJerk(const double max_jerk)
+void SmootherBase::set_max_jerk(const double max_jerk)
 {
   base_param_.max_jerk = max_jerk;
 }
 
-void SmootherBase::setParam(const BaseParam & param)
+void SmootherBase::set_param(const BaseParam & param)
 {
   base_param_ = param;
 }
 
-SmootherBase::BaseParam SmootherBase::getBaseParam() const
+SmootherBase::BaseParam SmootherBase::get_base_param() const
 {
   return base_param_;
 }
 
-double SmootherBase::getMaxAccel() const
+double SmootherBase::get_max_accel() const
 {
   return base_param_.max_accel;
 }
 
-double SmootherBase::getMinDecel() const
+double SmootherBase::get_min_decel() const
 {
   return base_param_.min_decel;
 }
 
-double SmootherBase::getMaxJerk() const
+double SmootherBase::get_max_jerk() const
 {
   return base_param_.max_jerk;
 }
 
-double SmootherBase::getMinJerk() const
+double SmootherBase::get_min_jerk() const
 {
   return base_param_.min_jerk;
 }
 
-TrajectoryPoints SmootherBase::applyLateralAccelerationFilter(
+TrajectoryPoints SmootherBase::apply_lateral_acceleration_filter(
   const TrajectoryPoints & input, [[maybe_unused]] const double v0,
   [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit,
   const bool use_resampling, const double input_points_interval) const
@@ -173,7 +173,7 @@ TrajectoryPoints SmootherBase::applyLateralAccelerationFilter(
     std::max(static_cast<int>((base_param_.curvature_calculation_distance) / points_interval), 1));
 
   // Calculate curvature assuming the trajectory points interval is constant
-  const auto curvature_v = trajectory_utils::calcTrajectoryCurvatureFrom3Points(output, idx_dist);
+  const auto curvature_v = trajectory_utils::calc_trajectory_curvature_from_3_points(output, idx_dist);
 
   //  Decrease speed according to lateral G
   const size_t before_decel_index =
@@ -183,7 +183,7 @@ TrajectoryPoints SmootherBase::applyLateralAccelerationFilter(
   const double max_lateral_accel_abs = std::fabs(base_param_.max_lateral_accel);
 
   const auto latacc_min_vel_arr =
-    enable_smooth_limit ? trajectory_utils::calcVelocityProfileWithConstantJerkAndAccelerationLimit(
+    enable_smooth_limit ? trajectory_utils::calc_velocity_profile_with_constant_jerk_and_acceleration_limit(
                             output, v0, a0, base_param_.min_jerk, base_param_.max_accel,
                             base_param_.min_decel_for_lateral_acc_lim_filter)
                         : std::vector<double>{};
@@ -210,7 +210,7 @@ TrajectoryPoints SmootherBase::applyLateralAccelerationFilter(
   return output;
 }
 
-TrajectoryPoints SmootherBase::applySteeringRateLimit(
+TrajectoryPoints SmootherBase::apply_steering_rate_limit(
   const TrajectoryPoints & input, const bool use_resampling,
   const double input_points_interval) const
 {
@@ -229,7 +229,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
     std::max(static_cast<int>((base_param_.curvature_calculation_distance) / points_interval), 1));
 
   // Step1. Calculate curvature assuming the trajectory points interval is constant.
-  const auto curvature_v = trajectory_utils::calcTrajectoryCurvatureFrom3Points(output, idx_dist);
+  const auto curvature_v = trajectory_utils::calc_trajectory_curvature_from_3_points(output, idx_dist);
 
   // Step2. Calculate steer rate for each trajectory point.
   std::vector<double> steer_rate_arr(output.size(), 0.0);

--- a/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
@@ -61,7 +61,7 @@ inline double integ_a(double a0, double j0, double t)
   return a0 + j0 * t;
 }
 
-TrajectoryPoint calcInterpolatedTrajectoryPoint(
+TrajectoryPoint calc_interpolated_trajectory_point(
   const TrajectoryPoints & trajectory, const Pose & target_pose, const size_t seg_idx)
 {
   TrajectoryPoint traj_p{};
@@ -97,7 +97,7 @@ TrajectoryPoint calcInterpolatedTrajectoryPoint(
   return traj_p;
 }
 
-TrajectoryPoints extractPathAroundIndex(
+TrajectoryPoints extract_path_around_index(
   const TrajectoryPoints & trajectory, const size_t index, const double & ahead_length,
   const double & behind_length)
 {
@@ -140,7 +140,7 @@ TrajectoryPoints extractPathAroundIndex(
   return extracted_traj;
 }
 
-std::vector<double> calcArclengthArray(const TrajectoryPoints & trajectory)
+std::vector<double> calc_arclength_array(const TrajectoryPoints & trajectory)
 {
   if (trajectory.empty()) {
     return {};
@@ -158,7 +158,7 @@ std::vector<double> calcArclengthArray(const TrajectoryPoints & trajectory)
   return arclength;
 }
 
-std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & trajectory)
+std::vector<double> calc_trajectory_interval_distance(const TrajectoryPoints & trajectory)
 {
   std::vector<double> intervals;
   for (unsigned int i = 1; i < trajectory.size(); ++i) {
@@ -170,7 +170,7 @@ std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & traj
   return intervals;
 }
 
-std::vector<double> calcTrajectoryCurvatureFrom3Points(
+std::vector<double> calc_trajectory_curvature_from_3_points(
   const TrajectoryPoints & trajectory, size_t idx_dist)
 {
   using autoware_utils::calc_curvature;
@@ -219,7 +219,7 @@ std::vector<double> calcTrajectoryCurvatureFrom3Points(
   return k_arr;
 }
 
-void applyMaximumVelocityLimit(
+void apply_maximum_velocity_limit(
   const size_t begin, const size_t end, const double max_vel, TrajectoryPoints & trajectory)
 {
   for (size_t idx = begin; idx < end; ++idx) {
@@ -229,7 +229,7 @@ void applyMaximumVelocityLimit(
   }
 }
 
-bool calcStopDistWithJerkConstraints(
+bool calc_stop_dist_with_jerk_constraints(
   const double v0, const double a0, const double jerk_acc, const double jerk_dec,
   const double min_acc, const double target_vel, std::map<double, double> & jerk_profile,
   double & stop_dist)
@@ -293,7 +293,7 @@ bool calcStopDistWithJerkConstraints(
       jerk_profile.insert(std::make_pair(jerk_acc, t3));
 
       // Calculate state = (x, v, a, j) at t = t1 + t2 + t3
-      const auto state = updateStateWithJerkConstraint(v0, a0, jerk_profile, t1 + t2 + t3);
+      const auto state = update_state_with_jerk_constraint(v0, a0, jerk_profile, t1 + t2 + t3);
       if (!state) {
         return false;
       }
@@ -329,7 +329,7 @@ bool calcStopDistWithJerkConstraints(
       jerk_profile.insert(std::make_pair(jerk_acc, t2));
 
       // Calculate state = (x, v, a, j) at t = t1 + t2
-      const auto state = updateStateWithJerkConstraint(v0, a0, jerk_profile, t1 + t2);
+      const auto state = update_state_with_jerk_constraint(v0, a0, jerk_profile, t1 + t2);
       if (!state) {
         return false;
       }
@@ -354,7 +354,7 @@ bool calcStopDistWithJerkConstraints(
       jerk_profile.insert(std::make_pair(jerk, t1));
 
       // Calculate state = (x, v, a, j) at t = t1 + t2
-      const auto state = updateStateWithJerkConstraint(v0, a0, jerk_profile, t1);
+      const auto state = update_state_with_jerk_constraint(v0, a0, jerk_profile, t1);
       if (!state) {
         return false;
       }
@@ -366,7 +366,7 @@ bool calcStopDistWithJerkConstraints(
   constexpr double v_margin = 0.3;  // [m/s]
   constexpr double a_margin = 0.1;  // [m/s^2]
   stop_dist = x;
-  if (!isValidStopDist(v, a, target_vel, a_target, v_margin, a_margin)) {
+  if (!is_valid_stop_dist(v, a, target_vel, a_target, v_margin, a_margin)) {
     RCLCPP_WARN_STREAM(
       rclcpp::get_logger("autoware_velocity_smoother").get_child("trajectory_utils"),
       "valid error. type = " << static_cast<size_t>(type));
@@ -375,7 +375,7 @@ bool calcStopDistWithJerkConstraints(
   return true;
 }
 
-bool isValidStopDist(
+bool is_valid_stop_dist(
   const double v_end, const double a_end, const double v_target, const double a_target,
   const double v_margin, const double a_margin)
 {
@@ -398,7 +398,7 @@ bool isValidStopDist(
   return true;
 }
 
-std::optional<std::tuple<double, double, double, double>> updateStateWithJerkConstraint(
+std::optional<std::tuple<double, double, double, double>> update_state_with_jerk_constraint(
   const double v0, const double a0, const std::map<double, double> & jerk_profile, const double t)
 {
   // constexpr double eps = 1.0E-05;
@@ -429,7 +429,7 @@ std::optional<std::tuple<double, double, double, double>> updateStateWithJerkCon
   return std::nullopt;
 }
 
-std::vector<double> calcVelocityProfileWithConstantJerkAndAccelerationLimit(
+std::vector<double> calc_velocity_profile_with_constant_jerk_and_acceleration_limit(
   const TrajectoryPoints & trajectory, const double v0, const double a0, const double jerk,
   const double acc_max, const double acc_min)
 {
@@ -440,7 +440,7 @@ std::vector<double> calcVelocityProfileWithConstantJerkAndAccelerationLimit(
   auto curr_v = v0;
   auto curr_a = a0;
 
-  const auto intervals = calcTrajectoryIntervalDistance(trajectory);
+  const auto intervals = calc_trajectory_interval_distance(trajectory);
 
   if (intervals.size() + 1 != trajectory.size()) {
     throw std::logic_error("interval calculation result has unexpected array size.");
@@ -456,7 +456,7 @@ std::vector<double> calcVelocityProfileWithConstantJerkAndAccelerationLimit(
   return velocities;
 }
 
-double calcStopDistance(const TrajectoryPoints & trajectory, const size_t closest)
+double calc_stop_distance(const TrajectoryPoints & trajectory, const size_t closest)
 {
   const auto idx = autoware::motion_utils::searchZeroVelocityIndex(trajectory);
 

--- a/planning/autoware_velocity_smoother/test/test_smoother_functions.cpp
+++ b/planning/autoware_velocity_smoother/test/test_smoother_functions.cpp
@@ -42,13 +42,13 @@ TrajectoryPoints genStraightTrajectory(const size_t size)
   return tps;
 }
 
-TEST(TestTrajectoryUtils, CalcTrajectoryCurvatureFrom3Points)
+TEST(TestTrajectoryUtils, calc_trajectory_curvature_from_3_points)
 {
   // the output curvature vector should have the same size of the input trajectory.
   const auto checkOutputSize = [](const size_t trajectory_size, const size_t idx_dist) {
     const auto trajectory_points = genStraightTrajectory(trajectory_size);
     const auto curvatures =
-      autoware::velocity_smoother::trajectory_utils::calcTrajectoryCurvatureFrom3Points(
+      autoware::velocity_smoother::trajectory_utils::calc_trajectory_curvature_from_3_points(
         trajectory_points, idx_dist);
     EXPECT_EQ(curvatures.size(), trajectory_size) << ", idx_dist = " << idx_dist;
   };

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -133,7 +133,7 @@ void BehaviorVelocityPlannerNode::onParam()
   // lock(mutex_);
   planner_data_.velocity_smoother_ =
     std::make_unique<autoware::velocity_smoother::AnalyticalJerkConstrainedSmoother>(*this);
-  planner_data_.velocity_smoother_->setWheelBase(planner_data_.vehicle_info_.wheel_base_m);
+  planner_data_.velocity_smoother_->set_wheel_base(planner_data_.vehicle_info_.wheel_base_m);
 }
 
 void BehaviorVelocityPlannerNode::processNoGroundPointCloud(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/trajectory_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/trajectory_utils.cpp
@@ -60,13 +60,13 @@ bool smoothPath(
 
   auto trajectory = autoware::motion_utils::convertToTrajectoryPoints<
     autoware_internal_planning_msgs::msg::PathWithLaneId>(in_path);
-  const auto traj_lateral_acc_filtered = smoother->applyLateralAccelerationFilter(trajectory);
+  const auto traj_lateral_acc_filtered = smoother->apply_lateral_acceleration_filter(trajectory);
 
   const auto traj_steering_rate_limited =
-    smoother->applySteeringRateLimit(traj_lateral_acc_filtered, false);
+    smoother->apply_steering_rate_limit(traj_lateral_acc_filtered, false);
 
   // Resample trajectory with ego-velocity based interval distances
-  auto traj_resampled = smoother->resampleTrajectory(
+  auto traj_resampled = smoother->resample_trajectory(
     traj_steering_rate_limited, v0, current_pose, planner_data->ego_nearest_dist_threshold,
     planner_data->ego_nearest_yaw_threshold);
   const size_t traj_resampled_closest =
@@ -89,7 +89,7 @@ bool smoothPath(
     traj_resampled.begin() + static_cast<std::ptrdiff_t>(traj_resampled_closest));
 
   if (external_v_limit) {
-    autoware::velocity_smoother::trajectory_utils::applyMaximumVelocityLimit(
+    autoware::velocity_smoother::trajectory_utils::apply_maximum_velocity_limit(
       traj_resampled_closest, traj_smoothed.size(), external_v_limit->max_velocity, traj_smoothed);
   }
   out_path = autoware::motion_utils::convertToPathWithLaneId<TrajectoryPoints>(traj_smoothed);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/dynamic_obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/dynamic_obstacle_stop_module.cpp
@@ -132,9 +132,9 @@ VelocityPlanningResult DynamicObstacleStopModule::plan(
   const auto min_stop_distance = autoware::motion_utils::calcDecelDistWithJerkAndAccConstraints(
                                    planner_data->current_odometry.twist.twist.linear.x, 0.0,
                                    planner_data->current_acceleration.accel.accel.linear.x,
-                                   planner_data->velocity_smoother_->getMinDecel(),
-                                   planner_data->velocity_smoother_->getMaxJerk(),
-                                   planner_data->velocity_smoother_->getMinJerk())
+                                   planner_data->velocity_smoother_->get_min_decel(),
+                                   planner_data->velocity_smoother_->get_max_jerk(),
+                                   planner_data->velocity_smoother_->get_min_jerk())
                                    .value_or(0.0);
   ego_data.earliest_stop_pose = autoware::motion_utils::calcLongitudinalOffsetPose(
     ego_data.trajectory, ego_data.pose.position, min_stop_distance);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/src/planner_data.cpp
@@ -86,8 +86,8 @@ std::optional<double> PlannerData::calculate_min_deceleration_distance(
 {
   return motion_utils::calcDecelDistWithJerkAndAccConstraints(
     current_odometry.twist.twist.linear.x, target_velocity,
-    current_acceleration.accel.accel.linear.x, velocity_smoother_->getMinDecel(),
-    std::abs(velocity_smoother_->getMinJerk()), velocity_smoother_->getMinJerk());
+    current_acceleration.accel.accel.linear.x, velocity_smoother_->get_min_decel(),
+    std::abs(velocity_smoother_->get_min_jerk()), velocity_smoother_->get_min_jerk());
 }
 
 double PlannerData::Object::get_dist_to_traj_poly(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/src/node.cpp
@@ -382,10 +382,10 @@ autoware::motion_velocity_planner::TrajectoryPoints MotionVelocityPlannerNode::s
   const auto & smoother = planner_data.velocity_smoother_;
 
   const auto traj_lateral_acc_filtered =
-    smoother->applyLateralAccelerationFilter(trajectory_points);
+    smoother->apply_lateral_acceleration_filter(trajectory_points);
 
   const auto traj_steering_rate_limited =
-    smoother->applySteeringRateLimit(traj_lateral_acc_filtered, false);
+    smoother->apply_steering_rate_limit(traj_lateral_acc_filtered, false);
 
   // Resample trajectory with ego-velocity based interval distances
   auto traj_resampled = traj_steering_rate_limited;


### PR DESCRIPTION
## Description
We are porting autoware_velocity_smoother to autoware.core, this PR:

1. refactor code according to porting [guide](https://docs.google.com/document/d/1kKshojZo8RuYQ-WhIqQCqTKQO3ojTb5RB77V3NjYpdU/edit?tab=t.0)
2. resolve the conflict caused by refactor
3. refactor readme according to porting [guide](https://docs.google.com/document/d/1kKshojZo8RuYQ-WhIqQCqTKQO3ojTb5RB77V3NjYpdU/edit?tab=t.0)

## Related links

**Parent Issue:**

Parent Issue: -- https://github.com/autowarefoundation/autoware_core/issues/192

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. concol build with all autoware packages， no error
2. running planning simulator A-2-B task，task finished

![p-sim-a-to-b-task](https://github.com/user-attachments/assets/3b768605-4ec5-480d-9f41-17a855e2f272)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
