### PR TITLE
feat(autoware_default_adapi): disable sample web server

### DIFF
--- a/system/autoware_default_adapi/launch/default_adapi.launch.py
+++ b/system/autoware_default_adapi/launch/default_adapi.launch.py
@@ -17,7 +17,6 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
-from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.parameter_descriptions import ParameterFile
 from launch_ros.substitutions import FindPackageShare

--- a/system/autoware_default_adapi/launch/default_adapi.launch.py
+++ b/system/autoware_default_adapi/launch/default_adapi.launch.py
@@ -64,11 +64,5 @@ def generate_launch_description():
         ros_arguments=["--log-level", "adapi.container:=WARN"],
         composable_node_descriptions=components,
     )
-    web_server = Node(
-        namespace="adapi",
-        package="autoware_default_adapi",
-        name="web_server",
-        executable="web_server.py",
-    )
     argument = DeclareLaunchArgument("config", default_value=get_default_config())
-    return launch.LaunchDescription([argument, container, web_server])
+    return launch.LaunchDescription([argument, container])


### PR DESCRIPTION
## Description

Disable launching the sample API server by default as the port may conflict with other services.

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/CJVHMJDJ7/p1742811292471779?thread_ts=1742356407.140849&cid=CJVHMJDJ7)

## How was this PR tested?

Check if the vehicle drives in planning simulator.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
