### PR TITLE
fix(autoware_radar_static_pointcloud_filter): add dependencies and use correct qos

### DIFF
--- a/sensing/autoware_radar_static_pointcloud_filter/config/radar_static_pointcloud_filter.param.yaml
+++ b/sensing/autoware_radar_static_pointcloud_filter/config/radar_static_pointcloud_filter.param.yaml
@@ -1,3 +1,4 @@
 /**:
   ros__parameters:
     doppler_velocity_sd: 4.0
+    max_queue_size: 5

--- a/sensing/autoware_radar_static_pointcloud_filter/package.xml
+++ b/sensing/autoware_radar_static_pointcloud_filter/package.xml
@@ -14,11 +14,14 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_utils</depend>
+  <depend>geometry_msgs</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
   <depend>radar_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/sensing/autoware_radar_static_pointcloud_filter/schema/radar_static_pointcloud_filter.schema.json
+++ b/sensing/autoware_radar_static_pointcloud_filter/schema/radar_static_pointcloud_filter.schema.json
@@ -11,9 +11,15 @@
           "default": "4.0",
           "minimum": 0.0,
           "description": "Standard deviation for radar doppler velocity. [m/s]"
+        },
+        "max_queue_size": {
+          "type": "integer",
+          "default": "5",
+          "minimum": 1,
+          "description": "Max queue size of input/output topics."
         }
       },
-      "required": ["doppler_velocity_sd"]
+      "required": ["doppler_velocity_sd", "max_queue_size"]
     }
   },
   "properties": {

--- a/sensing/autoware_radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.cpp
+++ b/sensing/autoware_radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.cpp
@@ -95,19 +95,26 @@ RadarStaticPointcloudFilterNode::RadarStaticPointcloudFilterNode(
 
   // Node Parameter
   node_param_.doppler_velocity_sd = declare_parameter<double>("doppler_velocity_sd");
+  node_param_.max_queue_size = declare_parameter<int64_t>("max_queue_size");
 
   // Subscriber
   transform_listener_ = std::make_shared<autoware_utils::TransformListener>(this);
 
-  sub_radar_.subscribe(this, "~/input/radar", rclcpp::QoS{1}.get_rmw_qos_profile());
-  sub_odometry_.subscribe(this, "~/input/odometry", rclcpp::QoS{1}.get_rmw_qos_profile());
+  sub_radar_.subscribe(
+    this, "~/input/radar",
+    rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size).get_rmw_qos_profile());
+  sub_odometry_.subscribe(
+    this, "~/input/odometry",
+    rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size).get_rmw_qos_profile());
 
   sync_ptr_ = std::make_shared<Sync>(SyncPolicy(10), sub_radar_, sub_odometry_);
   sync_ptr_->registerCallback(std::bind(&RadarStaticPointcloudFilterNode::onData, this, _1, _2));
 
   // Publisher
-  pub_static_radar_ = create_publisher<RadarScan>("~/output/static_radar_scan", 1);
-  pub_dynamic_radar_ = create_publisher<RadarScan>("~/output/dynamic_radar_scan", 1);
+  pub_static_radar_ = create_publisher<RadarScan>(
+    "~/output/static_radar_scan", rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size));
+  pub_dynamic_radar_ = create_publisher<RadarScan>(
+    "~/output/dynamic_radar_scan", rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size));
 }
 
 rcl_interfaces::msg::SetParametersResult RadarStaticPointcloudFilterNode::onSetParam(
@@ -117,6 +124,7 @@ rcl_interfaces::msg::SetParametersResult RadarStaticPointcloudFilterNode::onSetP
   try {
     auto & p = node_param_;
     update_param(params, "doppler_velocity_sd", p.doppler_velocity_sd);
+    update_param(params, "max_queue_size", p.max_queue_size);
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;
     result.reason = e.what();

--- a/sensing/autoware_radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.cpp
+++ b/sensing/autoware_radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.cpp
@@ -18,6 +18,7 @@
 #include <geometry_msgs/msg/twist_with_covariance.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <memory>
 #include <string>

--- a/sensing/autoware_radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.hpp
+++ b/sensing/autoware_radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.hpp
@@ -45,6 +45,7 @@ public:
   struct NodeParam
   {
     double doppler_velocity_sd{};
+    size_t max_queue_size{};
   };
 
 private:


### PR DESCRIPTION
## Description

The `autoware_radar_static_pointcloud_filter` package lacks some dependencies inside package.xml, a necessary header file wasn't included, and couldn't subscribe to input topic because of the wrong QoS setting.

This PR adds dependencies and fixes QoS profiles.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10155

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested with a bag file which includes ARS 548 RadarScan data via the following launch:

```xml
<?xml version="1.0"?>
<launch>
    <!-- Parameters -->
    <arg name="container_name" default="radar_scan_filter" />
    <arg name="radar_threshold_filter_param_path" default="$(find-pkg-share autoware_radar_threshold_filter)/config/radar_threshold_filter.param.yaml" />
    <arg name="radar_scan_to_pointcloud2_param_path" default="$(find-pkg-share autoware_radar_scan_to_pointcloud2)/config/radar_scan_to_pointcloud2.param.yaml" />

    <!-- External interfaces -->
    <arg name="input/radar_scan" default="/sensing/radar/front/scan_raw" />

    <!-- Radar scan filter pipeline -->
    <group>
        <push-ros-namespace namespace="scan" />
        <node_container pkg="rclcpp_components" exec="component_container_mt" name="$(var container_name)" namespace="">
            <composable_node pkg="autoware_radar_threshold_filter" plugin="autoware::radar_threshold_filter::RadarThresholdFilterNode" name="radar_threshold_filter" namespace="">
                <remap from="~/input/radar" to="$(var input/radar_scan)" />
                <remap from="~/output/radar" to="output/threshold_filtered_scan" />
                <param from="$(var radar_threshold_filter_param_path)" />
            </composable_node>

            <composable_node pkg="autoware_radar_static_pointcloud_filter" plugin="autoware::radar_static_pointcloud_filter::RadarStaticPointcloudFilterNode" name="radar_static_pointcloud_filter"
                             namespace="">
                <remap from="~/input/radar" to="output/threshold_filtered_scan" />
                <remap from="~/input/odometry" to="/localization/kinematic_state" />
                <remap from="~/output/static_radar_scan" to="output/static_radar_scan" />
                <remap from="~/output/dynamic_radar_scan" to="output/dynamic_radar_scan" />
                <param name="doppler_velocity_sd" value="4.0" />
                <param name="max_queue_size" value="5" />
            </composable_node>

            <composable_node pkg="autoware_radar_scan_to_pointcloud2" plugin="autoware::radar_scan_to_pointcloud2::RadarScanToPointcloud2Node" name="radar_scan_to_pointcloud2" namespace="">
                <remap from="~/input/radar" to="output/static_radar_scan" />
                <remap from="~/output/amplitude_pointcloud" to="output/amplitude_pointcloud" />
                <remap from="~/output/doppler_pointcloud" to="output/doppler_pointcloud" />
                <param from="$(var radar_scan_to_pointcloud2_param_path)" />
            </composable_node>

        </node_container>
    </group>
</launch>

```

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub |  |  | QoS 1 |
| New     | Pub/Sub |  |  | rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size) |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `max_queue_size`   | `integer` | `5`         | Max queue size of input/output topics. |
<!-- ⬇️🔴

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |


#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
