### PR TITLE
fix(image_projection_based_fusion): add outside of FOV checking

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -129,7 +129,7 @@ void RoiPointCloudFusionNode::fuse_on_single_image(
       *reinterpret_cast<const float *>(&transformed_cloud.data[offset + y_offset]);
     const float transformed_z =
       *reinterpret_cast<const float *>(&transformed_cloud.data[offset + z_offset]);
-    if (transformed_z <= 0.0) {
+    if (det2d_status.camera_projector_ptr->isOutsideHorizontalView(transformed_x, transformed_z)) {
       continue;
     }
 

--- a/perception/autoware_image_projection_based_fusion/src/segmentation_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/segmentation_pointcloud_fusion/node.cpp
@@ -122,8 +122,11 @@ void SegmentPointCloudFusionNode::fuse_on_single_image(
       *reinterpret_cast<float *>(&transformed_cloud.data[global_offset + y_offset]);
     float transformed_z =
       *reinterpret_cast<float *>(&transformed_cloud.data[global_offset + z_offset]);
-    // skip filtering pointcloud behind the camera or too far from camera
-    if (transformed_z <= 0.0 || transformed_z > filter_distance_threshold_) {
+    // skip pointcloud out of FOV
+    if (det2d_status.camera_projector_ptr->isOutsideHorizontalView(transformed_x, transformed_z)) {
+      continue;
+    }
+    if (transformed_z > filter_distance_threshold_) {
       continue;
     }
 


### PR DESCRIPTION
## Description
- Add camera FOV checking before processing pointcloud fusion for `roi_pointcloud_fusion` and `segmentation_pointcloud_fusion` nodes

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
