### PR TITLE
fix(control_validator): fix sign miss and add code test

### DIFF
--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -39,6 +39,8 @@
 #include <tuple>
 #include <utility>
 
+class AccelerationValidatorTest;
+
 namespace autoware::control_validator
 {
 using autoware_control_msgs::msg::Control;
@@ -67,6 +69,7 @@ struct ValidationParams
 class AccelerationValidator
 {
 public:
+  friend class ::AccelerationValidatorTest;
   explicit AccelerationValidator(rclcpp::Node & node)
   {
     e_offset =
@@ -83,6 +86,7 @@ public:
     const AccelWithCovarianceStamped & loc_acc);
 
 private:
+  bool is_in_error_range() const;
   double e_offset;
   double e_scale;
   autoware::signal_processing::LowpassFilter1d desired_acc_lpf{0.0};


### PR DESCRIPTION
## Description
fix sign miss in https://github.com/autowarefoundation/autoware_universe/pull/10326/
commits/9d2c834fff208d4a977bde96882ad5b6a94b0876

increase cut off velocity

add code tests

## Related links
https://github.com/autowarefoundation/autoware_universe/pull/10326

## How was this PR tested?
does not judge as error with current params including stop/start on slope(12.5%)
[Screencast from 2025年03月26日 17時24分09秒.webm](https://github.com/user-attachments/assets/f76f848f-600f-4e28-a906-4dfe1f1c8a03)

detect error if `acc_time_delay: 1.1` in simulator_model.param.yaml
[Screencast from 2025年03月26日 17時24分09秒.webm](https://github.com/user-attachments/assets/1864b151-34a5-4e4a-9e25-b0b514a97dc3)

tier4 scenario test was passed
https://evaluation.tier4.jp/evaluation/reports/eae98895-960f-5841-9981-afebd1a0553a?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
