### PR TITLE
fix(autoware_probabilistic_occupancy_grid_map): fixed transform issues and border conditions

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/utils.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/utils.hpp
@@ -22,6 +22,7 @@
 #include "autoware/probabilistic_occupancy_grid_map/utils/utils_kernel.hpp"
 #endif
 
+#include <autoware/cuda_utils/cuda_unique_ptr.hpp>
 #include <builtin_interfaces/msg/time.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -61,7 +62,9 @@ bool transformPointcloud(
 
 #ifdef USE_CUDA
 bool transformPointcloudAsync(
-  CudaPointCloud2 & input, const tf2_ros::Buffer & tf2, const std::string & target_frame);
+  CudaPointCloud2 & input, const tf2_ros::Buffer & tf2, const std::string & target_frame,
+  autoware::cuda_utils::CudaUniquePtr<Eigen::Matrix3f> & device_rotation,
+  autoware::cuda_utils::CudaUniquePtr<Eigen::Vector3f> & device_translation);
 #endif
 
 Eigen::Matrix4f getTransformMatrix(const geometry_msgs::msg::Pose & pose);

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/utils_kernel.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/utils_kernel.hpp
@@ -44,7 +44,7 @@ void copyMapRegionLaunch(
 
 void transformPointCloudLaunch(
   std::uint8_t * points, std::size_t num_points, std::size_t points_step,
-  const Eigen::Matrix3f & rotation, const Eigen::Vector3f & translation, cudaStream_t stream);
+  const Eigen::Matrix3f * rotation, const Eigen::Vector3f * translation, cudaStream_t stream);
 
 }  // namespace utils
 }  // namespace autoware::occupancy_grid_map

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed_kernel.cu
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed_kernel.cu
@@ -133,6 +133,10 @@ __global__ void fillUnknownSpaceKernel(
   int angle_bin_index = idx / range_bins;
   int range_bin_index = idx % range_bins;
 
+  if (range_bin_index == range_bins - 1) {
+    return;
+  }
+
   std::uint64_t obs_range_and_x =
     obstacle_points_tensor[2 * (angle_bin_index * range_bins + range_bin_index) + 0];
   std::uint64_t obs_range_and_y =
@@ -149,7 +153,7 @@ __global__ void fillUnknownSpaceKernel(
   int next_raw_range_bin_index = range_bin_index + 1;
   int next_obs_range_bin_index = range_bin_index + 1;
 
-  for (; next_raw_range_bin_index < range_bins; next_raw_range_bin_index++) {
+  for (; next_raw_range_bin_index < range_bins - 1; next_raw_range_bin_index++) {
     std::uint64_t next_raw_range_and_x =
       raw_points_tensor[2 * (angle_bin_index * range_bins + next_raw_range_bin_index) + 0];
     std::uint32_t next_raw_range_int = next_raw_range_and_x >> 32;
@@ -160,7 +164,7 @@ __global__ void fillUnknownSpaceKernel(
     }
   }
 
-  for (; next_obs_range_bin_index < range_bins; next_obs_range_bin_index++) {
+  for (; next_obs_range_bin_index < range_bins - 1; next_obs_range_bin_index++) {
     std::uint64_t next_obs_range_and_x =
       obstacle_points_tensor[2 * (angle_bin_index * range_bins + next_obs_range_bin_index) + 0];
     std::uint32_t next_obs_range_int = next_obs_range_and_x >> 32;
@@ -289,7 +293,7 @@ __global__ void fillObstaclesKernel(
 
   // Look for the next obstacle point
   int next_obs_range_bin_index = range_bin_index + 1;
-  for (; next_obs_range_bin_index < range_bins; next_obs_range_bin_index++) {
+  for (; next_obs_range_bin_index < range_bins - 1; next_obs_range_bin_index++) {
     std::uint64_t next_obs_range_and_x =
       obstacle_points_tensor[2 * (angle_bin_index * range_bins + next_obs_range_bin_index) + 0];
     std::uint32_t next_obs_range_int = next_obs_range_and_x >> 32;
@@ -298,6 +302,8 @@ __global__ void fillObstaclesKernel(
       break;
     }
   }
+
+  next_obs_range_bin_index = std::min<int>(next_obs_range_bin_index, range_bins - 1);
 
   std::uint64_t next_obs_range_and_x =
     obstacle_points_tensor[2 * (angle_bin_index * range_bins + range_bin_index) + 0];

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective_kernel.cu
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective_kernel.cu
@@ -255,6 +255,10 @@ __global__ void fillUnknownSpaceKernel(
   int angle_bin_index = idx / range_bins;
   int range_bin_index = idx % range_bins;
 
+  if (range_bin_index == range_bins - 1) {
+    return;
+  }
+
   std::uint64_t obs_range_and_x =
     obstacle_points_tensor[6 * (angle_bin_index * range_bins + range_bin_index) + 0];
   std::uint64_t obs_range_and_y =
@@ -277,7 +281,7 @@ __global__ void fillUnknownSpaceKernel(
   int next_raw_range_bin_index = range_bin_index + 1;
   int next_obs_range_bin_index = range_bin_index + 1;
 
-  for (; next_raw_range_bin_index < range_bins; next_raw_range_bin_index++) {
+  for (; next_raw_range_bin_index < range_bins - 1; next_raw_range_bin_index++) {
     std::uint64_t next_raw_range_and_x =
       raw_points_tensor[6 * (angle_bin_index * range_bins + next_raw_range_bin_index) + 0];
     std::uint32_t next_raw_range_int = next_raw_range_and_x >> 32;
@@ -292,7 +296,7 @@ __global__ void fillUnknownSpaceKernel(
     }
   }
 
-  for (; next_obs_range_bin_index < range_bins; next_obs_range_bin_index++) {
+  for (; next_obs_range_bin_index < range_bins - 1; next_obs_range_bin_index++) {
     std::uint64_t next_obs_range_and_x =
       obstacle_points_tensor[6 * (angle_bin_index * range_bins + next_obs_range_bin_index) + 0];
     std::uint32_t next_obs_range_int = next_obs_range_and_x >> 32;
@@ -414,7 +418,7 @@ __global__ void fillObstaclesKernel(
 
   // Look for the next obstacle point
   int next_obs_range_bin_index = range_bin_index + 1;
-  for (; next_obs_range_bin_index < range_bins; next_obs_range_bin_index++) {
+  for (; next_obs_range_bin_index < range_bins - 1; next_obs_range_bin_index++) {
     std::uint64_t next_obs_range_and_x =
       obstacle_points_tensor[6 * (angle_bin_index * range_bins + next_obs_range_bin_index) + 0];
     std::uint32_t next_obs_range_int = next_obs_range_and_x >> 32;
@@ -423,6 +427,8 @@ __global__ void fillObstaclesKernel(
       break;
     }
   }
+
+  next_obs_range_bin_index = std::min<int>(next_obs_range_bin_index, range_bins - 1);
 
   std::uint64_t next_obs_range_and_x =
     obstacle_points_tensor[6 * (angle_bin_index * range_bins + range_bin_index) + 0];

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/utils/utils.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/utils/utils.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/probabilistic_occupancy_grid_map/utils/utils.hpp"
 
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
 #include <autoware_utils/geometry/geometry.hpp>
 
 #include <string>
@@ -49,7 +51,9 @@ bool transformPointcloud(
 
 #ifdef USE_CUDA
 bool transformPointcloudAsync(
-  CudaPointCloud2 & input, const tf2_ros::Buffer & tf2, const std::string & target_frame)
+  CudaPointCloud2 & input, const tf2_ros::Buffer & tf2, const std::string & target_frame,
+  autoware::cuda_utils::CudaUniquePtr<Eigen::Matrix3f> & device_rotation,
+  autoware::cuda_utils::CudaUniquePtr<Eigen::Vector3f> & device_translation)
 {
   geometry_msgs::msg::TransformStamped tf_stamped;
   // lookup transform
@@ -66,9 +70,18 @@ bool transformPointcloudAsync(
   Eigen::Matrix4f tf_matrix = tf2::transformToEigen(tf_stamped.transform).matrix().cast<float>();
   Eigen::Matrix3f rotation = tf_matrix.block<3, 3>(0, 0);
   Eigen::Vector3f translation = tf_matrix.block<3, 1>(0, 3);
+
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    device_rotation.get(), rotation.data(), sizeof(Eigen::Matrix3f), cudaMemcpyHostToDevice,
+    input.stream));
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    device_translation.get(), translation.data(), sizeof(Eigen::Vector3f), cudaMemcpyHostToDevice,
+    input.stream));
+
   transformPointCloudLaunch(
-    input.data.get(), input.width * input.height, input.point_step, rotation, translation,
-    input.stream);
+    input.data.get(), input.width * input.height, input.point_step, device_rotation.get(),
+    device_translation.get(), input.stream);
+
   input.header.frame_id = target_frame;
   return true;
 }

--- a/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -122,6 +122,9 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
   occupancy_grid_map_ptr_->setCudaStream(stream_);
   occupancy_grid_map_updater_ptr_->setCudaStream(stream_);
 
+  device_rotation_ = autoware::cuda_utils::make_unique<Eigen::Matrix3f>();
+  device_translation_ = autoware::cuda_utils::make_unique<Eigen::Vector3f>();
+
   occupancy_grid_map_ptr_->initRosParam(*this);
   occupancy_grid_map_updater_ptr_->initRosParam(*this);
 
@@ -185,12 +188,14 @@ void PointcloudBasedOccupancyGridMapNode::onPointcloudWithObstacleAndRaw()
   if (use_height_filter_) {
     // Make sure that the frame is base_link
     if (raw_pointcloud_.header.frame_id != base_link_frame_) {
-      if (!utils::transformPointcloudAsync(raw_pointcloud_, *tf2_, base_link_frame_)) {
+      if (!utils::transformPointcloudAsync(
+            raw_pointcloud_, *tf2_, base_link_frame_, device_rotation_, device_translation_)) {
         return;
       }
     }
     if (obstacle_pointcloud_.header.frame_id != base_link_frame_) {
-      if (!utils::transformPointcloudAsync(obstacle_pointcloud_, *tf2_, base_link_frame_)) {
+      if (!utils::transformPointcloudAsync(
+            obstacle_pointcloud_, *tf2_, base_link_frame_, device_rotation_, device_translation_)) {
         return;
       }
     }

--- a/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
@@ -81,6 +81,9 @@ private:
   CudaPointCloud2 raw_pointcloud_;
   CudaPointCloud2 obstacle_pointcloud_;
 
+  autoware::cuda_utils::CudaUniquePtr<Eigen::Matrix3f> device_rotation_;
+  autoware::cuda_utils::CudaUniquePtr<Eigen::Vector3f> device_translation_;
+
   // ROS Parameters
   std::string map_frame_;
   std::string base_link_frame_;


### PR DESCRIPTION
## Description
When enabling the multi lidar version, it was discovered that the node was dying.
It seems to be due to how some kernel parameters are being handled, but instead of relying on implicit copies, I just moved the transform to device memory. In addition, cuda memcheck reported border conditions, so I addressed them as well :pray: 


## Related links

**Parent Issue:**

- [TIERIV INTERNAL LINK](https://star4.slack.com/archives/C076ZGRC15X/p1742782906061879)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
