### PR TITLE
fix(autoware_image_projection_based_fusion): unintended new container behavior

### DIFF
--- a/perception/autoware_image_projection_based_fusion/launch/roi_pointcloud_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/roi_pointcloud_fusion.launch.xml
@@ -34,7 +34,7 @@
   <arg name="input/image6" default="/image_raw6"/>
   <arg name="input/image7" default="/image_raw7"/>
   <group>
-    <node_container pkg="rclcpp_components" exec="component_container" name="$(var pointcloud_container_name)" namespace="/">
+    <load_composable_node target="$(var pointcloud_container_name)">
       <composable_node pkg="autoware_image_projection_based_fusion" plugin="autoware::image_projection_based_fusion::RoiPointCloudFusionNode" name="roi_pointcloud_fusion">
         <param name="rois_number" value="$(var input/rois_number)"/>
         <param from="$(var param_path)"/>
@@ -69,6 +69,6 @@
         <param name="input/camera_info7" value="$(var input/camera_info7)"/>
         <param name="input/image7" value="$(var input/image7)"/>
       </composable_node>
-    </node_container>
+    </load_composable_node>
   </group>
 </launch>


### PR DESCRIPTION
## Description

The current launcher was creating a new container with the same name as the `pointcloud_container`.
It effectively make nodes being load twice or in different containers.

Additionally, the new container is not a multithreaded one :sweat_smile:  (thanks to this at least I was able to find the source)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
