### PR TITLE
fix(autoware_radar_static_pointcloud_filter): lookup timestamp and er…

### DIFF
--- a/sensing/autoware_radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.cpp
+++ b/sensing/autoware_radar_static_pointcloud_filter/src/radar_static_pointcloud_filter_node.cpp
@@ -138,14 +138,13 @@ rcl_interfaces::msg::SetParametersResult RadarStaticPointcloudFilterNode::onSetP
 void RadarStaticPointcloudFilterNode::onData(
   const RadarScan::ConstSharedPtr radar_msg, const Odometry::ConstSharedPtr odom_msg)
 {
-  geometry_msgs::msg::TransformStamped::ConstSharedPtr transform;
-
-  try {
-    transform = transform_listener_->get_transform(
-      odom_msg->header.frame_id, radar_msg->header.frame_id, odom_msg->header.stamp,
+  const geometry_msgs::msg::TransformStamped::ConstSharedPtr transform =
+    transform_listener_->get_transform(
+      odom_msg->header.frame_id, radar_msg->header.frame_id, radar_msg->header.stamp,
       rclcpp::Duration::from_seconds(0.2));
-  } catch (tf2::TransformException & ex) {
-    RCLCPP_INFO(this->get_logger(), "Could not transform");
+
+  if (!transform) {
+    RCLCPP_WARN(this->get_logger(), "Could not transform");
     return;
   }
 


### PR DESCRIPTION
…ror handling

## Description

This PR fixes the lookup transform timestamp and error handling.

The node tries to get transform at map frame's timestamp, but it should use radar message's timestamp. 

Sometimes, tf cannot find a match and `get_transform` returns an empty pointer.

Instead of checking if the pointer is empty or not, the current code checks an exception. Since the exception is handled inside the utility function, the returned pointer should be checked here for an error.

The empty pointer causes a segmentation fault.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10349

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested with a bag file which includes ARS 548 RadarScan data via the following launch:

```xml
<?xml version="1.0"?>
<launch>
    <!-- Parameters -->
    <arg name="container_name" default="radar_scan_filter" />
    <arg name="radar_threshold_filter_param_path" default="$(find-pkg-share autoware_radar_threshold_filter)/config/radar_threshold_filter.param.yaml" />
    <arg name="radar_scan_to_pointcloud2_param_path" default="$(find-pkg-share autoware_radar_scan_to_pointcloud2)/config/radar_scan_to_pointcloud2.param.yaml" />

    <!-- External interfaces -->
    <arg name="input/radar_scan" default="/sensing/radar/front/scan_raw" />

    <!-- Radar scan filter pipeline -->
    <group>
        <push-ros-namespace namespace="scan" />
        <node_container pkg="rclcpp_components" exec="component_container_mt" name="$(var container_name)" namespace="">
            <composable_node pkg="autoware_radar_threshold_filter" plugin="autoware::radar_threshold_filter::RadarThresholdFilterNode" name="radar_threshold_filter" namespace="">
                <remap from="~/input/radar" to="$(var input/radar_scan)" />
                <remap from="~/output/radar" to="output/threshold_filtered_scan" />
                <param from="$(var radar_threshold_filter_param_path)" />
            </composable_node>

            <composable_node pkg="autoware_radar_static_pointcloud_filter" plugin="autoware::radar_static_pointcloud_filter::RadarStaticPointcloudFilterNode" name="radar_static_pointcloud_filter"
                             namespace="">
                <remap from="~/input/radar" to="output/threshold_filtered_scan" />
                <remap from="~/input/odometry" to="/localization/kinematic_state" />
                <remap from="~/output/static_radar_scan" to="output/static_radar_scan" />
                <remap from="~/output/dynamic_radar_scan" to="output/dynamic_radar_scan" />
                <param name="doppler_velocity_sd" value="4.0" />
                <param name="max_queue_size" value="5" />
            </composable_node>

            <composable_node pkg="autoware_radar_scan_to_pointcloud2" plugin="autoware::radar_scan_to_pointcloud2::RadarScanToPointcloud2Node" name="radar_scan_to_pointcloud2" namespace="">
                <remap from="~/input/radar" to="output/static_radar_scan" />
                <remap from="~/output/amplitude_pointcloud" to="output/amplitude_pointcloud" />
                <remap from="~/output/doppler_pointcloud" to="output/doppler_pointcloud" />
                <param from="$(var radar_scan_to_pointcloud2_param_path)" />
            </composable_node>

        </node_container>
    </group>
</launch>
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
