### PR TITLE
fix(compare_map_segmentation): last map update logic

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_grid_map_loader/voxel_grid_map_loader.cpp
@@ -428,8 +428,8 @@ void VoxelGridDynamicMapLoader::timer_callback()
     should_update_map(
       current_position.value(), last_updated_position_.value(), map_update_distance_threshold_)) {
     request_update_map(current_position.value());
+    last_updated_position_ = current_position;
   }
-  last_updated_position_ = current_position;
 }
 
 bool VoxelGridDynamicMapLoader::should_update_map(


### PR DESCRIPTION
## Description
Fix the bug which comes from [this change](https://github.com/autowarefoundation/autoware_universe/pull/10222/files#diff-6fcc7c77ce6950930e74d4badcd339667191e227f50b9eeb68ba4e6a53754fdaL408-R432) in https://github.com/autowarefoundation/autoware_universe/pull/10222

dynamic_map_loader stopped working because last_updated_position_ was being updated every time.
This was found by @KYabuuchi @zusizusi thank you.

## Related links

**Private Links:**

- [TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT0-35928)


## How was this PR tested?
lsim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes
N/A

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
