### PR TITLE
feat(autoware_default_adapi): log autoware state change

### DIFF
--- a/system/autoware_default_adapi/src/compatibility/autoware_state.hpp
+++ b/system/autoware_default_adapi/src/compatibility/autoware_state.hpp
@@ -59,6 +59,7 @@ private:
   LocalizationState localization_state_;
   RoutingState routing_state_;
   OperationModeState operation_mode_state_;
+  uint8_t prev_state_;
 
   void on_timer();
   void on_localization(const LocalizationState::ConstSharedPtr msg);


### PR DESCRIPTION
## Description

Log the autoware state change.

```
AutowareState: Initializing => WaitingForRoute
```

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C4P0NSMB5/p1742992518950999)

## How was this PR tested?

Use planning simulation and check if the autoware state change log is displayed.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
