### PR TITLE
feat(tier4_planning_rviz_plugin): add time from start text to Trajectory

### DIFF
--- a/visualization/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
+++ b/visualization/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
@@ -240,6 +240,7 @@ public:
 
 protected:
   virtual void visualizeDrivableArea([[maybe_unused]] const typename T::ConstSharedPtr msg_ptr) {}
+  virtual void visualizeTrajectory([[maybe_unused]] const typename T::ConstSharedPtr msg_ptr) {}
   virtual void preProcessMessageDetail() {}
   virtual void preVisualizePathFootprintDetail(
     [[maybe_unused]] const typename T::ConstSharedPtr msg_ptr)
@@ -285,6 +286,9 @@ protected:
 
     // visualize PathFootprint
     visualizePathFootprint(msg_ptr);
+
+    // visualize Trajectory
+    visualizeTrajectory(msg_ptr);
 
     last_msg_ptr_ = msg_ptr;
   }


### PR DESCRIPTION
## Description

Add visualization of the `time_from_start`  field of the `Trajectory` message.

![image](https://github.com/user-attachments/assets/a1e62fb6-da5f-44a0-b0e2-78495329d4d7)

![image](https://github.com/user-attachments/assets/1f34889b-02b7-4adf-bc64-38f937e484e3)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
