### PR TITLE
fix(control_validator): memory-related crash when processing large trajectories

### DIFF
--- a/control/autoware_control_validator/src/utils.cpp
+++ b/control/autoware_control_validator/src/utils.cpp
@@ -86,6 +86,25 @@ bool remove_front_trajectory_point(
 Trajectory align_trajectory_with_reference_trajectory(
   const Trajectory & trajectory, const Trajectory & predicted_trajectory)
 {
+  if (trajectory.points.empty() || predicted_trajectory.points.empty() ||
+      trajectory.points.size() < 2) {
+    return Trajectory();
+  }
+
+  constexpr size_t MAX_SAFE_SIZE = 5000;
+
+  if (predicted_trajectory.points.size() > MAX_SAFE_SIZE) {
+    Trajectory safe_predicted_trajectory;
+    safe_predicted_trajectory.header = predicted_trajectory.header;
+    safe_predicted_trajectory.points.reserve(MAX_SAFE_SIZE);
+
+    for (size_t i = 0; i < MAX_SAFE_SIZE && i < predicted_trajectory.points.size(); ++i) {
+      safe_predicted_trajectory.points.push_back(predicted_trajectory.points[i]);
+    }
+
+    return align_trajectory_with_reference_trajectory(trajectory, safe_predicted_trajectory);
+  }
+
   const auto last_seg_length = autoware::motion_utils::calcSignedArcLength(
     trajectory.points, trajectory.points.size() - 2, trajectory.points.size() - 1);
 
@@ -124,8 +143,10 @@ Trajectory align_trajectory_with_reference_trajectory(
     trajectory_points, modified_trajectory_points, predicted_trajectory_points);
 
   if (predicted_trajectory_point_removed) {
-    insert_point_in_predicted_trajectory(
-      modified_trajectory_points, trajectory_points.front().pose, predicted_trajectory_points);
+    if (!trajectory_points.empty() && !predicted_trajectory_points.empty()) {
+      insert_point_in_predicted_trajectory(
+        modified_trajectory_points, trajectory_points.front().pose, predicted_trajectory_points);
+    }
   }
 
   // If last point of predicted_trajectory is behind of end of trajectory, erase points which are
@@ -140,6 +161,11 @@ Trajectory align_trajectory_with_reference_trajectory(
     reverse_trajectory_points(predicted_trajectory_points);
   auto reversed_trajectory_points = reverse_trajectory_points(trajectory_points);
   auto reversed_modified_trajectory_points = reverse_trajectory_points(modified_trajectory_points);
+
+  if (reversed_trajectory_points.empty() || reversed_modified_trajectory_points.empty() ||
+      reversed_predicted_trajectory_points.empty()) {
+    return Trajectory();
+  }
 
   auto reversed_predicted_trajectory_point_removed = remove_front_trajectory_point(
     reversed_trajectory_points, reversed_modified_trajectory_points,

--- a/control/autoware_control_validator/src/utils.cpp
+++ b/control/autoware_control_validator/src/utils.cpp
@@ -86,8 +86,9 @@ bool remove_front_trajectory_point(
 Trajectory align_trajectory_with_reference_trajectory(
   const Trajectory & trajectory, const Trajectory & predicted_trajectory)
 {
-  if (trajectory.points.empty() || predicted_trajectory.points.empty() ||
-      trajectory.points.size() < 2) {
+  if (
+    trajectory.points.empty() || predicted_trajectory.points.empty() ||
+    trajectory.points.size() < 2) {
     return Trajectory();
   }
 
@@ -162,8 +163,9 @@ Trajectory align_trajectory_with_reference_trajectory(
   auto reversed_trajectory_points = reverse_trajectory_points(trajectory_points);
   auto reversed_modified_trajectory_points = reverse_trajectory_points(modified_trajectory_points);
 
-  if (reversed_trajectory_points.empty() || reversed_modified_trajectory_points.empty() ||
-      reversed_predicted_trajectory_points.empty()) {
+  if (
+    reversed_trajectory_points.empty() || reversed_modified_trajectory_points.empty() ||
+    reversed_predicted_trajectory_points.empty()) {
     return Trajectory();
   }
 


### PR DESCRIPTION
## Description

### Background
This PR fixes a memory-related crash in the control_validator component that occurs when processing large trajectories. The crash was happening in the align_trajectory_with_reference_trajectory function, specifically when using the convertToTrajectory function.

```
1743052338.5723131 [ERROR] [component_container_mt-116]: process has died [pid 4199, exit code -6, cmd '/home/autoware/pilot-auto.xx1/install/rclcpp_components/lib/rclcpp_components/component_container_mt --ros-args -r __node:=control_check_container -r __ns:=/control -p use_sim_time:=False -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.55'].
1743052332.5213943 [component_container_mt-116] *** Aborted at 1743052332 (unix time) try "date -d @1743052332" if you are using GNU date ***
1743052332.5248117 [component_container_mt-116] PC: @ 0x0 (unknown)
1743052332.5283709 [component_container_mt-116] @ 0x7f84034f94d6 google::(anonymous namespace)::FailureSignalHandler()
1743052332.5308003 [component_container_mt-116] @ 0x7f8402da9520 (unknown)
1743052332.5335472 [component_container_mt-116] @ 0x7f8402dfd9fc pthread_kill
1743052332.5359352 [component_container_mt-116] @ 0x7f8402da9476 raise
1743052332.5381107 [component_container_mt-116] @ 0x7f8402d8f7f3 abort
1743052332.5401011 [component_container_mt-116] @ 0x7f8402df0676 (unknown)
1743052332.5421193 [component_container_mt-116] @ 0x7f8402e07cfc (unknown)
1743052332.5439818 [component_container_mt-116] @ 0x7f8402e087e2 (unknown)
1743052332.5462718 [component_container_mt-116] @ 0x7f8402e0b62b (unknown)
1743052332.5483525 [component_container_mt-116] @ 0x7f8402e0c139 malloc
1743052332.5506630 [component_container_mt-116] @ 0x7f840305e98c operator new()
1743052332.5527916 [component_container_mt-116] @ 0x7f83f8c4c81b std::vector<>::_M_realloc_insert<>()
1743052332.5545368 [component_container_mt-116] @ 0x7f83f8c4c5ed autoware::motion_utils::convertToTrajectory()
1743052332.5547607 [component_container_mt-116] @ 0x7f8400020252 autoware::control_validator::insert_point_in_predicted_trajectory()
1743052332.5564361 [component_container_mt-116] @ 0x7f840002067d autoware::control_validator::align_trajectory_with_reference_trajectory()
1743052332.5581107 [component_container_mt-116] @ 0x7f8400020886 autoware::control_validator::calc_max_lateral_distance()
1743052332.5595820 [component_container_mt-116] @ 0x7f83f8d80ba0 autoware::control_validator::ControlValidator::calc_lateral_deviation_status()
1743052332.5597758 [component_container_mt-116] @ 0x7f83f8d8677d autoware::control_validator::ControlValidator::validate()
1743052332.5615165 [component_container_mt-116] @ 0x7f83f8d86ed9 autoware::control_validator::ControlValidator::on_predicted_trajectory()
1743052332.5617168 [component_container_mt-116] @ 0x7f83f8da05b8 std::_Function_handler<>::_M_invoke()
1743052332.5635943 [component_container_mt-116] @ 0x7f83f8d9fc97 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN22autoware_planning_msgs3msg11Trajectory_ISaIvEEESA_E8dispatchESt10shared_ptrISB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRKSB_EESN_IFvSP_SH_EESN_IFvRKNS5_17SerializedMessageEEESN_IFvSW_SH_EESN_IFvSt10unique_ptrISB_St14default_deleteISB_EEEESN_IFvS14_SH_EESN_IFvS11_ISU_S12_ISU_EEEESN_IFvS1A_SH_EESN_IFvSD_ISO_EEESN_IFvS1F_SH_EESN_IFvSD_ISV_EEESN_IFvS1K_SH_EESN_IFvRKS1F_EESN_IFvS1Q_SH_EESN_IFvRKS1K_EESN_IFvS1W_SH_EESN_IFvSE_EESN_IFvSE_SH_EESN_IFvSD_ISU_EEESN_IFvS25_SH_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESL_S2B_
1743052332.5638278 [component_container_mt-116] @ 0x7f83f8dc7075 rclcpp::Subscription<>::handle_message()
1743052332.5658934 [component_container_mt-116] @ 0x7f8403375ba0 rclcpp::Executor::execute_subscription()
1743052332.5683734 [component_container_mt-116] @ 0x7f840337710e rclcpp::Executor::execute_any_executable()
1743052332.5705764 [component_container_mt-116] @ 0x7f840337d432 rclcpp::executors::MultiThreadedExecutor::run()
```
### Solutions
Modified the `align_trajectory_with_reference_trajectory` function to safely handle large trajectories:

- Defined a maximum safe size ( `MAX_SAFE_SIZE` ) for trajectory processing
- When the input trajectory exceeds this size, limit it to a safe size for processing

These changes significantly reduce the possibility of memory allocation failures during processing and improve system stability when handling large trajectories.

## Related links
- [Internal ticket](https://tier4.atlassian.net/browse/RT0-36082)

## How was this PR tested?

- Scenario test result is not degraded from the base test: [3744/3749](https://evaluation.tier4.jp/evaluation/reports/ec85b7f3-5061-507a-9ce8-0f3f570f2a2e?project_id=prd_jt)
  - c.f. base test: [3742/3749](https://evaluation.tier4.jp/evaluation/reports/03bca330-e97e-5304-8b6b-b58ef7fc297b?project_id=prd_jt)
- Tested on the public road and found no degration.

## Notes for reviewers

### Calculating `MAX_SAFE_SIZE`
- To calculate the appropriate `MAX_SAFE_SIZE` that would keep the message size under 1MB, we need to estimate the size of `autoware_planning_msgs::msg::TrajectoryPoint`.

- A typical `TrajectoryPoint` usually contains:
  - `geometry_msgs::msg::Pose` (position and quaternion): ~56 bytes
    - position (x, y, z): 3 × 8 bytes = 24 bytes
    - orientation (quaternion): 4 × 8 bytes = 32 bytes
  - Additional info like velocity, acceleration: ~32-64 bytes
  - Other metadata and extra fields: ~8-16 bytes

- This gives us an estimated size of about 100-150 bytes per `TrajectoryPoint`.
- 1MB is 1,048,576 bytes. If each `TrajectoryPoint` is approximately 150 bytes:

```
1,048,576 bytes ÷ 150 bytes/point ≈ 6,990 points
```
- However, considering safety margins and accounting for message headers and other overhead, it would be wise to choose a more conservative `MAX_SAFE_SIZE`:

```cpp
// Safe value for a 1MB message size limit
const size_t MAX_SAFE_SIZE = 5000;  // About 750KB (assuming 150 bytes per point)
```
> [!CAUTION]
> Even with this PR, we cannot deal with the infinite trajectory.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
