### PR TITLE
fix(pred_path_checker,dyn_obstacle_stop): use output of removeOverlaps

### DIFF
--- a/control/autoware_predicted_path_checker/src/predicted_path_checker_node/predicted_path_checker_node.cpp
+++ b/control/autoware_predicted_path_checker/src/predicted_path_checker_node/predicted_path_checker_node.cpp
@@ -485,7 +485,7 @@ Trajectory PredictedPathCheckerNode::cutTrajectory(
     cut.points.push_back(point);
     total_length += points_distance;
   }
-  autoware::motion_utils::removeOverlapPoints(cut.points);
+  cut.points = autoware::motion_utils::removeOverlapPoints(cut.points);
 
   return cut;
 }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/dynamic_obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/dynamic_obstacle_stop_module.cpp
@@ -123,7 +123,7 @@ VelocityPlanningResult DynamicObstacleStopModule::plan(
   dynamic_obstacle_stop::EgoData ego_data;
   ego_data.pose = planner_data->current_odometry.pose.pose;
   ego_data.trajectory = smoothed_trajectory_points;
-  autoware::motion_utils::removeOverlapPoints(ego_data.trajectory);
+  ego_data.trajectory = autoware::motion_utils::removeOverlapPoints(ego_data.trajectory);
   ego_data.first_trajectory_idx =
     autoware::motion_utils::findNearestSegmentIndex(ego_data.trajectory, ego_data.pose.position);
   ego_data.longitudinal_offset_to_first_trajectory_idx =


### PR DESCRIPTION
## Description

There are currently build issues that can occur because the output of `removeOverlapPoints` is marked `[[no_discard]]` but is discarded.
```
error: ignoring return value of 'T autoware::motion_utils::removeOverlapPoints(const T&, size_t) [with T = std::vector<autoware_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> > >; size_t = long unsigned int]', declared with attribute 'nodiscard' [-Werror=unused-result]
  126 |   autoware::motion_utils::removeOverlapPoints(ego_data.trajectory);
      |                   
```
This PR fixes the issue in 2 packages.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
