### PR TITLE
fix(detection_area): integrate RTC feature

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/config/detection_area.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/config/detection_area.param.yaml
@@ -8,4 +8,5 @@
       state_clear_time: 2.0
       hold_stop_margin_distance: 0.0
       distance_to_judge_over_stop_line: 0.5
+      enable_rtc: false # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval
       suppress_pass_judge_when_stopping: false

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml
@@ -19,6 +19,7 @@
 
   <depend>autoware_behavior_velocity_planner</depend>
   <depend>autoware_behavior_velocity_planner_common</depend>
+  <depend>autoware_behavior_velocity_rtc_interface</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.cpp
@@ -34,7 +34,8 @@ using autoware_utils::get_or_declare_parameter;
 using lanelet::autoware::DetectionArea;
 
 DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
-: SceneModuleManagerInterface(node, getModuleName())
+: SceneModuleManagerInterfaceWithRTC(
+    node, getModuleName(), getEnableRTC(node, std::string(getModuleName()) + ".enable_rtc"))
 {
   const std::string ns(DetectionAreaModuleManager::getModuleName());
   planner_param_.stop_margin = get_or_declare_parameter<double>(node, ns + ".stop_margin");
@@ -68,20 +69,25 @@ void DetectionAreaModuleManager::launchNewModules(
         module_id, lane_id, *detection_area_with_lane_id.first, planner_param_,
         logger_.get_child("detection_area_module"), clock_, time_keeper_,
         planning_factor_interface_));
+      generate_uuid(module_id);
+      updateRTCStatus(
+        getUUID(module_id), true, State::WAITING_FOR_EXECUTION,
+        std::numeric_limits<double>::lowest(), path.header.stamp);
     }
   }
 }
 
-std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
+std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
 DetectionAreaModuleManager::getModuleExpiredFunction(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto detection_area_id_set = planning_utils::getRegElemIdSetOnPath<DetectionArea>(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return [detection_area_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
-    return detection_area_id_set.count(scene_module->getModuleId()) == 0;
-  };
+  return
+    [detection_area_id_set](const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module) {
+      return detection_area_id_set.count(scene_module->getModuleId()) == 0;
+    };
 }
 
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.hpp
@@ -19,7 +19,7 @@
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
@@ -29,7 +29,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class DetectionAreaModuleManager : public SceneModuleManagerInterface<>
+class DetectionAreaModuleManager : public SceneModuleManagerInterfaceWithRTC
 {
 public:
   explicit DetectionAreaModuleManager(rclcpp::Node & node);
@@ -41,7 +41,8 @@ private:
 
   void launchNewModules(const autoware_internal_planning_msgs::msg::PathWithLaneId & path) override;
 
-  std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
+  std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
+  getModuleExpiredFunction(
     const autoware_internal_planning_msgs::msg::PathWithLaneId & path) override;
 };
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
@@ -40,7 +40,7 @@ DetectionAreaModule::DetectionAreaModule(
   const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
-: SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),
+: SceneModuleInterfaceWithRTC(module_id, logger, clock, time_keeper, planning_factor_interface),
   lane_id_(lane_id),
   detection_area_reg_elem_(detection_area_reg_elem),
   state_(State::GO),
@@ -107,10 +107,12 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
     modified_stop_line_seg_idx = current_seg_idx;
   }
 
+  setDistance(stop_dist);
+
   // Check state
-  const bool is_safe = detection_area::can_clear_stop_state(
-    last_obstacle_found_time_, clock_->now(), planner_param_.state_clear_time);
-  if (is_safe) {
+  setSafe(detection_area::can_clear_stop_state(
+    last_obstacle_found_time_, clock_->now(), planner_param_.state_clear_time));
+  if (isActivated()) {
     last_obstacle_found_time_ = {};
     if (!planner_param_.suppress_pass_judge_when_stopping || !is_stopped) {
       state_ = State::GO;
@@ -139,6 +141,7 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
         dead_line_seg_idx);
       if (dist_from_ego_to_dead_line < 0.0) {
         RCLCPP_WARN(logger_, "[detection_area] vehicle is over dead line");
+        setSafe(true);
         return true;
       }
     }
@@ -151,6 +154,7 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
   if (
     state_ != State::STOP &&
     dist_from_ego_to_stop < -planner_param_.distance_to_judge_over_stop_line) {
+    setSafe(true);
     return true;
   }
 
@@ -167,6 +171,7 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
       RCLCPP_WARN_THROTTLE(
         logger_, *clock_, std::chrono::milliseconds(1000).count(),
         "[detection_area] vehicle is over stop border");
+      setSafe(true);
       return true;
     }
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
@@ -23,8 +23,8 @@
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/detection_area.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -38,7 +38,7 @@ using PathIndexWithPoint2d = std::pair<size_t, Point2d>;                // front
 using PathIndexWithOffset = std::pair<size_t, double>;                  // front index, offset
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 
-class DetectionAreaModule : public SceneModuleInterface
+class DetectionAreaModule : public SceneModuleInterfaceWithRTC
 {
 public:
   enum class State { GO, STOP };


### PR DESCRIPTION
## Description

Make it possible to use RTC for detection area module.

:warning: Review https://github.com/autowarefoundation/autoware_launch/pull/1383 at first.

Don't use RTC (Ego stops at stop line only when there are obstacles within detection area)

https://github.com/user-attachments/assets/080a380e-3f3b-47ee-8903-d87cc8f62bd2

Use RTC (Ego stops at stop line of detection area regardless of obstacle existance.)

https://github.com/user-attachments/assets/7abc94fd-f653-4ba6-b570-a53f54de522d

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/pull/9802

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] Psim
- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/0a5684a8-eff6-591a-b968-e3586eceb18c?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
