### PR TITLE
feat(autoware_default_adapi): release adapi v1.8.0

### DIFF
--- a/system/autoware_default_adapi/src/interface.cpp
+++ b/system/autoware_default_adapi/src/interface.cpp
@@ -21,7 +21,7 @@ InterfaceNode::InterfaceNode(const rclcpp::NodeOptions & options) : Node("interf
 {
   const auto on_interface_version = [](auto, auto res) {
     res->major = 1;
-    res->minor = 6;
+    res->minor = 8;
     res->patch = 0;
   };
 

--- a/system/autoware_default_adapi/test/node/interface_version.py
+++ b/system/autoware_default_adapi/test/node/interface_version.py
@@ -30,7 +30,7 @@ response = future.result()
 
 if response.major != 1:
     exit(1)
-if response.minor != 6:
+if response.minor != 8:
     exit(1)
 if response.patch != 0:
     exit(1)


### PR DESCRIPTION
## Description

Release AD API v1.8.0. See [release note page](https://github.com/isamu-takagi/autoware-documentation/blob/feat/adapi-v1.8.0/docs/design/autoware-interfaces/ad-api/release.md) for details.

## Related links

https://github.com/autowarefoundation/autoware-documentation/pull/658

## How was this PR tested?

None

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
