### PR TITLE
fix(roi_pointcloud_fusion): load even if same container with pointpainting

### DIFF
--- a/perception/autoware_image_projection_based_fusion/CMakeLists.txt
+++ b/perception/autoware_image_projection_based_fusion/CMakeLists.txt
@@ -54,6 +54,12 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE roi_pointcloud_fusion_node
 )
 
+install(
+  TARGETS
+    ${PROJECT_NAME}
+  DESTINATION lib
+)
+
 set(CUDA_VERBOSE OFF)
 
 # set flags for CUDA availability
@@ -157,7 +163,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
   )
 
   install(
-    TARGETS pointpainting_cuda_lib
+    TARGETS pointpainting_cuda_lib pointpainting_lib
     DESTINATION lib
   )
 else()


### PR DESCRIPTION
## Description
This PR enables to load roi_pointcloud_fusion even if same container w/ pointpainting.

before, It is not possible to load this node if container include pointpainting.


## Related links

https://github.com/autowarefoundation/autoware_universe/pull/10334

## How was this PR tested?

https://evaluation.ci.tier4.jp/evaluation/reports/bfdac88b-b636-51ea-98f9-8173b82f3c19?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
