### PR TITLE
fix(simple_planning_simulator): fix a small turn_signal bug

### DIFF
--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -909,10 +909,9 @@ void SimplePlanningSimulator::publish_turn_indicators_report()
   }
   TurnIndicatorsReport msg;
   msg.stamp = get_clock()->now();
-  if (current_turn_indicators_cmd_ptr_->command == TurnIndicatorsCommand::NO_COMMAND){
+  if (current_turn_indicators_cmd_ptr_->command == TurnIndicatorsCommand::NO_COMMAND) {
     msg.report = TurnIndicatorsReport::DISABLE;
-  }
-  else{
+  } else {
     msg.report = current_turn_indicators_cmd_ptr_->command;
   }
   pub_turn_indicators_report_->publish(msg);

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -909,7 +909,12 @@ void SimplePlanningSimulator::publish_turn_indicators_report()
   }
   TurnIndicatorsReport msg;
   msg.stamp = get_clock()->now();
-  msg.report = current_turn_indicators_cmd_ptr_->command;
+  if (current_turn_indicators_cmd_ptr_->command == TurnIndicatorsCommand::NO_COMMAND){
+    msg.report = TurnIndicatorsReport::DISABLE;
+  }
+  else{
+    msg.report = current_turn_indicators_cmd_ptr_->command;
+  }
   pub_turn_indicators_report_->publish(msg);
 }
 


### PR DESCRIPTION
## Description

The `TurnIndicatorsReport` msg has not `TurnIndicatorsCommand::NO_COMMAND`(0), but has only `TurnIndicatorsReport::DISABLE`(1). The simple_planning_simulator didn't convert this message properly.

This PR fixed this small bug.

## Related links

**Parent Issue:**

- Link
PR for scenario_simulator: https://github.com/tier4/scenario_simulator_v2/pull/1558
<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim:
![image](https://github.com/user-attachments/assets/14a1a2ea-d349-4635-814b-9182362f6774)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
