### PR TITLE
fix(agnocast_wrapper): separate message ptr types into unique and shared

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -18,7 +18,8 @@
 
 #include <agnocast/agnocast.hpp>
 
-#define AUTOWARE_MESSAGE_PTR(MessageT) agnocast::ipc_shared_ptr<MessageT>
+#define AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) agnocast::ipc_shared_ptr<MessageT>
+#define AUTOWARE_MESSAGE_SHARED_PTR(MessageT) agnocast::ipc_shared_ptr<MessageT>
 #define AUTOWARE_SUBSCRIPTION_PTR(MessageT) typename agnocast::Subscription<MessageT>::SharedPtr
 #define AUTOWARE_PUBLISHER_PTR(MessageT) typename agnocast::Publisher<MessageT>::SharedPtr
 
@@ -34,7 +35,8 @@
 #define AUTOWARE_SUBSCRIPTION_OPTIONS agnocast::SubscriptionOptions
 #define AUTOWARE_PUBLISHER_OPTIONS agnocast::PublisherOptions
 
-#define ALLOCATE_OUTPUT_MESSAGE(publisher) publisher->borrow_loaned_message()
+#define ALLOCATE_OUTPUT_MESSAGE_UNIQUE(publisher) publisher->borrow_loaned_message()
+#define ALLOCATE_OUTPUT_MESSAGE_SHARED(publisher) publisher->borrow_loaned_message()
 
 #else
 
@@ -44,7 +46,8 @@
 
 #include <memory>
 
-#define AUTOWARE_MESSAGE_PTR(MessageT) std::shared_ptr<MessageT>
+#define AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) std::unique_ptr<MessageT>
+#define AUTOWARE_MESSAGE_SHARED_PTR(MessageT) std::shared_ptr<MessageT>
 #define AUTOWARE_SUBSCRIPTION_PTR(MessageT) typename rclcpp::Subscription<MessageT>::SharedPtr
 #define AUTOWARE_PUBLISHER_PTR(MessageT) typename rclcpp::Publisher<MessageT>::SharedPtr
 
@@ -61,7 +64,9 @@
 #define AUTOWARE_SUBSCRIPTION_OPTIONS rclcpp::SubscriptionOptions
 #define AUTOWARE_PUBLISHER_OPTIONS rclcpp::PublisherOptions
 
-#define ALLOCATE_OUTPUT_MESSAGE(publisher) \
+#define ALLOCATE_OUTPUT_MESSAGE_UNIQUE(publisher) \
   std::make_unique<typename std::remove_reference<decltype(*publisher)>::type::ROSMessageType>()
+#define ALLOCATE_OUTPUT_MESSAGE_SHARED(publisher) \
+  std::make_shared<typename std::remove_reference<decltype(*publisher)>::type::ROSMessageType>()
 
 #endif


### PR DESCRIPTION
## Description

Separated `AUTOWARE_MESSAGE_PTR` and `ALLOCATE_OUTPUT_MESSAGE` into unique and shared ones.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
