### PR TITLE
fix(start_planner): fix segmentation fault when generating backward path

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -14,7 +14,6 @@
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/delete-closed-pr-docs.yaml
     - source: .github/workflows/deploy-docs.yaml
-    - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/pre-commit-optional-autoupdate.yaml

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -14,6 +14,7 @@
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/delete-closed-pr-docs.yaml
     - source: .github/workflows/deploy-docs.yaml
+    - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/pre-commit-optional-autoupdate.yaml

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
@@ -54,6 +54,11 @@ PathWithLaneId getBackwardPath(
     // forward center line path
     backward_path = route_handler.getCenterLinePath(shoulder_lanes, s_start, s_end, true);
 
+    // If the returned path is empty, return an empty path
+    if (backward_path.points.empty()) {
+      return backward_path;
+    }
+
     // backward center line path
     std::reverse(backward_path.points.begin(), backward_path.points.end());
     for (auto & p : backward_path.points) {


### PR DESCRIPTION
## Description

This PR resolves a critical issue in the `getBackwardPath` function where a segmentation fault occurs when route_handler.getCenterLinePath() returns an empty path.

### Changes

- Added an early return when the backward path is empty
- Prevents undefined behavior when trying to access elements of an empty container
- Resolves the node crash issue observed in real vehicle experiment

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-35983)

## How was this PR tested?

- [x] run psim and confirmed reported issue was fixed
- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/7bf13bd1-95a3-5c56-8600-950069737f3c?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
