### PR TITLE
feat(lidar_transfusion): add diagnostics for processing time

### DIFF
--- a/perception/autoware_lidar_transfusion/config/transfusion_common.param.yaml
+++ b/perception/autoware_lidar_transfusion/config/transfusion_common.param.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    # When the processing time exceeds the max_allowed_processing_time,
+    # a warning will be triggered.
+    diagnostics:
+      max_allowed_processing_time_ms: 200.0 # in milliseconds
+      # If the warning is triggered and if a timestamp of last normal processing is more than
+      # max_acceptable_consecutive_delay_ms, an error diagnostic message will be sent.
+      max_acceptable_consecutive_delay_ms: 1000.0
+      # interval of diagnostic callback in milliseconds
+      validation_callback_interval_ms: 100.0 # in milliseconds

--- a/perception/autoware_lidar_transfusion/config/transfusion_common.param.yaml
+++ b/perception/autoware_lidar_transfusion/config/transfusion_common.param.yaml
@@ -1,11 +1,6 @@
 /**:
   ros__parameters:
-    # When the processing time exceeds the max_allowed_processing_time,
-    # a warning will be triggered.
     diagnostics:
-      max_allowed_processing_time_ms: 200.0 # in milliseconds
-      # If the warning is triggered and if a timestamp of last normal processing is more than
-      # max_acceptable_consecutive_delay_ms, an error diagnostic message will be sent.
+      max_allowed_processing_time_ms: 200.0
       max_acceptable_consecutive_delay_ms: 1000.0
-      # interval of diagnostic callback in milliseconds
-      validation_callback_interval_ms: 100.0 # in milliseconds
+      validation_callback_interval_ms: 100.0

--- a/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/lidar_transfusion_node.hpp
+++ b/perception/autoware_lidar_transfusion/include/autoware/lidar_transfusion/lidar_transfusion_node.hpp
@@ -24,6 +24,7 @@
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
@@ -47,6 +48,8 @@ public:
 private:
   void cloudCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
 
+  void diagnoseProcessingTime(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::ConstSharedPtr cloud_sub_{nullptr};
   rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_{
     nullptr};
@@ -60,6 +63,14 @@ private:
   NonMaximumSuppression iou_bev_nms_;
 
   std::unique_ptr<TransfusionTRT> detector_ptr_{nullptr};
+
+  // for diagnostics
+  double max_allowed_processing_time_ms_;
+  double max_acceptable_consecutive_delay_ms_;
+  // set as optional to avoid sending error diagnostics before the node starts processing
+  std::optional<double> last_processing_time_ms_;
+  std::optional<rclcpp::Time> last_in_time_processing_timestamp_;
+  diagnostic_updater::Updater diagnostic_processing_time_updater_{this};
 
   // debugger
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{nullptr};

--- a/perception/autoware_lidar_transfusion/launch/lidar_transfusion.launch.xml
+++ b/perception/autoware_lidar_transfusion/launch/lidar_transfusion.launch.xml
@@ -8,6 +8,7 @@
   <arg name="model_param_path" default="$(find-pkg-share autoware_lidar_transfusion)/config/$(var model_name).param.yaml"/>
   <arg name="ml_package_param_path" default="$(var model_path)/$(var model_name)_ml_package.param.yaml"/>
   <arg name="class_remapper_param_path" default="$(find-pkg-share autoware_lidar_transfusion)/config/detection_class_remapper.param.yaml"/>
+  <arg name="common_param_path" default="$(find-pkg-share autoware_lidar_transfusion)/config/transfusion_common.param.yaml"/>
   <arg name="build_only" default="false" description="shutdown node after TensorRT engine file is built"/>
   <arg name="log_level" default="info"/>
 
@@ -22,6 +23,7 @@
         <param from="$(var model_param_path)" allow_substs="true"/>
         <param from="$(var ml_package_param_path)" allow_substs="true"/>
         <param from="$(var class_remapper_param_path)"/>
+        <param from="$(var common_param_path)"/>
 
         <!-- This parameter shall NOT be included in param file. See also: https://github.com/autowarefoundation/autoware_universe/pull/6167 -->
         <param name="build_only" value="$(var build_only)"/>
@@ -35,6 +37,7 @@
       <param from="$(var model_param_path)" allow_substs="true"/>
       <param from="$(var ml_package_param_path)" allow_substs="true"/>
       <param from="$(var class_remapper_param_path)"/>
+      <param from="$(var common_param_path)"/>
 
       <!-- This parameter shall NOT be included in param file. See also: https://github.com/autowarefoundation/autoware_universe/pull/6167 -->
       <param name="build_only" value="$(var build_only)"/>

--- a/perception/autoware_lidar_transfusion/schema/transfusion_common.schema.json
+++ b/perception/autoware_lidar_transfusion/schema/transfusion_common.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for TransFusion Diagnostics",
+  "type": "object",
+  "definitions": {
+    "transfusion_common": {
+      "type": "object",
+      "properties": {
+        "diagnostics": {
+          "type": "object",
+          "description": "Parameters for diagnostics.",
+          "properties": {
+            "max_allowed_processing_time_ms": {
+              "type": "number",
+              "description": "A threshold value for the allowed processing time. If the processing time exceeds this value, it will be considered a warning state. [ms]",
+              "default": 200.0,
+              "minimum": 0.0
+            },
+            "max_acceptable_consecutive_delay_ms": {
+              "type": "number",
+              "description": "A threshold value for the error state. If the duration since the last processing timestamp, which ended within max_allowed_processing_time_ms, exceeds this value, it will be considered an error state. [ms]",
+              "default": 1000.0,
+              "minimum": 0.0
+            },
+            "validation_callback_interval_ms": {
+              "type": "number",
+              "description": "An interval value for a timer callback that checks whether the current state meets the max_acceptable_consecutive_delay_ms condition. [ms]",
+              "default": 100.0,
+              "minimum": 1.0
+            }
+          }
+        }
+      },
+      "required": ["diagnostics"]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/transfusion_common"
+        }
+      },
+      "required": ["ros__parameters"]
+    }
+  },
+  "required": ["/**"]
+}

--- a/perception/autoware_lidar_transfusion/src/lidar_transfusion_node.cpp
+++ b/perception/autoware_lidar_transfusion/src/lidar_transfusion_node.cpp
@@ -114,12 +114,11 @@ LidarTransfusionNode::LidarTransfusionNode(const rclcpp::NodeOptions & options)
   // setup diagnostics
   {
     const double validation_callback_interval_ms =
-        declare_parameter<double>("diagnostics.validation_callback_interval_ms");
+      declare_parameter<double>("diagnostics.validation_callback_interval_ms");
 
     diagnostic_processing_time_updater_.setHardwareID(this->get_name());
     diagnostic_processing_time_updater_.add(
-      "processing_time_status", this,
-      &LidarTransfusionNode::diagnoseProcessingTime);
+      "processing_time_status", this, &LidarTransfusionNode::diagnoseProcessingTime);
     // msec -> sec
     diagnostic_processing_time_updater_.setPeriod(validation_callback_interval_ms / 1e3);
   }

--- a/perception/autoware_lidar_transfusion/src/lidar_transfusion_node.cpp
+++ b/perception/autoware_lidar_transfusion/src/lidar_transfusion_node.cpp
@@ -16,6 +16,8 @@
 
 #include "autoware/lidar_transfusion/utils.hpp"
 
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -90,6 +92,12 @@ LidarTransfusionNode::LidarTransfusionNode(const rclcpp::NodeOptions & options)
   detection_class_remapper_.setParameters(
     allow_remapping_by_area_matrix, min_area_matrix, max_area_matrix);
 
+  // diagnostics parameters
+  max_allowed_processing_time_ms_ =
+    declare_parameter<double>("diagnostics.max_allowed_processing_time_ms");
+  max_acceptable_consecutive_delay_ms_ =
+    declare_parameter<double>("diagnostics.max_acceptable_consecutive_delay_ms");
+
   auto trt_config = tensorrt_common::TrtCommonConfig(onnx_path, trt_precision, engine_path);
 
   detector_ptr_ = std::make_unique<TransfusionTRT>(trt_config, densification_param, config);
@@ -102,6 +110,19 @@ LidarTransfusionNode::LidarTransfusionNode(const rclcpp::NodeOptions & options)
     "~/output/objects", rclcpp::QoS(1));
 
   published_time_pub_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+
+  // setup diagnostics
+  {
+    const double validation_callback_interval_ms =
+        declare_parameter<double>("diagnostics.validation_callback_interval_ms");
+
+    diagnostic_processing_time_updater_.setHardwareID(this->get_name());
+    diagnostic_processing_time_updater_.add(
+      "processing_time_status", this,
+      &LidarTransfusionNode::diagnoseProcessingTime);
+    // msec -> sec
+    diagnostic_processing_time_updater_.setPeriod(validation_callback_interval_ms / 1e3);
+  }
 
   // initialize debug tool
   {
@@ -175,7 +196,64 @@ void LidarTransfusionNode::cloudCallback(const sensor_msgs::msg::PointCloud2::Co
       debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
         topic, time_ms);
     }
+
+    last_processing_time_ms_ = processing_time_ms;
   }
+}
+
+void LidarTransfusionNode::diagnoseProcessingTime(
+  diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  const rclcpp::Time timestamp_now = this->get_clock()->now();
+  diagnostic_msgs::msg::DiagnosticStatus::_level_type diag_level =
+    diagnostic_msgs::msg::DiagnosticStatus::OK;
+  std::stringstream message{"OK"};
+
+  // Check if the node has performed inference
+  if (last_processing_time_ms_) {
+    // check processing time is acceptable
+    if (last_processing_time_ms_ > max_allowed_processing_time_ms_) {
+      stat.add("is_processing_time_ms_in_expected_range", false);
+
+      message.clear();
+      message << "Processing time exceeds the acceptable limit of "
+              << max_allowed_processing_time_ms_ << " ms by "
+              << (last_processing_time_ms_.value() - max_allowed_processing_time_ms_) << " ms.";
+
+      // in case the processing starts with a delayed inference
+      if (!last_in_time_processing_timestamp_) {
+        last_in_time_processing_timestamp_ = timestamp_now;
+      }
+
+      diag_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    } else {
+      stat.add("is_processing_time_ms_in_expected_range", true);
+      last_in_time_processing_timestamp_ = timestamp_now;
+    }
+    stat.add("processing_time_ms", last_processing_time_ms_.value());
+
+    const double delayed_state_duration =
+      std::chrono::duration<double, std::milli>(
+        std::chrono::nanoseconds(
+          (timestamp_now - last_in_time_processing_timestamp_.value()).nanoseconds()))
+        .count();
+
+    // check consecutive delays
+    if (delayed_state_duration > max_acceptable_consecutive_delay_ms_) {
+      stat.add("is_consecutive_processing_delay_in_range", false);
+
+      message << " Processing delay has consecutively exceeded the acceptable limit continuously.";
+
+      diag_level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    } else {
+      stat.add("is_consecutive_processing_delay_in_range", true);
+    }
+    stat.add("consecutive_processing_delay_ms", delayed_state_duration);
+  } else {
+    message << "Waiting for the node to perform inference.";
+  }
+
+  stat.summary(diag_level, message.str());
 }
 
 }  // namespace autoware::lidar_transfusion


### PR DESCRIPTION
## Description
This PR adds processing time diagnostics.

If the processing time exceeds `max_allowed_processing_time_ms`, a warning topic will be published.

Consecutive delays will be also checked.
If the difference of two timestamp (current and last in-time processed timestamp) is larger than `max_acceptable_consecutive_delay_ms`, it will determine as an error state.

If the new processing time is below the `max_allowed_processing_time_ms`, it will update the timestamp of last in-time processed case.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested by checking the rqt_runtime_monitor.

Run rqt_runtime_monitor by
```sh
ros2 run rqt_runtime_monitor rqt_runtime_monitor
```

![Screenshot from 2025-04-04 15-36-39](https://github.com/user-attachments/assets/5f395231-5290-46a4-832c-65f85821d41a)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
