### PR TITLE
fix(autoware_path_optimizer): incorrect application of input velocity due to badly mapping output trajectory to input trajectory

### DIFF
--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -419,21 +419,20 @@ void PathOptimizer::applyInputVelocity(
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  const size_t ego_seg_idx =
-    trajectory_utils::findEgoSegmentIndex(input_traj_points, ego_pose, ego_nearest_param_);
-
   // trim to ego-pose
   const size_t ego_seg_idx_output_traj =
     trajectory_utils::findEgoSegmentIndex(output_traj_points, ego_pose, ego_nearest_param_);
+  output_traj_points = autoware::motion_utils::cropBackwardPoints(
+    output_traj_points, ego_pose.position, ego_seg_idx_output_traj,
+    traj_param_.output_backward_traj_length);
 
   // crop forward for faster calculation
   const auto forward_cropped_input_traj_points = [&]() {
     const double optimized_traj_length = mpt_optimizer_ptr_->getTrajectoryLength();
     constexpr double margin_traj_length = 10.0;
 
-    output_traj_points = std::vector<TrajectoryPoint>(
-      output_traj_points.begin() + ego_seg_idx_output_traj, output_traj_points.end());
-
+    const size_t ego_seg_idx =
+      trajectory_utils::findEgoSegmentIndex(input_traj_points, ego_pose, ego_nearest_param_);
     const auto cropped_points = autoware::motion_utils::cropForwardPoints(
       input_traj_points, ego_pose.position, ego_seg_idx,
       optimized_traj_length + margin_traj_length);

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -419,13 +419,21 @@ void PathOptimizer::applyInputVelocity(
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
+  const size_t ego_seg_idx =
+    trajectory_utils::findEgoSegmentIndex(input_traj_points, ego_pose, ego_nearest_param_);
+
+  // trim to ego-pose
+  const size_t ego_seg_idx_output_traj =
+    trajectory_utils::findEgoSegmentIndex(output_traj_points, ego_pose, ego_nearest_param_);
+
   // crop forward for faster calculation
   const auto forward_cropped_input_traj_points = [&]() {
     const double optimized_traj_length = mpt_optimizer_ptr_->getTrajectoryLength();
     constexpr double margin_traj_length = 10.0;
 
-    const size_t ego_seg_idx =
-      trajectory_utils::findEgoSegmentIndex(input_traj_points, ego_pose, ego_nearest_param_);
+    output_traj_points = std::vector<TrajectoryPoint>(
+      output_traj_points.begin() + ego_seg_idx_output_traj, output_traj_points.end());
+
     const auto cropped_points = autoware::motion_utils::cropForwardPoints(
       input_traj_points, ego_pose.position, ego_seg_idx,
       optimized_traj_length + margin_traj_length);


### PR DESCRIPTION
## Description
When applying the input velocity to the output of MPT, the initial pose of the output of MPT is used to trim the input trajectory. In certain cases when  there is a sharp U-turn, depending on the width of the adjacent, opposing lane into which Ego is turning into, the initial pose of the output trajectory may be mapped to a point in the opposing lane - leading to incorrect input velocity application.

This PR adds a yaw-thresholded closest-distance point search step to ensure that this doesn't occur and also trims the output of MPT to start from the current ego pose so that the initial pose of the MPT output will always map to a point within the current lane.
## Related links

**Parent Issue:**
https://tier4.atlassian.net/browse/RT0-35764

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Evaluator: https://evaluation.ci.tier4.jp/evaluation/reports/tables/new?catalog_id=095ae8b3-a23b-4a08-8674-10a681449693&filter=&job_id=4ce421ba-005b-5ca9-ae29-1f9a908a8733&project_id=prd_jt&table_config=date&target_ids=83c8bbb7-fdb5-53c8-ba72-4979a27e45b6

Failing tests are due to start-up delay - not caused due to changes
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
