### PR TITLE
fix(autoware_behavior_velocity_planner,motion_velocity_planner): missing grid map headers

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CMakeLists.txt
@@ -16,6 +16,14 @@ rclcpp_components_register_node(${PROJECT_NAME}_lib
   EXECUTABLE ${PROJECT_NAME}_node
 )
 
+find_package(grid_map_core REQUIRED)
+find_package(grid_map_ros REQUIRED)
+
+include_directories(
+  ${grid_map_core_INCLUDE_DIRS}
+  ${grid_map_ros_INCLUDE_DIRS}
+)
+
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
     test/test_node_interface.cpp

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/CMakeLists.txt
@@ -11,6 +11,14 @@ rosidl_generate_interfaces(
   DEPENDENCIES
 )
 
+find_package(grid_map_core REQUIRED)
+find_package(grid_map_ros REQUIRED)
+
+include_directories(
+  ${grid_map_core_INCLUDE_DIRS}
+  ${grid_map_ros_INCLUDE_DIRS}
+)
+
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED


### PR DESCRIPTION
## Description

I was creating Debian packages for Autoware in this [work](https://github.com/NEWSLabNTU/autoware-debian-packaging). The packaging was done using [bloom-generate](https://bloom.readthedocs.io/en/0.5.10/) to create packaging scripts and run generated scripts. It failed to compile `autoware_behavior_velocity_planner` and `motion_velocity_planner` on this error. 

```
fatal error: grid_map_core/eigen_plugins/FunctorsPlugin.hpp
``` 

The patch adds additional `find_package()` in `CMakeLists.txt` to fix this error. 

## Related links

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
