### PR TITLE
fix(autoware_traffic_light_visualization): add dependency `tinyxml2_vendor`

### DIFF
--- a/perception/autoware_traffic_light_visualization/CMakeLists.txt
+++ b/perception/autoware_traffic_light_visualization/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 find_package(OpenCV REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
 
 ament_auto_add_library(traffic_light_roi_visualizer SHARED
   src/traffic_light_roi_visualizer/node.cpp

--- a/perception/autoware_traffic_light_visualization/package.xml
+++ b/perception/autoware_traffic_light_visualization/package.xml
@@ -14,7 +14,6 @@
 
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_perception_msgs</depend>
-  <depend>tinyxml2_vendor</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
   <depend>message_filters</depend>
@@ -22,6 +21,7 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>tier4_perception_msgs</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/autoware_traffic_light_visualization/package.xml
+++ b/perception/autoware_traffic_light_visualization/package.xml
@@ -14,6 +14,7 @@
 
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>tinyxml2_vendor</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
   <depend>message_filters</depend>


### PR DESCRIPTION
## Description

This PR adds dependency `tinyxml2_vendor`. If there is not, it is impossible to build.

But I am not sure it is good to merge this PR or not.

- https://github.com/autowarefoundation/autoware_universe/issues/10410
- https://github.com/autowarefoundation/autoware_cmake/pull/24


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.ci.tier4.jp/evaluation/reports/cc26fa9f-db5c-5eeb-b037-1a0e76189f65?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
