### PR TITLE
feat(control_validator): add over run estimation feature

### DIFF
--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -57,12 +57,15 @@ The following parameters can be set for the `control_validator`:
 
 The input trajectory is detected as invalid if the index exceeds the following thresholds.
 
-| Name                                 | Type   | Description                                                                                                 | Default value |
-| :----------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
-| `thresholds.max_distance_deviation`  | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
-| `thresholds.rolling_back_velocity`   | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | 0.5           |
-| `thresholds.over_velocity_offset`    | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
-| `thresholds.over_velocity_ratio`     | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |
-| `thresholds.overrun_stop_point_dist` | double | threshold distance to overrun stop point [m]                                                                | 0.8           |
-| `thresholds.acc_error_offset`        | double | threshold ratio to valid the vehicle acceleration [*]                                                       | 0.8           |
-| `thresholds.acc_error_scale`         | double | threshold acceleration to valid the vehicle acceleration [m]                                                | 0.2           |
+| Name                                      | Type   | Description                                                                                                 | Default value |
+| :---------------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
+| `thresholds.max_distance_deviation`       | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
+| `thresholds.rolling_back_velocity`        | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | 0.5           |
+| `thresholds.over_velocity_offset`         | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
+| `thresholds.over_velocity_ratio`          | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |
+| `thresholds.overrun_stop_point_dist`      | double | threshold distance to overrun stop point [m]                                                                | 0.8           |
+| `thresholds.acc_error_offset`             | double | threshold ratio to valid the vehicle acceleration [*]                                                       | 0.8           |
+| `thresholds.acc_error_scale`              | double | threshold acceleration to valid the vehicle acceleration [m]                                                | 0.2           |
+| `thresholds.will_overrun_stop_point_dist` | double | threshold distance to overrun stop point [m]                                                                | 1.0           |
+| `thresholds.assumed_limit_acc`            | double | assumed acceleration for over run estimation [m]                                                            | 5.0           |
+| `thresholds.assumed_delay_time`           | double | assumed delay for over run estimation [m]                                                                   | 0.2           |

--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -13,6 +13,7 @@ The listed features below does not always correspond to the latest implementatio
 | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | :---------------------------------------------------: |
 | Inverse velocity: Measured velocity has a different sign from the target velocity. | measured velocity $v$, target velocity $\hat{v}$, and velocity parameter $c$                    |      $v \hat{v} < 0, \quad \lvert v \rvert > c$       |
 | Overspeed: Measured speed exceeds target speed significantly.                      | measured velocity $v$, target velocity $\hat{v}$, ratio parameter $r$, and offset parameter $c$ | $\lvert v \rvert > (1 + r) \lvert \hat{v} \rvert + c$ |
+| Overrun estimation: estimate overrun even if decelerate by assumed rate.           | assumed deceleration, assumed delay                                                             |                                                       |
 
 - **Deviation check between reference trajectory and predicted trajectory** : invalid when the largest deviation between the predicted trajectory and reference trajectory is greater than the given threshold.
 

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -15,6 +15,9 @@
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
       overrun_stop_point_dist: 0.8
+      will_overrun_stop_point_dist: 1.0
+      assumed_limit_acc: 5.0
+      assumed_delay_time: 0.2
       nominal_latency: 0.01
 
     acc_lpf_gain: 0.97 # Time constant 1.11s

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -156,6 +156,12 @@ public:
   explicit OverrunValidator(rclcpp::Node & node)
   : overrun_stop_point_dist_th{autoware_utils::get_or_declare_parameter<double>(
       node, "thresholds.overrun_stop_point_dist")},
+    will_overrun_stop_point_dist_th{autoware_utils::get_or_declare_parameter<double>(
+      node, "thresholds.will_overrun_stop_point_dist")},
+    assumed_limit_acc{
+      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.assumed_limit_acc")},
+    assumed_delay_time{
+      autoware_utils::get_or_declare_parameter<double>(node, "thresholds.assumed_delay_time")},
     vehicle_vel_lpf{autoware_utils::get_or_declare_parameter<double>(node, "vel_lpf_gain")} {};
 
   void validate(
@@ -164,6 +170,9 @@ public:
 
 private:
   const double overrun_stop_point_dist_th;
+  const double will_overrun_stop_point_dist_th;
+  const double assumed_limit_acc;
+  const double assumed_delay_time;
   autoware::signal_processing::LowpassFilter1d vehicle_vel_lpf;
 };
 

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -6,6 +6,7 @@ bool is_valid_acc
 bool is_rolling_back
 bool is_over_velocity
 bool has_overrun_stop_point
+bool will_overrun_stop_point
 bool is_valid_latency
 
 # values
@@ -15,6 +16,7 @@ float64 measured_acc
 float64 target_vel
 float64 vehicle_vel
 float64 dist_to_stop
+float64 pred_dist_to_stop
 float64 nearest_trajectory_vel
 float64 latency
 

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -122,6 +122,14 @@ void OverrunValidator::validate(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps;
 
+  /*
+  res.dist_to_stop: distance to stop according to the trajectory.
+  v_vel * assumed_delay_time : distance ego will travel before starting the limit deceleration.
+  v_vel * v_vel / (2.0 * assumed_limit_acc): distance to stop assuming we apply the limit
+  deceleration.
+  if res.pred_dist_to_stop is negative, it means that we predict we will stop after the stop point
+  contained in the trajectory.
+  */
   const double v_vel = vehicle_vel_lpf.filter(kinematics.twist.twist.linear.x);
   res.pred_dist_to_stop =
     res.dist_to_stop - v_vel * assumed_delay_time - v_vel * v_vel / (2.0 * assumed_limit_acc);
@@ -237,7 +245,7 @@ void ControlValidator::setup_diag()
   });
   d.add(ns + "will_overrun_stop_point", [&](auto & stat) {
     set_status(
-      stat, !validation_status_.has_overrun_stop_point,
+      stat, !validation_status_.will_overrun_stop_point,
       "In a few seconds ago, the vehicle will overrun the front stop point on the trajectory.");
   });
 


### PR DESCRIPTION
## Description
To guarantee DO NOT overrun the stop points or the goal point, this PR adds a new validation fetature.
The node publish error diag for the cases which the ego will overrun the stop points even if the ego decelerate by assumed deceleration value.
https://github.com/autowarefoundation/autoware_universe/pull/10422/files#diff-492e13c1cee80cc9825bff55dc294565ae2382b5e117a5f7f0cc03512280b08fR126-R127

## Related links
https://github.com/autowarefoundation/autoware_launch/pull/1394

**Parent Issue:**

- Link


## How was this PR tested?
With connnecting MRM,
- engage available in psim 
- tier4 internal DLR tests
- tier4 internal scenario tests


## Notes for reviewers

None.

## Interface changes

None.

<

## Effects on system behavior

None.
