### PR TITLE
feat(autoware_multi_object_tracker): vehicle's ego frame as a parameter

### DIFF
--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -12,6 +12,7 @@
     # default tracker node parameters
     publish_rate: 10.0
     world_frame_id: map
+    ego_frame_id: base_link
     enable_delay_compensation: false
     consider_odometry_uncertainty: false
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
@@ -36,7 +36,7 @@ class Odometry
 {
 public:
   Odometry(
-    rclcpp::Node & node, const std::string & world_frame_id,
+    rclcpp::Node & node, const std::string & world_frame_id, const std::string & ego_frame_id,
     bool enable_odometry_uncertainty = false);
 
   std::optional<geometry_msgs::msg::Transform> getTransform(
@@ -51,8 +51,8 @@ public:
 private:
   rclcpp::Node & node_;
   // frame id
-  std::string ego_frame_id_ = "base_link";  // ego vehicle frame
-  std::string world_frame_id_;              // absolute/relative ground frame
+  std::string ego_frame_id_;    // ego vehicle frame
+  std::string world_frame_id_;  // absolute/relative ground frame
   // tf
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;

--- a/perception/autoware_multi_object_tracker/lib/odometry.cpp
+++ b/perception/autoware_multi_object_tracker/lib/odometry.cpp
@@ -27,8 +27,10 @@ namespace autoware::multi_object_tracker
 {
 
 Odometry::Odometry(
-  rclcpp::Node & node, const std::string & world_frame_id, bool enable_odometry_uncertainty)
+  rclcpp::Node & node, const std::string & world_frame_id, const std::string & ego_frame_id,
+  bool enable_odometry_uncertainty)
 : node_(node),
+  ego_frame_id_(ego_frame_id),
   world_frame_id_(world_frame_id),
   tf_buffer_(node_.get_clock()),
   tf_listener_(tf_buffer_),

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -51,6 +51,11 @@
           "description": "Object kinematics definition frame.",
           "default": "map"
         },
+        "ego_frame_id": {
+          "type": "string",
+          "description": "Vehicle's ego frame.",
+          "default": "base_link"
+        },
         "enable_delay_compensation": {
           "type": "boolean",
           "description": "If True, tracker use timers to schedule publishers and use prediction step to extrapolate object state at desired timestamp.",
@@ -172,6 +177,7 @@
         "motorcycle_tracker",
         "publish_rate",
         "world_frame_id",
+        "ego_frame_id",
         "enable_delay_compensation",
         "consider_odometry_uncertainty",
         "tracker_lifetime",

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -57,6 +57,7 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   // Get parameters
   double publish_rate = declare_parameter<double>("publish_rate");  // [hz]
   world_frame_id_ = declare_parameter<std::string>("world_frame_id");
+  std::string ego_frame_id = declare_parameter<std::string>("ego_frame_id");
   bool enable_delay_compensation{declare_parameter<bool>("enable_delay_compensation")};
   bool enable_odometry_uncertainty = declare_parameter<bool>("consider_odometry_uncertainty");
 
@@ -69,7 +70,8 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
     create_publisher<autoware_perception_msgs::msg::TrackedObjects>("output", rclcpp::QoS{1});
 
   // Odometry manager
-  odometry_ = std::make_shared<Odometry>(*this, world_frame_id_, enable_odometry_uncertainty);
+  odometry_ =
+    std::make_shared<Odometry>(*this, world_frame_id_, ego_frame_id, enable_odometry_uncertainty);
 
   // ROS interface - Input channels
   // Get input channels configuration


### PR DESCRIPTION
## Description

Solves https://github.com/autowarefoundation/autoware_universe/issues/10427.

Related PR: https://github.com/autowarefoundation/autoware_launch/pull/1397.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
