### PR TITLE
chore(autoware_planning_evaluator): record goal_stop_deviation only when ego stop

### DIFF
--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -387,7 +387,10 @@ void PlanningEvaluatorNode::onModifiedGoal(
       continue;
     }
     AddMetricMsg(metric, *metric_stat);
-    if (output_metrics_) {
+    if (output_metrics_ 
+      && ego_state_ptr->twist.twist.linear.x < 0.01
+      && metric_stat->mean() < 3.0
+    ) { // only record when ego stop close to the target in 3m
       const OutputMetric output_metric = str_to_output_metric.at(metric_to_str.at(metric));
       metrics_accumulator_.accumulate(output_metric, *metric_stat);
     }

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -388,7 +388,7 @@ void PlanningEvaluatorNode::onModifiedGoal(
     }
     AddMetricMsg(metric, *metric_stat);
     if (output_metrics_ 
-      && ego_state_ptr->twist.twist.linear.x < 0.01
+      && ego_state_ptr->twist.twist.linear.x < 0.001
       && metric_stat->mean() < 3.0
     ) { // only record when ego stop close to the target in 3m
       const OutputMetric output_metric = str_to_output_metric.at(metric_to_str.at(metric));

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -26,6 +26,7 @@
 #include "boost/lexical_cast.hpp"
 
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -387,10 +388,9 @@ void PlanningEvaluatorNode::onModifiedGoal(
       continue;
     }
     AddMetricMsg(metric, *metric_stat);
-    if (output_metrics_ 
-      && ego_state_ptr->twist.twist.linear.x < 0.001
-      && metric_stat->mean() < 3.0
-    ) { // only record when ego stop close to the target in 3m
+    if (
+      output_metrics_ && std::abs(ego_state_ptr->twist.twist.linear.x) < 0.001 &&
+      metric_stat->mean() < 3.0) {  // only record when ego stop close to the target in 3m
       const OutputMetric output_metric = str_to_output_metric.at(metric_to_str.at(metric));
       metrics_accumulator_.accumulate(output_metric, *metric_stat);
     }


### PR DESCRIPTION
## Description
This PR makes a small change to record modified_goal related output_metrics only when the ego stops close to the goal. 
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
