### PR TITLE
feat(radar_object_tracker): add diagnostics for checking radar input status

### DIFF
--- a/perception/autoware_radar_object_tracker/config/radar_object_tracker.param.yaml
+++ b/perception/autoware_radar_object_tracker/config/radar_object_tracker.param.yaml
@@ -32,4 +32,4 @@
       # When the elapsed time from last radar data input exceeds the radar_input_stale_threshold_ms,
       # a warning will be triggered.
       radar_input_stale_threshold_ms: 500.0 # [milliseconds]
-      validation_callback_interval_ms: 100.0 # [milliseconds]
+      diagnose_callback_interval: 100.0 # [milliseconds]

--- a/perception/autoware_radar_object_tracker/config/radar_object_tracker.param.yaml
+++ b/perception/autoware_radar_object_tracker/config/radar_object_tracker.param.yaml
@@ -31,5 +31,5 @@
     diagnostics:
       # When the elapsed time from last radar data input exceeds the radar_data_stale_threshold_ms,
       # a warning will be triggered.
-      radar_data_stale_threshold_ms: 500.0 # [milliseconds]
+      radar_input_stale_threshold_ms: 500.0 # [milliseconds]
       validation_callback_interval_ms: 100.0 # [milliseconds]

--- a/perception/autoware_radar_object_tracker/config/radar_object_tracker.param.yaml
+++ b/perception/autoware_radar_object_tracker/config/radar_object_tracker.param.yaml
@@ -27,3 +27,9 @@
 
     # tracking model parameters
     tracking_config_directory: $(find-pkg-share radar_object_tracker)/config/tracking/
+
+    diagnostics:
+      # When the elapsed time from last radar data input exceeds the radar_data_stale_threshold_ms,
+      # a warning will be triggered.
+      radar_data_stale_threshold_ms: 500.0 # [milliseconds]
+      validation_callback_interval_ms: 100.0 # [milliseconds]

--- a/perception/autoware_radar_object_tracker/config/radar_object_tracker.param.yaml
+++ b/perception/autoware_radar_object_tracker/config/radar_object_tracker.param.yaml
@@ -29,7 +29,7 @@
     tracking_config_directory: $(find-pkg-share radar_object_tracker)/config/tracking/
 
     diagnostics:
-      # When the elapsed time from last radar data input exceeds the radar_data_stale_threshold_ms,
+      # When the elapsed time from last radar data input exceeds the radar_input_stale_threshold_ms,
       # a warning will be triggered.
       radar_input_stale_threshold_ms: 500.0 # [milliseconds]
       validation_callback_interval_ms: 100.0 # [milliseconds]

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
@@ -128,8 +128,8 @@ RadarObjectTrackerNode::RadarObjectTrackerNode(const rclcpp::NodeOptions & node_
     std::make_pair(Label::MOTORCYCLE, this->declare_parameter<std::string>("motorcycle_tracker")));
 
   {  // diagnostics
-    radar_data_stale_th_ms_ =
-      declare_parameter<double>("diagnostics.radar_data_stale_threshold_ms");
+    radar_input_stale_threshold_ms_ =
+      declare_parameter<double>("diagnostics.radar_input_stale_threshold_ms");
     const double validation_callback_interval_ms =
       declare_parameter<double>("diagnostics.validation_callback_interval_ms");
 

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
@@ -126,6 +126,19 @@ RadarObjectTrackerNode::RadarObjectTrackerNode(const rclcpp::NodeOptions & node_
     std::make_pair(Label::BICYCLE, this->declare_parameter<std::string>("bicycle_tracker")));
   tracker_map_.insert(
     std::make_pair(Label::MOTORCYCLE, this->declare_parameter<std::string>("motorcycle_tracker")));
+
+  { // diagnostics
+    radar_data_stale_th_ms_ =
+      declare_parameter<double>("diagnostics.radar_data_stale_threshold_ms");
+    const double validation_callback_interval_ms =
+      declare_parameter<double>("diagnostics.validation_callback_interval_ms");
+
+    diagnostic_updater_.setHardwareID(this->get_name());
+    diagnostic_updater_.add(
+      "radar_input_status", this, &RadarObjectTrackerNode::diagnoseRadarInputInterval);
+    // msec -> sec
+    diagnostic_updater_.setPeriod(validation_callback_interval_ms / 1e3);
+  }
 }
 
 // load map information to node parameter
@@ -154,6 +167,10 @@ void RadarObjectTrackerNode::onMeasurement(
         *input_objects_msg, world_frame_id_, tf_buffer_, transformed_objects)) {
     return;
   }
+
+  // track timestamp for diagnosis
+  last_processing_timestamp_ = this->now();
+
   /* tracker prediction */
   rclcpp::Time measurement_time = input_objects_msg->header.stamp;
   for (auto itr = list_tracker_.begin(); itr != list_tracker_.end(); ++itr) {
@@ -424,6 +441,39 @@ void RadarObjectTrackerNode::publish(const rclcpp::Time & time) const
 
   // Publish
   tracked_objects_pub_->publish(output_msg);
+}
+
+void RadarObjectTrackerNode::diagnoseRadarInputInterval(
+  diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  const rclcpp::Time timestamp_now = this->get_clock()->now();
+  diagnostic_msgs::msg::DiagnosticStatus::_level_type diag_level =
+    diagnostic_msgs::msg::DiagnosticStatus::OK;
+  std::stringstream message{"OK"};
+
+  if (last_processing_timestamp_) { // Check if the first input arrived
+    const double elapsed_since_last_input_ms =
+      std::chrono::duration<double, std::milli>(
+        std::chrono::nanoseconds(
+          (timestamp_now - last_processing_timestamp_.value()).nanoseconds()))
+        .count();
+
+    if (elapsed_since_last_input_ms > radar_data_stale_th_ms_) {
+      stat.add("is_radar_input_alive", false);
+
+      message.clear();
+      message << "The duration of radar input since the last reception has exceeded"
+        << " the stale threshold " << radar_data_stale_th_ms_ << " ms by"
+        << elapsed_since_last_input_ms - radar_data_stale_th_ms_ << " ms.";
+
+      diag_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    } else {
+      stat.add("is_radar_input_alive", true);
+    }
+    stat.add("elapsed_time_since_last_input_ms", elapsed_since_last_input_ms);
+  }
+
+  stat.summary(diag_level, message.str());
 }
 }  // namespace autoware::radar_object_tracker
 

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
@@ -464,7 +464,7 @@ void RadarObjectTrackerNode::diagnoseRadarInputInterval(
       message.clear();
       message << "The duration of radar input since the last reception has exceeded"
               << " the stale threshold " << radar_input_stale_threshold_ms_ << " ms by "
-              << elapsed_since_last_input_ms - radar_data_stale_th_ms_ << " ms.";
+              << elapsed_since_last_input_ms - radar_input_stale_threshold_ms_ << " ms.";
 
       diag_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
     } else {

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
@@ -130,14 +130,14 @@ RadarObjectTrackerNode::RadarObjectTrackerNode(const rclcpp::NodeOptions & node_
   {  // diagnostics
     radar_input_stale_threshold_ms_ =
       declare_parameter<double>("diagnostics.radar_input_stale_threshold_ms");
-    const double validation_callback_interval_ms =
-      declare_parameter<double>("diagnostics.validation_callback_interval_ms");
+    const double diagnose_callback_interval =
+      declare_parameter<double>("diagnostics.diagnose_callback_interval");
 
     diagnostic_updater_.setHardwareID(this->get_name());
     diagnostic_updater_.add(
       "radar_input_status", this, &RadarObjectTrackerNode::diagnoseRadarInputInterval);
     // msec -> sec
-    diagnostic_updater_.setPeriod(validation_callback_interval_ms / 1e3);
+    diagnostic_updater_.setPeriod(diagnose_callback_interval / 1e3);
   }
 }
 

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
@@ -127,7 +127,7 @@ RadarObjectTrackerNode::RadarObjectTrackerNode(const rclcpp::NodeOptions & node_
   tracker_map_.insert(
     std::make_pair(Label::MOTORCYCLE, this->declare_parameter<std::string>("motorcycle_tracker")));
 
-  { // diagnostics
+  {  // diagnostics
     radar_data_stale_th_ms_ =
       declare_parameter<double>("diagnostics.radar_data_stale_threshold_ms");
     const double validation_callback_interval_ms =
@@ -451,7 +451,7 @@ void RadarObjectTrackerNode::diagnoseRadarInputInterval(
     diagnostic_msgs::msg::DiagnosticStatus::OK;
   std::stringstream message{"OK"};
 
-  if (last_processing_timestamp_) { // Check if the first input arrived
+  if (last_processing_timestamp_) {  // Check if the first input arrived
     const double elapsed_since_last_input_ms =
       std::chrono::duration<double, std::milli>(
         std::chrono::nanoseconds(
@@ -463,8 +463,8 @@ void RadarObjectTrackerNode::diagnoseRadarInputInterval(
 
       message.clear();
       message << "The duration of radar input since the last reception has exceeded"
-        << " the stale threshold " << radar_data_stale_th_ms_ << " ms by"
-        << elapsed_since_last_input_ms - radar_data_stale_th_ms_ << " ms.";
+              << " the stale threshold " << radar_data_stale_th_ms_ << " ms by"
+              << elapsed_since_last_input_ms - radar_data_stale_th_ms_ << " ms.";
 
       diag_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
     } else {

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
@@ -458,7 +458,7 @@ void RadarObjectTrackerNode::diagnoseRadarInputInterval(
           (timestamp_now - last_processing_timestamp_.value()).nanoseconds()))
         .count();
 
-    if (elapsed_since_last_input_ms > radar_data_stale_th_ms_) {
+    if (elapsed_since_last_input_ms > radar_input_stale_threshold_ms_) {
       stat.add("is_radar_input_alive", false);
 
       message.clear();

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.cpp
@@ -463,7 +463,7 @@ void RadarObjectTrackerNode::diagnoseRadarInputInterval(
 
       message.clear();
       message << "The duration of radar input since the last reception has exceeded"
-              << " the stale threshold " << radar_data_stale_th_ms_ << " ms by"
+              << " the stale threshold " << radar_input_stale_threshold_ms_ << " ms by "
               << elapsed_since_last_input_ms - radar_data_stale_th_ms_ << " ms.";
 
       diag_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.hpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.hpp
@@ -116,7 +116,7 @@ private:
   // lanelet::ConstLanelets crosswalks_;
 
   // diagnostics
-  double radar_data_stale_th_ms_;
+  double radar_input_stale_threshold_ms_;
   std::optional<rclcpp::Time> last_processing_timestamp_;
   diagnostic_updater::Updater diagnostic_updater_{this};
 

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.hpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.hpp
@@ -137,8 +137,7 @@ private:
   void publish(const rclcpp::Time & time) const;
   inline bool shouldTrackerPublish(const std::shared_ptr<const Tracker> tracker) const;
 
-  void diagnoseRadarInputInterval(
-    diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void diagnoseRadarInputInterval(diagnostic_updater::DiagnosticStatusWrapper & stat);
 };
 
 }  // namespace autoware::radar_object_tracker

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.hpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.hpp
@@ -20,6 +20,7 @@
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
@@ -114,6 +115,11 @@ private:
   // Crosswalk Entry Points
   // lanelet::ConstLanelets crosswalks_;
 
+  // diagnostics
+  double radar_data_stale_th_ms_;
+  std::optional<rclcpp::Time> last_processing_timestamp_;
+  diagnostic_updater::Updater diagnostic_updater_{this};
+
   void checkTrackerLifeCycle(
     std::list<std::shared_ptr<Tracker>> & list_tracker, const rclcpp::Time & time,
     const geometry_msgs::msg::Transform & self_transform);
@@ -130,6 +136,9 @@ private:
 
   void publish(const rclcpp::Time & time) const;
   inline bool shouldTrackerPublish(const std::shared_ptr<const Tracker> tracker) const;
+
+  void diagnoseRadarInputInterval(
+    diagnostic_updater::DiagnosticStatusWrapper & stat);
 };
 
 }  // namespace autoware::radar_object_tracker


### PR DESCRIPTION
## Description
This PR adds a diagnostic to radar_object_tracker to check the radar topic arrives within a specified period.

`radar_data_stale_threshold_ms` will determine radar topic input is alive.
If the duration since last process time exceeds `radar_data_stale_threshold_ms`, it will send a warning.

This must merge with https://github.com/autowarefoundation/autoware_launch/pull/1399

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested by checking the rqt_runtime_monitor.

Run rqt_runtime_monitor by
```sh
ros2 run rqt_runtime_monitor rqt_runtime_monitor
```

![sample_radar_object_tracker_diag](https://github.com/user-attachments/assets/2d211fba-8643-4849-b2c3-30c53ab7c7d4)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
