### PR TITLE
fix(control_evaluator): fix bugs about output_metrics

### DIFF
--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -73,12 +73,10 @@ public:
   explicit ControlEvaluatorNode(const rclcpp::NodeOptions & node_options);
   ~ControlEvaluatorNode() override;
 
-  void AddMetricMsg(const Metric & metric, const double & metric_value);
+  void AddMetricMsg(const Metric & metric, const double & metric_value, const bool & accumulate_metric = true);
   void AddLateralDeviationMetricMsg(const Trajectory & traj, const Point & ego_point);
   void AddYawDeviationMetricMsg(const Trajectory & traj, const Pose & ego_pose);
-  void AddGoalLongitudinalDeviationMetricMsg(const Pose & ego_pose);
-  void AddGoalLateralDeviationMetricMsg(const Pose & ego_pose);
-  void AddGoalYawDeviationMetricMsg(const Pose & ego_pose);
+  void AddGoalDeviationMetricMsg(const Odometry & odom);
   void AddBoundaryDistanceMetricMsg(const PathWithLaneId & behavior_path, const Pose & ego_pose);
 
   void AddLaneletInfoMsg(const Pose & ego_pose);

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -23,6 +23,7 @@
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_math/accumulator.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -73,7 +74,8 @@ public:
   explicit ControlEvaluatorNode(const rclcpp::NodeOptions & node_options);
   ~ControlEvaluatorNode() override;
 
-  void AddMetricMsg(const Metric & metric, const double & metric_value, const bool & accumulate_metric = true);
+  void AddMetricMsg(
+    const Metric & metric, const double & metric_value, const bool & accumulate_metric = true);
   void AddLateralDeviationMetricMsg(const Trajectory & traj, const Point & ego_point);
   void AddYawDeviationMetricMsg(const Trajectory & traj, const Pose & ego_pose);
   void AddGoalDeviationMetricMsg(const Odometry & odom);
@@ -83,8 +85,7 @@ public:
   void AddKinematicStateMetricMsg(
     const Odometry & odom, const AccelWithCovarianceStamped & accel_stamped);
   void AddSteeringMetricMsg(const SteeringReport & steering_report);
-  void AddStopDeviationMetricMsg(
-    const PlanningFactorArray::ConstSharedPtr & planning_factors, const std::string & module_name);
+  void AddStopDeviationMetricMsg(const Odometry & odom);
   void onTimer();
 
 private:
@@ -106,6 +107,7 @@ private:
   std::unordered_map<
     std::string, autoware_utils::InterProcessPollingSubscriber<PlanningFactorArray>>
     planning_factors_sub_;
+  std::unordered_map<std::string, Accumulator<double>> stop_deviation_accumulators_;
   std::unordered_set<std::string> stop_deviation_modules_;
 
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
@@ -121,6 +123,9 @@ private:
   // Metric
   const std::vector<Metric> metrics_ = {
     // collect all metrics
+    Metric::velocity,
+    Metric::acceleration,
+    Metric::jerk,
     Metric::lateral_deviation,
     Metric::yaw_deviation,
     Metric::goal_longitudinal_deviation,
@@ -131,6 +136,7 @@ private:
     Metric::steering_angle,
     Metric::steering_rate,
     Metric::steering_acceleration,
+    Metric::stop_deviation,
   };
 
   std::array<Accumulator<double>, static_cast<size_t>(Metric::SIZE)>

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
@@ -26,6 +26,9 @@ namespace control_diagnostics
  * @brief Enumeration of trajectory metrics
  */
 enum class Metric {
+  velocity,
+  acceleration,
+  jerk,
   lateral_deviation,
   yaw_deviation,
   goal_longitudinal_deviation,
@@ -41,6 +44,9 @@ enum class Metric {
 };
 
 static const std::unordered_map<std::string, Metric> str_to_metric = {
+  {"velocity", Metric::velocity},
+  {"acceleration", Metric::acceleration},
+  {"jerk", Metric::jerk},
   {"lateral_deviation", Metric::lateral_deviation},
   {"yaw_deviation", Metric::yaw_deviation},
   {"goal_longitudinal_deviation", Metric::goal_longitudinal_deviation},
@@ -55,6 +61,9 @@ static const std::unordered_map<std::string, Metric> str_to_metric = {
 };
 
 static const std::unordered_map<Metric, std::string> metric_to_str = {
+  {Metric::velocity, "velocity"},
+  {Metric::acceleration, "acceleration"},
+  {Metric::jerk, "jerk"},
   {Metric::lateral_deviation, "lateral_deviation"},
   {Metric::yaw_deviation, "yaw_deviation"},
   {Metric::goal_longitudinal_deviation, "goal_longitudinal_deviation"},
@@ -70,6 +79,9 @@ static const std::unordered_map<Metric, std::string> metric_to_str = {
 
 // Metrics descriptions
 static const std::unordered_map<Metric, std::string> metric_descriptions = {
+  {Metric::velocity, "Velocity[m/s]"},
+  {Metric::acceleration, "Acceleration[m/s^2]"},
+  {Metric::jerk, "Jerk[m/s^3]"},
   {Metric::lateral_deviation, "Lateral deviation from the reference trajectory[m]"},
   {Metric::yaw_deviation, "Yaw deviation from the reference trajectory[rad]"},
   {Metric::goal_longitudinal_deviation, "Longitudinal deviation from the goal point[m]"},

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -347,7 +347,7 @@ void ControlEvaluatorNode::AddGoalDeviationMetricMsg(const Odometry & odom)
 
 void ControlEvaluatorNode::AddStopDeviationMetricMsg(const Odometry & odom)
 {
-  auto get_min_distance =
+  const auto get_min_distance =
     [](const PlanningFactorArray::ConstSharedPtr & planning_factors) -> std::optional<double> {
     std::optional<double> min_distance = std::nullopt;
     for (const auto & factor : planning_factors->factors) {
@@ -372,7 +372,7 @@ void ControlEvaluatorNode::AddStopDeviationMetricMsg(const Odometry & odom)
       stop_deviation_modules_.count(module_name) == 0) {
       continue;
     }
-    auto min_distance = get_min_distance(planning_factors);
+    const auto min_distance = get_min_distance(planning_factors);
     if (min_distance) {
       min_distances.emplace_back(module_name, *min_distance);
     }
@@ -382,7 +382,7 @@ void ControlEvaluatorNode::AddStopDeviationMetricMsg(const Odometry & odom)
   }
 
   // find the stop decision closest to the ego, accumulate its metric
-  auto min_distance_pair = std::min_element(
+  const auto min_distance_pair = std::min_element(
     min_distances.begin(), min_distances.end(),
     [](const auto & a, const auto & b) { return a.second < b.second; });
 

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -227,17 +227,10 @@ void ControlEvaluatorNode::AddBoundaryDistanceMetricMsg(
 void ControlEvaluatorNode::AddKinematicStateMetricMsg(
   const Odometry & odom, const AccelWithCovarianceStamped & accel_stamped)
 {
-  const std::string base_name = "kinematic_state/";
-  MetricMsg metric_msg;
+  AddMetricMsg(Metric::velocity, odom.twist.twist.linear.x);
 
-  metric_msg.name = base_name + "vel";
-  metric_msg.value = std::to_string(odom.twist.twist.linear.x);
-  metrics_msg_.metric_array.push_back(metric_msg);
-
-  metric_msg.name = base_name + "acc";
   const auto & acc = accel_stamped.accel.accel.linear.x;
-  metric_msg.value = std::to_string(acc);
-  metrics_msg_.metric_array.push_back(metric_msg);
+  AddMetricMsg(Metric::acceleration, acc);
 
   const auto jerk = [&]() {
     if (!prev_acc_stamped_.has_value()) {
@@ -255,11 +248,7 @@ void ControlEvaluatorNode::AddKinematicStateMetricMsg(
     prev_acc_stamped_ = accel_stamped;
     return (acc - prev_acc) / dt;
   }();
-
-  metric_msg.name = base_name + "jerk";
-  metric_msg.value = std::to_string(jerk);
-  metrics_msg_.metric_array.push_back(metric_msg);
-  return;
+  AddMetricMsg(Metric::jerk, jerk);
 }
 
 void ControlEvaluatorNode::AddSteeringMetricMsg(const SteeringReport & steering_status)

--- a/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
@@ -261,7 +261,7 @@ TEST_F(EvalTest, TestLateralDeviation)
 
 TEST_F(EvalTest, TestKinematicStateAcc)
 {
-  setTargetMetric("kinematic_state/acc");
+  setTargetMetric("acceleration");
   Trajectory t = makeTrajectory({{0.0, 0.0}, {1.0, 0.0}});
   publishTrajectory(t);
   publishEgoPose(0.0, 0.0, 0.0);
@@ -270,7 +270,7 @@ TEST_F(EvalTest, TestKinematicStateAcc)
 
 TEST_F(EvalTest, TestKinematicStateJerk)
 {
-  setTargetMetric("kinematic_state/jerk");
+  setTargetMetric("jerk");
   Trajectory t = makeTrajectory({{0.0, 0.0}, {1.0, 0.0}});
   publishTrajectory(t);
   publishEgoPose(0.0, 0.0, 0.0);


### PR DESCRIPTION
## Description
This PR fixes 3 bugs about metric JSON outputs.
- The `vel`, `acc`, and `jark` statistics were not output to the JSON.
- The `GoalDeviation` metrics are now only counted when the ego stops near the stop line.
- Output `StopDeviation` metrics.

## Related links


https://tier4.atlassian.net/browse/RT1-9859

## How was this PR tested?
Psim


## Notes for reviewers

None.

## Interface changes

The original metric names of published  `vel`, `acc`, and `jark` are changed:

`kinematic_state/vel`-> `velocity`
`kinematic_state/acc`-> `acceleration`
`kinematic_state/jerk`-> `jerk`

Before:
![image](https://github.com/user-attachments/assets/c7172ba1-9485-40ec-89f9-bd93f0344780)

After:
![image](https://github.com/user-attachments/assets/290141e2-f05d-4b4e-98ea-21dbc68205ac)

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
