### PR TITLE
refactor(planning_validator): separate validation check for steering and steering rate

### DIFF
--- a/planning/autoware_planning_validator/README.md
+++ b/planning/autoware_planning_validator/README.md
@@ -111,8 +111,15 @@ The following parameters can be set for the `autoware_planning_validator`:
 | :------------------------------------- | :----- | :------------------------------------------------------------ | :------------ |
 | `validity_checks.steering.enable`      | bool   | flag to enable/disable steering validation check              | true          |
 | `validity_checks.steering.threshold`   | double | max valid steering value along the trajectory [rad]           | 1.414         |
-| `validity_checks.steering.rate_th`     | double | max valid steering rate along the trajectory [rad/s]          | 10.0          |
 | `validity_checks.steering.is_critical` | bool   | if true, will use handling type specified for critical checks | false         |
+
+#### Steering Rate Check
+
+| Name                                        | Type   | Description                                                   | Default value |
+| :------------------------------------------ | :----- | :------------------------------------------------------------ | :------------ |
+| `validity_checks.steering_rate.enable`      | bool   | flag to enable/disable steering rate validation check         | true          |
+| `validity_checks.steering_rate.threshold`   | double | max valid steering rate along the trajectory [rad/s]          | 10.0          |
+| `validity_checks.steering_rate.is_critical` | bool   | if true, will use handling type specified for critical checks | false         |
 
 #### Deviation Check
 

--- a/planning/autoware_planning_validator/config/planning_validator.param.yaml
+++ b/planning/autoware_planning_validator/config/planning_validator.param.yaml
@@ -42,7 +42,10 @@
       steering:
         enable: true
         threshold: 1.414
-        rate_th: 10.0
+        is_critical: false
+      steering_rate:
+        enable: true
+        threshold: 10.0
         is_critical: false
       deviation:
         enable: true

--- a/planning/autoware_planning_validator/include/autoware/planning_validator/parameters.hpp
+++ b/planning/autoware_planning_validator/include/autoware/planning_validator/parameters.hpp
@@ -29,7 +29,7 @@ struct ValidityCheck
 {
   bool enable = false;
   bool is_critical = false;
-  double threshold;
+  double threshold{0.0};
 };
 
 struct ValidationParams
@@ -38,11 +38,8 @@ struct ValidationParams
   ValidityCheck relative_angle;
   ValidityCheck curvature;
   ValidityCheck latency;
-
-  struct SteeringCheck : ValidityCheck
-  {
-    double rate_th;
-  } steering;
+  ValidityCheck steering;
+  ValidityCheck steering_rate;
 
   struct AccelerationCheck : ValidityCheck
   {

--- a/planning/autoware_planning_validator/include/autoware/planning_validator/parameters.hpp
+++ b/planning/autoware_planning_validator/include/autoware/planning_validator/parameters.hpp
@@ -27,9 +27,9 @@ enum class InvalidTrajectoryHandlingType : uint8_t {
 
 struct ValidityCheck
 {
-  bool enable = false;
+  bool enable = true;
   bool is_critical = false;
-  double threshold{0.0};
+  double threshold{};
 };
 
 struct ValidationParams
@@ -46,7 +46,7 @@ struct ValidationParams
     double lateral_th;
     double longitudinal_max_th;
     double longitudinal_min_th;
-  } acceleration;
+  } acceleration{};
 
   struct DeviationCheck : ValidityCheck
   {
@@ -54,13 +54,13 @@ struct ValidationParams
     double distance_th;
     double lon_distance_th;
     double yaw_th;
-  } deviation;
+  } deviation{};
 
   struct ForwardTrajectoryLength : ValidityCheck
   {
     double acceleration;
     double margin;
-  } forward_trajectory_length;
+  } forward_trajectory_length{};
 };
 
 struct Params
@@ -68,10 +68,10 @@ struct Params
   bool enable_soft_stop_on_prev_traj = true;
   bool publish_diag = true;
   bool display_on_terminal = true;
-  double soft_stop_deceleration = -1.0;
-  int diag_error_count_threshold = 0;
-  ValidationParams validation_params;
-  InvalidTrajectoryHandlingType inv_traj_handling_type;
-  InvalidTrajectoryHandlingType inv_traj_critical_handling_type;
+  double soft_stop_deceleration{};
+  int diag_error_count_threshold{};
+  ValidationParams validation_params{};
+  InvalidTrajectoryHandlingType inv_traj_handling_type{};
+  InvalidTrajectoryHandlingType inv_traj_critical_handling_type{};
 };
 }  // namespace autoware::planning_validator

--- a/planning/autoware_planning_validator/src/planning_validator.cpp
+++ b/planning/autoware_planning_validator/src/planning_validator.cpp
@@ -93,7 +93,7 @@ void PlanningValidator::setupParameters()
     set_validation_params(p.curvature, t + "curvature");
     set_validation_params(p.latency, t + "latency");
     set_validation_params(p.steering, t + "steering");
-    p.steering.rate_th = declare_parameter<double>(t + "steering.rate_th");
+    set_validation_params(p.steering_rate, t + "steering_rate");
 
     set_validation_flags(p.acceleration, t + "acceleration");
     p.acceleration.lateral_th = declare_parameter<double>(t + "acceleration.lateral_th");
@@ -522,7 +522,7 @@ bool PlanningValidator::checkValidSteeringRate(const Trajectory & trajectory)
   const auto [max_steering_rate, i] = calcMaxSteeringRates(trajectory, vehicle_info_.wheel_base_m);
   validation_status_.max_steering_rate = max_steering_rate;
 
-  if (max_steering_rate > params_.validation_params.steering.rate_th) {
+  if (max_steering_rate > params_.validation_params.steering_rate.threshold) {
     debug_pose_publisher_->pushPoseMarker(trajectory.points.at(i).pose, "max_steering_rate");
     is_critical_error_ |= params_.validation_params.steering.is_critical;
     return false;

--- a/planning/autoware_planning_validator/test/src/test_planning_validator_helper.cpp
+++ b/planning/autoware_planning_validator/test/src/test_planning_validator_helper.cpp
@@ -236,9 +236,12 @@ rclcpp::NodeOptions getNodeOptionsWithDefaultParams()
 
   node_options.append_parameter_override("validity_checks.steering.enable", true);
   node_options.append_parameter_override("validity_checks.steering.threshold", THRESHOLD_STEERING);
-  node_options.append_parameter_override(
-    "validity_checks.steering.rate_th", THRESHOLD_STEERING_RATE);
   node_options.append_parameter_override("validity_checks.steering.is_critical", false);
+
+  node_options.append_parameter_override("validity_checks.steering_rate.enable", true);
+  node_options.append_parameter_override(
+    "validity_checks.steering_rate.threshold", THRESHOLD_STEERING_RATE);
+  node_options.append_parameter_override("validity_checks.steering_rate.is_critical", false);
 
   node_options.append_parameter_override("validity_checks.forward_trajectory_length.enable", true);
   node_options.append_parameter_override(


### PR DESCRIPTION
## Description

parameter change https://github.com/autowarefoundation/autoware_launch/pull/1402 should be merged first

- Split steering and steering_rate into separate ValidityCheck parameters
- Implemented consistent brace initialization `{}` for all parameters


## How was this PR tested?

- run psim
  - set steering rate threshold as very small value and detect error with following message 
  ```
  [planning_validator_node-36] [ERROR 1744369637.232292726] [planning.planning_validator]: Caution! Invalid Trajectory published. (publishTrajectory():271)
  [planning_validator_node-36] [WARN 1744369637.232379583] [planning.planning_validator]: planning trajectory expected steering angle rate is too high!! (operator()():713)
  ``` 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
