### PR TITLE
feat(autoware_universe_utils): add intersect and getPoint for Point2d type

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
@@ -105,6 +105,12 @@ geometry_msgs::msg::Point getPoint(const T & p)
 }
 
 template <>
+inline geometry_msgs::msg::Point getPoint(const Point2d & p)
+{
+  return geometry_msgs::build<geometry_msgs::msg::Point>().x(p.x()).y(p.y()).z(0.0);
+}
+
+template <>
 inline geometry_msgs::msg::Point getPoint(const geometry_msgs::msg::Point & p)
 {
   return p;
@@ -580,6 +586,9 @@ bool isTwistCovarianceValid(const geometry_msgs::msg::TwistWithCovariance & twis
 std::optional<geometry_msgs::msg::Point> intersect(
   const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2,
   const geometry_msgs::msg::Point & p3, const geometry_msgs::msg::Point & p4);
+
+std::optional<Point2d> intersect(
+  const Point2d & p1, const Point2d & p2, const Point2d & p3, const Point2d & p4);
 
 /**
  * @brief Check if 2 convex polygons intersect using the GJK algorithm

--- a/common/autoware_universe_utils/src/geometry/geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/geometry.cpp
@@ -387,6 +387,29 @@ std::optional<geometry_msgs::msg::Point> intersect(
   return intersect_point;
 }
 
+std::optional<Point2d> intersect(
+  const Point2d & p1, const Point2d & p2, const Point2d & p3, const Point2d & p4)
+{
+  // calculate intersection point
+  const double det = (p1.x() - p2.x()) * (p4.y() - p3.y()) - (p4.x() - p3.x()) * (p1.y() - p2.y());
+  if (det == 0.0) {
+    return std::nullopt;
+  }
+
+  const double t =
+    ((p4.y() - p3.y()) * (p4.x() - p2.x()) + (p3.x() - p4.x()) * (p4.y() - p2.y())) / det;
+  const double s =
+    ((p2.y() - p1.y()) * (p4.x() - p2.x()) + (p1.x() - p2.x()) * (p4.y() - p2.y())) / det;
+  if (t < 0 || 1 < t || s < 0 || 1 < s) {
+    return std::nullopt;
+  }
+
+  Point2d intersect_point;
+  intersect_point.x() = t * p1.x() + (1.0 - t) * p2.x();
+  intersect_point.y() = t * p1.y() + (1.0 - t) * p2.y();
+  return intersect_point;
+}
+
 bool intersects_convex(const Polygon2d & convex_polygon1, const Polygon2d & convex_polygon2)
 {
   return gjk::intersects(convex_polygon1, convex_polygon2);


### PR DESCRIPTION
## Description

Add 2 convenience functions when working with `autoware_universe_utils::Point2d` to convert to `Point` message or efficiently calculate segment intersections.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
