### PR TITLE
feat(out_of_lane): revise logic for using previous stop pose

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -14,7 +14,6 @@
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/delete-closed-pr-docs.yaml
     - source: .github/workflows/deploy-docs.yaml
-    - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/pre-commit-optional-autoupdate.yaml

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -14,6 +14,7 @@
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/delete-closed-pr-docs.yaml
     - source: .github/workflows/deploy-docs.yaml
+    - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/pre-commit-optional-autoupdate.yaml

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -23,6 +23,7 @@
         longitudinal_distance_buffer: 1.5  # [m] safety distance buffer to keep in front of the ego vehicle
         lateral_distance_buffer: 1.0  # [m] safety distance buffer to keep on the side of the ego vehicle
         min_duration: 1.0  # [s] minimum duration needed before a decision can be canceled
+        min_update_distance: 5.0 # [m] minimum distance needed to update previous stop pose position
         slowdown:
           distance_threshold: 30.0 # [m] insert a slowdown when closer than this distance from an overlap
           velocity: 2.0  # [m/s] slowdown velocity

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -23,7 +23,7 @@
         longitudinal_distance_buffer: 1.5  # [m] safety distance buffer to keep in front of the ego vehicle
         lateral_distance_buffer: 1.0  # [m] safety distance buffer to keep on the side of the ego vehicle
         min_duration: 1.0  # [s] minimum duration needed before a decision can be canceled
-        min_update_distance: 5.0 # [m] minimum distance needed to update previous stop pose position
+        update_distance_th: 5.0 # [m] distance threshold for updating previous stop pose position
         slowdown:
           distance_threshold: 30.0 # [m] insert a slowdown when closer than this distance from an overlap
           velocity: 2.0  # [m/s] slowdown velocity

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -245,7 +245,7 @@ void OutOfLaneModule::update_slowdown_pose_buffer(
 {
   std::vector<out_of_lane::SlowdownPose> valid_poses;
   for (auto & sp : slowdown_pose_buffer_) {
-    if ((clock_->now() - sp.start_time).seconds() <= params_.min_decision_duration)
+    if ((clock_->now() - sp.start_time).seconds() > params_.min_decision_duration)
       continue;
     sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
     valid_poses.push_back(sp);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -98,7 +98,8 @@ void OutOfLaneModule::init_parameters(rclcpp::Node & node)
   pp.precision = get_or_declare_parameter<double>(node, ns_ + ".action.precision");
   pp.use_map_stop_lines = get_or_declare_parameter<bool>(node, ns_ + ".action.use_map_stop_lines");
   pp.min_decision_duration = get_or_declare_parameter<double>(node, ns_ + ".action.min_duration");
-  pp.min_update_distance = get_or_declare_parameter<double>(node, ns_ + ".action.min_update_distance");
+  pp.update_distance_th =
+    get_or_declare_parameter<double>(node, ns_ + ".action.update_distance_th");
   pp.lon_dist_buffer =
     get_or_declare_parameter<double>(node, ns_ + ".action.longitudinal_distance_buffer");
   pp.lat_dist_buffer =
@@ -234,20 +235,21 @@ std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose
     if (sp.arc_length < min_arc_length) nearest_slowdown_pose = sp;
   }
 
-  slowdown_pose =
-    motion_utils::calcInterpolatedPose(ego_data.trajectory_points, nearest_slowdown_pose.arc_length);
+  slowdown_pose = motion_utils::calcInterpolatedPose(
+    ego_data.trajectory_points, nearest_slowdown_pose.arc_length);
 
   return slowdown_pose;
 }
 
 void OutOfLaneModule::update_slowdown_pose_buffer(
-  const out_of_lane::EgoData & ego_data, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose)
+  const out_of_lane::EgoData & ego_data,
+  const std::optional<geometry_msgs::msg::Pose> & slowdown_pose)
 {
   std::vector<out_of_lane::SlowdownPose> valid_poses;
   for (auto & sp : slowdown_pose_buffer_) {
-    if ((clock_->now() - sp.start_time).seconds() > params_.min_decision_duration)
-      continue;
-    sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
+    if ((clock_->now() - sp.start_time).seconds() > params_.min_decision_duration) continue;
+    sp.arc_length =
+      motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
     valid_poses.push_back(sp);
   }
   slowdown_pose_buffer_ = valid_poses;
@@ -266,7 +268,7 @@ void OutOfLaneModule::update_slowdown_pose_buffer(
   auto min_relative_dist = std::numeric_limits<double>::max();
   for (auto it = slowdown_pose_buffer_.begin(); it < slowdown_pose_buffer_.end(); ++it) {
     const auto rel_dist = it->arc_length - slowdown_pose_arc_length;
-    if (std::abs(rel_dist) < params_.min_update_distance && rel_dist < min_relative_dist) {
+    if (std::abs(rel_dist) < params_.update_distance_th && rel_dist < min_relative_dist) {
       nearest_prev_pose_it = it;
       min_relative_dist = rel_dist;
     }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -229,10 +229,10 @@ std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose
   if (slowdown_pose_buffer_.empty()) return {};
 
   // get nearest slowdown pose
-  const auto min_arc_length = std::numeric_limits<double>::max();
   out_of_lane::SlowdownPose nearest_slowdown_pose;
+  nearest_slowdown_pose.arc_length = std::numeric_limits<double>::max();
   for (const auto & sp : slowdown_pose_buffer_) {
-    if (sp.arc_length < min_arc_length) nearest_slowdown_pose = sp;
+    if (sp.arc_length < nearest_slowdown_pose.arc_length) nearest_slowdown_pose = sp;
   }
 
   slowdown_pose = motion_utils::calcInterpolatedPose(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -41,6 +41,7 @@
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -97,6 +98,7 @@ void OutOfLaneModule::init_parameters(rclcpp::Node & node)
   pp.precision = get_or_declare_parameter<double>(node, ns_ + ".action.precision");
   pp.use_map_stop_lines = get_or_declare_parameter<bool>(node, ns_ + ".action.use_map_stop_lines");
   pp.min_decision_duration = get_or_declare_parameter<double>(node, ns_ + ".action.min_duration");
+  pp.min_update_distance = get_or_declare_parameter<double>(node, ns_ + ".action.min_update_distance");
   pp.lon_dist_buffer =
     get_or_declare_parameter<double>(node, ns_ + ".action.longitudinal_distance_buffer");
   pp.lat_dist_buffer =
@@ -219,37 +221,67 @@ out_of_lane::OutOfLaneData prepare_out_of_lane_data(const out_of_lane::EgoData &
 std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose(
   const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data)
 {
-  if (  // reset the previous inserted point if the timer expired
-    previous_slowdown_pose_ &&
-    (clock_->now() - previous_slowdown_time_).seconds() > params_.min_decision_duration) {
-    previous_slowdown_pose_.reset();
-  }
-
   auto slowdown_pose = out_of_lane::calculate_slowdown_pose(ego_data, out_of_lane_data, params_);
 
-  // reuse previous stop pose if there is no new one or if its velocity is not higher than the new
-  // one and its arc length is lower
-  if (slowdown_pose) {  // reset the clock when we could calculate a valid slowdown pose
-    previous_slowdown_time_ = clock_->now();
-  }
-  const auto should_use_previous_pose = [&]() {
-    if (slowdown_pose && previous_slowdown_pose_) {
-      const auto arc_length =
-        motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, slowdown_pose->position);
-      const auto prev_arc_length = motion_utils::calcSignedArcLength(
-        ego_data.trajectory_points, 0LU, previous_slowdown_pose_->position);
-      return prev_arc_length < arc_length;
-    }
-    return slowdown_pose && previous_slowdown_pose_;
-  }();
-  if (should_use_previous_pose) {
-    // if the trajectory changed the prev point is no longer on the trajectory so we project it
-    const auto new_arc_length = motion_utils::calcSignedArcLength(
-      ego_data.trajectory_points, 0UL, previous_slowdown_pose_->position);
-    slowdown_pose = motion_utils::calcInterpolatedPose(ego_data.trajectory_points, new_arc_length);
+  update_slowdown_pose_buffer(ego_data, slowdown_pose);
+
+  if (slowdown_pose_buffer_.empty()) return {};
+
+  // get nearest slowdown pose
+  const auto min_arc_length = std::numeric_limits<double>::max();
+  out_of_lane::SlowdownPose nearest_slowdown_pose;
+  for (const auto & sp : slowdown_pose_buffer_) {
+    if (sp.arc_length < min_arc_length) nearest_slowdown_pose = sp;
   }
 
+  slowdown_pose =
+    motion_utils::calcInterpolatedPose(ego_data.trajectory_points, nearest_slowdown_pose.arc_length);
+
   return slowdown_pose;
+}
+
+void OutOfLaneModule::update_slowdown_pose_buffer(
+  const out_of_lane::EgoData & ego_data, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose)
+{
+  std::vector<out_of_lane::SlowdownPose> valid_poses;
+  for (auto & sp : slowdown_pose_buffer_) {
+    if ((clock_->now() - sp.start_time).seconds() <= params_.min_decision_duration)
+      continue;
+    sp.arc_length = motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, sp.pose.position);
+    valid_poses.push_back(sp);
+  }
+  slowdown_pose_buffer_ = valid_poses;
+
+  if (!slowdown_pose) return;
+
+  const auto slowdown_pose_arc_length =
+    motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0LU, slowdown_pose->position);
+
+  if (slowdown_pose_buffer_.empty()) {
+    slowdown_pose_buffer_.emplace_back(slowdown_pose_arc_length, clock_->now(), *slowdown_pose);
+    return;
+  }
+
+  auto nearest_prev_pose_it = slowdown_pose_buffer_.end();
+  auto min_relative_dist = std::numeric_limits<double>::max();
+  for (auto it = slowdown_pose_buffer_.begin(); it < slowdown_pose_buffer_.end(); ++it) {
+    const auto rel_dist = it->arc_length - slowdown_pose_arc_length;
+    if (std::abs(rel_dist) < params_.min_update_distance && rel_dist < min_relative_dist) {
+      nearest_prev_pose_it = it;
+      min_relative_dist = rel_dist;
+    }
+  }
+
+  if (nearest_prev_pose_it == slowdown_pose_buffer_.end()) {
+    slowdown_pose_buffer_.emplace_back(slowdown_pose_arc_length, clock_->now(), *slowdown_pose);
+    return;
+  }
+
+  if (min_relative_dist > 0) {
+    nearest_prev_pose_it->pose = *slowdown_pose;
+    nearest_prev_pose_it->arc_length = slowdown_pose_arc_length;
+  }
+  nearest_prev_pose_it->start_time = clock_->now();
 }
 
 void OutOfLaneModule::update_result(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -57,6 +57,8 @@ private:
   /// @brief calculate the first slowdown pose (if any)
   std::optional<geometry_msgs::msg::Pose> calculate_slowdown_pose(
     const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data);
+  void update_slowdown_pose_buffer(
+    const out_of_lane::EgoData & ego_data, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose);
   /// @brief update the given planning result and some internal states of the module
   void update_result(
     VelocityPlanningResult & result, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose,
@@ -68,7 +70,7 @@ private:
   std::string module_name_{"uninitialized"};
   rclcpp::Clock::SharedPtr clock_{nullptr};
   std::optional<geometry_msgs::msg::Pose> previous_slowdown_pose_{std::nullopt};
-  rclcpp::Time previous_slowdown_time_{0};
+  std::vector<out_of_lane::SlowdownPose> slowdown_pose_buffer_{};
 
 protected:
   // Debug

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -58,7 +58,8 @@ private:
   std::optional<geometry_msgs::msg::Pose> calculate_slowdown_pose(
     const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data);
   void update_slowdown_pose_buffer(
-    const out_of_lane::EgoData & ego_data, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose);
+    const out_of_lane::EgoData & ego_data,
+    const std::optional<geometry_msgs::msg::Pose> & slowdown_pose);
   /// @brief update the given planning result and some internal states of the module
   void update_result(
     VelocityPlanningResult & result, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -66,9 +66,9 @@ struct PlannerParam
                                // try to insert a stop point
   double precision;            // [m] precision when inserting a stop pose in the trajectory
   double
-    min_decision_duration;  // [s] duration needed before a stop or slowdown point can be removed
-  double min_update_distance; // [m] minimum distance needed to update previous stop pose position
-  bool use_map_stop_lines;  // if true, try to stop at stop lines defined in the map
+    min_decision_duration;    // [s] duration needed before a stop or slowdown point can be removed
+  double update_distance_th;  // [m] distance threshold for updating previous stop pose position
+  bool use_map_stop_lines;    // if true, try to stop at stop lines defined in the map
 
   // ego dimensions used to create its polygon footprint
   double front_offset;        // [m]  front offset (from vehicle info)
@@ -134,14 +134,18 @@ struct OutOfLanePoint
   bool to_avoid = false;
 };
 
-struct SlowdownPose {
+struct SlowdownPose
+{
   double arc_length;
   rclcpp::Time start_time{0};
   geometry_msgs::msg::Pose pose;
 
   SlowdownPose() = default;
-  SlowdownPose(const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose) :
-    arc_length(arc_length), start_time(start_time), pose(pose) {}
+  SlowdownPose(
+    const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose)
+  : arc_length(arc_length), start_time(start_time), pose(pose)
+  {
+  }
 };
 
 /// @brief data related to the out of lane points

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -67,6 +67,7 @@ struct PlannerParam
   double precision;            // [m] precision when inserting a stop pose in the trajectory
   double
     min_decision_duration;  // [s] duration needed before a stop or slowdown point can be removed
+  double min_update_distance; // [m] minimum distance needed to update previous stop pose position
   bool use_map_stop_lines;  // if true, try to stop at stop lines defined in the map
 
   // ego dimensions used to create its polygon footprint
@@ -131,6 +132,16 @@ struct OutOfLanePoint
   std::optional<double> ttc;
   lanelet::ConstLanelets overlapped_lanelets;
   bool to_avoid = false;
+};
+
+struct SlowdownPose {
+  double arc_length;
+  rclcpp::Time start_time{0};
+  geometry_msgs::msg::Pose pose;
+
+  SlowdownPose() = default;
+  SlowdownPose(const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose) :
+    arc_length(arc_length), start_time(start_time), pose(pose) {}
 };
 
 /// @brief data related to the out of lane points

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -136,7 +136,7 @@ struct OutOfLanePoint
 
 struct SlowdownPose
 {
-  double arc_length;
+  double arc_length{0.0};
   rclcpp::Time start_time{0};
   geometry_msgs::msg::Pose pose;
 


### PR DESCRIPTION
## Description

Currently, in `out_of_lane_module`, when a collision is detected and a stop pose is computed. The stop pose will remain as long as a collision is detected within the `min_duration` value, even if the new detected collision is far away from the original inserted stop pose. Which can, in certain situations, result in unnecessary stopping behavior.

This PR addresses issue by introducing a distance threshold for preserving the previous stop pose. If a collision is detected within a threshold distance from the previous stop pose, then the stop pose is kept and the timer is reset.

## Related links

[Launcher PR](https://github.com/autowarefoundation/autoware_launch/pull/1404)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM.
- [TIER IV Internal Evaluator](https://evaluation.tier4.jp/evaluation/reports/6ee6f5dd-c993-5a46-a290-85d244ff840c?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

🔴⬆️ -->

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `update_distance_th`   | `double` | `10.0`         | [m] distance threshold for updating previous stop pose position |


## Effects on system behavior

out_of_lane stop pose is not kept unnecessarily.
