### PR TITLE
feat(out_of_lane): add ttc threshold for releasing stop decision

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -14,7 +14,6 @@
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/delete-closed-pr-docs.yaml
     - source: .github/workflows/deploy-docs.yaml
-    - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/pre-commit-optional-autoupdate.yaml

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -14,6 +14,7 @@
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/delete-closed-pr-docs.yaml
     - source: .github/workflows/deploy-docs.yaml
+    - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/pre-commit-optional-autoupdate.yaml

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -9,8 +9,8 @@
       threshold:
         time_threshold: 5.0  # [s] consider objects that will reach an overlap within this time
       ttc:
-        threshold: 1.0 # [s] threshold for difference in time to ovelrap region between ego and target object to trigger stop decision
-        release_threshold: 2.0 # [s] threshold for difference in time to the ovelrap region between ego and target object to release stop decision
+        threshold: 1.0 # [s] threshold for difference in time to overlap region between ego and target object to trigger stop decision
+        release_threshold: 2.0 # [s] threshold for difference in time to the overlap region between ego and target object to release stop decision
 
 
       objects:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -9,7 +9,9 @@
       threshold:
         time_threshold: 5.0  # [s] consider objects that will reach an overlap within this time
       ttc:
-        threshold: 1.0 # [s] consider objects with an estimated time to collision bellow this value while on the overlap
+        threshold: 1.0 # [s] threshold for difference in time to ovelrap region between ego and target object to trigger stop decision
+        release_threshold: 2.0 # [s] threshold for difference in time to the ovelrap region between ego and target object to release stop decision
+
 
       objects:
         minimum_velocity: 0.5  # [m/s] objects lower than this velocity will be ignored

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
@@ -115,12 +115,13 @@ void calculate_min_max_arrival_times(
 void calculate_collisions_to_avoid(
   OutOfLaneData & out_of_lane_data,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
-  const PlannerParam & params)
+  const PlannerParam & params, const bool is_stopping)
 {
   for (auto & p : out_of_lane_data.outside_points) {
     calculate_min_max_arrival_times(p, trajectory);
     if (params.mode == "ttc") {
-      p.to_avoid = p.ttc && p.ttc <= params.ttc_threshold;
+      const auto threshold = is_stopping ? params.ttc_release_threshold : params.ttc_threshold;
+      p.to_avoid = p.ttc && p.ttc <= threshold;
     } else {
       p.to_avoid = p.min_object_arrival_time && p.min_object_arrival_time <= params.time_threshold;
     }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
@@ -45,7 +45,7 @@ void calculate_objects_time_collisions(
 void calculate_collisions_to_avoid(
   OutOfLaneData & out_of_lane_data,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
-  const PlannerParam & params);
+  const PlannerParam & params, const bool is_stopping = false);
 
 /// @brief calculate the out of lane points
 std::vector<OutOfLanePoint> calculate_out_of_lane_points(const EgoData & ego_data);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -330,7 +330,8 @@ VelocityPlanningResult OutOfLaneModule::plan(
 
   stopwatch.tic("calculate_times");
   const auto is_stopping = previous_slowdown_pose_ ? true : false;
-  out_of_lane::calculate_collisions_to_avoid(out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
+  out_of_lane::calculate_collisions_to_avoid(
+    out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
   const auto calculate_times_us = stopwatch.toc("calculate_times");
 
   const auto is_already_overlapping =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -85,6 +85,7 @@ void OutOfLaneModule::init_parameters(rclcpp::Node & node)
 
   pp.time_threshold = get_or_declare_parameter<double>(node, ns_ + ".threshold.time_threshold");
   pp.ttc_threshold = get_or_declare_parameter<double>(node, ns_ + ".ttc.threshold");
+  pp.ttc_release_threshold = get_or_declare_parameter<double>(node, ns_ + ".ttc.release_threshold");
 
   pp.objects_min_vel = get_or_declare_parameter<double>(node, ns_ + ".objects.minimum_velocity");
   pp.objects_min_confidence =
@@ -126,6 +127,7 @@ void OutOfLaneModule::update_parameters(const std::vector<rclcpp::Parameter> & p
 
   update_param(parameters, ns_ + ".threshold.time_threshold", pp.time_threshold);
   update_param(parameters, ns_ + ".ttc.threshold", pp.ttc_threshold);
+  update_param(parameters, ns_ + ".ttc.release_threshold", pp.ttc_release_threshold);
 
   update_param(parameters, ns_ + ".objects.minimum_velocity", pp.objects_min_vel);
   update_param(
@@ -327,7 +329,8 @@ VelocityPlanningResult OutOfLaneModule::plan(
   const auto calculate_time_collisions_us = stopwatch.toc("calculate_time_collisions");
 
   stopwatch.tic("calculate_times");
-  out_of_lane::calculate_collisions_to_avoid(out_of_lane_data, ego_data.trajectory_points, params_);
+  const auto is_stopping = previous_slowdown_pose_ ? true : false;
+  out_of_lane::calculate_collisions_to_avoid(out_of_lane_data, ego_data.trajectory_points, params_, is_stopping);
   const auto calculate_times_us = stopwatch.toc("calculate_times");
 
   const auto is_already_overlapping =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -51,6 +51,7 @@ struct PlannerParam
 
   double time_threshold;  // [s](mode="threshold") objects time threshold
   double ttc_threshold;  // [s](mode="ttc") threshold on time to collision between ego and an object
+  double ttc_release_threshold;
 
   bool objects_cut_predicted_paths_beyond_red_lights;  // whether to cut predicted paths beyond red
                                                        // lights' stop lines


### PR DESCRIPTION
## Description

Currently `out_of_lane_module` uses one `ttc.threshold` value to check for collision and insert a stop point. If the measured ttc value is close to the threshold value and varies between iterations, it could result in a flickering stop decision.

This PR addressed the issue by introducing a second threshold value `ttc.release_threshold` for hysteresis. At first `ttc.threshold` is used to detect a collision and insert a stop pose. Then `ttc.release_threshold` is used to check for collisions to determine if the stop pose should be kept or can be released.

## Related links

[Launcher PR](https://github.com/autowarefoundation/autoware_launch/pull/1404)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM
- [TIER IV Internal Evaluator](https://evaluation.tier4.jp/evaluation/reports/6ee6f5dd-c993-5a46-a290-85d244ff840c?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

🔴⬆️ -->

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `ttc.release_threshold`   | `double` | `2.0`         | [s] threshold for difference in time to the ovelrap region between ego and target object to release stop decision |

## Effects on system behavior

out_of_lane stop pose is more consistent
