### PR TITLE
fix(autoware_multi_object_tracker): fix bicycle renovation vector dimension

### DIFF
--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -184,7 +184,7 @@ bool BicycleMotionModel::updateStatePoseVel(
   if (!checkInitialized()) return false;
 
   // update state, with velocity
-  constexpr int DIM_Y = 4;
+  constexpr int DIM_Y = 3;
 
   // update state
   Eigen::MatrixXd Y(DIM_Y, 1);


### PR DESCRIPTION
## Description

When a bicycle motion model tracker gets update with velocity and without yaw, the tracker couldn't get update.

It turns out that there is a bug on the renovation vector has wring dimension size.

- Before
```c++
 // update state, with velocity
  constexpr int DIM_Y = 4;

  // update state
  Eigen::MatrixXd Y(DIM_Y, 1);
  Y << x, y, vel;
```

- after
```c++
 // update state, with velocity
  constexpr int DIM_Y = 3;

  // update state
  Eigen::MatrixXd Y(DIM_Y, 1);
  Y << x, y, vel;
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
