### PR TITLE
refactor(operation_mode_transition_manager): less member variable

### DIFF
--- a/control/autoware_operation_mode_transition_manager/package.xml
+++ b/control/autoware_operation_mode_transition_manager/package.xml
@@ -3,6 +3,7 @@
   <version>0.44.0</version>
   <description>The operation_mode_transition_manager package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <license>Apache License 2.0</license>

--- a/control/autoware_operation_mode_transition_manager/src/node.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.cpp
@@ -291,7 +291,10 @@ OperationModeTransitionManager::subscribeData()
   if (gate_operation_mode_ptr) {
     input_data.gate_operation_mode = *gate_operation_mode_ptr;
   } else {
-    is_ready = false;
+    // NOTE: initial state when the data is not subscribed yet.
+    input_data.gate_operation_mode = OperationModeState{};
+    input_data.gate_operation_mode.mode = OperationModeState::UNKNOWN;
+    input_data.gate_operation_mode.is_in_transition = false;
   }
 
   const auto control_mode_report_ptr = sub_control_mode_report_.take_data();

--- a/control/autoware_operation_mode_transition_manager/src/node.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.cpp
@@ -261,45 +261,49 @@ OperationModeTransitionManager::subscribeData()
 {
   InputData input_data;
 
+  // NOTE: Regarding some of the following inputs, do not update is_ready
+  // since the planning component depends on the output of this node.
+  bool is_ready = true;
+
   const auto kinematics_ptr = sub_kinematics_.take_data();
-  if (!kinematics_ptr) {
-    return std::nullopt;
+  if (kinematics_ptr) {
+    input_data.kinematics = *kinematics_ptr;
+  } else {
+    is_ready = false;
   }
-  input_data.kinematics = *kinematics_ptr;
 
   const auto trajectory_ptr = sub_trajectory_.take_data();
-  if (!trajectory_ptr) {
-    return std::nullopt;
+  if (trajectory_ptr) {
+    input_data.trajectory = *trajectory_ptr;
   }
-  input_data.trajectory = *trajectory_ptr;
 
   const auto trajectory_follower_control_cmd_ptr = sub_trajectory_follower_control_cmd_.take_data();
-  if (!trajectory_follower_control_cmd_ptr) {
-    return std::nullopt;
+  if (trajectory_follower_control_cmd_ptr) {
+    input_data.trajectory_follower_control_cmd = *trajectory_follower_control_cmd_ptr;
   }
-  input_data.trajectory_follower_control_cmd = *trajectory_follower_control_cmd_ptr;
 
   const auto control_cmd_ptr = sub_control_cmd_.take_data();
-  if (!control_cmd_ptr) {
-    return std::nullopt;
+  if (control_cmd_ptr) {
+    input_data.control_cmd = *control_cmd_ptr;
   }
-  input_data.control_cmd = *control_cmd_ptr;
 
   const auto gate_operation_mode_ptr = sub_gate_operation_mode_.take_data();
-  if (!gate_operation_mode_ptr) {
-    return std::nullopt;
+  if (gate_operation_mode_ptr) {
+    input_data.gate_operation_mode = *gate_operation_mode_ptr;
+  } else {
+    is_ready = false;
   }
-  input_data.gate_operation_mode = *gate_operation_mode_ptr;
 
   const auto control_mode_report_ptr = sub_control_mode_report_.take_data();
-  if (!control_mode_report_ptr) {
-    return std::nullopt;
+  if (control_mode_report_ptr) {
+    // NOTE: This will be used outside the onTimer function. Therefore, it
+    // has to be a member variable
+    control_mode_report_ = *control_mode_report_ptr;
+  } else {
+    is_ready = false;
   }
-  // NOTE: This will be used outside the onTimer function. Therefore, it
-  // has to be a member variable
-  control_mode_report_ = *control_mode_report_ptr;
 
-  return input_data;
+  return is_ready ? input_data : std::optional<InputData>{};
 }
 
 void OperationModeTransitionManager::publishData()

--- a/control/autoware_operation_mode_transition_manager/src/node.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.hpp
@@ -32,6 +32,15 @@ namespace autoware::operation_mode_transition_manager
 class OperationModeTransitionManager : public rclcpp::Node
 {
 public:
+  struct InputData
+  {
+    Odometry kinematics;
+    Trajectory trajectory;
+    Control trajectory_follower_control_cmd;
+    Control control_cmd;
+    OperationModeState gate_operation_mode;
+  };
+
   explicit OperationModeTransitionManager(const rclcpp::NodeOptions & options);
 
 private:
@@ -55,19 +64,28 @@ private:
     const ChangeOperationModeAPI::Service::Response::SharedPtr response);
 
   using ControlModeCommandType = ControlModeCommand::Request::_mode_type;
-  autoware_utils::InterProcessPollingSubscriber<ControlModeReport> sub_control_mode_report_{
-    this, "control_mode_report"};
+  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_kinematics_{this, "kinematics"};
+  autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_trajectory_{this, "trajectory"};
+  autoware_utils::InterProcessPollingSubscriber<Control> sub_trajectory_follower_control_cmd_{
+    this, "trajectory_follower_control_cmd"};
+  autoware_utils::InterProcessPollingSubscriber<Control> sub_control_cmd_{this, "control_cmd"};
   autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_gate_operation_mode_{
     this, "gate_operation_mode"};
+  autoware_utils::InterProcessPollingSubscriber<ControlModeReport> sub_control_mode_report_{
+    this, "control_mode_report"};
+
   rclcpp::Client<ControlModeCommand>::SharedPtr cli_control_mode_;
   rclcpp::Publisher<ModeChangeBase::DebugInfo>::SharedPtr pub_debug_info_;
   rclcpp::TimerBase::SharedPtr timer_;
   void onTimer();
+  std::optional<InputData> subscribeData();
   void publishData();
   void changeControlMode(ControlModeCommandType mode);
   void changeOperationMode(std::optional<OperationMode> request_mode);
   void cancelTransition();
-  void processTransition(const OperationModeState & gate_operation_mode);
+  void processTransition(
+    const Odometry & kinematics, const Trajectory & trajectory,
+    const OperationModeState & gate_operation_mode);
 
   double transition_timeout_;
   OperationMode current_mode_;

--- a/control/autoware_operation_mode_transition_manager/src/node.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/node.hpp
@@ -67,14 +67,13 @@ private:
   void changeControlMode(ControlModeCommandType mode);
   void changeOperationMode(std::optional<OperationMode> request_mode);
   void cancelTransition();
-  void processTransition();
+  void processTransition(const OperationModeState & gate_operation_mode);
 
   double transition_timeout_;
   OperationMode current_mode_;
   std::unique_ptr<Transition> transition_;
   std::unordered_map<OperationMode, std::unique_ptr<ModeChangeBase>> modes_;
   std::unordered_map<OperationMode, bool> available_mode_change_;
-  OperationModeState gate_operation_mode_;
   ControlModeReport control_mode_report_;
 
   std::optional<OperationModeStateAPI::Message> prev_state_;

--- a/control/autoware_operation_mode_transition_manager/src/state.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.hpp
@@ -30,14 +30,22 @@
 
 namespace autoware::operation_mode_transition_manager
 {
+using Control = autoware_control_msgs::msg::Control;
+using Odometry = nav_msgs::msg::Odometry;
+using Trajectory = autoware_planning_msgs::msg::Trajectory;
 
 class ModeChangeBase
 {
 public:
   virtual ~ModeChangeBase() = default;
   virtual void update([[maybe_unused]] bool transition) {}
-  virtual bool isModeChangeCompleted() = 0;
-  virtual bool isModeChangeAvailable() = 0;
+  virtual bool isModeChangeCompleted(
+    [[maybe_unused]] const Odometry & kinematics,
+    [[maybe_unused]] const Trajectory & trajectory) = 0;
+  virtual bool isModeChangeAvailable(
+    [[maybe_unused]] const Odometry & kinematics, [[maybe_unused]] const Trajectory & trajectory,
+    [[maybe_unused]] const Control & trajectory_follower_control_cmd,
+    [[maybe_unused]] const Control & control_cmd) = 0;
 
   using DebugInfo =
     autoware_operation_mode_transition_manager::msg::OperationModeTransitionManagerDebug;
@@ -47,8 +55,19 @@ public:
 class StopMode : public ModeChangeBase
 {
 public:
-  bool isModeChangeCompleted() override { return true; }
-  bool isModeChangeAvailable() override { return true; }
+  bool isModeChangeCompleted(
+    [[maybe_unused]] const Odometry & kinematics,
+    [[maybe_unused]] const Trajectory & trajectory) override
+  {
+    return true;
+  }
+  bool isModeChangeAvailable(
+    [[maybe_unused]] const Odometry & kinematics, [[maybe_unused]] const Trajectory & trajectory,
+    [[maybe_unused]] const Control & trajectory_follower_control_cmd,
+    [[maybe_unused]] const Control & control_cmd) override
+  {
+    return true;
+  }
 };
 
 class AutonomousMode : public ModeChangeBase
@@ -56,21 +75,17 @@ class AutonomousMode : public ModeChangeBase
 public:
   explicit AutonomousMode(rclcpp::Node * node);
   void update(bool transition) override;
-  bool isModeChangeCompleted() override;
-  bool isModeChangeAvailable() override;
+  bool isModeChangeCompleted(const Odometry & kinematics, const Trajectory & trajectory) override;
+  bool isModeChangeAvailable(
+    const Odometry & kinematics, const Trajectory & trajectory,
+    const Control & trajectory_follower_control_cmd, const Control & control_cmd) override;
   DebugInfo getDebugInfo() override { return debug_info_; }
 
 private:
-  bool hasDangerAcceleration();
-  std::pair<bool, bool> hasDangerLateralAcceleration();
+  bool hasDangerAcceleration(const Odometry & odometry, const Control & control_cmd);
+  std::pair<bool, bool> hasDangerLateralAcceleration(
+    const Odometry & kinematics, const Control & control_cmd);
 
-  using Control = autoware_control_msgs::msg::Control;
-  using Odometry = nav_msgs::msg::Odometry;
-  using Trajectory = autoware_planning_msgs::msg::Trajectory;
-  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
-  rclcpp::Subscription<Control>::SharedPtr sub_trajectory_follower_control_cmd_;
-  rclcpp::Subscription<Odometry>::SharedPtr sub_kinematics_;
-  rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
 
@@ -80,9 +95,6 @@ private:
   double nearest_yaw_deviation_threshold_;   // [rad] for finding nearest index
   EngageAcceptableParam engage_acceptable_param_;
   StableCheckParam stable_check_param_;
-  Control control_cmd_;
-  Control trajectory_follower_control_cmd_;
-  Odometry kinematics_;
   Trajectory trajectory_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
@@ -94,16 +106,38 @@ private:
 class LocalMode : public ModeChangeBase
 {
 public:
-  bool isModeChangeCompleted() override { return true; }
-  bool isModeChangeAvailable() override { return true; }
+  bool isModeChangeCompleted(
+    [[maybe_unused]] const Odometry & kinematics,
+    [[maybe_unused]] const Trajectory & trajectory) override
+  {
+    return true;
+  }
+  bool isModeChangeAvailable(
+    [[maybe_unused]] const Odometry & kinematics, [[maybe_unused]] const Trajectory & trajectory,
+    [[maybe_unused]] const Control & trajectory_follower_control_cmd,
+    [[maybe_unused]] const Control & control_cmd) override
+  {
+    return true;
+  }
 };
 
 // TODO(Takagi, Isamu): Connect with status from remote operation node
 class RemoteMode : public ModeChangeBase
 {
 public:
-  bool isModeChangeCompleted() override { return true; }
-  bool isModeChangeAvailable() override { return true; }
+  bool isModeChangeCompleted(
+    [[maybe_unused]] const Odometry & kinematics,
+    [[maybe_unused]] const Trajectory & trajectory) override
+  {
+    return true;
+  }
+  bool isModeChangeAvailable(
+    [[maybe_unused]] const Odometry & kinematics, [[maybe_unused]] const Trajectory & trajectory,
+    [[maybe_unused]] const Control & trajectory_follower_control_cmd,
+    [[maybe_unused]] const Control & control_cmd) override
+  {
+    return true;
+  }
 };
 
 }  // namespace autoware::operation_mode_transition_manager

--- a/control/autoware_operation_mode_transition_manager/src/state.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.hpp
@@ -38,14 +38,12 @@ class ModeChangeBase
 {
 public:
   virtual ~ModeChangeBase() = default;
-  virtual void update([[maybe_unused]] bool transition) {}
+  virtual void update(bool) {}
   virtual bool isModeChangeCompleted(
-    [[maybe_unused]] const Odometry & kinematics,
-    [[maybe_unused]] const Trajectory & trajectory) = 0;
+    const Odometry & kinematics, const Trajectory & trajectory) = 0;
   virtual bool isModeChangeAvailable(
-    [[maybe_unused]] const Odometry & kinematics, [[maybe_unused]] const Trajectory & trajectory,
-    [[maybe_unused]] const Control & trajectory_follower_control_cmd,
-    [[maybe_unused]] const Control & control_cmd) = 0;
+    const Odometry & kinematics, const Trajectory & trajectory,
+    const Control & trajectory_follower_control_cmd, const Control & control_cmd) = 0;
 
   using DebugInfo =
     autoware_operation_mode_transition_manager::msg::OperationModeTransitionManagerDebug;
@@ -55,16 +53,9 @@ public:
 class StopMode : public ModeChangeBase
 {
 public:
-  bool isModeChangeCompleted(
-    [[maybe_unused]] const Odometry & kinematics,
-    [[maybe_unused]] const Trajectory & trajectory) override
-  {
-    return true;
-  }
+  bool isModeChangeCompleted(const Odometry &, const Trajectory &) override { return true; }
   bool isModeChangeAvailable(
-    [[maybe_unused]] const Odometry & kinematics, [[maybe_unused]] const Trajectory & trajectory,
-    [[maybe_unused]] const Control & trajectory_follower_control_cmd,
-    [[maybe_unused]] const Control & control_cmd) override
+    const Odometry &, const Trajectory &, const Control &, const Control &) override
   {
     return true;
   }
@@ -106,16 +97,9 @@ private:
 class LocalMode : public ModeChangeBase
 {
 public:
-  bool isModeChangeCompleted(
-    [[maybe_unused]] const Odometry & kinematics,
-    [[maybe_unused]] const Trajectory & trajectory) override
-  {
-    return true;
-  }
+  bool isModeChangeCompleted(const Odometry &, const Trajectory &) override { return true; }
   bool isModeChangeAvailable(
-    [[maybe_unused]] const Odometry & kinematics, [[maybe_unused]] const Trajectory & trajectory,
-    [[maybe_unused]] const Control & trajectory_follower_control_cmd,
-    [[maybe_unused]] const Control & control_cmd) override
+    const Odometry &, const Trajectory &, const Control &, const Control &) override
   {
     return true;
   }
@@ -125,16 +109,9 @@ public:
 class RemoteMode : public ModeChangeBase
 {
 public:
-  bool isModeChangeCompleted(
-    [[maybe_unused]] const Odometry & kinematics,
-    [[maybe_unused]] const Trajectory & trajectory) override
-  {
-    return true;
-  }
+  bool isModeChangeCompleted(const Odometry &, const Trajectory &) override { return true; }
   bool isModeChangeAvailable(
-    [[maybe_unused]] const Odometry & kinematics, [[maybe_unused]] const Trajectory & trajectory,
-    [[maybe_unused]] const Control & trajectory_follower_control_cmd,
-    [[maybe_unused]] const Control & control_cmd) override
+    const Odometry &, const Trajectory &, const Control &, const Control &) override
   {
     return true;
   }

--- a/control/autoware_operation_mode_transition_manager/src/state.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.hpp
@@ -82,7 +82,7 @@ public:
   DebugInfo getDebugInfo() override { return debug_info_; }
 
 private:
-  bool hasDangerAcceleration(const Odometry & odometry, const Control & control_cmd);
+  bool hasDangerAcceleration(const Odometry & kinematics, const Control & control_cmd);
   std::pair<bool, bool> hasDangerLateralAcceleration(
     const Odometry & kinematics, const Control & control_cmd);
 


### PR DESCRIPTION
## Description

The package has a lot of unnecessary member variables which decreases the maintainability and readability.
This PR eliminates the member variables as much as possible.
## Related links

## How was this PR tested?
can transit the operation mode on the simple planning simulator

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
