### PR TITLE
feat(autoware_motion_velocity_planner): point-cloud clustering optimization

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
@@ -2,9 +2,6 @@
   <arg name="interface_input_topic" default="/planning/scenario_planning/lane_driving/behavior_planning/path"/>
   <arg name="interface_output_topic" default="/planning/scenario_planning/lane_driving/trajectory"/>
 
-  <arg name="launch_obstacle_stop_module" default="true"/>
-  <arg name="launch_obstacle_slow_down_module" default="true"/>
-  <arg name="launch_obstacle_cruise_module" default="true"/>
   <arg name="launch_dynamic_obstacle_stop_module" default="true"/>
   <arg name="launch_out_of_lane_module" default="true"/>
   <arg name="launch_obstacle_velocity_limiter_module" default="true"/>
@@ -12,21 +9,6 @@
 
   <!-- assemble launch config for motion velocity planner -->
   <arg name="motion_velocity_planner_launch_modules" default="["/>
-  <let
-    name="motion_velocity_planner_launch_modules"
-    value="$(eval &quot;'$(var motion_velocity_planner_launch_modules)' + 'autoware::motion_velocity_planner::ObstacleStopModule, '&quot;)"
-    if="$(var launch_obstacle_stop_module)"
-  />
-  <let
-    name="motion_velocity_planner_launch_modules"
-    value="$(eval &quot;'$(var motion_velocity_planner_launch_modules)' + 'autoware::motion_velocity_planner::ObstacleSlowDownModule, '&quot;)"
-    if="$(var launch_obstacle_slow_down_module)"
-  />
-  <let
-    name="motion_velocity_planner_launch_modules"
-    value="$(eval &quot;'$(var motion_velocity_planner_launch_modules)' + 'autoware::motion_velocity_planner::ObstacleCruiseModule, '&quot;)"
-    if="$(var launch_obstacle_cruise_module)"
-  />
   <let
     name="motion_velocity_planner_launch_modules"
     value="$(eval &quot;'$(var motion_velocity_planner_launch_modules)' + 'autoware::motion_velocity_planner::OutOfLaneModule, '&quot;)"
@@ -45,7 +27,7 @@
   <let name="motion_velocity_planner_launch_modules" value="$(eval &quot;'$(var motion_velocity_planner_launch_modules)' + '$(var launch_module_list_end)'&quot;)"/>
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="motion_planning_container" namespace="" args="" output="screen">
-    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
+    <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component" namespace=""/>
   </node_container>
 
   <!-- path smoothing -->
@@ -137,7 +119,7 @@
   <!-- plan slowdown or stops on the final trajectory -->
   <group>
     <load_composable_node target="/planning/scenario_planning/lane_driving/motion_planning/motion_planning_container">
-      <composable_node pkg="autoware_motion_velocity_planner" plugin="autoware::motion_velocity_planner::MotionVelocityPlannerNode" name="motion_velocity_planner" namespace="">
+      <composable_node pkg="autoware_motion_velocity_planner_node" plugin="autoware::motion_velocity_planner::MotionVelocityPlannerNode" name="motion_velocity_planner" namespace="">
         <!-- topic remap -->
         <remap from="~/input/trajectory" to="path_optimizer/trajectory"/>
         <remap from="~/input/vector_map" to="/map/vector_map"/>
@@ -149,8 +131,6 @@
         <remap from="~/input/virtual_traffic_light_states" to="/perception/virtual_traffic_light_states"/>
         <remap from="~/input/occupancy_grid" to="/perception/occupancy_grid_map/map"/>
         <remap from="~/output/trajectory" to="motion_velocity_planner/trajectory"/>
-        <remap from="~/output/velocity_limit" to="/planning/scenario_planning/max_velocity_candidates"/>
-        <remap from="~/output/clear_velocity_limit" to="/planning/scenario_planning/clear_velocity_limit"/>
         <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
         <remap from="~/output/velocity_factors" to="/planning/velocity_factors/motion_velocity_planner"/>
         <!-- params -->
@@ -161,9 +141,6 @@
         <param from="$(var velocity_smoother_param_path)"/>
         <param from="$(var motion_velocity_planner_velocity_smoother_type_param_path)"/>
         <param from="$(var motion_velocity_planner_param_path)"/>
-        <param from="$(var motion_velocity_planner_obstacle_stop_module_param_path)"/>
-        <param from="$(var motion_velocity_planner_obstacle_slow_down_module_param_path)"/>
-        <param from="$(var motion_velocity_planner_obstacle_cruise_module_param_path)"/>
         <param from="$(var motion_velocity_planner_dynamic_obstacle_stop_module_param_path)"/>
         <param from="$(var motion_velocity_planner_out_of_lane_module_param_path)"/>
         <param from="$(var motion_velocity_planner_obstacle_velocity_limiter_param_path)"/>

--- a/perception/autoware_multi_object_tracker/lib/association/association.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/association.cpp
@@ -19,6 +19,8 @@
 #include "autoware/multi_object_tracker/object_model/types.hpp"
 
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/unit_conversion.hpp>
 
 #include <algorithm>
 #include <list>

--- a/perception/autoware_multi_object_tracker/lib/uncertainty/uncertainty_processor.cpp
+++ b/perception/autoware_multi_object_tracker/lib/uncertainty/uncertainty_processor.cpp
@@ -20,6 +20,9 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/unit_conversion.hpp>
+
 #include <tf2/utils.h>
 
 #include <algorithm>

--- a/perception/autoware_radar_object_tracker/src/association/data_association.cpp
+++ b/perception/autoware_radar_object_tracker/src/association/data_association.cpp
@@ -16,6 +16,9 @@
 
 #include "autoware_radar_object_tracker/association/solver/gnn_solver.hpp"
 
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/normalization.hpp>
+
 #include <nlohmann/json.hpp>
 
 #include <algorithm>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
@@ -40,15 +40,6 @@
           motorcycle: true
           bicycle: true
           pedestrian: true
-          pointcloud: false
-
-        pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
 
         min_lat_margin: 0.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
@@ -101,7 +101,8 @@ private:
   std::vector<SlowDownObstacle> filter_slow_down_obstacle_for_point_cloud(
     const Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
     const std::vector<TrajectoryPoint> & decimated_traj_points,
-    const PlannerData::Pointcloud & point_cloud, const VehicleInfo & vehicle_info,
+    const PlannerData::Pointcloud & point_cloud,
+    const bool use_pointcloud, const VehicleInfo & vehicle_info,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check, size_t ego_idx);
   std::optional<SlowDownObstacle> create_slow_down_obstacle_for_predicted_object(
     const std::vector<TrajectoryPoint> & traj_points,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/parameters.hpp
@@ -56,15 +56,6 @@ struct CommonParam
 
 struct ObstacleFilteringParam
 {
-  struct PointcloudObstacleFilteringParam
-  {
-    double pointcloud_voxel_grid_x{};
-    double pointcloud_voxel_grid_y{};
-    double pointcloud_voxel_grid_z{};
-    double pointcloud_cluster_tolerance{};
-    double pointcloud_min_cluster_size{};
-    double pointcloud_max_cluster_size{};
-  };
 
   PointcloudObstacleFilteringParam pointcloud_obstacle_filtering_param;
   std::vector<uint8_t> object_types{};
@@ -82,8 +73,6 @@ struct ObstacleFilteringParam
   ObstacleFilteringParam() = default;
   explicit ObstacleFilteringParam(rclcpp::Node & node)
   {
-    use_pointcloud = get_or_declare_parameter<bool>(
-      node, "obstacle_slow_down.obstacle_filtering.object_type.pointcloud");
     object_types =
       utils::get_target_object_type(node, "obstacle_slow_down.obstacle_filtering.object_type.");
     min_lat_margin = get_or_declare_parameter<double>(
@@ -96,20 +85,6 @@ struct ObstacleFilteringParam
       node, "obstacle_slow_down.obstacle_filtering.successive_num_to_entry_slow_down_condition");
     successive_num_to_exit_slow_down_condition = get_or_declare_parameter<int>(
       node, "obstacle_slow_down.obstacle_filtering.successive_num_to_exit_slow_down_condition");
-
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_x = get_or_declare_parameter<double>(
-      node, "obstacle_slow_down.obstacle_filtering.pointcloud.pointcloud_voxel_grid_x");
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_y = get_or_declare_parameter<double>(
-      node, "obstacle_slow_down.obstacle_filtering.pointcloud.pointcloud_voxel_grid_y");
-    pointcloud_obstacle_filtering_param.pointcloud_voxel_grid_z = get_or_declare_parameter<double>(
-      node, "obstacle_slow_down.obstacle_filtering.pointcloud.pointcloud_voxel_grid_z");
-    pointcloud_obstacle_filtering_param.pointcloud_cluster_tolerance =
-      get_or_declare_parameter<double>(
-        node, "obstacle_slow_down.obstacle_filtering.pointcloud.pointcloud_cluster_tolerance");
-    pointcloud_obstacle_filtering_param.pointcloud_min_cluster_size = get_or_declare_parameter<int>(
-      node, "obstacle_slow_down.obstacle_filtering.pointcloud.pointcloud_min_cluster_size");
-    pointcloud_obstacle_filtering_param.pointcloud_max_cluster_size = get_or_declare_parameter<int>(
-      node, "obstacle_slow_down.obstacle_filtering.pointcloud.pointcloud_max_cluster_size");
   }
 };
 


### PR DESCRIPTION
## Description
universe changes for https://github.com/autowarefoundation/autoware_core/pull/377

Removes point-cloud clustering for autoware_obstacle_stop and autoware_obstacle_slowdown.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
