### PR TITLE
fix(autoware_gyro_odometer): fix deprecated autoware_utils header

### DIFF
--- a/localization/autoware_gyro_odometer/package.xml
+++ b/localization/autoware_gyro_odometer/package.xml
@@ -18,7 +18,10 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_localization_util</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_diagnostics</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_logging</depend>
+  <depend>autoware_utils_tf</depend>
   <depend>diagnostic_msgs</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
@@ -72,8 +72,8 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
   twist_with_covariance_pub_ = create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(
     "twist_with_covariance", rclcpp::QoS{10});
 
-  diagnostics_ =
-    std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(this, "gyro_odometer_status");
+  diagnostics_ = std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(
+    this, "gyro_odometer_status");
 
   // TODO(YamatoAndo) createTimer
 }

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
@@ -34,7 +34,7 @@ namespace autoware::gyro_odometer
 
 std::array<double, 9> transform_covariance(const std::array<double, 9> & cov)
 {
-  using COV_IDX = autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+  using COV_IDX = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
 
   double max_cov = std::max({cov[COV_IDX::X_X], cov[COV_IDX::Y_Y], cov[COV_IDX::Z_Z]});
 
@@ -53,8 +53,8 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
   vehicle_twist_arrived_(false),
   imu_arrived_(false)
 {
-  transform_listener_ = std::make_shared<autoware_utils::TransformListener>(this);
-  logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
+  transform_listener_ = std::make_shared<autoware_utils_tf::TransformListener>(this);
+  logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
 
   vehicle_twist_sub_ = create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
     "vehicle/twist_with_covariance", rclcpp::QoS{100},
@@ -73,7 +73,7 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
     "twist_with_covariance", rclcpp::QoS{10});
 
   diagnostics_ =
-    std::make_unique<autoware_utils::DiagnosticsInterface>(this, "gyro_odometer_status");
+    std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(this, "gyro_odometer_status");
 
   // TODO(YamatoAndo) createTimer
 }
@@ -210,8 +210,8 @@ void GyroOdometerNode::concat_gyro_and_odometer()
     gyro.angular_velocity_covariance = transform_covariance(gyro.angular_velocity_covariance);
   }
 
-  using COV_IDX_XYZ = autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
-  using COV_IDX_XYZRPY = autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  using COV_IDX_XYZ = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
+  using COV_IDX_XYZRPY = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 
   // calc mean, covariance
   double vx_mean = 0;

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_core.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_core.hpp
@@ -19,7 +19,6 @@
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_tf/transform_listener.hpp>
-
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/twist_stamped.hpp>

--- a/localization/autoware_gyro_odometer/src/gyro_odometer_core.hpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_core.hpp
@@ -15,10 +15,10 @@
 #ifndef GYRO_ODOMETER_CORE_HPP_
 #define GYRO_ODOMETER_CORE_HPP_
 
-#include "autoware_utils/ros/diagnostics_interface.hpp"
-#include "autoware_utils/ros/logger_level_configure.hpp"
-#include "autoware_utils/ros/msg_covariance.hpp"
-#include "autoware_utils/ros/transform_listener.hpp"
+#include <autoware_utils_diagnostics/diagnostics_interface.hpp>
+#include <autoware_utils_geometry/msg/covariance.hpp>
+#include <autoware_utils_logging/logger_level_configure.hpp>
+#include <autoware_utils_tf/transform_listener.hpp>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -43,7 +43,7 @@ namespace autoware::gyro_odometer
 class GyroOdometerNode : public rclcpp::Node
 {
 private:
-  using COV_IDX = autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+  using COV_IDX = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
 
 public:
   explicit GyroOdometerNode(const rclcpp::NodeOptions & node_options);
@@ -67,8 +67,8 @@ private:
   rclcpp::Publisher<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
     twist_with_covariance_pub_;
 
-  std::shared_ptr<autoware_utils::TransformListener> transform_listener_;
-  std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
+  std::shared_ptr<autoware_utils_tf::TransformListener> transform_listener_;
+  std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
 
   std::string output_frame_;
   double message_timeout_sec_;
@@ -80,7 +80,7 @@ private:
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> vehicle_twist_queue_;
   std::deque<sensor_msgs::msg::Imu> gyro_queue_;
 
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_;
+  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_;
 };
 
 }  // namespace autoware::gyro_odometer


### PR DESCRIPTION
## Description
This PR fixes the include headers of `autoware_utils` to follow the current package style (`autoware_utils_*`) for `gyro_odometer` package.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10474
  - https://github.com/autowarefoundation/autoware_universe/issues/10482

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Checked the behavior with the sample rosbag and confirmed it works as expected.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
