### PR TITLE
ci: fix conditions of prepare build_depends.repos file (main branch)

### DIFF
--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -68,7 +68,7 @@ jobs:
         shell: bash
 
       - name: Prepare build_depends.repos file (main branch)
-        if: ${{ github.event.pull_request.base.ref == 'main' }}
+        if: ${{ github.event.pull_request.base.ref != 'humble' }}
         uses: ./.github/actions/combine-repos-action
         with:
           base_file: build_depends_humble.repos

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -97,7 +97,7 @@ jobs:
         shell: bash
 
       - name: Prepare build_depends.repos file (main branch)
-        if: ${{ github.event.pull_request.base.ref == 'main' }}
+        if: ${{ github.event.pull_request.base.ref != 'humble' }}
         uses: ./.github/actions/combine-repos-action
         with:
           base_file: build_depends_humble.repos

--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -97,7 +97,7 @@ jobs:
         shell: bash
 
       - name: Prepare build_depends.repos file (main branch)
-        if: ${{ github.event.pull_request.base.ref == 'main' }}
+        if: ${{ github.event.pull_request.base.ref != 'humble' }}
         uses: ./.github/actions/combine-repos-action
         with:
           base_file: build_depends_humble.repos

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
       - name: Prepare build_depends.repos file (main branch)
-        if: ${{ github.event.pull_request.base.ref == 'main' }}
+        if: ${{ github.event.pull_request.base.ref != 'humble' }}
         uses: ./.github/actions/combine-repos-action
         with:
           base_file: build_depends_humble.repos

--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -66,7 +66,7 @@ jobs:
         shell: bash
 
       - name: Prepare build_depends.repos file (main branch)
-        if: ${{ github.event.pull_request.base.ref == 'main' }}
+        if: ${{ github.event.pull_request.base.ref != 'humble' }}
         uses: ./.github/actions/combine-repos-action
         with:
           base_file: build_depends_humble.repos


### PR DESCRIPTION
## Description

Current implementation of build testing workflow has hard coding conditions.
To be robust with branch name changing, I fixed the conditions in workflow files.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://github.com/autowarefoundation/autoware_universe/actions/runs/14529930679/job/40767929231?pr=10502

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
