### PR TITLE
fix(autoware_system_monitor): quick fix for autoware_system_monitor

### DIFF
--- a/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
@@ -567,7 +567,7 @@ bool ProcessMonitor::getCommandLineFromPid(const std::string & pid, std::string 
   // Leave the last 0x00 (end-of-C-string) intact.
   std::replace(buffer.begin(), (buffer.end() - 1), '\0', ' ');
   // Make sure the last character is a null terminator.
-  *(buffer.end() - 1) = '\0';
+  buffer[buffer.size() - 1] = '\0';
   try {
     std::string cmdline = std::string(buffer.begin(), (buffer.end() - 1));
     // Remove trailing spaces

--- a/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
@@ -567,6 +567,10 @@ bool ProcessMonitor::getCommandLineFromPid(const std::string & pid, std::string 
   // Leave the last 0x00 (end-of-C-string) intact.
   std::replace(buffer.begin(), (buffer.end() - 1), '\0', ' ');
   // Make sure the last character is a null terminator.
+
+  // Although buffer.back() is safer and more idiomatic,
+  // using it here causes a compile error with -Werror=stringop-overflow.
+  // Therefore, we safely access the last element by index.
   buffer[buffer.size() - 1] = '\0';
   try {
     std::string cmdline = std::string(buffer.begin(), (buffer.end() - 1));


### PR DESCRIPTION
fix sompile issue

## Description
compile using colcon with latest autoware main branch code, i got an error like below

![Screenshot from 2025-04-20 15-10-33](https://github.com/user-attachments/assets/a951a775-87e2-415e-bfc0-0e9a04712ee8)

it seems that the author want to set value '\0' to the last element of the vector to use it as a terminator
i look through the code make sure there is null pointor protection code serveral lines before, so i modify the last element access method by a tiny fix

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. using AWF official docker
2. clone the latest main branch code
3. compile the entier autoware with " colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --symlink-install"
4. no error occours any more

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
