### PR TITLE
fix(autoware_pose_estimator_arbiter): fix deprecated autoware_utils header

### DIFF
--- a/localization/autoware_pose_estimator_arbiter/example_rule/src/switch_rule/pcd_map_based_rule.cpp
+++ b/localization/autoware_pose_estimator_arbiter/example_rule/src/switch_rule/pcd_map_based_rule.cpp
@@ -14,7 +14,7 @@
 
 #include "switch_rule/pcd_map_based_rule.hpp"
 
-#include <autoware_utils/ros/parameter.hpp>
+#include <autoware_utils_rclcpp/parameter.hpp>
 
 #include <memory>
 #include <unordered_map>
@@ -31,9 +31,9 @@ PcdMapBasedRule::PcdMapBasedRule(
   shared_data_(std::move(shared_data))
 {
   const int pcd_density_upper_threshold =
-    autoware_utils::get_or_declare_parameter<int>(node, "pcd_density_upper_threshold");
+    autoware_utils_rclcpp::get_or_declare_parameter<int>(node, "pcd_density_upper_threshold");
   const int pcd_density_lower_threshold =
-    autoware_utils::get_or_declare_parameter<int>(node, "pcd_density_lower_threshold");
+    autoware_utils_rclcpp::get_or_declare_parameter<int>(node, "pcd_density_lower_threshold");
 
   pcd_occupancy_ = std::make_unique<rule_helper::PcdOccupancy>(
     pcd_density_upper_threshold, pcd_density_lower_threshold);

--- a/localization/autoware_pose_estimator_arbiter/package.xml
+++ b/localization/autoware_pose_estimator_arbiter/package.xml
@@ -20,8 +20,8 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
-  <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_utils_logging</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>magic_enum</depend>

--- a/localization/autoware_pose_estimator_arbiter/package.xml
+++ b/localization/autoware_pose_estimator_arbiter/package.xml
@@ -20,7 +20,8 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_rclcpp</depend>
+  <depend>autoware_utils_logging</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>magic_enum</depend>

--- a/localization/autoware_pose_estimator_arbiter/src/pose_estimator_arbiter.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/pose_estimator_arbiter.hpp
@@ -19,7 +19,7 @@
 #include "stopper/base_stopper.hpp"
 #include "switch_rule/base_switch_rule.hpp"
 
-#include <autoware_utils/ros/logger_level_configure.hpp>
+#include <autoware_utils_logging/logger_level_configure.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
@@ -53,7 +53,7 @@ private:
   // Set of running pose estimators specified by ros param `pose_sources`
   const std::unordered_set<PoseEstimatorType> running_estimator_list_;
   // Configuration to allow changing the log level by service
-  const std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
+  const std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
 
   // This is passed to several modules (stoppers & rule) so that all modules can access common data
   // without passing them as arguments. Also, modules can register subscriber callbacks through

--- a/localization/autoware_pose_estimator_arbiter/src/pose_estimator_arbiter_core.cpp
+++ b/localization/autoware_pose_estimator_arbiter/src/pose_estimator_arbiter_core.cpp
@@ -54,7 +54,7 @@ PoseEstimatorArbiter::PoseEstimatorArbiter(const rclcpp::NodeOptions & options)
 : rclcpp::Node("pose_estimator_arbiter", options),
   running_estimator_list_(parse_estimator_name_args(
     declare_parameter<std::vector<std::string>>("pose_sources"), get_logger())),
-  logger_configure_(std::make_unique<autoware_utils::LoggerLevelConfigure>(this))
+  logger_configure_(std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this))
 {
   // Shared data
   shared_data_ = std::make_shared<SharedData>();


### PR DESCRIPTION
## Description
This PR fixes the include headers of autoware_utils to follow the current package style (autoware_utils_*) for autoware_pose_estimator_arbiter package.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10474
  - https://github.com/autowarefoundation/autoware_universe/issues/10488


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
