### PR TITLE
fix(autoware_lidar_marker_localizer): fix deprecated autoware_utils header

### DIFF
--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
@@ -18,7 +18,9 @@
   <depend>autoware_localization_util</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_point_types</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_diagnostics</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_pcl</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -15,8 +15,8 @@
 #include "lidar_marker_localizer.hpp"
 
 #include <autoware/point_types/types.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
-#include <autoware_utils/transform/transforms.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_pcl/transforms.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/qos.hpp>
 
@@ -125,7 +125,7 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this, false);
 
   diagnostics_interface_.reset(
-    new autoware_utils::DiagnosticsInterface(this, "marker_detection_status"));
+    new autoware_utils_diagnostics::DiagnosticsInterface(this, "marker_detection_status"));
 }
 
 void LidarMarkerLocalizer::initialize_diagnostics()
@@ -226,7 +226,7 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
   // (4) check distance to the nearest marker
   const landmark_manager::Landmark nearest_marker = get_nearest_landmark(self_pose, map_landmarks);
   const Pose nearest_marker_pose_on_base_link =
-    autoware_utils::inverse_transform_pose(nearest_marker.pose, self_pose);
+    autoware_utils_geometry::inverse_transform_pose(nearest_marker.pose, self_pose);
 
   const double distance_from_self_pose_to_nearest_marker =
     std::abs(nearest_marker_pose_on_base_link.position.x);
@@ -261,7 +261,7 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
     pose_array_msg.header.stamp = sensor_ros_time;
     pose_array_msg.header.frame_id = "map";
     for (const landmark_manager::Landmark & landmark : detected_landmarks) {
-      const Pose detected_marker_on_map = autoware_utils::transform_pose(landmark.pose, self_pose);
+      const Pose detected_marker_on_map = autoware_utils_geometry::transform_pose(landmark.pose, self_pose);
       pose_array_msg.poses.push_back(detected_marker_on_map);
     }
     pub_marker_detected_->publish(pose_array_msg);
@@ -458,7 +458,7 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
       marker_pose_on_base_link.position.y = min_y[i];
       marker_pose_on_base_link.position.z = param_.marker_height_from_ground;
       marker_pose_on_base_link.orientation =
-        autoware_utils::create_quaternion_from_rpy(M_PI_2, 0.0, 0.0);  // TODO(YamatoAndo)
+        autoware_utils_geometry::create_quaternion_from_rpy(M_PI_2, 0.0, 0.0);  // TODO(YamatoAndo)
       detected_landmarks.push_back(landmark_manager::Landmark{"0", marker_pose_on_base_link});
     }
   }
@@ -475,7 +475,7 @@ landmark_manager::Landmark get_nearest_landmark(
 
   for (const auto & landmark : landmarks) {
     const double curr_distance =
-      autoware_utils::calc_distance3d(landmark.pose.position, self_pose.position);
+      autoware_utils_geometry::calc_distance3d(landmark.pose.position, self_pose.position);
 
     if (curr_distance > min_distance) {
       continue;
@@ -613,7 +613,7 @@ void LidarMarkerLocalizer::transform_sensor_measurement(
   }
 
   const geometry_msgs::msg::PoseStamped target_to_source_pose_stamped =
-    autoware_utils::transform2pose(transform);
+    autoware_utils_geometry::transform2pose(transform);
   const Eigen::Matrix4f base_to_sensor_matrix =
     autoware::localization_util::pose_to_matrix4f(target_to_source_pose_stamped.pose);
   pcl_ros::transformPointCloud(

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -16,7 +16,7 @@
 #define LIDAR_MARKER_LOCALIZER_HPP_
 
 #include "autoware/localization_util/smart_pose_buffer.hpp"
-#include "autoware_utils/ros/diagnostics_interface.hpp"
+#include "autoware_utils_diagnostics/diagnostics_interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -134,7 +134,7 @@ private:
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_debug_pose_with_covariance_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_marker_pointcloud_;
 
-  std::shared_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_;
+  std::shared_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_interface_;
 
   Param param_;
   bool is_activated_;


### PR DESCRIPTION
## Description
This PR fixes the include headers of `autoware_utils` to follow the current package style (`autoware_utils_*`) for autoware_lidar_marker_localizer package.


## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10474
  - https://github.com/autowarefoundation/autoware_universe/issues/10490

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
