### PR TITLE
fix(autoware_pose_initializer): fix deprecated autoware_utils header

### DIFF
--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/package.xml
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/package.xml
@@ -21,7 +21,7 @@
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_localization_util</depend>
   <depend>autoware_map_msgs</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>tf2_eigen</depend>

--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/src/landmark_manager.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/src/landmark_manager.cpp
@@ -16,7 +16,7 @@
 
 #include "autoware/localization_util/util_func.hpp"
 #include "autoware_lanelet2_extension/utility/message_conversion.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils_geometry/geometry.hpp"
 
 #include <Eigen/Core>
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -63,7 +63,7 @@ void LandmarkManager::parse_landmarks(
     const auto center = (v0 + v1 + v2 + v3) / 4.0;
 
     // Define axes
-    const auto x_axis = (v1 - v0).normalized();
+    const auto x_axis = \(v1 - v0).normalized();
     const auto y_axis = (v2 - v1).normalized();
     const auto z_axis = x_axis.cross(y_axis).normalized();
 
@@ -165,7 +165,7 @@ geometry_msgs::msg::Pose LandmarkManager::calculate_new_self_pose(
 
     // convert base_link to map
     const Pose detected_landmark_on_map =
-      autoware_utils::transform_pose(detected_landmark_on_base_link, self_pose);
+      autoware_utils_geometry::transform_pose(detected_landmark_on_base_link, self_pose);
 
     // match to map
     if (landmarks_map_.count(landmark.id) == 0) {
@@ -175,7 +175,7 @@ geometry_msgs::msg::Pose LandmarkManager::calculate_new_self_pose(
     // check all poses
     for (const Pose mapped_landmark_on_map : landmarks_map_.at(landmark.id)) {
       // check distance
-      const double curr_distance = autoware_utils::calc_distance3d(
+      const double curr_distance = autoware_utils_geometry::calc_distance3d(
         mapped_landmark_on_map.position, detected_landmark_on_map.position);
       if (curr_distance > min_distance) {
         continue;

--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/src/landmark_manager.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/src/landmark_manager.cpp
@@ -63,7 +63,7 @@ void LandmarkManager::parse_landmarks(
     const auto center = (v0 + v1 + v2 + v3) / 4.0;
 
     // Define axes
-    const auto x_axis = \(v1 - v0).normalized();
+    const auto x_axis = (v1 - v0).normalized();
     const auto y_axis = (v2 - v1).normalized();
     const auto z_axis = x_axis.cross(y_axis).normalized();
 

--- a/localization/autoware_pose_initializer/package.xml
+++ b/localization/autoware_pose_initializer/package.xml
@@ -23,7 +23,8 @@
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_map_height_fitter</depend>
   <depend>autoware_motion_utils</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_diagnostics</depend>
+  <depend>autoware_utils_logging</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -41,7 +41,7 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
   gnss_particle_covariance_ = get_covariance_parameter(this, "gnss_particle_covariance");
 
   diagnostics_pose_reliable_ =
-    std::make_unique<autoware_utils::DiagnosticsInterface>(this, "pose_initializer_status");
+    std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(this, "pose_initializer_status");
 
   if (declare_parameter<bool>("ekf_enabled")) {
     ekf_localization_trigger_ = std::make_unique<EkfLocalizationTriggerModule>(this);
@@ -64,7 +64,7 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
   if (declare_parameter<bool>("pose_error_check_enabled")) {
     pose_error_check_ = std::make_unique<PoseErrorCheckModule>(this);
   }
-  logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
+  logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
 
   change_state(State::Message::UNINITIALIZED);
 

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -40,8 +40,8 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
   output_pose_covariance_ = get_covariance_parameter(this, "output_pose_covariance");
   gnss_particle_covariance_ = get_covariance_parameter(this, "gnss_particle_covariance");
 
-  diagnostics_pose_reliable_ =
-    std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(this, "pose_initializer_status");
+  diagnostics_pose_reliable_ = std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(
+    this, "pose_initializer_status");
 
   if (declare_parameter<bool>("ekf_enabled")) {
     ekf_localization_trigger_ = std::make_unique<EkfLocalizationTriggerModule>(this);

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -17,8 +17,8 @@
 
 #include <autoware/component_interface_specs_universe/localization.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
-#include <autoware_utils/ros/diagnostics_interface.hpp>
-#include <autoware_utils/ros/logger_level_configure.hpp>
+#include <autoware_utils_diagnostics/diagnostics_interface.hpp>
+#include <autoware_utils_logging/logger_level_configure.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -59,8 +59,8 @@ private:
   std::unique_ptr<PoseErrorCheckModule> pose_error_check_;
   std::unique_ptr<EkfLocalizationTriggerModule> ekf_localization_trigger_;
   std::unique_ptr<NdtLocalizationTriggerModule> ndt_localization_trigger_;
-  std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_pose_reliable_;
+  std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
+  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_pose_reliable_;
   double stop_check_duration_;
 
   void change_node_trigger(bool flag, bool need_spin = false);


### PR DESCRIPTION
## Description
This PR fixes the include headers of autoware_utils to follow the current package style (autoware_utils_*) for autoware_pose_initializer package.


## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10474
  - https://github.com/autowarefoundation/autoware_universe/issues/10492

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
