### PR TITLE
fix(autoware_dummy_perception_publisher): fix deprecated autoware_utils header

### DIFF
--- a/simulator/autoware_dummy_perception_publisher/package.xml
+++ b/simulator/autoware_dummy_perception_publisher/package.xml
@@ -22,7 +22,7 @@
   <test_depend>autoware_lint_common</test_depend>
 
   <depend>autoware_perception_msgs</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>

--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/dummy_perception_publisher/node.hpp"
 
-#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils_geometry/geometry.hpp"
 
 #include <pcl/filters/voxel_grid_occlusion_estimation.h>
 #include <tf2/LinearMath/Quaternion.h>
@@ -97,7 +97,7 @@ ObjectInfo::ObjectInfo(
     }
   }
 
-  const auto current_pose = autoware_utils::calc_offset_pose(initial_pose, move_distance, 0.0, 0.0);
+  const auto current_pose = autoware_utils_geometry::calc_offset_pose(initial_pose, move_distance, 0.0, 0.0);
 
   // calculate tf from map to moved_object
   geometry_msgs::msg::Transform ros_map2moved_object;


### PR DESCRIPTION
## Description
This PR fixes the include headers of `autoware_utils` to follow the current package style (`autoware_utils_*`) for This PR fixes the include headers of autoware_utils to follow the current package style (autoware_utils_*) for autoware_pose_instability_detector package. package.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10470

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
