### PR TITLE
fix(autoware_simple_planning_simulator ): fix deprecated autoware_utils header

### DIFF
--- a/simulator/autoware_simple_planning_simulator/package.xml
+++ b/simulator/autoware_simple_planning_simulator/package.xml
@@ -23,7 +23,8 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -17,9 +17,9 @@
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model.hpp"
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model_actuation_cmd.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
-#include "autoware_utils/ros/msg_covariance.hpp"
-#include "autoware_utils/ros/update_param.hpp"
+#include "autoware_utils_geometry/geometry.hpp"
+#include "autoware_utils_geometry/msg_covariance.hpp"
+#include "autoware_utils_rclcpp/update_param.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
@@ -63,7 +63,7 @@ nav_msgs::msg::Odometry to_odometry(
   odometry.pose.pose.position.x = vehicle_model_ptr->getX();
   odometry.pose.pose.position.y = vehicle_model_ptr->getY();
   odometry.pose.pose.orientation =
-    autoware_utils::create_quaternion_from_rpy(0.0, ego_pitch_angle, vehicle_model_ptr->getYaw());
+    autoware_utils_geometry::create_quaternion_from_rpy(0.0, ego_pitch_angle, vehicle_model_ptr->getYaw());
   odometry.twist.twist.linear.x = vehicle_model_ptr->getVx();
   odometry.twist.twist.angular.z = vehicle_model_ptr->getWz();
 
@@ -403,8 +403,8 @@ rcl_interfaces::msg::SetParametersResult SimplePlanningSimulator::on_parameter(
   result.reason = "success";
 
   try {
-    autoware_utils::update_param(parameters, "x_stddev", x_stddev_);
-    autoware_utils::update_param(parameters, "y_stddev", y_stddev_);
+    autoware_utils_rclcpp::update_param(parameters, "x_stddev", x_stddev_);
+    autoware_utils_rclcpp::update_param(parameters, "y_stddev", y_stddev_);
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;
     result.reason = e.what();
@@ -422,7 +422,7 @@ double SimplePlanningSimulator::calculate_ego_pitch() const
   geometry_msgs::msg::Pose ego_pose;
   ego_pose.position.x = ego_x;
   ego_pose.position.y = ego_y;
-  ego_pose.orientation = autoware_utils::create_quaternion_from_yaw(ego_yaw);
+  ego_pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(ego_yaw);
 
   // calculate prev/next point of lanelet centerline nearest to ego pose.
   lanelet::Lanelet ego_lanelet;
@@ -497,7 +497,7 @@ void SimplePlanningSimulator::on_timer()
 
   // add estimate covariance
   {
-    using COV_IDX = autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+    using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
     current_odometry_.pose.covariance[COV_IDX::X_X] = x_stddev_;
     current_odometry_.pose.covariance[COV_IDX::Y_Y] = y_stddev_;
   }
@@ -695,7 +695,7 @@ void SimplePlanningSimulator::add_measurement_noise(
   odom.twist.twist.linear.x += velocity_noise;
   double yaw = tf2::getYaw(odom.pose.pose.orientation);
   yaw += static_cast<float>((*n.rpy_dist_)(*n.rand_engine_));
-  odom.pose.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
+  odom.pose.pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
 
   vel.longitudinal_velocity += static_cast<double>(velocity_noise);
 
@@ -823,7 +823,7 @@ void SimplePlanningSimulator::publish_pose(const Odometry & odometry)
   geometry_msgs::msg::PoseWithCovarianceStamped msg;
 
   msg.pose = odometry.pose;
-  using COV_IDX = autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   constexpr auto COV_POS = 0.0225;      // same value as current ndt output
   constexpr auto COV_ANGLE = 0.000625;  // same value as current ndt output
   msg.pose.covariance.at(COV_IDX::X_X) = COV_POS;
@@ -853,7 +853,7 @@ void SimplePlanningSimulator::publish_acceleration()
   msg.accel.accel.linear.x = vehicle_model_ptr_->getAx();
   msg.accel.accel.linear.y = vehicle_model_ptr_->getWz() * vehicle_model_ptr_->getVx();
 
-  using COV_IDX = autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   constexpr auto COV = 0.001;
   msg.accel.covariance.at(COV_IDX::X_X) = COV;          // linear x
   msg.accel.covariance.at(COV_IDX::Y_Y) = COV;          // linear y
@@ -866,7 +866,7 @@ void SimplePlanningSimulator::publish_acceleration()
 
 void SimplePlanningSimulator::publish_imu()
 {
-  using COV_IDX = autoware_utils::xyz_covariance_index::XYZ_COV_IDX;
+  using COV_IDX = autoware_utils_geometry::xyz_covariance_index::XYZ_COV_IDX;
 
   sensor_msgs::msg::Imu imu;
   imu.header.frame_id = "base_link";

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -62,8 +62,8 @@ nav_msgs::msg::Odometry to_odometry(
   nav_msgs::msg::Odometry odometry;
   odometry.pose.pose.position.x = vehicle_model_ptr->getX();
   odometry.pose.pose.position.y = vehicle_model_ptr->getY();
-  odometry.pose.pose.orientation =
-    autoware_utils_geometry::create_quaternion_from_rpy(0.0, ego_pitch_angle, vehicle_model_ptr->getYaw());
+  odometry.pose.pose.orientation = autoware_utils_geometry::create_quaternion_from_rpy(
+    0.0, ego_pitch_angle, vehicle_model_ptr->getYaw());
   odometry.twist.twist.linear.x = vehicle_model_ptr->getVx();
   odometry.twist.twist.angular.z = vehicle_model_ptr->getWz();
 

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -18,8 +18,8 @@
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model.hpp"
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model_actuation_cmd.hpp"
 #include "autoware_utils_geometry/geometry.hpp"
-#include "autoware_utils_geometry/msg_covariance.hpp"
-#include "autoware_utils_rclcpp/update_param.hpp"
+#include "autoware_utils_geometry/msg/covariance.hpp"
+#include "autoware_utils_rclcpp/parameter.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 


### PR DESCRIPTION
## Description
This PR fixes the include headers of autoware_utils to follow the current package style (autoware_utils_*) for autoware_simple_planning_simulator package.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10470
<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
