### PR TITLE
fix(autoware_fault_injection): fix deprecated autoware_utils header

### DIFF
--- a/simulator/autoware_fault_injection/package.xml
+++ b/simulator/autoware_fault_injection/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>diagnostic_aggregator</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/simulator/autoware_fault_injection/src/fault_injection_node/fault_injection_node.cpp
+++ b/simulator/autoware_fault_injection/src/fault_injection_node/fault_injection_node.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/fault_injection/fault_injection_node.hpp"
 
-#include <autoware_utils/ros/update_param.hpp>
+#include <autoware_utils_rclcpp/update_param.hpp>
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Description
This PR fixes the include headers of autoware_utils to follow the current package style (autoware_utils_*) for autoware_fault_injection package.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10470

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
