### PR TITLE
perf(cuda_sync_blocking)

### DIFF
--- a/perception/autoware_bevfusion/src/bevfusion_node.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node.cpp
@@ -28,6 +28,10 @@ namespace autoware::bevfusion
 BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
 : Node("bevfusion", options), tf_buffer_(this->get_clock())
 {
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   auto descriptor = rcl_interfaces::msg::ParameterDescriptor{}.set__read_only(true);
 
   // Modality

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -95,6 +95,10 @@ inline bool isUnknown(int label2d)
 PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & options)
 : FusionNode<PointCloudMsgType, RoiMsgType, DetectedObjects>("pointpainting_fusion", options)
 {
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   omp_num_threads_ = this->declare_parameter<int>("omp_params.num_threads");
   const float score_threshold =
     static_cast<float>(this->declare_parameter<double>("post_process_params.score_threshold"));

--- a/perception/autoware_lidar_apollo_instance_segmentation/src/node.cpp
+++ b/perception/autoware_lidar_apollo_instance_segmentation/src/node.cpp
@@ -30,6 +30,11 @@ LidarInstanceSegmentationNode::LidarInstanceSegmentationNode(
 : Node("lidar_apollo_instance_segmentation_node", node_options)
 {
   using std::placeholders::_1;
+
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   // initialize debug tool
   {
     using autoware_utils::DebugPublisher;

--- a/perception/autoware_lidar_centerpoint/src/node.cpp
+++ b/perception/autoware_lidar_centerpoint/src/node.cpp
@@ -38,6 +38,10 @@ namespace autoware::lidar_centerpoint
 LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_options)
 : Node("lidar_center_point", node_options), tf_buffer_(this->get_clock())
 {
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   const float score_threshold =
     static_cast<float>(this->declare_parameter<double>("post_process_params.score_threshold"));
   const float circle_nms_dist_threshold = static_cast<float>(

--- a/perception/autoware_lidar_transfusion/src/lidar_transfusion_node.cpp
+++ b/perception/autoware_lidar_transfusion/src/lidar_transfusion_node.cpp
@@ -30,6 +30,11 @@ LidarTransfusionNode::LidarTransfusionNode(const rclcpp::NodeOptions & options)
 : Node("lidar_transfusion", options), tf_buffer_(this->get_clock())
 {
   auto descriptor = rcl_interfaces::msg::ParameterDescriptor{}.set__read_only(true);
+
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   // network
   class_names_ = this->declare_parameter<std::vector<std::string>>("class_names", descriptor);
   const std::string trt_precision =

--- a/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -57,6 +57,10 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
   using std::placeholders::_1;
   using std::placeholders::_2;
 
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   /* params */
   map_frame_ = this->declare_parameter<std::string>("map_frame");
   base_link_frame_ = this->declare_parameter<std::string>("base_link_frame");

--- a/perception/autoware_shape_estimation/src/shape_estimation_node.cpp
+++ b/perception/autoware_shape_estimation/src/shape_estimation_node.cpp
@@ -41,6 +41,7 @@ ShapeEstimationNode::ShapeEstimationNode(const rclcpp::NodeOptions & node_option
 : Node("shape_estimation", node_options)
 {
   using std::placeholders::_1;
+
   sub_ = create_subscription<DetectedObjectsWithFeature>(
     "input", rclcpp::QoS{1}, std::bind(&ShapeEstimationNode::callback, this, _1));
 
@@ -57,6 +58,10 @@ ShapeEstimationNode::ShapeEstimationNode(const rclcpp::NodeOptions & node_option
     std::make_unique<ShapeEstimator>(use_corrector, use_filter, use_boost_bbox_optimizer);
 
 #ifdef USE_CUDA
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   use_ml_shape_estimation_ = declare_parameter<bool>("model_params.use_ml_shape_estimator");
   if (use_ml_shape_estimation_) {
     std::string model_path = declare_parameter<std::string>("model_path");

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -30,6 +30,10 @@ namespace autoware::tensorrt_yolox
 TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
 : Node("tensorrt_yolox", node_options)
 {
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   {
     stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
     debug_publisher_ = std::make_unique<autoware_utils::DebugPublisher>(this, this->get_name());

--- a/perception/autoware_tensorrt_yolox/src/yolox_single_image_inference_node.cpp
+++ b/perception/autoware_tensorrt_yolox/src/yolox_single_image_inference_node.cpp
@@ -36,6 +36,10 @@ public:
   explicit YoloXSingleImageInferenceNode(const rclcpp::NodeOptions & node_options)
   : Node("yolox_single_image_inference", node_options)
   {
+    // Set CUDA device flags
+    // note: Device flags are process-wide
+    cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
     const auto image_path = declare_parameter("image_path", "");
     const auto model_path = declare_parameter("model_path", "");
     const auto precision = declare_parameter("precision", "fp32");

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -26,6 +26,10 @@ namespace autoware::traffic_light
 TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeOptions & options)
 : Node("traffic_light_classifier_node", options)
 {
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   classify_traffic_light_type_ = this->declare_parameter<int>("traffic_light_type");
 
   using std::placeholders::_1;

--- a/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
+++ b/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
@@ -54,6 +54,10 @@ namespace autoware::traffic_light
 TrafficLightFineDetectorNode::TrafficLightFineDetectorNode(const rclcpp::NodeOptions & options)
 : Node("traffic_light_fine_detector_node", options)
 {
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   int num_class = 2;
   using std::placeholders::_1;
   using std::placeholders::_2;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -44,6 +44,10 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
 {
   using std::placeholders::_1;
 
+  // Set CUDA device flags
+  // note: Device flags are process-wide
+  cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+
   // Parameters
   base_frame_ = declare_parameter<std::string>("base_frame");
 


### PR DESCRIPTION
## Description

Depending on the type of GPU, busy waiting may be used when synchronizing with a CUDA device (cudaStreamSynchronize, etc.). (cf. [CUDA Runtime API :: CUDA Toolkit Documentation](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html#group__CUDART__DEVICE_1g69e73c7dda3fc05306ae7c811a690fac))
In that case, a CPU core will be occupied while waiting for the device.
In this pull request, we use the CUDA Runtime API to configure it to block the CPU thread while waiting for the device.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

Please let me know if you know of any other nodes that use CUDA.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

This change will slightly increase the latency when synchronizing with the device.
Since `cudaSetDeviceFlags` affects the entire process, it may affect the behavior of other nodes in the same component.
