### PR TITLE
refactor(virtual_traffic_light, QC): replace checkCollision with autoware_utils_geometry

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
@@ -73,10 +73,9 @@ std::optional<SegmentIndexWithPoint> findLastCollisionBeforeEndLine(
        --i) {  // NOTE: size_t can be used since it will not be negative.
     const auto & p1 = autoware_utils::get_point(points.at(i));
     const auto & p2 = autoware_utils::get_point(points.at(i - 1));
-    const auto collision_point =
-      arc_lane_utils::checkCollision(p1, p2, target_line_p1, target_line_p2);
-
-    if (collision_point) {
+    if (const auto collision_point =
+          autoware_utils_geometry::intersect(p1, p2, target_line_p1, target_line_p2);
+        collision_point) {
       return SegmentIndexWithPoint{i, collision_point.value()};
     }
   }


### PR DESCRIPTION
## Description

avoid the usage of duplicated function

## Related links

https://github.com/autowarefoundation/autoware_core/pull/429

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/e6b5c106-3b3e-52e4-8f5d-e1a2e87a96b7?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
