### PR TITLE
refactor(goal_planner): do not use only_route_lanes = false

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -2283,9 +2283,6 @@ bool GoalPlannerModule::isCrossingPossible(
     // NOTE: this line does not specify the /forward/backward length, so if the shoulders form a
     // loop, this returns all shoulder lanes in the loop
     end_lane_sequence = route_handler->getShoulderLaneletSequence(end_lane, end_lane_pose);
-  } else {
-    const double dist = std::numeric_limits<double>::max();
-    end_lane_sequence = route_handler->getLaneletSequence(end_lane, dist, dist, false);
   }
 
   const auto getNeighboringLane =

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -76,10 +76,11 @@ lanelet::ConstLanelets getPullOverLanes(
   } else {
     outermost_lane = route_handler.getMostRightLanelet(closest_lane, false, true);
   }
-
-  constexpr bool only_route_lanes = false;
-  return route_handler.getLaneletSequence(
-    outermost_lane, backward_distance_with_buffer, forward_distance, only_route_lanes);
+  if (route_handler.isShoulderLanelet(outermost_lane)) {
+    return route_handler.get_shoulder_lanelet_sequence(
+      outermost_lane, backward_distance_with_buffer, forward_distance);
+  }
+  return {outermost_lane};
 }
 
 static double getOffsetToLanesBoundary(
@@ -750,6 +751,9 @@ std::optional<Pose> calcRefinedGoal(
   const lanelet::ConstLanelets pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking, parameters.backward_goal_search_length,
     parameters.forward_goal_search_length);
+  if (pull_over_lanes.empty()) {
+    return {};
+  }
 
   lanelet::Lanelet closest_pull_over_lanelet{};
   lanelet::utils::query::getClosestLanelet(pull_over_lanes, goal_pose, &closest_pull_over_lanelet);


### PR DESCRIPTION
## Description

this PR is one of the ones to remove the usage of `getLaneletSequence()` with `only_route_lanes = false`

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/431

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/c891c69f-30ca-5707-9d6a-7b0abce78e13?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
