### PR TITLE
fix(multi_object_tracker): remove unused function isChannelSpawnEnabled

### DIFF
--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
@@ -96,11 +96,6 @@ public:
 
   bool getObjects(const rclcpp::Time & now, ObjectsList & objects_list);
 
-  bool isChannelSpawnEnabled(const uint & index) const
-  {
-    return input_streams_[index]->isSpawnEnabled();
-  }
-
 private:
   rclcpp::Node & node_;
   std::shared_ptr<Odometry> odometry_;


### PR DESCRIPTION
## Description

Based on cppcheck `unusedFunction` warning
```
perception/autoware_multi_object_tracker/src/processor/input_manager.hpp:99:0: style: The function 'isChannelSpawnEnabled' is never used. [unusedFunction]
  bool isChannelSpawnEnabled(const uint & index) const
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
