### PR TITLE
fix(traffic_light_selector): remove unused function calIOU

### DIFF
--- a/perception/autoware_traffic_light_selector/src/utils.cpp
+++ b/perception/autoware_traffic_light_selector/src/utils.cpp
@@ -43,22 +43,6 @@ bool isInsideRoughRoi(
   return false;
 }
 
-float calIOU(
-  const sensor_msgs::msg::RegionOfInterest & bbox1,
-  const sensor_msgs::msg::RegionOfInterest & bbox2)
-{
-  int x1 = std::max(bbox1.x_offset, bbox2.x_offset);
-  int x2 = std::min(bbox1.x_offset + bbox1.width, bbox2.x_offset + bbox2.width);
-  int y1 = std::max(bbox1.y_offset, bbox2.y_offset);
-  int y2 = std::min(bbox1.y_offset + bbox1.height, bbox2.y_offset + bbox2.height);
-  int area1 = std::max(x2 - x1, 0) * std::max(y2 - y1, 0);
-  int area2 = bbox1.width * bbox1.height + bbox2.width * bbox2.height - area1;
-  if (area2 == 0) {
-    return 0.0;
-  }
-  return static_cast<float>(area1) / static_cast<float>(area2);
-}
-
 // create binary image from list of rois
 cv::Mat createBinaryImageFromRois(
   const std::vector<sensor_msgs::msg::RegionOfInterest> & rois, const cv::Size & size)

--- a/perception/autoware_traffic_light_selector/src/utils.hpp
+++ b/perception/autoware_traffic_light_selector/src/utils.hpp
@@ -54,10 +54,6 @@ bool isInsideRoughRoi(
   const sensor_msgs::msg::RegionOfInterest & detected_roi,
   const sensor_msgs::msg::RegionOfInterest & rough_roi);
 
-float calIOU(
-  const sensor_msgs::msg::RegionOfInterest & bbox1,
-  const sensor_msgs::msg::RegionOfInterest & bbox2);
-
 double getGenIoU(
   const sensor_msgs::msg::RegionOfInterest & roi1, const sensor_msgs::msg::RegionOfInterest & roi2);
 // create binary image from list of rois


### PR DESCRIPTION
## Description

Based on cppcheck `unusedFunction` warning
```
perception/autoware_traffic_light_selector/src/utils.cpp:46:0: style: The function 'calIOU' is never used. [unusedFunction]
float calIOU(
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
