### PR TITLE
feat(ring_outlier_filter): update filtering parameter and process

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/config/ring_outlier_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/ring_outlier_filter_node.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     distance_ratio: 1.03
-    object_length_threshold: 0.1
+    object_length_threshold: 0.05
     max_rings_num: 128
     max_points_num_per_ring: 4000
     publish_outlier_pointcloud: false

--- a/sensing/autoware_pointcloud_preprocessor/config/ring_outlier_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/ring_outlier_filter_node.param.yaml
@@ -2,7 +2,6 @@
   ros__parameters:
     distance_ratio: 1.03
     object_length_threshold: 0.1
-    num_points_threshold: 4
     max_rings_num: 128
     max_points_num_per_ring: 4000
     publish_outlier_pointcloud: false

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/outlier_filter/ring_outlier_filter_node.hpp
@@ -61,7 +61,6 @@ private:
 
   double distance_ratio_;
   double object_length_threshold_;
-  int num_points_threshold_;
   uint16_t max_rings_num_;
   size_t max_points_num_per_ring_;
   bool publish_outlier_pointcloud_;
@@ -81,11 +80,8 @@ private:
   /** \brief Parameter service callback */
   rcl_interfaces::msg::SetParametersResult paramCallback(const std::vector<rclcpp::Parameter> & p);
 
-  bool isCluster(
-    const PointCloud2ConstPtr & input, std::pair<int, int> data_idx_both_ends, int walk_size)
+  bool isCluster(const PointCloud2ConstPtr & input, std::pair<int, int> data_idx_both_ends)
   {
-    if (walk_size > num_points_threshold_) return true;
-
     auto first_point =
       reinterpret_cast<const InputPointType *>(&input->data[data_idx_both_ends.first]);
     auto last_point =

--- a/sensing/autoware_pointcloud_preprocessor/schema/ring_outlier_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/ring_outlier_filter_node.schema.json
@@ -76,7 +76,6 @@
       "required": [
         "distance_ratio",
         "object_length_threshold",
-        "num_points_threshold",
         "max_rings_num",
         "max_points_num_per_ring",
         "publish_outlier_pointcloud",

--- a/sensing/autoware_pointcloud_preprocessor/schema/ring_outlier_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/ring_outlier_filter_node.schema.json
@@ -18,12 +18,6 @@
           "default": "0.1",
           "minimum": 0.0
         },
-        "num_points_threshold": {
-          "type": "integer",
-          "description": "num_points_threshold",
-          "default": "4",
-          "minimum": 0
-        },
         "max_rings_num": {
           "type": "integer",
           "description": "max_rings_num",

--- a/sensing/autoware_pointcloud_preprocessor/schema/ring_outlier_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/ring_outlier_filter_node.schema.json
@@ -15,7 +15,7 @@
         "object_length_threshold": {
           "type": "number",
           "description": "object_length_threshold",
-          "default": "0.1",
+          "default": "0.05",
           "minimum": 0.0
         },
         "max_rings_num": {

--- a/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_node.cpp
@@ -51,7 +51,6 @@ RingOutlierFilterComponent::RingOutlierFilterComponent(const rclcpp::NodeOptions
   {
     distance_ratio_ = declare_parameter<double>("distance_ratio");
     object_length_threshold_ = declare_parameter<double>("object_length_threshold");
-    num_points_threshold_ = declare_parameter<int>("num_points_threshold");
     max_rings_num_ = static_cast<uint16_t>(declare_parameter<int64_t>("max_rings_num"));
     max_points_num_per_ring_ =
       static_cast<size_t>(declare_parameter<int64_t>("max_points_num_per_ring"));
@@ -150,9 +149,7 @@ void RingOutlierFilterComponent::faster_filter(
         continue;                               // Determined to be included in the same walk
       }
 
-      if (isCluster(
-            input, std::make_pair(indices[walk_first_idx], indices[walk_last_idx]),
-            walk_last_idx - walk_first_idx + 1)) {
+      if (isCluster(input, std::make_pair(indices[walk_first_idx], indices[walk_last_idx]))) {
         for (int i = walk_first_idx; i <= walk_last_idx; i++) {
           auto output_ptr = reinterpret_cast<OutputPointType *>(&output.data[output_size]);
           auto input_ptr = reinterpret_cast<const InputPointType *>(&input->data[indices[i]]);
@@ -205,9 +202,7 @@ void RingOutlierFilterComponent::faster_filter(
 
     if (walk_first_idx > walk_last_idx) continue;
 
-    if (isCluster(
-          input, std::make_pair(indices[walk_first_idx], indices[walk_last_idx]),
-          walk_last_idx - walk_first_idx + 1)) {
+    if (isCluster(input, std::make_pair(indices[walk_first_idx], indices[walk_last_idx]))) {
       for (int i = walk_first_idx; i <= walk_last_idx; i++) {
         auto output_ptr = reinterpret_cast<OutputPointType *>(&output.data[output_size]);
         auto input_ptr = reinterpret_cast<const InputPointType *>(&input->data[indices[i]]);
@@ -309,9 +304,6 @@ rcl_interfaces::msg::SetParametersResult RingOutlierFilterComponent::paramCallba
   if (get_param(p, "object_length_threshold", object_length_threshold_)) {
     RCLCPP_DEBUG(
       get_logger(), "Setting new object length threshold to: %f.", object_length_threshold_);
-  }
-  if (get_param(p, "num_points_threshold", num_points_threshold_)) {
-    RCLCPP_DEBUG(get_logger(), "Setting new num_points_threshold to: %d.", num_points_threshold_);
   }
   if (get_param(p, "publish_outlier_pointcloud", publish_outlier_pointcloud_)) {
     RCLCPP_DEBUG(


### PR DESCRIPTION
## Description

This PR updates parameter for filtering out outliers:

- Set `object_length_threshold = 0.05` as a default value.
- Remove process to check the number of points inside of cluster.

## Related links

- PR to update `aip_launcher`: https://github.com/tier4/aip_launcher/pull/438

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

[TIER IV INTERNAL EVALUATOR RESULT](https://evaluation.ci.tier4.jp/evaluation/reports/40cb0f7c-4b19-5977-9b3e-b5a34079d7de?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
