### PR TITLE
feat(default_adapi): add state diagnostics

### DIFF
--- a/system/autoware_default_adapi/config/default_adapi.param.yaml
+++ b/system/autoware_default_adapi/config/default_adapi.param.yaml
@@ -7,9 +7,18 @@
     require_accept_start: false
     stop_check_duration: 1.0
 
+/adapi/node/localization:
+  ros__parameters:
+    diagnostic_updater:
+      period: 1.0
+      use_fqn: true
+
 /adapi/node/routing:
   ros__parameters:
     stop_check_duration: 1.0
+    diagnostic_updater:
+      period: 1.0
+      use_fqn: true
 
 /adapi/node/vehicle_door:
   ros__parameters:

--- a/system/autoware_default_adapi/package.xml
+++ b/system/autoware_default_adapi/package.xml
@@ -26,6 +26,7 @@
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>geographic_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_default_adapi/src/localization.hpp
+++ b/system/autoware_default_adapi/src/localization.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/adapi_specs/localization.hpp>
 #include <autoware/component_interface_specs_universe/localization.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 // This file should be included after messages.
@@ -31,15 +32,22 @@ public:
   explicit LocalizationNode(const rclcpp::NodeOptions & options);
 
 private:
+  using ImplState = autoware::component_interface_specs_universe::localization::InitializationState;
+
   rclcpp::CallbackGroup::SharedPtr group_cli_;
   Srv<autoware::adapi_specs::localization::Initialize> srv_initialize_;
   Pub<autoware::adapi_specs::localization::InitializationState> pub_state_;
   Cli<autoware::component_interface_specs_universe::localization::Initialize> cli_initialize_;
   Sub<autoware::component_interface_specs_universe::localization::InitializationState> sub_state_;
 
+  void diagnose_state(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void on_state(const ImplState::Message::ConstSharedPtr msg);
   void on_initialize(
     const autoware::adapi_specs::localization::Initialize::Service::Request::SharedPtr req,
     const autoware::adapi_specs::localization::Initialize::Service::Response::SharedPtr res);
+
+  ImplState::Message state_;
+  diagnostic_updater::Updater diagnostics_;
 };
 
 }  // namespace autoware::default_adapi

--- a/system/autoware_default_adapi/src/routing.hpp
+++ b/system/autoware_default_adapi/src/routing.hpp
@@ -20,6 +20,7 @@
 #include <autoware/component_interface_specs_universe/system.hpp>
 #include <autoware/component_interface_utils/status.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 // This file should be included after messages.
@@ -57,10 +58,8 @@ private:
   Cli<autoware::component_interface_specs_universe::system::ChangeOperationMode>
     cli_operation_mode_;
   Sub<autoware::component_interface_specs_universe::system::OperationModeState> sub_operation_mode_;
-  bool is_autoware_control_;
-  bool is_auto_mode_;
-  State::Message state_;
 
+  void diagnose_state(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void change_stop_mode();
   void on_operation_mode(const OperationModeState::Message::ConstSharedPtr msg);
   void on_state(const State::Message::ConstSharedPtr msg);
@@ -80,6 +79,11 @@ private:
   void on_change_route(
     const autoware::adapi_specs::routing::SetRoute::Service::Request::SharedPtr req,
     const autoware::adapi_specs::routing::SetRoute::Service::Response::SharedPtr res);
+
+  bool is_autoware_control_;
+  bool is_auto_mode_;
+  State::Message state_;
+  diagnostic_updater::Updater diagnostics_;
 
   // Stop check for route clear.
   autoware::motion_utils::VehicleStopChecker vehicle_stop_checker_;


### PR DESCRIPTION
## Description

Publish routing and localization state diagnostics.
This replaces [component_state_diagnostics](https://github.com/autowarefoundation/autoware_universe/blob/main/system/autoware_system_diagnostic_monitor/script/component_state_diagnostics.py) script in system_diagnostic_monitor package.

## Related links

https://github.com/autowarefoundation/autoware_launch/pull/1417

## How was this PR tested?

Check that the vehicle drives in autonomous mode using simple planning simulator.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
