### PR TITLE
feat(autoware_bevfusion): integrated the cuda blackboard to bevfusion

### DIFF
--- a/perception/autoware_bevfusion/config/bevfusion_common.param.yaml
+++ b/perception/autoware_bevfusion/config/bevfusion_common.param.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    # When the processing time exceeds the max_allowed_processing_time,
+    # a warning will be triggered.
+    diagnostics:
+      max_allowed_processing_time_ms: 200.0 # in milliseconds
+      # If the warning is triggered and if a timestamp of last normal processing is more than
+      # max_acceptable_consecutive_delay_ms, an error diagnostic message will be sent.
+      max_acceptable_consecutive_delay_ms: 1000.0
+      # interval of diagnostic callback in milliseconds
+      validation_callback_interval_ms: 100.0 # in milliseconds

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
@@ -26,6 +26,7 @@
 #include <autoware/cuda_utils/cuda_unique_ptr.hpp>
 #include <autoware/tensorrt_common/tensorrt_common.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
@@ -77,10 +78,11 @@ public:
   virtual ~BEVFusionTRT();
 
   bool detect(
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg,
+    const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & input_pointcloud_msg_ptr,
     const std::vector<sensor_msgs::msg::Image::ConstSharedPtr> & image_msgs,
     const std::vector<float> & camera_masks, const tf2_ros::Buffer & tf_buffer,
-    std::vector<Box3D> & det_boxes3d, std::unordered_map<std::string, double> & proc_timing);
+    std::vector<Box3D> & det_boxes3d, std::unordered_map<std::string, double> & proc_timing,
+    bool & is_num_voxels_within_range);
 
   void setIntrinsicsExtrinsics(
     std::vector<sensor_msgs::msg::CameraInfo> & camera_info_vector,
@@ -91,9 +93,10 @@ protected:
   void initTrt(const tensorrt_common::TrtCommonConfig & trt_config);
 
   bool preProcess(
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & pc_msg,
+    const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & pc_msg_ptr,
     const std::vector<sensor_msgs::msg::Image::ConstSharedPtr> & image_msgs,
-    const std::vector<float> & camera_masks, const tf2_ros::Buffer & tf_buffer);
+    const std::vector<float> & camera_masks, const tf2_ros::Buffer & tf_buffer,
+    bool & is_num_voxels_within_range);
 
   bool inference();
 

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/preprocess/voxel_generator.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/preprocess/voxel_generator.hpp
@@ -22,6 +22,7 @@
 #include <autoware/cuda_utils/cuda_check_error.hpp>
 #include <autoware/cuda_utils/cuda_unique_ptr.hpp>
 #include <autoware/point_types/types.hpp>
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -44,10 +45,8 @@ public:
     cudaStream_t stream);
   std::size_t generateSweepPoints(CudaUniquePtr<float[]> & points_d);
   bool enqueuePointCloud(
-    const sensor_msgs::msg::PointCloud2 & msg, const tf2_ros::Buffer & tf_buffer);
-  void initCloudInfo(const sensor_msgs::msg::PointCloud2 & msg);
-  std::tuple<const std::uint32_t, const std::uint8_t, const std::uint8_t> getFieldInfo(
-    const sensor_msgs::msg::PointCloud2 & msg, const std::string & field_name);
+    const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & msg_ptr,
+    const tf2_ros::Buffer & tf_buffer);
 
 private:
   std::unique_ptr<PointCloudDensification> pd_ptr_{nullptr};

--- a/perception/autoware_bevfusion/launch/bevfusion.launch.xml
+++ b/perception/autoware_bevfusion/launch/bevfusion.launch.xml
@@ -11,6 +11,7 @@
   <arg name="model_param_path" default="$(find-pkg-share autoware_bevfusion)/config/$(var model_name).param.yaml"/>
   <arg name="ml_package_param_path" default="$(var model_path)/ml_package_$(var model_name).param.yaml"/>
   <arg name="class_remapper_param_path" default="$(var model_path)/detection_class_remapper.param.yaml"/>
+  <arg name="common_param_path" default="$(find-pkg-share autoware_bevfusion)/config/bevfusion_common.param.yaml"/>
   <arg name="build_only" default="false" description="shutdown node after TensorRT engine file is built"/>
   <arg name="log_level" default="info"/>
 
@@ -74,10 +75,12 @@
     <load_composable_node target="$(var pointcloud_container_name)">
       <composable_node pkg="autoware_bevfusion" plugin="autoware::bevfusion::BEVFusionNode" name="bevfusion">
         <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+        <remap from="~/input/pointcloud/cuda" to="$(var input/pointcloud)/cuda"/>
         <remap from="~/output/objects" to="$(var output/objects)"/>
         <param from="$(var model_param_path)" allow_substs="true"/>
         <param from="$(var ml_package_param_path)" allow_substs="true"/>
         <param from="$(var class_remapper_param_path)"/>
+        <param from="$(var common_param_path)"/>
 
         <remap from="~/input/camera_info0" to="$(var camera_info0)"/>
         <remap from="~/input/camera_info1" to="$(var camera_info1)"/>
@@ -100,10 +103,12 @@
   <group unless="$(var use_pointcloud_container)">
     <node pkg="autoware_bevfusion" exec="autoware_bevfusion_node" name="bevfusion" output="screen" args="--ros-args --log-level $(var log_level)">
       <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+      <remap from="~/input/pointcloud/cuda" to="$(var input/pointcloud)/cuda"/>
       <remap from="~/output/objects" to="$(var output/objects)"/>
       <param from="$(var model_param_path)" allow_substs="true"/>
       <param from="$(var ml_package_param_path)" allow_substs="true"/>
       <param from="$(var class_remapper_param_path)"/>
+      <param from="$(var common_param_path)"/>
 
       <remap from="~/input/camera_info0" to="$(var camera_info0)"/>
       <remap from="~/input/camera_info1" to="$(var camera_info1)"/>

--- a/perception/autoware_bevfusion/lib/preprocess/pointcloud_densification.cpp
+++ b/perception/autoware_bevfusion/lib/preprocess/pointcloud_densification.cpp
@@ -19,6 +19,7 @@
 
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -60,9 +61,10 @@ PointCloudDensification::PointCloudDensification(
 }
 
 bool PointCloudDensification::enqueuePointCloud(
-  const sensor_msgs::msg::PointCloud2 & pointcloud_msg, const tf2_ros::Buffer & tf_buffer)
+  const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & pointcloud_msg_ptr,
+  const tf2_ros::Buffer & tf_buffer)
 {
-  const auto header = pointcloud_msg.header;
+  const auto header = pointcloud_msg_ptr->header;
 
   if (param_.getPointcloudCacheSize() > 1) {
     auto transform_world2current =
@@ -72,9 +74,9 @@ bool PointCloudDensification::enqueuePointCloud(
     }
     auto affine_world2current = transformToEigen(transform_world2current.value());
 
-    enqueue(pointcloud_msg, affine_world2current);
+    enqueue(pointcloud_msg_ptr, affine_world2current);
   } else {
-    enqueue(pointcloud_msg, Eigen::Affine3f::Identity());
+    enqueue(pointcloud_msg_ptr, Eigen::Affine3f::Identity());
   }
 
   dequeue();
@@ -83,19 +85,13 @@ bool PointCloudDensification::enqueuePointCloud(
 }
 
 void PointCloudDensification::enqueue(
-  const sensor_msgs::msg::PointCloud2 & msg, const Eigen::Affine3f & affine_world2current)
+  const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & msg_ptr,
+  const Eigen::Affine3f & affine_world2current)
 {
   affine_world2current_ = affine_world2current;
-  current_timestamp_ = rclcpp::Time(msg.header.stamp).seconds();
+  current_timestamp_ = rclcpp::Time(msg_ptr->header.stamp).seconds();
 
-  auto data_d = autoware::cuda_utils::make_unique<InputPointType[]>(msg.width * msg.height);
-
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    data_d.get(), msg.data.data(), sizeof(std::uint8_t) * msg.width * msg.height * msg.point_step,
-    cudaMemcpyHostToDevice, stream_));
-
-  PointCloudWithTransform pointcloud = {
-    std::move(data_d), msg.header, msg.width * msg.height, affine_world2current.inverse()};
+  PointCloudWithTransform pointcloud = {msg_ptr, affine_world2current.inverse()};
 
   pointcloud_cache_.push_front(std::move(pointcloud));
 }

--- a/perception/autoware_bevfusion/package.xml
+++ b/perception/autoware_bevfusion/package.xml
@@ -18,6 +18,7 @@
   <depend>autoware_point_types</depend>
   <depend>autoware_tensorrt_common</depend>
   <depend>autoware_universe_utils</depend>
+  <depend>cuda_blackboard</depend>
   <depend>launch_ros</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>

--- a/perception/autoware_bevfusion/schema/bevfusion_common.schema.json
+++ b/perception/autoware_bevfusion/schema/bevfusion_common.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for BEVFusion Diagnostics",
+  "type": "object",
+  "definitions": {
+    "bevfusion_common": {
+      "type": "object",
+      "properties": {
+        "diagnostics": {
+          "type": "object",
+          "description": "Parameters for diagnostics.",
+          "properties": {
+            "max_allowed_processing_time_ms": {
+              "type": "number",
+              "description": "A threshold value for the allowed processing time. If the processing time exceeds this value, it will be considered a warning state. [ms]",
+              "default": 200.0,
+              "minimum": 0.0
+            },
+            "max_acceptable_consecutive_delay_ms": {
+              "type": "number",
+              "description": "A threshold value for the error state. If the duration since the last processing timestamp, which ended within max_allowed_processing_time_ms, exceeds this value, it will be considered an error state. [ms]",
+              "default": 1000.0,
+              "minimum": 0.0
+            },
+            "validation_callback_interval_ms": {
+              "type": "number",
+              "description": "An interval value for a timer callback that checks whether the current state meets the max_acceptable_consecutive_delay_ms condition. [ms]",
+              "default": 100.0,
+              "minimum": 1.0
+            }
+          }
+        }
+      },
+      "required": ["diagnostics"]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/bevfusion_common"
+        }
+      },
+      "required": ["ros__parameters"]
+    }
+  },
+  "required": ["/**"]
+}

--- a/perception/autoware_bevfusion/src/bevfusion_node.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node.cpp
@@ -142,10 +142,13 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
   auto trt_config =
     tensorrt_common::TrtCommonConfig(onnx_path, trt_precision, engine_path, 1ULL << 32U);
   detector_ptr_ = std::make_unique<BEVFusionTRT>(trt_config, densification_param, config);
+  diagnostics_detector_trt_ =
+    std::make_unique<autoware_utils::DiagnosticsInterface>(this, "bevfusion_trt");
 
-  cloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
-    "~/input/pointcloud", rclcpp::SensorDataQoS{}.keep_last(1),
-    std::bind(&BEVFusionNode::cloudCallback, this, std::placeholders::_1));
+  cloud_sub_ =
+    std::make_unique<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/input/pointcloud",
+      std::bind(&BEVFusionNode::cloudCallback, this, std::placeholders::_1));
 
   objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "~/output/objects", rclcpp::QoS(1));
@@ -172,12 +175,12 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
     }
   }
 
-  published_time_pub_ = std::make_unique<autoware::universe_utils::PublishedTimePublisher>(this);
+  published_time_pub_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
 
   // initialize debug tool
   {
-    using autoware::universe_utils::DebugPublisher;
-    using autoware::universe_utils::StopWatch;
+    using autoware_utils::DebugPublisher;
+    using autoware_utils::StopWatch;
     stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
     debug_publisher_ptr_ = std::make_unique<DebugPublisher>(this, this->get_name());
     stop_watch_ptr_->tic("cyclic");
@@ -190,9 +193,10 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
   }
 }
 
-void BEVFusionNode::cloudCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr pc_msg)
+void BEVFusionNode::cloudCallback(
+  const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & pc_msg_ptr)
 {
-  lidar_frame_ = pc_msg->header.frame_id;
+  lidar_frame_ = pc_msg_ptr->header.frame_id;
 
   if (sensor_fusion_ && (!extrinsics_available_ || !images_available_ || !intrinsics_available_)) {
     return;
@@ -223,8 +227,9 @@ void BEVFusionNode::cloudCallback(const sensor_msgs::msg::PointCloud2::ConstShar
   if (stop_watch_ptr_) {
     stop_watch_ptr_->toc("processing/total", true);
   }
+  diagnostics_detector_trt_->clear();
 
-  double lidar_stamp = rclcpp::Time(pc_msg->header.stamp).seconds();
+  double lidar_stamp = rclcpp::Time(pc_msg_ptr->header.stamp).seconds();
   camera_masks_.resize(camera_info_msgs_.size());
   for (std::size_t i = 0; i < camera_masks_.size(); ++i) {
     camera_masks_[i] =
@@ -235,10 +240,22 @@ void BEVFusionNode::cloudCallback(const sensor_msgs::msg::PointCloud2::ConstShar
 
   std::vector<Box3D> det_boxes3d;
   std::unordered_map<std::string, double> proc_timing;
-  bool is_success =
-    detector_ptr_->detect(pc_msg, image_msgs_, camera_masks_, tf_buffer_, det_boxes3d, proc_timing);
+  bool is_num_voxels_within_range = true;
+  bool is_success = detector_ptr_->detect(
+    pc_msg_ptr, image_msgs_, camera_masks_, tf_buffer_, det_boxes3d, proc_timing,
+    is_num_voxels_within_range);
   if (!is_success) {
     return;
+  }
+
+  diagnostics_detector_trt_->add_key_value(
+    "is_num_voxels_within_range", is_num_voxels_within_range);
+  if (!is_num_voxels_within_range) {
+    std::stringstream message;
+    message << "BEVFusiontTRT::detect: The actual number of voxels exceeds its maximum value, "
+            << "which may limit the detection performance.";
+    diagnostics_detector_trt_->update_level_and_message(
+      diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
   }
 
   std::vector<autoware_perception_msgs::msg::DetectedObject> raw_objects;
@@ -250,7 +267,7 @@ void BEVFusionNode::cloudCallback(const sensor_msgs::msg::PointCloud2::ConstShar
   }
 
   autoware_perception_msgs::msg::DetectedObjects output_msg;
-  output_msg.header = pc_msg->header;
+  output_msg.header = pc_msg_ptr->header;
   output_msg.objects = iou_bev_nms_.apply(raw_objects);
 
   detection_class_remapper_.mapClasses(output_msg);
@@ -259,6 +276,8 @@ void BEVFusionNode::cloudCallback(const sensor_msgs::msg::PointCloud2::ConstShar
     objects_pub_->publish(output_msg);
     published_time_pub_->publish_if_subscribed(objects_pub_, output_msg.header.stamp);
   }
+
+  diagnostics_detector_trt_->publish(pc_msg_ptr->header.stamp);
 
   // add processing time for debug
   if (debug_publisher_ptr_ && stop_watch_ptr_) {
@@ -269,14 +288,15 @@ void BEVFusionNode::cloudCallback(const sensor_msgs::msg::PointCloud2::ConstShar
         std::chrono::nanoseconds(
           (this->get_clock()->now() - output_msg.header.stamp).nanoseconds()))
         .count();
-    debug_publisher_ptr_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/cyclic_time_ms", cyclic_time_ms);
-    debug_publisher_ptr_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/pipeline_latency_ms", pipeline_latency_ms);
-    debug_publisher_ptr_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/processing_time/total_ms", processing_time_ms);
     for (const auto & [topic, time_ms] : proc_timing) {
-      debug_publisher_ptr_->publish<tier4_debug_msgs::msg::Float64Stamped>(topic, time_ms);
+      debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+        topic, time_ms);
     }
   }
 }
@@ -330,6 +350,67 @@ void BEVFusionNode::cameraInfoCallback(
     [](const auto & opt) { return opt.has_value(); });
 
   extrinsics_available_ = num_valid_extrinsics == lidar2camera_extrinsics_.size();
+}
+
+// Check the processing time and delayed timestamp
+// If the node is consistently delayed, publish an error diagnostic message
+void BEVFusionNode::diagnoseProcessingTime(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  const rclcpp::Time timestamp_now = this->get_clock()->now();
+  diagnostic_msgs::msg::DiagnosticStatus::_level_type diag_level =
+    diagnostic_msgs::msg::DiagnosticStatus::OK;
+  std::stringstream message{"OK"};
+
+  // Check if the node has performed inference
+  if (last_processing_time_ms_) {
+    // check processing time is acceptable
+    if (last_processing_time_ms_ > max_allowed_processing_time_ms_) {
+      stat.add("is_processing_time_ms_in_expected_range", false);
+
+      message.clear();
+      message << "Processing time exceeds the acceptable limit of "
+              << max_allowed_processing_time_ms_ << " ms by "
+              << (last_processing_time_ms_.value() - max_allowed_processing_time_ms_) << " ms.";
+
+      // in case the processing starts with a delayed inference
+      if (!last_in_time_processing_timestamp_) {
+        last_in_time_processing_timestamp_ = timestamp_now;
+      }
+
+      diag_level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    } else {
+      stat.add("is_processing_time_ms_in_expected_range", true);
+      last_in_time_processing_timestamp_ = timestamp_now;
+    }
+    stat.add("processing_time_ms", last_processing_time_ms_.value());
+
+    const double delayed_state_duration =
+      std::chrono::duration<double, std::milli>(
+        std::chrono::nanoseconds(
+          (timestamp_now - last_in_time_processing_timestamp_.value()).nanoseconds()))
+        .count();
+
+    // check consecutive delays
+    if (delayed_state_duration > max_acceptable_consecutive_delay_ms_) {
+      stat.add("is_consecutive_processing_delay_in_range", false);
+
+      message << " Processing delay has consecutively exceeded the acceptable limit continuously.";
+
+      diag_level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    } else {
+      stat.add("is_consecutive_processing_delay_in_range", true);
+    }
+    stat.add("consecutive_processing_delay_ms", delayed_state_duration);
+  } else {
+    stat.add("is_processing_time_ms_in_expected_range", true);
+    stat.add("processing_time_ms", 0.0);
+    stat.add("is_consecutive_processing_delay_in_range", true);
+    stat.add("consecutive_processing_delay_ms", 0.0);
+
+    message << "Waiting for the node to perform inference.";
+  }
+
+  stat.summary(diag_level, message.str());
 }
 
 }  // namespace autoware::bevfusion


### PR DESCRIPTION
## Description
Integrated the cuda blackboard to bevfusion as part of https://github.com/autowarefoundation/autoware_universe/issues/9722
Also added the diagnostics that were added to other detectors (sorry for not making separate PRs)

## Related links

**Parent Issue:**

- [Link](https://github.com/autowarefoundation/autoware_universe/issues/9722)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
