### PR TITLE
fix(ndt_scan_matcher): implicit double to float conversion

### DIFF
--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/hyper_parameters.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/hyper_parameters.hpp
@@ -118,7 +118,7 @@ public:
 
     ndt.trans_epsilon = node->declare_parameter<double>("ndt.trans_epsilon");
     ndt.step_size = node->declare_parameter<double>("ndt.step_size");
-    ndt.resolution = node->declare_parameter<double>("ndt.resolution");
+    ndt.resolution = node->declare_parameter<float>("ndt.resolution");
     ndt.max_iterations = static_cast<int>(node->declare_parameter<int64_t>("ndt.max_iterations"));
     ndt.num_threads = static_cast<int>(node->declare_parameter<int64_t>("ndt.num_threads"));
     ndt.num_threads = std::max(ndt.num_threads, 1);

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
@@ -158,7 +158,9 @@ public:
   inline void addTarget(const PointCloudTargetConstPtr & cloud, const std::string & target_id)
   {
     BaseRegType::setInputTarget(cloud);
-    target_cells_.setLeafSize(params_.resolution, params_.resolution, params_.resolution);
+    target_cells_.setLeafSize(
+      static_cast<float>(params_.resolution), static_cast<float>(params_.resolution),
+      static_cast<float>(params_.resolution));
     target_cells_.setInputCloudAndFilter(cloud, target_id);
   }
 

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
@@ -157,10 +157,9 @@ public:
    */
   inline void addTarget(const PointCloudTargetConstPtr & cloud, const std::string & target_id)
   {
+    const auto resolution = static_cast<float>(params_.resolution);
     BaseRegType::setInputTarget(cloud);
-    target_cells_.setLeafSize(
-      static_cast<float>(params_.resolution), static_cast<float>(params_.resolution),
-      static_cast<float>(params_.resolution));
+    target_cells_.setLeafSize(resolution, resolution, resolution);
     target_cells_.setInputCloudAndFilter(cloud, target_id);
   }
 

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
@@ -157,9 +157,8 @@ public:
    */
   inline void addTarget(const PointCloudTargetConstPtr & cloud, const std::string & target_id)
   {
-    const auto resolution = static_cast<float>(params_.resolution);
     BaseRegType::setInputTarget(cloud);
-    target_cells_.setLeafSize(resolution, resolution, resolution);
+    target_cells_.setLeafSize(params_.resolution, params_.resolution, params_.resolution);
     target_cells_.setInputCloudAndFilter(cloud, target_id);
   }
 

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/ndt_struct.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/ndt_struct.hpp
@@ -91,7 +91,7 @@ struct NdtParams
 {
   double trans_epsilon{};
   double step_size{};
-  double resolution{};
+  float resolution{};
   int max_iterations{};
   NeighborSearchMethod search_method{};
   int num_threads{};


### PR DESCRIPTION
## Description

There is an implicit conversion error in the code. In struct NdtParams [resolution](https://github.com/autowarefoundation/autoware_universe/blob/65c834c77e8b2f36f746f20e1cb1db9e6b620a04/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/ndt_struct.hpp#L94) is double, and [VoxelGrid setLeafSize (const Eigen::Vector4f &leaf_size)](https://github.com/PointCloudLibrary/pcl/blob/f36a69a5e89953708990c4669317f989d532cf08/filters/include/pcl/filters/voxel_grid.h#L221) takes floats. 

## Related links
https://github.com/autowarefoundation/autoware_universe/blob/65c834c77e8b2f36f746f20e1cb1db9e6b620a04/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/ndt_struct.hpp#L94

https://github.com/PointCloudLibrary/pcl/blob/f36a69a5e89953708990c4669317f989d532cf08/filters/include/pcl/filters/voxel_grid.h#L221

## Effects on system behavior

None.
