### PR TITLE
feat(behavior_velocity_planner): only wait for the required subscriptions

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/manager.hpp
@@ -38,6 +38,13 @@ public:
 
   const char * getModuleName() override { return "blind_spot"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.predicted_objects = true;
+    return required_subscription_info;
+  }
+
 private:
   PlannerParam planner_param_;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.hpp
@@ -43,6 +43,15 @@ public:
 
   const char * getModuleName() override { return "crosswalk"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.traffic_signals = true;
+    required_subscription_info.predicted_objects = true;
+    required_subscription_info.occupancy_grid_map = true;
+    return required_subscription_info;
+  }
+
 private:
   CrosswalkModule::PlannerParam crosswalk_planner_param_{};
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.hpp
@@ -36,6 +36,13 @@ public:
 
   const char * getModuleName() override { return "detection_area"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.no_ground_pointcloud = true;
+    return required_subscription_info;
+  }
+
 private:
   DetectionAreaModule::PlannerParam planner_param_;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.hpp
@@ -41,6 +41,15 @@ public:
 
   const char * getModuleName() override { return "intersection"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.traffic_signals = true;
+    required_subscription_info.predicted_objects = true;
+    required_subscription_info.occupancy_grid_map = true;
+    return required_subscription_info;
+  }
+
 private:
   IntersectionModule::PlannerParam intersection_param_;
   // additional for INTERSECTION_OCCLUSION
@@ -72,6 +81,11 @@ public:
   explicit MergeFromPrivateModuleManager(rclcpp::Node & node);
 
   const char * getModuleName() override { return "merge_from_private"; }
+
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    return RequiredSubscriptionInfo{};
+  }
 
 private:
   MergeFromPrivateRoadModule::PlannerParam merge_from_private_area_param_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/manager.hpp
@@ -36,6 +36,11 @@ public:
 
   const char * getModuleName() override { return "no_drivable_lane"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    return RequiredSubscriptionInfo{};
+  }
+
 private:
   NoDrivableLaneModule::PlannerParam planner_param_;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/manager.hpp
@@ -36,6 +36,11 @@ public:
 
   const char * getModuleName() override { return "no_stopping_area"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    return RequiredSubscriptionInfo{};
+  }
+
 private:
   NoStoppingAreaModule::PlannerParam planner_param_{};
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/manager.hpp
@@ -46,6 +46,14 @@ public:
 
   const char * getModuleName() override { return "occlusion_spot"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.predicted_objects = true;
+    required_subscription_info.occupancy_grid_map = true;
+    return required_subscription_info;
+  }
+
 private:
   enum class ModuleID { OCCUPANCY, OBJECT };
   using PlannerParam = occlusion_spot_utils::PlannerParam;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/manager.hpp
@@ -32,6 +32,14 @@ public:
 
   const char * getModuleName() override { return "run_out"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.traffic_signals = true;
+    required_subscription_info.predicted_objects = true;
+    return required_subscription_info;
+  }
+
 private:
   run_out_utils::PlannerParam planner_param_;
   std::shared_ptr<RunOutDebug> debug_ptr_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/manager.hpp
@@ -36,6 +36,11 @@ public:
 
   const char * getModuleName() override { return "speed_bump"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    return RequiredSubscriptionInfo{};
+  }
+
 private:
   SpeedBumpModule::PlannerParam planner_param_;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/manager.hpp
@@ -53,6 +53,11 @@ public:
    */
   const char * getModuleName() override { return "template"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    return RequiredSubscriptionInfo{};
+  }
+
 private:
   double dummy_parameter_{0.0};
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.hpp
@@ -37,6 +37,13 @@ public:
 
   const char * getModuleName() override { return "traffic_light"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.traffic_signals = true;
+    return required_subscription_info;
+  }
+
 private:
   TrafficLightModule::PlannerParam planner_param_;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
@@ -40,6 +40,11 @@ public:
 
   const char * getModuleName() override { return "virtual_traffic_light"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    return RequiredSubscriptionInfo{};
+  }
+
 private:
   VirtualTrafficLightModule::PlannerParam planner_param_;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/manager.hpp
@@ -42,6 +42,11 @@ public:
 
   const char * getModuleName() override { return "walkway"; }
 
+  RequiredSubscriptionInfo getRequiredSubscriptions() const override
+  {
+    return RequiredSubscriptionInfo{};
+  }
+
 private:
   WalkwayModule::PlannerParam walkway_planner_param_{};
 


### PR DESCRIPTION
## Description

Universe changes for https://github.com/autowarefoundation/autoware_core/pull/433

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

planning simulator worked.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
