### PR TITLE
fix(motion_velocity_planner/run_out): fix tf2 include (.hpp->.h)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collisions.cpp
@@ -23,7 +23,6 @@
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/math/normalization.hpp>
 #include <rclcpp/logger.hpp>
-#include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
@@ -33,6 +32,8 @@
 #include <boost/geometry/algorithms/length.hpp>
 #include <boost/geometry/algorithms/within.hpp>
 #include <boost/geometry/index/predicates.hpp>
+
+#include <tf2/utils.h>
 
 #include <algorithm>
 #include <iomanip>


### PR DESCRIPTION
## Description

In some environments `tf2/utils.hpp` does not exist which causes the package build to fail.
This PR switched to using `tf2/utils.h`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
