### PR TITLE
fix(autoware_probabilistic_occupancy_grid_map): skipped first iteration

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_base.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_base.hpp
@@ -121,6 +121,7 @@ protected:
 
   double resolution_inv_;
   bool use_cuda_;
+  bool first_iteration_{true};
 
 #ifdef USE_CUDA
   cudaStream_t stream_;

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_base.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_base.cpp
@@ -114,6 +114,13 @@ void OccupancyGridMapInterface::updateOrigin(double new_origin_x, double new_ori
   double new_grid_ox{origin_x_ + cell_ox * resolution_};
   double new_grid_oy{origin_y_ + cell_oy * resolution_};
 
+  if (first_iteration_) {
+    origin_x_ = new_grid_ox;
+    origin_y_ = new_grid_oy;
+    first_iteration_ = false;
+    return;
+  }
+
   // To save casting from unsigned int to int a bunch of times
   int size_x{static_cast<int>(size_x_)};
   int size_y{static_cast<int>(size_y_)};


### PR DESCRIPTION
## Description

The first iteration was printing errors due to the delta poses between the null pose and the first pose being to big.
However, for the first iteration, the update routine is not needed (the map is empty), so I just skipped it

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested that the error disappeared with this PR

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
