### PR TITLE
fix(motion_velocity_planner): remove unused function

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/objects_filtering.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/objects_filtering.cpp
@@ -172,23 +172,6 @@ void calculate_predicted_path_footprints(
   }
 }
 
-std::optional<size_t> get_first_intersecting_segment_idx(
-  const ObjectPredictedPathFootprint & footprint, const universe_utils::Segment2d & segment)
-{
-  for (auto i = 0UL; i + 1 < footprint.predicted_path_footprint.size(); ++i) {
-    for (const auto & ls :
-         {footprint.predicted_path_footprint.corner_linestrings[front_left],
-          footprint.predicted_path_footprint.corner_linestrings[front_right],
-          footprint.predicted_path_footprint.corner_linestrings[rear_left],
-          footprint.predicted_path_footprint.corner_linestrings[rear_right]}) {
-      if (universe_utils::intersect(segment.first, segment.second, ls[i], ls[i + 1])) {
-        return i;
-      }
-    }
-  }
-  return std::nullopt;
-}
-
 void cut_footprint_after_index(ObjectPredictedPathFootprint & footprint, const size_t index)
 {
   footprint.predicted_path_footprint.corner_linestrings[front_left].resize(index);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/objects_filtering.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/objects_filtering.hpp
@@ -61,10 +61,6 @@ void calculate_predicted_path_footprints(
   Object & object, const autoware_perception_msgs::msg::PredictedObject & predicted_object,
   [[maybe_unused]] const Parameters & params);
 
-/// @brief get the first footprint segment index which intersect with the given segment
-std::optional<size_t> get_first_intersecting_segment_idx(
-  const ObjectPredictedPathFootprint & footprint, const universe_utils::Segment2d & segment);
-
 /// @brief return true if the incoming vector crosses from the rear
 bool crosses_from_the_rear(
   const universe_utils::Segment2d & incoming, const universe_utils::Segment2d & rear);


### PR DESCRIPTION
## Description

Based on cppcheck `unusedFunction` warning
```
        <error id="unusedFunction" severity="style" msg="The function &apos;get_first_intersecting_segment_idx&apos; is never used." verbose="The function &apos;get_first_intersecting_segment_idx&apos; is never used." cwe="561">
            <location file="planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/objects_filtering.cpp" line="175" column="0"/>
            <symbol>get_first_intersecting_segment_idx</symbol>
        </error>
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
