### PR TITLE
fix(autoware_probabilistic_occupancy_grid_map): incorrect placement of updateOrigin init call check

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_base.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_base.cpp
@@ -114,13 +114,6 @@ void OccupancyGridMapInterface::updateOrigin(double new_origin_x, double new_ori
   double new_grid_ox{origin_x_ + cell_ox * resolution_};
   double new_grid_oy{origin_y_ + cell_oy * resolution_};
 
-  if (first_iteration_) {
-    origin_x_ = new_grid_ox;
-    origin_y_ = new_grid_oy;
-    first_iteration_ = false;
-    return;
-  }
-
   // To save casting from unsigned int to int a bunch of times
   int size_x{static_cast<int>(size_x_)};
   int size_y{static_cast<int>(size_y_)};
@@ -173,6 +166,13 @@ void OccupancyGridMapInterface::updateOrigin(double new_origin_x, double new_ori
   // compute the starting cell location for copying data back in
   int start_x{lower_left_x - cell_ox};
   int start_y{lower_left_y - cell_oy};
+
+  if (first_iteration_) {
+    origin_x_ = new_grid_ox;
+    origin_y_ = new_grid_oy;
+    first_iteration_ = false;
+    return;
+  }
 
   // now we want to copy the overlapping information back into the map, but in its new location
 #ifdef USE_CUDA


### PR DESCRIPTION
## Description

Fixes issue with delayed OGM output.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
