### PR TITLE
feat(localization): replace tier4_localization_msgs used by ndt_align_srv with autoware_internal_localization_msgs

### DIFF
--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
@@ -20,14 +20,14 @@
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <tier4_localization_msgs/srv/initialize_localization.hpp>
+#include <autoware_internal_localization_msgs/srv/initialize_localization.hpp>
 
 namespace autoware::component_interface_specs_universe::localization
 {
 
 struct Initialize
 {
-  using Service = tier4_localization_msgs::srv::InitializeLocalization;
+  using Service = autoware_internal_localization_msgs::srv::InitializeLocalization;
   static constexpr char name[] = "/localization/initialize";
 };
 

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
@@ -18,9 +18,9 @@
 #include <rclcpp/qos.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
+#include <autoware_internal_localization_msgs/srv/initialize_localization.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <autoware_internal_localization_msgs/srv/initialize_localization.hpp>
 
 namespace autoware::component_interface_specs_universe::localization
 {

--- a/common/autoware_component_interface_specs_universe/package.xml
+++ b/common/autoware_component_interface_specs_universe/package.xml
@@ -21,7 +21,7 @@
   <depend>rclcpp</depend>
   <depend>rosidl_runtime_cpp</depend>
   <depend>tier4_control_msgs</depend>
-  <depend>tier4_localization_msgs</depend>
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>

--- a/common/autoware_component_interface_specs_universe/package.xml
+++ b/common/autoware_component_interface_specs_universe/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
@@ -21,7 +22,6 @@
   <depend>rclcpp</depend>
   <depend>rosidl_runtime_cpp</depend>
   <depend>tier4_control_msgs</depend>
-  <depend>autoware_internal_localization_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>

--- a/localization/autoware_ndt_scan_matcher/README.md
+++ b/localization/autoware_ndt_scan_matcher/README.md
@@ -50,7 +50,7 @@ One optional function is regularization. Please see the regularization chapter i
 
 | Name            | Type                                                         | Description                      |
 | --------------- | ------------------------------------------------------------ | -------------------------------- |
-| `ndt_align_srv` | `autoware_localization_srvs::srv::PoseWithCovarianceStamped` | service to estimate initial pose |
+| `ndt_align_srv` | `autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped` | service to estimate initial pose |
 
 ## Parameters
 

--- a/localization/autoware_ndt_scan_matcher/README.md
+++ b/localization/autoware_ndt_scan_matcher/README.md
@@ -48,8 +48,8 @@ One optional function is regularization. Please see the regularization chapter i
 
 ### Service
 
-| Name            | Type                                                         | Description                      |
-| --------------- | ------------------------------------------------------------ | -------------------------------- |
+| Name            | Type                                                                  | Description                      |
+| --------------- | --------------------------------------------------------------------- | -------------------------------- |
 | `ndt_align_srv` | `autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped` | service to estimate initial pose |
 
 ## Parameters

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -35,7 +35,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_srvs/srv/set_bool.hpp>
-#include <tier4_localization_msgs/srv/pose_with_covariance_stamped.hpp>
+#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <fmt/format.h>
@@ -109,11 +109,11 @@ private:
     std_srvs::srv::SetBool::Response::SharedPtr res);
 
   void service_ndt_align(
-    const tier4_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
-    tier4_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res);
+    const autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
+    autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res);
   void service_ndt_align_main(
-    const tier4_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
-    tier4_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res);
+    const autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
+    autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res);
 
   std::tuple<geometry_msgs::msg::PoseWithCovarianceStamped, double> align_pose(
     const geometry_msgs::msg::PoseWithCovarianceStamped & initial_pose_with_cov);
@@ -189,7 +189,7 @@ private:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     ndt_monte_carlo_initial_pose_marker_pub_;
 
-  rclcpp::Service<tier4_localization_msgs::srv::PoseWithCovarianceStamped>::SharedPtr service_;
+  rclcpp::Service<autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped>::SharedPtr service_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr service_trigger_node_;
 
   tf2_ros::TransformBroadcaster tf2_broadcaster_;

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -28,6 +28,7 @@
 
 #include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/int32_stamped.hpp>
+#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -35,7 +36,6 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_srvs/srv/set_bool.hpp>
-#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <fmt/format.h>
@@ -109,10 +109,12 @@ private:
     std_srvs::srv::SetBool::Response::SharedPtr res);
 
   void service_ndt_align(
-    const autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
+    const autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr
+      req,
     autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res);
   void service_ndt_align_main(
-    const autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
+    const autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr
+      req,
     autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res);
 
   std::tuple<geometry_msgs::msg::PoseWithCovarianceStamped, double> align_pose(
@@ -189,7 +191,8 @@ private:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr
     ndt_monte_carlo_initial_pose_marker_pub_;
 
-  rclcpp::Service<autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped>::SharedPtr service_;
+  rclcpp::Service<autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped>::SharedPtr
+    service_;
   rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr service_trigger_node_;
 
   tf2_ros::TransformBroadcaster tf2_broadcaster_;

--- a/localization/autoware_ndt_scan_matcher/package.xml
+++ b/localization/autoware_ndt_scan_matcher/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_localization_util</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_utils_diagnostics</depend>
@@ -38,7 +39,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_sensor_msgs</depend>
-  <depend>tier4_localization_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -192,7 +192,7 @@ NDTScanMatcher::NDTScanMatcher(const rclcpp::NodeOptions & options)
     this->create_publisher<visualization_msgs::msg::MarkerArray>(
       "monte_carlo_initial_pose_marker", 10);
 
-  service_ = this->create_service<tier4_localization_msgs::srv::PoseWithCovarianceStamped>(
+  service_ = this->create_service<autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped>(
     "ndt_align_srv",
     std::bind(
       &NDTScanMatcher::service_ndt_align, this, std::placeholders::_1, std::placeholders::_2),
@@ -973,8 +973,8 @@ void NDTScanMatcher::service_trigger_node(
 }
 
 void NDTScanMatcher::service_ndt_align(
-  const tier4_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
-  tier4_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res)
+  const autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
+  autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res)
 {
   const rclcpp::Time ros_time_now = this->now();
 
@@ -998,8 +998,8 @@ void NDTScanMatcher::service_ndt_align(
 }
 
 void NDTScanMatcher::service_ndt_align_main(
-  const tier4_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
-  tier4_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res)
+  const autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Request::SharedPtr req,
+  autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped::Response::SharedPtr res)
 {
   // get TF from pose_frame to map_frame
   const std::string & target_frame = param_.frame.map_frame;

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -192,11 +192,12 @@ NDTScanMatcher::NDTScanMatcher(const rclcpp::NodeOptions & options)
     this->create_publisher<visualization_msgs::msg::MarkerArray>(
       "monte_carlo_initial_pose_marker", 10);
 
-  service_ = this->create_service<autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped>(
-    "ndt_align_srv",
-    std::bind(
-      &NDTScanMatcher::service_ndt_align, this, std::placeholders::_1, std::placeholders::_2),
-    rclcpp::ServicesQoS().get_rmw_qos_profile(), sensor_callback_group);
+  service_ =
+    this->create_service<autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped>(
+      "ndt_align_srv",
+      std::bind(
+        &NDTScanMatcher::service_ndt_align, this, std::placeholders::_1, std::placeholders::_2),
+      rclcpp::ServicesQoS().get_rmw_qos_profile(), sensor_callback_group);
   service_trigger_node_ = this->create_service<std_srvs::srv::SetBool>(
     "trigger_node_srv",
     std::bind(

--- a/localization/autoware_ndt_scan_matcher/test/stub_initialpose_client.hpp
+++ b/localization/autoware_ndt_scan_matcher/test/stub_initialpose_client.hpp
@@ -17,8 +17,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include "autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp"
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 
 #include <memory>
 

--- a/localization/autoware_ndt_scan_matcher/test/stub_initialpose_client.hpp
+++ b/localization/autoware_ndt_scan_matcher/test/stub_initialpose_client.hpp
@@ -17,14 +17,14 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include "tier4_localization_msgs/srv/pose_with_covariance_stamped.hpp"
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include "autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp"
 
 #include <memory>
 
 class StubInitialposeClient : public rclcpp::Node
 {
-  using AlignSrv = tier4_localization_msgs::srv::PoseWithCovarianceStamped;
+  using AlignSrv = autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped;
 
 public:
   StubInitialposeClient() : Node("stub_initialpose_client")

--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -25,7 +25,8 @@ This node depends on the map height fitter library.
 
 | Name                                         | Type                                                    | Description             |
 | -------------------------------------------- | ------------------------------------------------------- | ----------------------- |
-| `/localization/pose_estimator/ndt_align_srv` | tier4_localization_msgs::srv::PoseWithCovarianceStamped | pose estimation service |
+| `/localization/pose_estimator/ndt_align_srv` | autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped | pose estimation service |
+| `/localization/pose_estimator/yabloc/initializer/yabloc_align_srv` | autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped | yabloc pose estimation service |
 
 ### Subscriptions
 

--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -17,15 +17,15 @@ This node depends on the map height fitter library.
 
 ### Services
 
-| Name                       | Type                                                 | Description           |
-| -------------------------- | ---------------------------------------------------- | --------------------- |
+| Name                       | Type                                                             | Description           |
+| -------------------------- | ---------------------------------------------------------------- | --------------------- |
 | `/localization/initialize` | autoware_internal_localization_msgs::srv::InitializeLocalization | initial pose from api |
 
 ### Clients
 
-| Name                                         | Type                                                    | Description             |
-| -------------------------------------------- | ------------------------------------------------------- | ----------------------- |
-| `/localization/pose_estimator/ndt_align_srv` | autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped | pose estimation service |
+| Name                                                               | Type                                                                | Description                    |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------- | ------------------------------ |
+| `/localization/pose_estimator/ndt_align_srv`                       | autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped | pose estimation service        |
 | `/localization/pose_estimator/yabloc/initializer/yabloc_align_srv` | autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped | yabloc pose estimation service |
 
 ### Subscriptions

--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -19,7 +19,7 @@ This node depends on the map height fitter library.
 
 | Name                       | Type                                                 | Description           |
 | -------------------------- | ---------------------------------------------------- | --------------------- |
-| `/localization/initialize` | tier4_localization_msgs::srv::InitializeLocalization | initial pose from api |
+| `/localization/initialize` | autoware_internal_localization_msgs::srv::InitializeLocalization | initial pose from api |
 
 ### Clients
 
@@ -62,7 +62,7 @@ This `autoware_pose_initializer` is used via default AD API. For detailed descri
 ### Using the GNSS estimated position
 
 ```bash
-ros2 service call /localization/initialize tier4_localization_msgs/srv/InitializeLocalization
+ros2 service call /localization/initialize autoware_internal_localization_msgs/srv/InitializeLocalization
 ```
 
 The GNSS estimated position is used as the initial guess, and the localization algorithm automatically estimates a more accurate position.
@@ -70,7 +70,7 @@ The GNSS estimated position is used as the initial guess, and the localization a
 ### Using the input position
 
 ```bash
-ros2 service call /localization/initialize tier4_localization_msgs/srv/InitializeLocalization "
+ros2 service call /localization/initialize autoware_internal_localization_msgs/srv/InitializeLocalization "
 pose_with_covariance:
   - header:
       frame_id: map
@@ -95,7 +95,7 @@ The input position is used as the initial guess, and the localization algorithm 
 ### Direct initial position set
 
 ```bash
-ros2 service call /localization/initialize tier4_localization_msgs/srv/InitializeLocalization "
+ros2 service call /localization/initialize autoware_internal_localization_msgs/srv/InitializeLocalization "
 pose_with_covariance:
   - header:
       frame_id: map

--- a/localization/autoware_pose_initializer/package.xml
+++ b/localization/autoware_pose_initializer/package.xml
@@ -21,6 +21,7 @@
 
   <depend>autoware_component_interface_specs_universe</depend>
   <depend>autoware_component_interface_utils</depend>
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_map_height_fitter</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_utils_diagnostics</depend>
@@ -29,7 +30,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_srvs</depend>
-  <depend>tier4_localization_msgs</depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_gmock</test_depend>

--- a/localization/autoware_pose_initializer/src/localization_module.hpp
+++ b/localization/autoware_pose_initializer/src/localization_module.hpp
@@ -17,8 +17,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
-#include <tier4_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 
 #include <string>
 #include <tuple>
@@ -29,7 +29,7 @@ class LocalizationModule
 {
 private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
-  using RequestPoseAlignment = tier4_localization_msgs::srv::PoseWithCovarianceStamped;
+  using RequestPoseAlignment = autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped;
 
 public:
   LocalizationModule(rclcpp::Node * node, const std::string & service_name);

--- a/localization/yabloc/yabloc_pose_initializer/README.md
+++ b/localization/yabloc/yabloc_pose_initializer/README.md
@@ -63,6 +63,6 @@ Converted model URL
 
 ### Services
 
-| Name               | Type                                                      | Description                     |
-| ------------------ | --------------------------------------------------------- | ------------------------------- |
+| Name               | Type                                                                  | Description                     |
+| ------------------ | --------------------------------------------------------------------- | ------------------------------- |
 | `yabloc_align_srv` | `autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped` | initial pose estimation request |

--- a/localization/yabloc/yabloc_pose_initializer/README.md
+++ b/localization/yabloc/yabloc_pose_initializer/README.md
@@ -65,4 +65,4 @@ Converted model URL
 
 | Name               | Type                                                      | Description                     |
 | ------------------ | --------------------------------------------------------- | ------------------------------- |
-| `yabloc_align_srv` | `tier4_localization_msgs::srv::PoseWithCovarianceStamped` | initial pose estimation request |
+| `yabloc_align_srv` | `autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped` | initial pose estimation request |

--- a/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp
+++ b/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp
@@ -23,11 +23,11 @@
 #include <opencv2/core.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 
 #include <memory>
 

--- a/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp
+++ b/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/camera_pose_initializer.hpp
@@ -27,7 +27,7 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tier4_localization_msgs/srv/pose_with_covariance_stamped.hpp>
+#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 
 #include <memory>
 
@@ -41,7 +41,7 @@ public:
   using PointCloud2 = sensor_msgs::msg::PointCloud2;
   using Image = sensor_msgs::msg::Image;
   using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
-  using RequestPoseAlignment = tier4_localization_msgs::srv::PoseWithCovarianceStamped;
+  using RequestPoseAlignment = autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped;
 
   explicit CameraPoseInitializer(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 

--- a/localization/yabloc/yabloc_pose_initializer/package.xml
+++ b/localization/yabloc/yabloc_pose_initializer/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
   <depend>cv_bridge</depend>
@@ -24,7 +25,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
-  <depend>autoware_internal_localization_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>yabloc_common</depend>
 

--- a/localization/yabloc/yabloc_pose_initializer/package.xml
+++ b/localization/yabloc/yabloc_pose_initializer/package.xml
@@ -24,7 +24,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
-  <depend>tier4_localization_msgs</depend>
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>yabloc_common</depend>
 

--- a/map/autoware_map_height_fitter/package.xml
+++ b/map/autoware_map_height_fitter/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
   <depend>geometry_msgs</depend>
@@ -28,7 +29,6 @@
   <depend>sensor_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_internal_localization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/map/autoware_map_height_fitter/package.xml
+++ b/map/autoware_map_height_fitter/package.xml
@@ -28,7 +28,7 @@
   <depend>sensor_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_localization_msgs</depend>
+  <depend>autoware_internal_localization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/map/autoware_map_height_fitter/src/map_height_fitter_node.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter_node.cpp
@@ -14,13 +14,13 @@
 
 #include "autoware/map_height_fitter/map_height_fitter.hpp"
 
-#include <tier4_localization_msgs/srv/pose_with_covariance_stamped.hpp>
+#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
 
 #include <memory>
 
 namespace autoware::map_height_fitter
 {
-using tier4_localization_msgs::srv::PoseWithCovarianceStamped;
+using autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped;
 
 class MapHeightFitterNode : public rclcpp::Node
 {

--- a/system/autoware_default_adapi/src/utils/localization_conversion.cpp
+++ b/system/autoware_default_adapi/src/utils/localization_conversion.cpp
@@ -23,7 +23,8 @@ InternalInitializeRequest convert_request(const ExternalInitializeRequest & exte
 {
   auto internal = std::make_shared<InternalInitializeRequest::element_type>();
   internal->pose_with_covariance = external->pose;
-  internal->method = autoware_internal_localization_msgs::srv::InitializeLocalization::Request::AUTO;
+  internal->method =
+    autoware_internal_localization_msgs::srv::InitializeLocalization::Request::AUTO;
   return internal;
 }
 

--- a/system/autoware_default_adapi/src/utils/localization_conversion.cpp
+++ b/system/autoware_default_adapi/src/utils/localization_conversion.cpp
@@ -23,7 +23,7 @@ InternalInitializeRequest convert_request(const ExternalInitializeRequest & exte
 {
   auto internal = std::make_shared<InternalInitializeRequest::element_type>();
   internal->pose_with_covariance = external->pose;
-  internal->method = tier4_localization_msgs::srv::InitializeLocalization::Request::AUTO;
+  internal->method = autoware_internal_localization_msgs::srv::InitializeLocalization::Request::AUTO;
   return internal;
 }
 

--- a/system/autoware_default_adapi/src/utils/localization_conversion.hpp
+++ b/system/autoware_default_adapi/src/utils/localization_conversion.hpp
@@ -18,7 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_adapi_v1_msgs/srv/initialize_localization.hpp>
-#include <tier4_localization_msgs/srv/initialize_localization.hpp>
+#include <autoware_internal_localization_msgs/srv/initialize_localization.hpp>
 
 namespace autoware::default_adapi::localization_conversion
 {
@@ -26,7 +26,7 @@ namespace autoware::default_adapi::localization_conversion
 using ExternalInitializeRequest =
   autoware_adapi_v1_msgs::srv::InitializeLocalization::Request::SharedPtr;
 using InternalInitializeRequest =
-  tier4_localization_msgs::srv::InitializeLocalization::Request::SharedPtr;
+  autoware_internal_localization_msgs::srv::InitializeLocalization::Request::SharedPtr;
 InternalInitializeRequest convert_request(const ExternalInitializeRequest & external);
 
 using ExternalResponse = autoware_adapi_v1_msgs::msg::ResponseStatus;


### PR DESCRIPTION
## Description
in order to port ndt-scan-matcher to autoware.core, we have to replace tier4 related dependency with autoware dependency

## Related links

**Parent Issue:**

- Link https://github.com/autowarefoundation/autoware_core/issues/454

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. colcon build with entier autoware -- `colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --symlink-install`
2. using AWSIM‘s pointcloud and gnss for input, using rviz for visual checking that auto-localization-initialize and continus localization using ndt works
2.1  in terminal 1 launch AWSIM and use `ros2 topic list` to confirm that the pointcloud and gnss topic exist 
2.2  in terminal 2 source autoware workspace first, then type `ros2 launch autoware_launch e2e_simulator.launch.xml vehicle_model:=sample_vehicle sensor_model:=awsim_sensor_kit map_path:=<your mapfile location>` to launch autoware manually
2.3 wait about 5 seconds in rviz opened by step 2.2 you can see that autoware use gnss data from awim for auto-localization-init success
2.4 manually drag a goal for ego and press auto button on rviz panel, then you can see ego moves smoothly and localization works the whole time
2.5 meanwhile, try press `init_pose_with_gnss` button in rviz or manually drag a init pose will trigger pose_initializer spread particles again,that prove that pose_initializer with service `autoware_internal_localization_msgs::srv::InitializeLocalization` works

![Screenshot from 2025-05-08 13-51-48](https://github.com/user-attachments/assets/84f9f5f1-2e4e-4e60-a638-2de4aeed3ed1)


## Notes for reviewers

- [x] must merge after pr for porting service https://github.com/autowarefoundation/autoware_internal_msgs/pull/62
- [x] must merge after pr for porting service https://github.com/autowarefoundation/autoware_internal_msgs/pull/65

## Interface changes

None.



### Topic changes

#### Additions and removals


#### Modifications
`autoware_ndt_scan_matcher`
| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Srv | `/ndt_align_srv` | ` tier4_localization_msgs::srv::PoseWithCovarianceStamped` | service provide ndt align service |
| New      | Srv | `/ndt_align_srv` | ` autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped` | service provide ndt align service |

`yabloc_pose_initializer`
| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Srv | `/yabloc_align_srv` | ` tier4_localization_msgs::srv::PoseWithCovarianceStamped` | service provide initial pose estimation |
| New      | Srv | `/yabloc_align_srv` | ` autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped` | service provide ninitial pose estimation |

`autoware_pose_initializer`
| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Srv | `/localization/pose_estimator/ndt_align_srv` | ` tier4_localization_msgs::srv::PoseWithCovarianceStamped` | pose estimation service |
| Old     | Srv | `/localization/pose_estimator/yabloc/initializer/yabloc_align_srv`  | ` tier4_localization_msgs::srv::PoseWithCovarianceStamped` |  yabloc pose estimation service |
| Old     | `/localization/initialize` | tier4_localization_msgs::srv::InitializeLocalization | initial pose from api |
| New      | `/localization/pose_estimator/ndt_align_srv` | autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped | pose estimation service |
| New      | `/localization/pose_estimator/yabloc/initializer/yabloc_align_srv` | autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped | yabloc pose estimation service |
| New      | `/localization/initialize` | autoware_internal_localization_msgs::srv::InitializeLocalization | initial pose from api |

`autoware_map_height_fitter`
| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Srv | `/map/map_height_fitter/service` | ` tier4_localization_msgs::srv::PoseWithCovarianceStamped` | fits the given point |
| New      | Srv | `/map/map_height_fitter/service` | ` autoware_internal_localization_msgs::srv::PoseWithCovarianceStamped` | fits the given point |

## Effects on system behavior

None.
