### PR TITLE
fix(tier4_planning_rviz_plugin): handle empty trajectory

### DIFF
--- a/visualization/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display.hpp
+++ b/visualization/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display.hpp
@@ -264,6 +264,10 @@ public:
   void visualizeTrajectory(
     const typename autoware_planning_msgs::msg::Trajectory::ConstSharedPtr msg_ptr) override
   {
+    if (msg_ptr->points.empty()) {
+      return;
+    }
+
     if (msg_ptr->points.size() > time_texts_.size()) {
       for (size_t i = time_texts_.size(); i < msg_ptr->points.size(); i++) {
         Ogre::SceneNode * node = this->scene_node_->createChildSceneNode();


### PR DESCRIPTION
## Description

When the size of trajectory points changes from the positive value to 0, the rviz node died due to the tier4_planning_rviz_plugin to visualize the trajectory.
```
[rviz2-4] terminate called after throwing an instance of 'std::out_of_range'
[rviz2-4]   what():  vector::_M_range_check: __n (which is 18446744073709551615) >= this->size() (which is 7)
[ERROR] [rviz2-4]: process has died [pid 1405070, exit code -6, cmd '/opt/ros/humble/lib/rviz2/rviz2 -d /home/takayuki/pilot-auto/install/autoware_static_centerline_generator/share/autoware_static_centerline_generator/rviz/static_centerline_generator.rviz --ros-args -r __node:=rviz2 -p use_sim_time:=False -p wheel_radius:=0.258 -p wheel_width:=0.145 -p wheel_base:=1.335 -p wheel_tread:=0.955 -p front_overhang:=0.53 -p rear_overhang:=0.375 -p left_overhang:=0.0725 -p right_overhang:=0.0725 -p vehicle_height:=1.87 -p max_steer_angle:=0.64'].
```

The error handling for the empty points was implemented for the Path, but not the Trajectory.
This PR introduces the error handling to the Trajectory.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
