### PR TITLE
fix(autoware_compare_map_segmentation): handle empty output point cloud 

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.cpp
@@ -158,9 +158,19 @@ void VoxelBasedCompareMapFilterComponent::input_indices_callback(
 bool VoxelBasedCompareMapFilterComponent::convert_output_costly(
   std::unique_ptr<PointCloud2> & output)
 {
-  if (!output || output->data.empty() || output->fields.empty()) {
+  if (!output || output->fields.empty()) {
     RCLCPP_ERROR(this->get_logger(), "Invalid output point cloud!");
     return false;
+  }
+  if (output->data.empty()){
+    // empty point cloud, could happen under certain conditions
+    // e.g. when the input point cloud is empty or all points are filtered out
+    if (!tf_output_frame_.empty()) {
+      output->header.frame_id = tf_output_frame_;
+    } else {
+      output->header.frame_id = tf_input_orig_frame_;
+    }
+    return true;
   }
   if (
     pcl::getFieldIndex(*output, "x") == -1 || pcl::getFieldIndex(*output, "y") == -1 ||
@@ -168,6 +178,7 @@ bool VoxelBasedCompareMapFilterComponent::convert_output_costly(
     RCLCPP_ERROR(this->get_logger(), "Input pointcloud does not have xyz fields");
     return false;
   }
+  // A. the output frame is set, transform the point cloud to the output frame
   if (!tf_output_frame_.empty() && output->header.frame_id != tf_output_frame_) {
     auto cloud_transformed = std::make_unique<PointCloud2>();
     try {
@@ -184,7 +195,7 @@ bool VoxelBasedCompareMapFilterComponent::convert_output_costly(
       return false;
     }
   }
-
+  // B. the output frame is not set, the output frame is the same as the input frame
   if (tf_output_frame_.empty() && output->header.frame_id != tf_input_orig_frame_) {
     auto cloud_transformed = std::make_unique<PointCloud2>();
     try {

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.cpp
@@ -162,7 +162,7 @@ bool VoxelBasedCompareMapFilterComponent::convert_output_costly(
     RCLCPP_ERROR(this->get_logger(), "Invalid output point cloud!");
     return false;
   }
-  if (output->data.empty()){
+  if (output->data.empty()) {
     // empty point cloud, could happen under certain conditions
     // e.g. when the input point cloud is empty or all points are filtered out
     if (!tf_output_frame_.empty()) {


### PR DESCRIPTION
## Description

When the filtered pointcloud is empty, we expect to publish the empty message.

Fix a check of the output data, and split in the case the output message is a normal empty message.

## Related links

**Parent Issue:**

- Link

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C03S84LDJGG/p1745981452114449)


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
