### PR TITLE
build: update build_depends_humble.repos for 0.44.1 release

### DIFF
--- a/build_depends_humble.repos
+++ b/build_depends_humble.repos
@@ -1,5 +1,18 @@
 repositories:
   # core
+  core/autoware_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_msgs.git
+    version: 1.7.0
+  # TODO (isamu-takagi): Use a released version when autoware_universe uses a released version.
+  core/autoware_adapi_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+    version: 12287684e096a02d279299a7e6cb44740fc34467
+  core/autoware_internal_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: 1.8.1
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git
@@ -11,37 +24,25 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.7.0
+    version: 0.7.1
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
-    version: 0.3.0
-  core/autoware_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: 1.7.0
-  core/autoware_adapi_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: e62ea6fdb9ee50e49c7642c77e85250cb15b8e80
-  core/autoware_internal_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-    version: 1.8.1
+    version: 1.1.0
   # universe
   universe/external/tier4_autoware_msgs:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
     version: v0.41.0
-  universe/external/mussp:
-    type: git
-    url: https://github.com/tier4/muSSP.git
-    version: c79e98fd5e658f4f90c06d93472faa977bc873b9
   # Fix the version not to merge https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9
   universe/external/morai_msgs:
     type: git
     url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
     version: e2e75fc1603a9798773e467a679edf68b448e705
+  universe/external/muSSP:
+    type: git
+    url: https://github.com/tier4/muSSP.git
+    version: c79e98fd5e658f4f90c06d93472faa977bc873b9
   universe/external/glog:  # TODO: to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware_universe/pull/10576 with this PR, we have merged this commit: https://github.com/autowarefoundation/autoware_universe/commit/5c5561fce7277243b748d3807ff6aca6930a29cd
  - With that commit, the Autoware was able to compile and run with those versions.
- With this PR, I'm bringing those changes to also to the main branch to keep things consistent and changes minimal between the branches.

**Changes:**
- This Universe tag required to update Autoware Core from `0.3.0` ➡️ `1.1.0` due to many moved packages.
- autoware_lanelet2_extension: `0.7.0` ➡️ `0.7.1`
- autoware_adapi_msgs: `e62ea6fdb9ee50e49c7642c77e85250cb15b8e80` ➡️ `12287684e096a02d279299a7e6cb44740fc34467` (current main HEAD)
  - We should make a proper release for this some time.
- `universe/external/mussp` directory renamed to `universe/external/muSSP` for consistency with autoware.repos in parent repo.
- Repositories are reordered to match autoware.repos in parent repo.

## How was this PR tested?

Manually and by the CI.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
