### PR TITLE
refactor(control_validator): visualize stop reason to virtual wall

### DIFF
--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -213,6 +213,11 @@ private:
   void publish_debug_info(const geometry_msgs::msg::Pose & ego_pose);
 
   /**
+   * @brief Generate error message based on validation status
+   */
+  std::string generate_error_message(const ControlValidatorStatus & s);
+
+  /**
    * @brief Display validation status on terminal
    */
   void display_status();

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -107,7 +107,7 @@ public:
     const AccelWithCovarianceStamped & loc_acc);
 
 private:
-  bool is_in_error_range() const;
+  bool is_in_error_range(const double filtered_acceleration) const;
   const double e_offset;
   const double e_scale;
   autoware::signal_processing::LowpassFilter1d desired_acc_lpf;

--- a/control/autoware_control_validator/include/autoware/control_validator/debug_marker.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/debug_marker.hpp
@@ -38,15 +38,9 @@ public:
   /**
    * @brief Push a virtual wall
    * @param pose pose of the virtual wall
+   * @param msg message to be displayed
    */
-  void push_virtual_wall(const geometry_msgs::msg::Pose & pose);
-
-  /**
-   * @brief Push a warning message
-   * @param pose pose of the warning message
-   * @param msg warning message
-   */
-  void push_warning_msg(const geometry_msgs::msg::Pose & pose, const std::string & msg);
+  void push_virtual_wall(const geometry_msgs::msg::Pose & pose, const std::string & msg);
 
   /**
    * @brief Publish markers

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::control_validator
 {
@@ -328,7 +329,9 @@ void ControlValidator::publish_debug_info(const geometry_msgs::msg::Pose & ego_p
     geometry_msgs::msg::Pose front_pose = ego_pose;
     shift_pose(front_pose, vehicle_info_.front_overhang_m + vehicle_info_.wheel_base_m);
     debug_pose_publisher_->push_virtual_wall(front_pose);
-    debug_pose_publisher_->push_warning_msg(front_pose, "INVALID CONTROL");
+
+    std::string error_message = generate_error_message(validation_status_);
+    debug_pose_publisher_->push_warning_msg(front_pose, error_message);
   }
   debug_pose_publisher_->publish();
 
@@ -343,6 +346,53 @@ bool ControlValidator::is_all_valid(const ControlValidatorStatus & s)
 {
   return s.is_valid_max_distance_deviation && s.is_valid_acc && !s.is_rolling_back &&
          !s.is_over_velocity && !s.has_overrun_stop_point && !s.will_overrun_stop_point;
+}
+
+std::string ControlValidator::generate_error_message(const ControlValidatorStatus & s)
+{
+  std::vector<std::string> error_messages;
+
+  if (!s.is_valid_steering_rate) {
+    error_messages.push_back("HIGH STEERING RATE");
+  }
+
+  if (!s.is_valid_max_distance_deviation) {
+    error_messages.push_back("TRAJECTORY DEVIATION");
+  }
+
+  if (!s.is_valid_acc) {
+    error_messages.push_back("ACCELERATION ERROR");
+  }
+
+  if (s.is_rolling_back) {
+    error_messages.push_back("ROLLING BACK");
+  }
+
+  if (s.is_over_velocity) {
+    error_messages.push_back("OVER SPEED");
+  }
+
+  if (s.has_overrun_stop_point) {
+    error_messages.push_back("OVERRUN STOP");
+  }
+
+  if (s.will_overrun_stop_point) {
+    error_messages.push_back("WILL OVERRUN STOP");
+  }
+
+  if (error_messages.empty()) {
+    return "INVALID CONTROL";
+  }
+
+  if (error_messages.size() == 1) {
+    return error_messages[0];
+  } else {
+    std::string result = error_messages[0];
+    for (size_t i = 1; i < error_messages.size(); ++i) {
+      result += ", " + error_messages[i];
+    }
+    return result;
+  }
 }
 
 void ControlValidator::display_status()

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -341,10 +341,8 @@ void ControlValidator::publish_debug_info(const geometry_msgs::msg::Pose & ego_p
   if (!is_all_valid(validation_status_)) {
     geometry_msgs::msg::Pose front_pose = ego_pose;
     shift_pose(front_pose, vehicle_info_.front_overhang_m + vehicle_info_.wheel_base_m);
-    debug_pose_publisher_->push_virtual_wall(front_pose);
-
     std::string error_message = generate_error_message(validation_status_);
-    debug_pose_publisher_->push_warning_msg(front_pose, error_message);
+    debug_pose_publisher_->push_virtual_wall(front_pose, error_message);
   }
   debug_pose_publisher_->publish();
 
@@ -364,10 +362,6 @@ bool ControlValidator::is_all_valid(const ControlValidatorStatus & s)
 std::string ControlValidator::generate_error_message(const ControlValidatorStatus & s)
 {
   std::vector<std::string> error_messages;
-
-  if (!s.is_valid_steering_rate) {
-    error_messages.push_back("HIGH STEERING RATE");
-  }
 
   if (!s.is_valid_max_distance_deviation) {
     error_messages.push_back("TRAJECTORY DEVIATION");

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -355,15 +355,15 @@ std::string ControlValidator::generate_error_message(const ControlValidatorStatu
   }
 
   if (s.is_over_velocity) {
-    error_messages.push_back("OVER SPEED");
+    error_messages.push_back("OVER VELOCITY");
   }
 
   if (s.has_overrun_stop_point) {
-    error_messages.push_back("OVERRUN STOP");
+    error_messages.push_back("OVERRUN STOP POINT");
   }
 
   if (s.will_overrun_stop_point) {
-    error_messages.push_back("WILL OVERRUN STOP");
+    error_messages.push_back("WILL OVERRUN STOP POINT");
   }
 
   if (error_messages.empty()) {

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -49,59 +49,59 @@ void TrajectoryValidator::validate(
 
 void AccelerationValidator::validate(
   ControlValidatorStatus & res, const Odometry & kinematic_state, const Control & control_cmd,
-  const double filtered_acceleration)
+  const AccelWithCovarianceStamped & loc_acc)
 {
   desired_acc_lpf.filter(
     control_cmd.longitudinal.acceleration +
     9.8 * autoware_utils::get_rpy(kinematic_state.pose.pose).y);
+  measured_acc_lpf.filter(loc_acc.accel.accel.linear.x);
   if (std::abs(kinematic_state.twist.twist.linear.x) < 0.3) {
     desired_acc_lpf.reset(0.0);
+    measured_acc_lpf.reset(0.0);
   }
 
-  const double desired_acc = desired_acc_lpf.getValue().value();
-
-  res.desired_acc = desired_acc;
-  res.is_valid_acc = is_in_error_range(filtered_acceleration);
+  res.desired_acc = desired_acc_lpf.getValue().value();
+  res.measured_acc = measured_acc_lpf.getValue().value();
+  res.is_valid_acc = is_in_error_range();
 }
 
-bool AccelerationValidator::is_in_error_range(const double measured_acceleration) const
+bool AccelerationValidator::is_in_error_range() const
 {
   const double des = desired_acc_lpf.getValue().value();
+  const double mes = measured_acc_lpf.getValue().value();
 
-  return measured_acceleration <= des + std::abs(e_scale * des) + e_offset &&
-         measured_acceleration >= des - std::abs(e_scale * des) - e_offset;
+  return mes <= des + std::abs(e_scale * des) + e_offset &&
+         mes >= des - std::abs(e_scale * des) - e_offset;
 }
 
 void VelocityValidator::validate(
   ControlValidatorStatus & res, const Trajectory & reference_trajectory,
-  const Odometry & kinematics, const double filtered_velocity)
+  const Odometry & kinematics)
 {
+  const double v_vel = vehicle_vel_lpf.filter(kinematics.twist.twist.linear.x);
   const double t_vel = target_vel_lpf.filter(
     autoware::motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose)
       .longitudinal_velocity_mps);
 
-  const bool is_rolling_back = std::signbit(filtered_velocity * t_vel) &&
-                               std::abs(filtered_velocity) > rolling_back_velocity_th;
-  if (
-    !hold_velocity_error_until_stop || !res.is_rolling_back || std::abs(filtered_velocity) < 0.05) {
+  const bool is_rolling_back =
+    std::signbit(v_vel * t_vel) && std::abs(v_vel) > rolling_back_velocity_th;
+  if (!hold_velocity_error_until_stop || !res.is_rolling_back || std::abs(v_vel) < 0.05) {
     res.is_rolling_back = is_rolling_back;
   }
 
   const bool is_over_velocity =
-    std::abs(filtered_velocity) >
-    std::abs(t_vel) * (1.0 + over_velocity_ratio_th) + over_velocity_offset_th;
-  if (
-    !hold_velocity_error_until_stop || !res.is_over_velocity ||
-    std::abs(filtered_velocity) < 0.05) {
+    std::abs(v_vel) > std::abs(t_vel) * (1.0 + over_velocity_ratio_th) + over_velocity_offset_th;
+  if (!hold_velocity_error_until_stop || !res.is_over_velocity || std::abs(v_vel) < 0.05) {
     res.is_over_velocity = is_over_velocity;
   }
 
+  res.vehicle_vel = v_vel;
   res.target_vel = t_vel;
 }
 
 void OverrunValidator::validate(
   ControlValidatorStatus & res, const Trajectory & reference_trajectory,
-  const Odometry & kinematics, const double filtered_velocity)
+  const Odometry & kinematics)
 {
   const auto stop_idx_opt =
     autoware::motion_utils::searchZeroVelocityIndex(reference_trajectory.points);
@@ -114,19 +114,19 @@ void OverrunValidator::validate(
       .longitudinal_velocity_mps;
 
   /*
-  clang-format off
   res.dist_to_stop: distance to stop according to the trajectory.
-  filtered_velocity * assumed_delay_time : distance ego will travel before starting the limit deceleration.
-  filtered_velocity * filtered_velocity / (2.0 * assumed_limit_acc): distance to stop assuming we apply the limit deceleration.
+  v_vel * assumed_delay_time : distance ego will travel before starting the limit deceleration.
+  v_vel * v_vel / (2.0 * assumed_limit_acc): distance to stop assuming we apply the limit
+  deceleration.
   if res.pred_dist_to_stop is negative, it means that we predict we will stop after the stop point
   contained in the trajectory.
-  clang format on
   */
-  res.pred_dist_to_stop = res.dist_to_stop - filtered_velocity * assumed_delay_time -
-                          filtered_velocity * filtered_velocity / (2.0 * assumed_limit_acc);
+  const double v_vel = vehicle_vel_lpf.filter(kinematics.twist.twist.linear.x);
+  res.pred_dist_to_stop =
+    res.dist_to_stop - v_vel * assumed_delay_time - v_vel * v_vel / (2.0 * assumed_limit_acc);
 
   // NOTE: the same velocity threshold as autoware::motion_utils::searchZeroVelocity
-  if (filtered_velocity < 1e-3) {
+  if (v_vel < 1e-3) {
     res.has_overrun_stop_point = false;
     res.will_overrun_stop_point = false;
     return;
@@ -139,14 +139,6 @@ void OverrunValidator::validate(
 ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)
 : Node("control_validator", options), vehicle_info_()
 {
-  double vel_lpf_gain = get_or_declare_parameter<double>(*this, "vel_lpf_gain");
-  double acc_lpf_gain = get_or_declare_parameter<double>(*this, "acc_lpf_gain");
-
-  common_velocity_lpf_ =
-    std::make_unique<autoware::signal_processing::LowpassFilter1d>(vel_lpf_gain);
-  common_acceleration_lpf_ =
-    std::make_unique<autoware::signal_processing::LowpassFilter1d>(acc_lpf_gain);
-
   using std::placeholders::_1;
 
   sub_control_cmd_ = create_subscription<Control>(
@@ -293,16 +285,6 @@ void ControlValidator::on_control_cmd(const Control::ConstSharedPtr msg)
     return waiting(sub_measured_acc_->subscriber()->get_topic_name());
   }
 
-  const double filtered_velocity =
-    common_velocity_lpf_->filter(kinematics_msg->twist.twist.linear.x);
-  const double filtered_acceleration =
-    common_acceleration_lpf_->filter(acceleration_msg->accel.accel.linear.x);
-  if (std::abs(kinematics_msg->twist.twist.linear.x) < 0.3) {
-    common_acceleration_lpf_->reset(0.0);
-  }
-  validation_status_.measured_acc = filtered_acceleration;
-  validation_status_.target_vel = filtered_velocity;
-
   // pre process
   debug_pose_publisher_->clear_markers();
   validation_status_.stamp = get_clock()->now();
@@ -318,13 +300,10 @@ void ControlValidator::on_control_cmd(const Control::ConstSharedPtr msg)
       validation_status_, *predicted_trajectory_msg, *reference_trajectory_msg);
   }
   acceleration_validator.validate(
-    validation_status_, *kinematics_msg, *control_cmd_msg, filtered_acceleration);
+    validation_status_, *kinematics_msg, *control_cmd_msg, *acceleration_msg);
+  velocity_validator.validate(validation_status_, *reference_trajectory_msg, *kinematics_msg);
+  overrun_validator.validate(validation_status_, *reference_trajectory_msg, *kinematics_msg);
 
-  velocity_validator.validate(
-    validation_status_, *reference_trajectory_msg, *kinematics_msg, filtered_velocity);
-
-  overrun_validator.validate(
-    validation_status_, *reference_trajectory_msg, *kinematics_msg, filtered_velocity);
   // post process
   validation_status_.invalid_count =
     is_all_valid(validation_status_) ? 0 : validation_status_.invalid_count + 1;

--- a/control/autoware_control_validator/src/debug_marker.cpp
+++ b/control/autoware_control_validator/src/debug_marker.cpp
@@ -37,24 +37,13 @@ void ControlValidatorDebugMarkerPublisher::clear_markers()
   marker_array_virtual_wall_.markers.clear();
 }
 
-void ControlValidatorDebugMarkerPublisher::push_warning_msg(
+void ControlValidatorDebugMarkerPublisher::push_virtual_wall(
   const geometry_msgs::msg::Pose & pose, const std::string & msg)
 {
-  visualization_msgs::msg::Marker marker = autoware_utils::create_default_marker(
-    "map", node_->get_clock()->now(), "warning_msg", 0, Marker::TEXT_VIEW_FACING,
-    autoware_utils::create_marker_scale(0.0, 0.0, 1.0),
-    autoware_utils::create_marker_color(1.0, 0.1, 0.1, 0.999));
-  marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-  marker.pose = pose;
-  marker.text = msg;
-  marker_array_virtual_wall_.markers.push_back(marker);
-}
-
-void ControlValidatorDebugMarkerPublisher::push_virtual_wall(const geometry_msgs::msg::Pose & pose)
-{
   const auto now = node_->get_clock()->now();
+  std::string display_msg = "control_validator \n(" + msg + ")";
   const auto stop_wall_marker =
-    autoware::motion_utils::createStopVirtualWallMarker(pose, "control_validator", now, 0);
+    autoware::motion_utils::createStopVirtualWallMarker(pose, display_msg, now, 0);
   autoware_utils::append_marker_array(stop_wall_marker, &marker_array_virtual_wall_, now);
 }
 

--- a/control/autoware_control_validator/test/test_control_validator.cpp
+++ b/control/autoware_control_validator/test/test_control_validator.cpp
@@ -184,9 +184,11 @@ INSTANTIATE_TEST_SUITE_P(
 class AccelerationValidatorTest : public ::testing::TestWithParam<std::tuple<bool, double, double>>
 {
 public:
-  bool is_in_error_range() { return acceleration_validator_->is_in_error_range(); }
-  void set_desired(double x) { acceleration_validator_->desired_acc_lpf.reset(x); }
-  void set_measured(double x) { acceleration_validator_->measured_acc_lpf.reset(x); }
+  bool is_in_error_range(const double filtered_acceleration)
+  {
+    return acceleration_validator_->is_in_error_range(filtered_acceleration);
+  }
+  void set_desired(const double x) { acceleration_validator_->desired_acc_lpf.reset(x); }
 
 protected:
   void SetUp() override
@@ -214,9 +216,8 @@ TEST_P(AccelerationValidatorTest, test_is_in_error_range)
 {
   auto [expected, des, mes] = GetParam();
   set_desired(des);
-  set_measured(mes);
 
-  ASSERT_EQ(expected, is_in_error_range());
+  ASSERT_EQ(expected, is_in_error_range(mes));
 };
 
 INSTANTIATE_TEST_SUITE_P(

--- a/control/autoware_control_validator/test/test_control_validator.cpp
+++ b/control/autoware_control_validator/test/test_control_validator.cpp
@@ -184,11 +184,9 @@ INSTANTIATE_TEST_SUITE_P(
 class AccelerationValidatorTest : public ::testing::TestWithParam<std::tuple<bool, double, double>>
 {
 public:
-  bool is_in_error_range(const double filtered_acceleration)
-  {
-    return acceleration_validator_->is_in_error_range(filtered_acceleration);
-  }
-  void set_desired(const double x) { acceleration_validator_->desired_acc_lpf.reset(x); }
+  bool is_in_error_range() { return acceleration_validator_->is_in_error_range(); }
+  void set_desired(double x) { acceleration_validator_->desired_acc_lpf.reset(x); }
+  void set_measured(double x) { acceleration_validator_->measured_acc_lpf.reset(x); }
 
 protected:
   void SetUp() override
@@ -216,8 +214,9 @@ TEST_P(AccelerationValidatorTest, test_is_in_error_range)
 {
   auto [expected, des, mes] = GetParam();
   set_desired(des);
+  set_measured(mes);
 
-  ASSERT_EQ(expected, is_in_error_range(mes));
+  ASSERT_EQ(expected, is_in_error_range());
 };
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## Description

- ~~Added common velocity and acceleration filters to ControlValidator class~~
- Added detailed error message generation for virtual wall display
- Updated tests to match new interfaces while maintaining test coverage

## How was this PR tested?

- [x] run psim and confirmed stop reason is visualized 
![image](https://github.com/user-attachments/assets/e1c4ea1d-a353-49d2-baa5-865fc6ea90e0)

- [x] [PASSED TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/c9757785-8e9e-5979-9b8a-8e93bdfc2a31?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
