### PR TITLE
fix(autoware_mrm_handler): add emergency turn indicators

### DIFF
--- a/control/autoware_vehicle_cmd_gate/README.md
+++ b/control/autoware_vehicle_cmd_gate/README.md
@@ -22,6 +22,7 @@
 | `~/input/external_emergency_stop_heartbeat` | `tier4_external_api_msgs::msg::Heartbeat`           | heartbeat                                                            |
 | `~/input/gate_mode`                         | `tier4_control_msgs::msg::GateMode`                 | gate mode (AUTO or EXTERNAL)                                         |
 | `~/input/emergency/control_cmd`             | `autoware_control_msgs::msg::Control`               | command for lateral and longitudinal velocity from emergency handler |
+| `~/input/emergency/turn_indicators_cmd`     | `autoware_vehicle_msgs::msg::TurnIndicatorsCommand` | turn indicators command from emergency handler                       |
 | `~/input/emergency/hazard_lights_cmd`       | `autoware_vehicle_msgs::msg::HazardLightsCommand`   | hazard lights command from emergency handler                         |
 | `~/input/emergency/gear_cmd`                | `autoware_vehicle_msgs::msg::GearCommand`           | gear command from emergency handler                                  |
 | `~/input/engage`                            | `autoware_vehicle_msgs::msg::Engage`                | engage signal                                                        |

--- a/control/autoware_vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
+++ b/control/autoware_vehicle_cmd_gate/launch/vehicle_cmd_gate.launch.xml
@@ -21,6 +21,7 @@
     <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
 
     <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
+    <remap from="input/emergency/turn_indicators_cmd" to="/system/emergency/turn_indicators_cmd"/>
     <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
     <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
     <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -406,6 +406,10 @@ void VehicleCmdGate::onTimer()
   if (msg_emergency_command_hazard_light)
     emergency_commands_.hazard_light = *msg_emergency_command_hazard_light;
 
+  const auto msg_emergency_command_turn_indicator = emergency_turn_indicator_cmd_sub_.take_data();
+  if (msg_emergency_command_turn_indicator)
+    emergency_commands_.turn_indicator = *msg_emergency_command_turn_indicator;
+
   const auto msg_emergency_command_gear = emergency_gear_cmd_sub_.take_data();
   if (msg_emergency_command_gear) emergency_commands_.gear = *msg_emergency_command_gear;
 
@@ -489,7 +493,9 @@ void VehicleCmdGate::onTimer()
       getContinuousTopic(prev_turn_indicator_, turn_indicator, "TurnIndicatorsCommand");
     turn_indicator_cmd_pub_->publish(*prev_turn_indicator_);
   } else {
-    if (msg_auto_command_turn_indicator || msg_remote_command_turn_indicator) {
+    if (
+      msg_auto_command_turn_indicator || msg_remote_command_turn_indicator ||
+      msg_emergency_command_turn_indicator) {
       prev_turn_indicator_ = std::make_shared<TurnIndicatorsCommand>(turn_indicator);
     }
     turn_indicator_cmd_pub_->publish(turn_indicator);

--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.hpp
@@ -181,6 +181,8 @@ private:
   // Subscription for emergency
   Commands emergency_commands_;
   rclcpp::Subscription<Control>::SharedPtr emergency_control_cmd_sub_;
+  autoware_utils::InterProcessPollingSubscriber<TurnIndicatorsCommand>
+    emergency_turn_indicator_cmd_sub_{this, "input/emergency/turn_indicators_cmd"};
   autoware_utils::InterProcessPollingSubscriber<HazardLightsCommand>
     emergency_hazard_light_cmd_sub_{this, "input/emergency/hazard_lights_cmd"};
   autoware_utils::InterProcessPollingSubscriber<GearCommand> emergency_gear_cmd_sub_{

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -76,6 +76,7 @@
           <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
           <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
           <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
+          <remap from="input/emergency/turn_indicators_cmd" to="/system/emergency/turn_indicators_cmd"/>
           <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
           <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
           <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>

--- a/system/autoware_mrm_handler/README.md
+++ b/system/autoware_mrm_handler/README.md
@@ -26,14 +26,15 @@ MRM Handler is a node to select a proper MRM from a system failure state contain
 
 ### Output
 
-| Name                                    | Type                                              | Description                                           |
-| --------------------------------------- | ------------------------------------------------- | ----------------------------------------------------- |
-| `/system/emergency/gear_cmd`            | `autoware_vehicle_msgs::msg::GearCommand`         | Required to execute proper MRM (send gear cmd)        |
-| `/system/emergency/hazard_lights_cmd`   | `autoware_vehicle_msgs::msg::HazardLightsCommand` | Required to execute proper MRM (send turn signal cmd) |
-| `/system/fail_safe/mrm_state`           | `autoware_adapi_v1_msgs::msg::MrmState`           | Inform MRM execution state and selected MRM behavior  |
-| `/system/mrm/emergency_stop/operate`    | `tier4_system_msgs::srv::OperateMrm`              | Execution order for MRM emergency stop                |
-| `/system/mrm/comfortable_stop/operate`  | `tier4_system_msgs::srv::OperateMrm`              | Execution order for MRM comfortable stop              |
-| `/system/mrm/pull_over_manager/operate` | `tier4_system_msgs::srv::OperateMrm`              | Execution order for MRM pull over                     |
+| Name                                    | Type                                                | Description                                             |
+| --------------------------------------- | --------------------------------------------------- | ------------------------------------------------------- |
+| `/system/emergency/gear_cmd`            | `autoware_vehicle_msgs::msg::GearCommand`           | Required to execute proper MRM (send gear cmd)          |
+| `/system/emergency/turn_indicators_cmd` | `autoware_vehicle_msgs::msg::TurnIndicatorsCommand` | Required to execute proper MRM (send turn signal cmd)   |
+| `/system/emergency/hazard_lights_cmd`   | `autoware_vehicle_msgs::msg::HazardLightsCommand`   | Required to execute proper MRM (send hazard signal cmd) |
+| `/system/fail_safe/mrm_state`           | `autoware_adapi_v1_msgs::msg::MrmState`             | Inform MRM execution state and selected MRM behavior    |
+| `/system/mrm/emergency_stop/operate`    | `tier4_system_msgs::srv::OperateMrm`                | Execution order for MRM emergency stop                  |
+| `/system/mrm/comfortable_stop/operate`  | `tier4_system_msgs::srv::OperateMrm`                | Execution order for MRM comfortable stop                |
+| `/system/mrm/pull_over_manager/operate` | `tier4_system_msgs::srv::OperateMrm`                | Execution order for MRM pull over                       |
 
 ## Parameters
 

--- a/system/autoware_mrm_handler/config/mrm_handler.param.yaml
+++ b/system/autoware_mrm_handler/config/mrm_handler.param.yaml
@@ -15,3 +15,6 @@
     # setting whether to turn hazard lamp on for each situation
     turning_hazard_on:
       emergency: true
+
+    turning_indicator_on:
+      emergency: true

--- a/system/autoware_mrm_handler/include/autoware/mrm_handler/mrm_handler_core.hpp
+++ b/system/autoware_mrm_handler/include/autoware/mrm_handler/mrm_handler_core.hpp
@@ -50,6 +50,11 @@ struct HazardLampPolicy
   bool emergency;
 };
 
+struct TurnIndicatorPolicy
+{
+  bool emergency;
+};
+
 struct Param
 {
   int update_rate;
@@ -62,6 +67,7 @@ struct Param
   bool use_pull_over;
   bool use_comfortable_stop;
   HazardLampPolicy turning_hazard_on{};
+  TurnIndicatorPolicy turning_indicator_on{};
 };
 
 class MrmHandler : public rclcpp::Node

--- a/system/autoware_mrm_handler/include/autoware/mrm_handler/mrm_handler_core.hpp
+++ b/system/autoware_mrm_handler/include/autoware/mrm_handler/mrm_handler_core.hpp
@@ -29,6 +29,7 @@
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <tier4_system_msgs/msg/emergency_holding_state.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/msg/operation_mode_availability.hpp>
@@ -100,9 +101,12 @@ private:
 
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::ShiftStamped>::SharedPtr pub_shift_;
   // rclcpp::Publisher<tier4_vehicle_msgs::msg::TurnSignal>::SharedPtr pub_turn_signal_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr
+    pub_turn_indicator_cmd_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr pub_hazard_cmd_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_gear_cmd_;
 
+  void publishTurnIndicatorCmd();
   void publishHazardCmd();
   void publishGearCmd();
 

--- a/system/autoware_mrm_handler/launch/mrm_handler.launch.xml
+++ b/system/autoware_mrm_handler/launch/mrm_handler.launch.xml
@@ -10,6 +10,7 @@
   <arg name="input_gear" default="/control/command/gear_cmd"/>
 
   <arg name="output_gear" default="/system/emergency/gear_cmd"/>
+  <arg name="output_turn_indicators" default="/system/emergency/turn_indicators_cmd"/>
   <arg name="output_hazard" default="/system/emergency/hazard_lights_cmd"/>
   <arg name="output_mrm_state" default="/system/fail_safe/mrm_state"/>
   <arg name="output_emergency_holding" default="/system/emergency_holding"/>
@@ -31,6 +32,7 @@
     <remap from="~/input/gear" to="$(var input_gear)"/>
 
     <remap from="~/output/gear" to="$(var output_gear)"/>
+    <remap from="~/output/turn_indicators" to="$(var output_turn_indicators)"/>
     <remap from="~/output/hazard" to="$(var output_hazard)"/>
     <remap from="~/output/mrm/state" to="$(var output_mrm_state)"/>
     <remap from="~/output/emergency_holding" to="$(var output_emergency_holding)"/>

--- a/system/autoware_mrm_handler/schema/mrm_handler.schema.json
+++ b/system/autoware_mrm_handler/schema/mrm_handler.schema.json
@@ -61,6 +61,17 @@
             }
           },
           "required": ["emergency"]
+        },
+        "turning_indicator_on": {
+          "type": "object",
+          "properties": {
+            "emergency": {
+              "type": "boolean",
+              "description": "If this parameter is true, turning indicators will be disabled during emergency state.",
+              "default": "true"
+            }
+          },
+          "required": ["emergency"]
         }
       },
       "required": [
@@ -73,7 +84,8 @@
         "use_parking_after_stopped",
         "use_pull_over",
         "use_comfortable_stop",
-        "turning_hazard_on"
+        "turning_hazard_on",
+        "turning_indicator_on"
       ],
       "additionalProperties": false
     }

--- a/system/autoware_mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/autoware_mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -36,7 +36,8 @@ MrmHandler::MrmHandler(const rclcpp::NodeOptions & options) : Node("mrm_handler"
   param_.use_pull_over = declare_parameter<bool>("use_pull_over", false);
   param_.use_comfortable_stop = declare_parameter<bool>("use_comfortable_stop", false);
   param_.turning_hazard_on.emergency = declare_parameter<bool>("turning_hazard_on.emergency", true);
-  param_.turning_indicator_on.emergency = declare_parameter<bool>("turning_indicator_on.emergency", true);
+  param_.turning_indicator_on.emergency =
+    declare_parameter<bool>("turning_indicator_on.emergency", true);
 
   using std::placeholders::_1;
 

--- a/system/autoware_mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/autoware_mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -36,6 +36,7 @@ MrmHandler::MrmHandler(const rclcpp::NodeOptions & options) : Node("mrm_handler"
   param_.use_pull_over = declare_parameter<bool>("use_pull_over", false);
   param_.use_comfortable_stop = declare_parameter<bool>("use_comfortable_stop", false);
   param_.turning_hazard_on.emergency = declare_parameter<bool>("turning_hazard_on.emergency", true);
+  param_.turning_indicator_on.emergency = declare_parameter<bool>("turning_indicator_on.emergency", true);
 
   using std::placeholders::_1;
 
@@ -120,7 +121,7 @@ void MrmHandler::publishTurnIndicatorCmd()
   TurnIndicatorsCommand msg;
 
   msg.stamp = this->now();
-  if (param_.turning_hazard_on.emergency && isEmergency()) {
+  if (param_.turning_indicator_on.emergency && isEmergency()) {
     msg.command = TurnIndicatorsCommand::DISABLE;
   } else {
     msg.command = TurnIndicatorsCommand::NO_COMMAND;

--- a/system/autoware_mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/autoware_mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -46,6 +46,8 @@ MrmHandler::MrmHandler(const rclcpp::NodeOptions & options) : Node("mrm_handler"
       std::bind(&MrmHandler::onOperationModeAvailability, this, _1));
 
   // Publisher
+  pub_turn_indicator_cmd_ = create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
+    "~/output/turn_indicators", rclcpp::QoS{1});
   pub_hazard_cmd_ = create_publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>(
     "~/output/hazard", rclcpp::QoS{1});
   pub_gear_cmd_ =
@@ -110,6 +112,21 @@ void MrmHandler::onOperationModeAvailability(
   const auto emergency_duration =
     (this->now() - stamp_autonomous_become_unavailable_.value()).seconds();
   is_emergency_holding_ = (emergency_duration > param_.timeout_emergency_recovery);
+}
+
+void MrmHandler::publishTurnIndicatorCmd()
+{
+  using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
+  TurnIndicatorsCommand msg;
+
+  msg.stamp = this->now();
+  if (param_.turning_hazard_on.emergency && isEmergency()) {
+    msg.command = TurnIndicatorsCommand::DISABLE;
+  } else {
+    msg.command = TurnIndicatorsCommand::NO_COMMAND;
+  }
+
+  pub_turn_indicator_cmd_->publish(msg);
 }
 
 void MrmHandler::publishHazardCmd()
@@ -358,6 +375,7 @@ void MrmHandler::onTimer()
 
   // Publish
   publishMrmState();
+  publishTurnIndicatorCmd();
   publishHazardCmd();
   publishGearCmd();
   publishEmergencyHolding();


### PR DESCRIPTION
## Description

MRM handler doesn't send turn indicators message and during MRM emergency the `vehicle_cmd_gate` node sending annoying log every 100~200ms:

```
The operation mode is changed, but the TurnIndicatorsCommand is not received yet:
```

This MR fixes that.

## How was this PR tested?

It was tested on carla simulator after force invoking _out of lane_ from MRM handler.

## Notes for reviewers

None.

## Interface changes

Topic `/system/emergency/turn_indicators_cmd` has added (from MRM Handler to Vehicle Cmd Gate).

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Sub | `~/input/emergency/turn_indicators_cmd` | `autoware_vehicle_msgs::msg::TurnIndicatorsCommand`   | Sub to Vehicle Cmd Gate  |
| Added | Pub | `/system/emergency/turn_indicators_cmd` | `autoware_vehicle_msgs::msg::TurnIndicatorsCommand`   | Pub from MRM Handler |

## Effects on system behavior

None.