### PR TITLE
fix(autoware_probabilistic_occupancy_grid_map): fix to avoid division by zero

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/cuda_pointcloud.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/cuda_pointcloud.hpp
@@ -40,7 +40,7 @@ public:
     row_step = msg_ptr->row_step;
     is_dense = msg_ptr->is_dense;
 
-    if (!data || capacity_ < msg_ptr->data.size()) {
+    if ((!data || capacity_ < msg_ptr->data.size()) && point_step > 0) {
       const int factor = 4096 * point_step;
       capacity_ = factor * (msg_ptr->data.size() / factor + 1);
       data = autoware::cuda_utils::make_unique<std::uint8_t[]>(capacity_);


### PR DESCRIPTION
## Description
I added the condition of `point_step > 0` to avoid the error caused by division by zero.

This is the glog dumped when `PointcloudBasedOccupancyGridMapNode` died with the error.
```
[component_container_mt-1] *** Aborted at 1746763152 (unix time) try "date -d @1746763152" if you are using GNU date ***
[component_container_mt-1] PC: @                0x0 (unknown)
[component_container_mt-1] *** SIGFPE (@0x7f5c1cd228c7) received by PID 375013 (TID 0x7f5cf0ff1640) from PID 483535047; stack trace: ***
[component_container_mt-1]     @     0x7f5d124404d6 google::(anonymous namespace)::FailureSignalHandler()
[component_container_mt-1]     @     0x7f5d11842520 (unknown)
[component_container_mt-1]     @     0x7f5c1cd228c7 CudaPointCloud2::fromROSMsgAsync()
[component_container_mt-1]     @     0x7f5c1cd0e054 autoware::occupancy_grid_map::PointcloudBasedOccupancyGridMapNode::rawPointcloudCallback()
[component_container_mt-1]     @     0x7f5c1cd372e5 rclcpp::experimental::SubscriptionIntraProcess<>::execute_impl<>()
[component_container_mt-1]     @     0x7f5d1215f2c3 rclcpp::Executor::execute_any_executable()
[component_container_mt-1]     @     0x7f5d12165432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-1]     @     0x7f5d11cdc253 (unknown)
[component_container_mt-1]     @     0x7f5d11894ac3 (unknown)
[component_container_mt-1]     @     0x7f5d11926850 (unknown)
```

I confirmed the occupancy grid map node works after this change.
![image](https://github.com/user-attachments/assets/28ce4d1a-d6ce-4082-90fc-f92e6f148e28)

## Related links

**Parent Issue:**

- [TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT0-37150)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
