### PR TITLE
feat(out_of_lane): resample object predicted paths to prevent empty gaps

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
@@ -18,6 +18,7 @@
 
   <depend>autoware_motion_utils</depend>
   <depend>autoware_motion_velocity_planner_common</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
@@ -187,10 +187,9 @@ autoware_perception_msgs::msg::PredictedObjects filter_predicted_objects(
         [](const auto & p) { return p.path.empty(); }),
       predicted_paths.end());
 
-    resample_predicted_paths(predicted_paths, filtered_object.shape);
-
     if (!filtered_object.kinematics.predicted_paths.empty())
-      filtered_objects.objects.push_back(filtered_object);
+      resample_predicted_paths(predicted_paths, filtered_object.shape);
+    filtered_objects.objects.push_back(filtered_object);
   }
   return filtered_objects;
 }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.cpp
@@ -15,6 +15,7 @@
 #include "filter_predicted_objects.hpp"
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/object_recognition_utils/predicted_path_utils.hpp>
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
@@ -103,6 +104,38 @@ void cut_predicted_path_beyond_red_lights(
   }
 }
 
+void resample_predicted_paths(
+  std::vector<autoware_perception_msgs::msg::PredictedPath> & predicted_paths,
+  const autoware_perception_msgs::msg::Shape & shape)
+{
+  auto min_gap_distance = 0.0;
+  if (
+    shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX ||
+    shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+    min_gap_distance = shape.dimensions.x;
+  } else {  // POLYGON not implemented
+    return;
+  }
+  for (auto & path : predicted_paths) {
+    const auto time_step = rclcpp::Duration(path.time_step).seconds();
+    const auto time_horizon = time_step * static_cast<double>(path.path.size() - 1);
+    auto max_distance_interval = 0.0;
+    for (auto i = 0UL; i + 1 < path.path.size(); ++i) {
+      max_distance_interval = std::max(
+        max_distance_interval, autoware_utils::calc_distance2d(path.path[i], path.path[i + 1]));
+    }
+    const auto resample_ratio = min_gap_distance / max_distance_interval;
+    if (resample_ratio > 1.0) {
+      continue;
+    }
+    const auto new_time_step = resample_ratio * time_step;
+    const auto new_path =
+      object_recognition_utils::resamplePredictedPath(path, new_time_step, time_horizon);
+    path.time_step = new_path.time_step;
+    path.path = new_path.path;
+  }
+}
+
 autoware_perception_msgs::msg::PredictedObjects filter_predicted_objects(
   const PlannerData & planner_data, const EgoData & ego_data, const PlannerParam & params)
 {
@@ -153,6 +186,8 @@ autoware_perception_msgs::msg::PredictedObjects filter_predicted_objects(
         predicted_paths.begin(), predicted_paths.end(),
         [](const auto & p) { return p.path.empty(); }),
       predicted_paths.end());
+
+    resample_predicted_paths(predicted_paths, filtered_object.shape);
 
     if (!filtered_object.kinematics.predicted_paths.empty())
       filtered_objects.objects.push_back(filtered_object);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
@@ -20,6 +20,7 @@
 #include <autoware/motion_velocity_planner_common/planner_data.hpp>
 
 #include <optional>
+#include <vector>
 
 namespace autoware::motion_velocity_planner::out_of_lane
 {
@@ -44,6 +45,11 @@ std::optional<autoware_utils::LineString2d> find_next_stop_line(
 void cut_predicted_path_beyond_red_lights(
   autoware_perception_msgs::msg::PredictedPath & predicted_path, const EgoData & ego_data,
   const double object_front_overhang);
+
+/// @brief resample the predicted paths such that there are no gaps between successive footprints
+void resample_predicted_paths(
+  std::vector<autoware_perception_msgs::msg::PredictedPath> & predicted_paths,
+  const autoware_perception_msgs::msg::Shape & shape);
 
 /// @brief filter predicted objects and their predicted paths
 /// @param [in] planner_data planner data


### PR DESCRIPTION
## Description

This PR fixes an issue with the current `out_of_lane`  module where an object's predicted path can contain "gaps" between successive footprint, causing collision detection to become inaccurate.
This PR add resampling of the predicted path to ensure no gaps in the predicted path.

| Current :-1: | With this PR :+1: |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/081f038e-34b7-408f-a780-66e570e4ff84" /> | <video src="https://github.com/user-attachments/assets/6b0da037-1b6e-4709-ba87-02fc5d3cf27e" /> |

## Related links

https://tier4.atlassian.net/browse/RT1-10111

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim and perception reproducer

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
