### PR TITLE
fix(autoware_pointcloud_preprocessor): combine_cloud_handler always set XYZIRC

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
@@ -135,6 +135,18 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
   // Before combining the pointclouds, initialize and reserve space for the concatenated pointcloud
   concatenate_cloud_result.concatenate_cloud_ptr =
     std::make_unique<sensor_msgs::msg::PointCloud2>();
+  {
+    // Normally, pcl::concatenatePointCloud() copies the field layout (e.g., XYZIRC)
+    // from the non-empty point cloud when given one empty and one non-empty input.
+    //
+    // However, if all input clouds in topic_to_cloud_map are empty,
+    // the function receives two empty point clouds and does nothing,
+    // resulting in concatenate_cloud_ptr not being compatible with the XYZIRC format.
+    //
+    // To avoid this, we explicitly set the fields of concatenate_cloud_ptr to XYZIRC here.
+    PointCloud2Modifier<PointXYZIRC, autoware::point_types::PointXYZIRCGenerator>
+      concatenate_cloud_modifier{*concatenate_cloud_result.concatenate_cloud_ptr, output_frame_};
+  }
 
   // Reserve space based on the total size of the pointcloud data to speed up the concatenation
   // process


### PR DESCRIPTION
## Description

In the current concatenation implementation, it is possible for a point cloud that is not compatible with the `XYZIRC` format to be published when only point cloud topics with zero points is received — even if the input empty point clouds have fields compatible with `XYZIRC`.

For example, this condition can occur shortly after the sensors starts up, when only some of the LiDAR sensors are active.
If a topic that is not `XYZIRC`-compatible is published from the concatenation node, some subsequent nodes may output a large number of log messages like the example below.

```
[ERROR 1747041202.864305347] [localization.util.crop_box_filter_measurement_range]: The pointcloud layout is not compatible with PointXYZIRCAEDT or PointXYZIRC. Aborting
[ERROR 1747041202.864633111] [perception.object_recognition.detection.irregular_object.crop_box_filter]: The pointcloud layout is not compatible with PointXYZIRCAEDT or PointXYZIRC. Aborting
[ERROR 1747041202.864708886] [perception.obstacle_segmentation.crop_box_filter]: The pointcloud layout is not compatible with PointXYZIRCAEDT or PointXYZIRC. Aborting

```

This PR fixes the behavior so that the published topic is always compatible with the `XYZIRC` format, regardless of the situation.

### Details

The current implementation uses `pcl::concatenatePointCloud` for point cloud concatenation.
 https://github.com/ros-perception/perception_pcl/blob/93af46d5f284c272a61a356691f8dcb3d3bd223c/pcl_conversions/include/pcl_conversions/pcl_conversions.h#L650-L679

If both input point clouds are empty and their fields differ, it aborts at line 678. As a result, a default point cloud that is not XYZIRC-compatible gets published.

## Related links

None. 

## How was this PR tested?

I tested `logging_simulator.launch.xml`, published only empty point cloud, and confirmed that the field of `/sensing/lidar/concatenated/pointcloud` was XYZIRC.
I used this [TIER IV INTERNAL rosbag](https://console.data-search.tier4.jp/projects/prd_jt/environments/c73f858a-20d4-4ea8-9a3c-81581584ea0f/rosbags/bde2bb4c-e967-44ae-a987-9fc416d9603e) for testing. (The /sensing/lidar/rear/velodyne_packets topic in this rosbag always contains empty point clouds.)

## Notes for reviewers

| Subscribed Input Condition                          | Published PointCloud                         |
|-----------------------------------------------------|----------------------------------------------|
| Only empty pointclouds that are **not XYZIRC**          |   empty pointcloud with **XYZIRC**  |
| Only empty pointclouds with **XYZIRC**            |   empty pointcloud with **XYZIRC**  |
| Non-empty pointclouds that are **not XYZIRC**           |  pointcloud with fields copied from input |
| Non-empty pointclouds with **XYZIRC**            |  pointcloud with **XYZIRC**          |

## Interface changes

None.

## Effects on system behavior

None.
