### PR TITLE
fix(detection_area_module,virtual_traffic_light,no_stopping_area): support overlap lane

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
@@ -74,10 +74,13 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
   const auto & self_pose = planner_data_->current_odometry->pose;
   const size_t current_seg_idx = findEgoSegmentIndex(path->points);
 
+  // Get current lanelet and connected lanelets
+  const auto connected_lane_ids =
+    planning_utils::collectConnectedLaneIds(lane_id_, planner_data_->route_handler_);
   // Get stop point
   const auto stop_point = arc_lane_utils::createTargetPoint(
     original_path, stop_line, planner_param_.stop_margin,
-    planner_data_->vehicle_info_.max_longitudinal_offset_m);
+    planner_data_->vehicle_info_.max_longitudinal_offset_m, connected_lane_ids);
   if (!stop_point) {
     return true;
   }
@@ -125,7 +128,7 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
     // Use '-' for margin because it's the backward distance from stop line
     const auto dead_line_point = arc_lane_utils::createTargetPoint(
       original_path, stop_line, -planner_param_.dead_line_margin,
-      planner_data_->vehicle_info_.max_longitudinal_offset_m);
+      planner_data_->vehicle_info_.max_longitudinal_offset_m, connected_lane_ids);
 
     if (dead_line_point) {
       const size_t dead_line_point_idx = dead_line_point->first;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -80,7 +80,7 @@ bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path)
   }
   const auto stop_point = arc_lane_utils::createTargetPoint(
     original_path, stop_line.value(), planner_param_.stop_margin,
-    planner_data_->vehicle_info_.max_longitudinal_offset_m);
+    planner_data_->vehicle_info_.max_longitudinal_offset_m, {lane_id_});
   if (!stop_point) {
     setSafe(true);
     return true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -220,8 +220,12 @@ std::optional<size_t> VirtualTrafficLightModule::getPathIndexOfFirstEndLine()
     end_line_p2.x = end_line.back().x();
     end_line_p2.y = end_line.back().y();
 
-    const auto collision =
-      arc_lane_utils::findCollisionSegment(module_data_.path, end_line_p1, end_line_p2);
+    const auto connected_lane_ids =
+      planning_utils::collectConnectedLaneIds(lane_id_, planner_data_->route_handler_);
+
+    const auto collision = arc_lane_utils::findCollisionSegment(
+      module_data_.path, end_line_p1, end_line_p2, connected_lane_ids);
+
     if (!collision) {
       continue;
     }


### PR DESCRIPTION
## Description

- Detection Area Module: Now considers connected lanelets when creating stop points and dead line points
- No Stopping Area Module: Explicitly passes current lane ID when creating stop points
- Virtual Traffic Light Module: Takes connected lane IDs into account when finding collision segments

## Related links

- Link

## How was this PR tested?

- [CommonScenario_Future:5](https://evaluation.tier4.jp/evaluation/reports/19203a51-fab3-5e97-b138-5629179a146d?project_id=prd_jt)
- [CommonScenario_Basic:8](https://evaluation.tier4.jp/evaluation/reports/c65c5c74-c266-5b2f-b0d4-a5d0cd1e1ac8?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
