### PR TITLE
feat(tier4_planning_rviz_plugin): add glog in the path visualization

### DIFF
--- a/visualization/tier4_planning_rviz_plugin/CMakeLists.txt
+++ b/visualization/tier4_planning_rviz_plugin/CMakeLists.txt
@@ -32,6 +32,7 @@ ament_auto_add_library(tier4_planning_rviz_plugin SHARED
 
 target_link_libraries(tier4_planning_rviz_plugin
   ${QT_LIBRARIES}
+  glog::glog
 )
 
 # Export the plugin to be imported by rviz2

--- a/visualization/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display.hpp
+++ b/visualization/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display.hpp
@@ -128,6 +128,12 @@ public:
     property_drivable_area_alpha_.setMin(0.0);
     property_drivable_area_alpha_.setMax(1.0);
     property_drivable_area_width_.setMin(0.001);
+
+    // glog for debug
+    if (!google::IsGoogleLoggingInitialized()) {
+      google::InitGoogleLogging("path_with_lane_id_display");
+      google::InstallFailureSignalHandler();
+    }
   }
 
   ~AutowarePathWithDrivableAreaDisplay()
@@ -235,6 +241,11 @@ public:
   : property_time_text_view_{"View Text Time", false, "", this},
     property_time_text_scale_{"Scale", 0.3, "", &property_time_text_view_}
   {
+    // glog for debug
+    if (!google::IsGoogleLoggingInitialized()) {
+      google::InitGoogleLogging("path_with_lane_id_display");
+      google::InstallFailureSignalHandler();
+    }
   }
 
   ~AutowareTrajectoryDisplay() override

--- a/visualization/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
+++ b/visualization/tier4_planning_rviz_plugin/include/tier4_planning_rviz_plugin/path/display_base.hpp
@@ -34,6 +34,7 @@
 #include <OgreMaterialManager.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
+#include <glog/logging.h>
 
 #include <deque>
 #include <limits>

--- a/visualization/tier4_planning_rviz_plugin/package.xml
+++ b/visualization/tier4_planning_rviz_plugin/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
+  <depend>glog</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/visualization/tier4_planning_rviz_plugin/src/path/display.cpp
+++ b/visualization/tier4_planning_rviz_plugin/src/path/display.cpp
@@ -26,6 +26,11 @@ AutowarePathWithLaneIdDisplay::AutowarePathWithLaneIdDisplay()
 : property_lane_id_view_{"View LaneId", true, "", this},
   property_lane_id_scale_{"Scale", 0.1, "", &property_lane_id_view_}
 {
+  // glog for debug
+  if (!google::IsGoogleLoggingInitialized()) {
+    google::InitGoogleLogging("path_with_lane_id_display");
+    google::InstallFailureSignalHandler();
+  }
 }
 
 void AutowarePathWithLaneIdDisplay::preProcessMessageDetail()


### PR DESCRIPTION
## Description

When the rviz is directly not via autoware.launch.xml, since glog is not included in the tier4_planning_rviz_plugin, when the rviz process dies, there is no information of glog for the debugging.
This PR introduces the glog in the path visualization of the tier4_planning_rviz_plugin package.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
