### PR TITLE
fix(intersection): interpolate object polygons precisely

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/package.xml
@@ -27,6 +27,7 @@
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/scripts/ttc.py
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/scripts/ttc.py
@@ -241,8 +241,6 @@ class TTCVisualizer(Node):
         if not self.last_sub:
             return
 
-        now = time.time()
-
         self.plot_ttc()
         self.plot_world()
         self.fig.canvas.flush_events()

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/scripts/ttc.py
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/scripts/ttc.py
@@ -146,7 +146,7 @@ class TTCVisualizer(Node):
         v = [d / t for d, t in zip(dd, dt)]
         self.ttc_vel_ax.yaxis.set_label_position("right")
         self.ttc_vel_ax.set_ylabel("ego velocity")
-        # self.ttc_vel_ax.set_ylim(0.0, max(v) + 1.0)
+        self.ttc_vel_ax.set_ylim(0.0, 10.0)
         time_velocity_plot = self.ttc_vel_ax.plot(ego_ttc_time[1:], v, label="time-v", c="red")
         lines = time_dist_plot + time_velocity_plot
         labels = [line.get_label() for line in lines]
@@ -235,33 +235,28 @@ class TTCVisualizer(Node):
         rclpy.shutdown()
 
     def on_plot_timer(self):
-        with self.lock:
-            if (not self.ego_ttc_data) or (not self.object_ttc_data):
-                return
+        if (not self.ego_ttc_data) or (not self.object_ttc_data):
+            return
 
-            if not self.last_sub:
-                return
+        if not self.last_sub:
+            return
 
-            now = time.time()
-            if (now - self.last_sub) > 1.0:
-                print("elapsed more than 1sec from last sub, exit/save fig")
-                self.cleanup()
+        now = time.time()
 
-            self.plot_ttc()
-            self.plot_world()
-            self.fig.canvas.flush_events()
+        self.plot_ttc()
+        self.plot_world()
+        self.fig.canvas.flush_events()
 
-            if self.args.save:
-                image = np.frombuffer(self.fig.canvas.tostring_rgb(), dtype="uint8")
-                image = image.reshape(self.fig.canvas.get_width_height()[::-1] + (3,))
-                image = Image.fromarray(image.astype(np.uint8))
-                self.images.append(image)
+        if self.args.save:
+            image = np.frombuffer(self.fig.canvas.tostring_rgb(), dtype="uint8")
+            image = image.reshape(self.fig.canvas.get_width_height()[::-1] + (3,))
+            image = Image.fromarray(image.astype(np.uint8))
+            self.images.append(image)
 
     def on_ego_ttc(self, msg):
-        with self.lock:
-            if int(msg.data[0]) == self.lane_id:
-                self.ego_ttc_data = msg
-                self.last_sub = time.time()
+        if int(msg.data[0]) == self.lane_id:
+            self.ego_ttc_data = msg
+            self.last_sub = time.time()
 
     def parse_npc_vehicles(self):
         self.npc_vehicles = []
@@ -272,11 +267,10 @@ class TTCVisualizer(Node):
             self.npc_vehicles.append(NPC(data))
 
     def on_object_ttc(self, msg):
-        with self.lock:
-            if int(msg.data[0]) == self.lane_id:
-                self.object_ttc_data = msg
-                self.parse_npc_vehicles()
-                self.last_sub = time.time()
+        if int(msg.data[0]) == self.lane_id:
+            self.object_ttc_data = msg
+            self.parse_npc_vehicles()
+            self.last_sub = time.time()
 
 
 if __name__ == "__main__":

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp
@@ -289,6 +289,14 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       &debug_marker_array, now);
   }
 
+  if (debug_data_.candidate_collision_object_polygon) {
+    append_marker_array(
+      debug::createPolygonMarkerArray(
+        debug_data_.candidate_collision_object_polygon.value(),
+        "candidate_collision_object_polygon", module_id_, now, 0.3, 0.0, 0.0, 0.5, 0.0, 0.0),
+      &debug_marker_array, now);
+  }
+
   static constexpr auto white = ::white();
   static constexpr auto green = ::green();
   static constexpr auto yellow = ::yellow();

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -226,6 +226,7 @@ public:
     std::optional<std::vector<lanelet::CompoundPolygon3d>> yield_stuck_detect_area{std::nullopt};
 
     std::optional<geometry_msgs::msg::Polygon> candidate_collision_ego_lane_polygon{std::nullopt};
+    std::optional<geometry_msgs::msg::Polygon> candidate_collision_object_polygon{std::nullopt};
     autoware_perception_msgs::msg::PredictedObjects safe_under_traffic_control_targets;
     autoware_perception_msgs::msg::PredictedObjects unsafe_targets;
     autoware_perception_msgs::msg::PredictedObjects misjudge_targets;


### PR DESCRIPTION
## Description

If the object is at relatively high speed, the object polygons may get sparse and cause inaccuracy in collision checking.

## Related links

https://tier4.atlassian.net/browse/RT0-36216

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/0e35cacd-436d-5f7e-bfbc-849aa9db2f2a?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
