### PR TITLE
fix(traffic_light_utils): remove condition in `setSignalUnknown`

### DIFF
--- a/common/autoware_traffic_light_utils/src/traffic_light_utils.cpp
+++ b/common/autoware_traffic_light_utils/src/traffic_light_utils.cpp
@@ -24,10 +24,7 @@ void setSignalUnknown(tier4_perception_msgs::msg::TrafficLight & signal, float c
   signal.elements.resize(1);
   signal.elements[0].shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
   signal.elements[0].color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-  // the default value is -1, which means to not set confidence
-  if (confidence > 0) {
-    signal.elements[0].confidence = confidence;
-  }
+  signal.elements[0].confidence = confidence;
 }
 
 bool hasTrafficLightCircleColor(


### PR DESCRIPTION
## Description

This PR gets to delete if condition and wrong comment.
- `// the default value is -1, which means to not set confidence` is wrong because default value is 0 in  numeric type ros msg (and that value does not set -1 in autoware_traffic_light_classifier).
  - https://design.ros2.org/articles/interface_definition.html
- if condition `if (confidence > 0)` does not need because of avobe description. And `setSignalUnknown` is only used in autoware_traffic_light_occlusion_predictor. But in this package, it is used as if confidence 0.0 can be set. (actually it is not set as 0.0 now.)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I have checked this PR works(as traffic light recognition) on my local pc.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
