### PR TITLE
ci(build-and-test-daily): offload uploading coverage to public runners

### DIFF
--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -61,6 +61,8 @@ jobs:
   build-and-test:
     runs-on: ${{ fromJson(inputs.runner) }}
     container: ${{ inputs.container }}${{ inputs.container-suffix }}
+    outputs:
+      coverage-files: ${{ steps.test.outputs.coverage-report-files }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -161,15 +163,37 @@ jobs:
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: build_depends.repos
 
-      - name: Upload coverage to CodeCov
+      # Cache lcov/coverage directories for next job
+      - name: Upload coverage artifacts
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v4
+        uses: actions/upload-artifact@v4
         with:
-          files: ${{ steps.test.outputs.coverage-report-files }}
-          fail_ci_if_error: false
-          verbose: true
-          flags: ${{ inputs.codecov-flag }}
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-${{ inputs.codecov-flag }}-${{ inputs.rosdistro }}
+          path: |
+            build
+            lcov
 
       - name: Show disk space after the tasks
         run: df -h
+
+  upload-coverage:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: ${{ needs.build-and-test.outputs.coverage-files != '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-${{ inputs.codecov-flag }}-${{ inputs.rosdistro }}
+
+      - name: Upload coverage to CodeCov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ${{ needs.build-and-test.outputs.coverage-files }}
+          fail_ci_if_error: false
+          verbose: true
+          flags: ${{ inputs.codecov-flag }}
+          token: ${{ secrets.codecov-token }}


### PR DESCRIPTION
## Description

Uploading codecov files takes too long **(21 mins)** on the self hosted machine and its time is more valuable since it has so many cores.

So this sequential low cpu requiring task can be offloaded to github public runners.

build-and-test run:
- https://github.com/autowarefoundation/autoware_universe/actions/runs/15026621945/job/42228865629

build-and-test-daily run:
- https://github.com/autowarefoundation/autoware_universe/actions/runs/14985413918/job/42098339475

## How was this PR tested?

- Tested here:
   - https://github.com/autowarefoundation/autoware_universe/actions/runs/15135662117

## Notes for reviewers

For some reason this same job is (or at least used to be when we still could fit autoware in public runners) faster on github public runners and codebuild. But slower on the ovh machines.

Yet uploading first to github artifacts and letting github hosted machines upload to codecov ends up much faster 🤷‍♂️

So this PR does that.

## Interface changes

None.

## Effects on system behavior

None.
