### PR TITLE
feat(collision_detector): time buffer and ignore behind rear axle

### DIFF
--- a/control/autoware_collision_detector/README.md
+++ b/control/autoware_collision_detector/README.md
@@ -2,11 +2,16 @@
 
 ## Purpose
 
-This module subscribes required data (ego-pose, obstacles, etc), and publishes diagnostics if an object is within a specific distance.
+This module publishes an `ERROR` diagnostic if a collision is detected with the current ego footprint.
 
 ## Inner-workings / Algorithms
 
 ### Flow chart
+
+1. Check input data.
+2. Filter dynamic objects.
+3. Find nearest object and its distance to ego.
+4. Publish an `ERROR` diagnostic depending on the recent collision detection results.
 
 ### Algorithms
 
@@ -42,6 +47,14 @@ Check that `collision_detector` receives no ground pointcloud, dynamic objects.
 
 Calculate distance between ego vehicle and the nearest object.
 In this function, it calculates the minimum distance between the polygon of ego vehicle and all points in pointclouds and the polygons of dynamic objects.
+If the minimum distance is lower than the `collision_distance` parameter, then a collision is detected.
+
+### Time buffer and distance hysteresis
+
+Before publishing an `ERROR` diagnostic, a collision must be detected for at least a duration set by the parameter `time_buffer.on`.
+Once an `ERROR` diagnostic is published, the `time_buffer.off_distance_hysteresis` parameter is used to make the ego footprint larger,
+making it easier to detect a collision.
+To stop publishing the `ERROR` diagnostic, no collision must be detected for at least a duration set by the parameter `time_buffer.off`.
 
 ## Inputs / Outputs
 
@@ -56,20 +69,25 @@ In this function, it calculates the minimum distance between the polygon of ego 
 
 ### Output
 
-| Name           | Type                                    | Description |
-| -------------- | --------------------------------------- | ----------- |
-| `/diagnostics` | `diagnostic_msgs::msg::DiagnosticArray` | Diagnostics |
+| Name              | Type                                    | Description   |
+| ----------------- | --------------------------------------- | ------------- |
+| `/diagnostics`    | `diagnostic_msgs::msg::DiagnosticArray` | Diagnostics   |
+| `~/debug_markers` | `visualization_msgs::msg::MarkerArray`  | Debug markers |
 
 ## Parameters
 
-| Name                         | Type                    | Description                                                                              | Default value                    |
-| :--------------------------- | :---------------------- | :--------------------------------------------------------------------------------------- | :------------------------------- |
-| `use_pointcloud`             | `bool`                  | Use pointcloud as obstacle check                                                         | `true`                           |
-| `use_dynamic_object`         | `bool`                  | Use dynamic object as obstacle check                                                     | `true`                           |
-| `collision_distance`         | `double`                | Distance threshold at which an object is considered a collision. [m]                     | 0.15                             |
-| `nearby_filter_radius`       | `double`                | Distance range for filtering objects. Objects within this radius are considered. [m]     | 5.0                              |
-| `keep_ignoring_time`         | `double`                | Time to keep filtering objects that first appeared in the vicinity [sec]                 | 10.0                             |
-| `nearby_object_type_filters` | `object of bool values` | Specifies which object types to filter. Only objects with `true` value will be filtered. | `{unknown: true, others: false}` |
+| Name                                  | Type                    | Description                                                                                                               | Default value                    |
+| :------------------------------------ | :---------------------- | :------------------------------------------------------------------------------------------------------------------------ | :------------------------------- |
+| `use_pointcloud`                      | `bool`                  | Use pointcloud as obstacle check                                                                                          | `true`                           |
+| `use_dynamic_object`                  | `bool`                  | Use dynamic object as obstacle check                                                                                      | `true`                           |
+| `collision_distance`                  | `double`                | Distance threshold at which an object is considered a collision. [m]                                                      | 0.15                             |
+| `nearby_filter_radius`                | `double`                | Distance range for filtering objects. Objects within this radius are considered. [m]                                      | 5.0                              |
+| `keep_ignoring_time`                  | `double`                | Time to keep filtering objects that first appeared in the vicinity [sec]                                                  | 10.0                             |
+| `nearby_object_type_filters`          | `object of bool values` | Specifies which object types to filter. Only objects with `true` value will be filtered.                                  | `{unknown: true, others: false}` |
+| `ignore_behind_rear_axle`             | `bool`                  | If true, collisions detected behind the rear axle of the ego vehicle are ignored                                          | `true`                           |
+| `time_buffer.on`                      | `double`                | [s] minimum consecutive detection time before triggering the ERROR diagnostic                                             | 0.2                              |
+| `time_buffer.off`                     | `double`                | [s] minimum consecutive time without collision detection (including the hysteresis) before releasing the ERROR diagnostic | 5.0                              |
+| `time_buffer.off_distance_hysteresis` | `double`                | [m] extra distance used to detect collisions once the diagnostic is triggered                                             | 1.0                              |
 
 ## Assumptions / Known limits
 

--- a/control/autoware_collision_detector/config/collision_detector.param.yaml
+++ b/control/autoware_collision_detector/config/collision_detector.param.yaml
@@ -14,3 +14,8 @@
       filter_motorcycle: false
       filter_pedestrian: false
       filter_unknown: true
+    ignore_behind_rear_axle: true  # If true, collisions detected behind the rear axle of the ego vehicle are ignored
+    time_buffer:  # buffer to start or stop publishing the ERROR diagnostic
+      on: 0.2  # [s] minimum consecutive detection time before triggering the ERROR diagnostic
+      off: 5.0  # [s] minimum consecutive time without collision detection (including the hysteresis) before releasing the ERROR diagnostic
+      off_distance_hysteresis: 1.0  # [m] extra distance used to detect collisions once the diagnostic is triggered

--- a/control/autoware_collision_detector/include/autoware/collision_detector/debug.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/debug.hpp
@@ -28,7 +28,8 @@ namespace autoware::collision_detector
 {
 inline visualization_msgs::msg::MarkerArray generate_debug_markers(
   const autoware_utils_geometry::Polygon2d & ego_polygon,
-  const std::optional<std::pair<double, geometry_msgs::msg::Point>> & nearest_obstacle_data)
+  const std::optional<std::pair<double, geometry_msgs::msg::Point>> & nearest_obstacle_data,
+  const bool is_error)
 {
   visualization_msgs::msg::MarkerArray marker_array;
   visualization_msgs::msg::Marker marker;
@@ -37,7 +38,11 @@ inline visualization_msgs::msg::MarkerArray generate_debug_markers(
   marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
   marker.action = visualization_msgs::msg::Marker::ADD;
   marker.scale = autoware_utils::create_marker_scale(0.1, 0.0, 0.0);
-  marker.color = autoware_utils::create_marker_color(0.0, 1.0, 0.0, 0.8);
+  if (is_error) {
+    marker.color = autoware_utils::create_marker_color(1.0, 0.0, 0.0, 0.8);
+  } else {
+    marker.color = autoware_utils::create_marker_color(0.0, 1.0, 0.0, 0.8);
+  }
 
   for (const auto & p : ego_polygon.outer()) {
     marker.points.push_back(autoware_utils::create_marker_position(p.x(), p.y(), 0.0));

--- a/control/autoware_collision_detector/include/autoware/collision_detector/debug.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/debug.hpp
@@ -1,0 +1,67 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COLLISION_DETECTOR__DEBUG_HPP_
+#define AUTOWARE__COLLISION_DETECTOR__DEBUG_HPP_
+
+#include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_visualization/marker_helper.hpp>
+
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <optional>
+
+namespace autoware::collision_detector
+{
+inline visualization_msgs::msg::MarkerArray generate_debug_markers(
+  const autoware_utils_geometry::Polygon2d & ego_polygon,
+  const std::optional<std::pair<double, geometry_msgs::msg::Point>> & nearest_obstacle_data)
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+  visualization_msgs::msg::Marker marker;
+  marker.header.frame_id = "base_link";
+  marker.ns = "ego_footprint";
+  marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  marker.scale = autoware_utils::create_marker_scale(0.1, 0.0, 0.0);
+  marker.color = autoware_utils::create_marker_color(0.0, 1.0, 0.0, 0.8);
+
+  for (const auto & p : ego_polygon.outer()) {
+    marker.points.push_back(autoware_utils::create_marker_position(p.x(), p.y(), 0.0));
+  }
+  if (!ego_polygon.outer().empty()) {
+    marker.points.push_back(marker.points.front());
+  }
+  marker_array.markers.push_back(marker);
+
+  marker.header.frame_id = "map";
+  marker.ns = "nearest_obstacle";
+  marker.type = visualization_msgs::msg::Marker::SPHERE;
+  marker.scale = autoware_utils::create_marker_scale(0.5, 0.5, 0.5);       // Sphere diameter
+  marker.color = autoware_utils::create_marker_color(1.0, 0.0, 0.0, 0.8);  // Red
+  if (nearest_obstacle_data) {
+    const auto & [_, nearest_point_msg] = *nearest_obstacle_data;
+    marker.pose.position = nearest_point_msg;
+    marker.action = visualization_msgs::msg::Marker::ADD;
+  } else {
+    marker.action = visualization_msgs::msg::Marker::DELETE;
+  }
+  marker_array.markers.push_back(marker);
+  return marker_array;
+}
+}  // namespace autoware::collision_detector
+
+#endif  // AUTOWARE__COLLISION_DETECTOR__DEBUG_HPP_

--- a/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2024-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/subscription.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <boost/optional.hpp>
 
@@ -66,12 +68,19 @@ public:
 
   struct NodeParam
   {
-    bool use_pointcloud;
-    bool use_dynamic_object;
-    double collision_distance;
-    double nearby_filter_radius;
-    double keep_ignoring_time;
+    bool use_pointcloud{};
+    bool use_dynamic_object{};
+    double collision_distance{};
+    double nearby_filter_radius{};
+    double keep_ignoring_time{};
     NearbyObjectTypeFilters nearby_object_type_filters;
+    bool ignore_behind_rear_axle{};
+    struct
+    {
+      double on{};
+      double off{};
+      double off_distance_hysteresis{};
+    } time_buffer;
   };
 
   struct TimestampedObject
@@ -92,13 +101,16 @@ private:
 
   void checkCollision(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
-  boost::optional<Obstacle> getNearestObstacle() const;
+  std::optional<Obstacle> getNearestObstacle(
+    const autoware_utils_geometry::Polygon2d & ego_polygon) const;
 
-  boost::optional<Obstacle> getNearestObstacleByPointCloud() const;
+  std::optional<Obstacle> getNearestObstacleByPointCloud(
+    const autoware_utils_geometry::Polygon2d & ego_polygon) const;
 
-  boost::optional<Obstacle> getNearestObstacleByDynamicObject() const;
+  std::optional<Obstacle> getNearestObstacleByDynamicObject(
+    const autoware_utils_geometry::Polygon2d & ego_polygon) const;
 
-  boost::optional<geometry_msgs::msg::TransformStamped> getTransform(
+  std::optional<geometry_msgs::msg::TransformStamped> getTransform(
     const std::string & source, const std::string & target, const rclcpp::Time & stamp,
     double duration_sec) const;
 
@@ -116,6 +128,8 @@ private:
     this, "~/input/objects"};
   autoware_utils::InterProcessPollingSubscriber<autoware_adapi_v1_msgs::msg::OperationModeState>
     sub_operation_mode_{this, "/api/operation_mode/state", rclcpp::QoS{1}.transient_local()};
+  std::shared_ptr<rclcpp::Publisher<visualization_msgs::msg::MarkerArray>> pub_debug_ =
+    create_publisher<visualization_msgs::msg::MarkerArray>("~/debug_markers", 1);
 
   // parameter
   NodeParam node_param_;

--- a/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
@@ -140,7 +140,9 @@ private:
   sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_ptr_;
   PredictedObjects::ConstSharedPtr object_ptr_;
   OperationModeState::ConstSharedPtr operation_mode_ptr_;
-  rclcpp::Time last_obstacle_found_stamp_;
+  std::optional<rclcpp::Time> start_of_consecutive_collision_stamp_;
+  std::optional<rclcpp::Time> most_recent_collision_stamp_;
+  bool is_error_diag_ = false;
   std::shared_ptr<PredictedObjects> filtered_object_ptr_;
   std::vector<TimestampedObject> observed_objects_;
   std::vector<TimestampedObject> ignored_objects_;

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2024-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
 
 #include "autoware/collision_detector/node.hpp"
 
+#include "autoware/collision_detector/debug.hpp"
+
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/uuid_helper.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
-#include <boost/assert.hpp>
-#include <boost/assign/list_of.hpp>
-#include <boost/format.hpp>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
@@ -42,8 +42,6 @@
 namespace autoware::collision_detector
 {
 namespace bg = boost::geometry;
-using Point2d = bg::model::d2::point_xy<double>;
-using Polygon2d = bg::model::polygon<Point2d>;
 using autoware_utils::create_point;
 using autoware_utils::pose2transform;
 
@@ -59,7 +57,7 @@ geometry_msgs::msg::Point32 createPoint32(const double x, const double y, const 
   return p;
 }
 
-Polygon2d createObjPolygon(
+autoware_utils_geometry::Polygon2d createObjPolygon(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Polygon & footprint)
 {
   geometry_msgs::msg::Polygon transformed_polygon{};
@@ -67,9 +65,9 @@ Polygon2d createObjPolygon(
   geometry_tf.transform = pose2transform(pose);
   tf2::doTransform(footprint, transformed_polygon, geometry_tf);
 
-  Polygon2d object_polygon;
+  autoware_utils_geometry::Polygon2d object_polygon;
   for (const auto & p : transformed_polygon.points) {
-    object_polygon.outer().push_back(Point2d(p.x, p.y));
+    object_polygon.outer().push_back(autoware_utils_geometry::Point2d(p.x, p.y));
   }
 
   bg::correct(object_polygon);
@@ -77,7 +75,7 @@ Polygon2d createObjPolygon(
   return object_polygon;
 }
 
-Polygon2d createObjPolygon(
+autoware_utils_geometry::Polygon2d createObjPolygon(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & size)
 {
   const double length_m = size.x / 2.0;
@@ -93,7 +91,8 @@ Polygon2d createObjPolygon(
   return createObjPolygon(pose, polygon);
 }
 
-Polygon2d createObjPolygonForCylinder(const geometry_msgs::msg::Pose & pose, const double diameter)
+autoware_utils_geometry::Polygon2d createObjPolygonForCylinder(
+  const geometry_msgs::msg::Pose & pose, const double diameter)
 {
   geometry_msgs::msg::Polygon polygon{};
 
@@ -109,19 +108,20 @@ Polygon2d createObjPolygonForCylinder(const geometry_msgs::msg::Pose & pose, con
   return createObjPolygon(pose, polygon);
 }
 
-Polygon2d createSelfPolygon(const VehicleInfo & vehicle_info)
+autoware_utils_geometry::Polygon2d createSelfPolygon(
+  const VehicleInfo & vehicle_info, const bool ignore_behind_rear_axle)
 {
   const double & front_m = vehicle_info.max_longitudinal_offset_m;
   const double & width_left_m = vehicle_info.max_lateral_offset_m;
   const double & width_right_m = vehicle_info.min_lateral_offset_m;
-  const double & rear_m = vehicle_info.min_longitudinal_offset_m;
+  const double & rear_m = ignore_behind_rear_axle ? 0.0 : vehicle_info.min_longitudinal_offset_m;
 
-  Polygon2d ego_polygon;
+  autoware_utils_geometry::Polygon2d ego_polygon;
 
-  ego_polygon.outer().push_back(Point2d(front_m, width_left_m));
-  ego_polygon.outer().push_back(Point2d(front_m, width_right_m));
-  ego_polygon.outer().push_back(Point2d(rear_m, width_right_m));
-  ego_polygon.outer().push_back(Point2d(rear_m, width_left_m));
+  ego_polygon.outer().push_back(autoware_utils_geometry::Point2d(front_m, width_left_m));
+  ego_polygon.outer().push_back(autoware_utils_geometry::Point2d(front_m, width_right_m));
+  ego_polygon.outer().push_back(autoware_utils_geometry::Point2d(rear_m, width_right_m));
+  ego_polygon.outer().push_back(autoware_utils_geometry::Point2d(rear_m, width_left_m));
 
   bg::correct(ego_polygon);
 
@@ -156,6 +156,11 @@ CollisionDetectorNode::CollisionDetectorNode(const rclcpp::NodeOptions & node_op
       this->declare_parameter<bool>("nearby_object_type_filters.filter_motorcycle");
     p.nearby_object_type_filters.filter_pedestrian =
       this->declare_parameter<bool>("nearby_object_type_filters.filter_pedestrian");
+    p.ignore_behind_rear_axle = this->declare_parameter<bool>("ignore_behind_rear_axle");
+    p.time_buffer.on = this->declare_parameter<double>("time_buffer.on");
+    p.time_buffer.off = this->declare_parameter<double>("time_buffer.off");
+    p.time_buffer.off_distance_hysteresis =
+      this->declare_parameter<double>("time_buffer.off_distance_hysteresis");
   }
 
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
@@ -192,7 +197,7 @@ PredictedObjects CollisionDetectorNode::filterObjects(const PredictedObjects & i
     return filtered_objects;
   }
 
-  Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.get().transform).cast<float>();
+  Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped->transform).cast<float>();
 
   for (const auto & object : input_objects.objects) {
     // Transform object position to base_link frame
@@ -349,10 +354,11 @@ void CollisionDetectorNode::checkCollision(diagnostic_updater::DiagnosticStatusW
   }
   filtered_object_ptr_ = std::make_shared<PredictedObjects>(filterObjects(*object_ptr_));
 
-  const auto nearest_obstacle = getNearestObstacle();
+  const auto ego_polygon = createSelfPolygon(vehicle_info_, node_param_.ignore_behind_rear_axle);
+  const auto nearest_obstacle = getNearestObstacle(ego_polygon);
 
   const auto is_obstacle_found =
-    !nearest_obstacle ? false : nearest_obstacle.get().first < node_param_.collision_distance;
+    !nearest_obstacle ? false : nearest_obstacle->first < node_param_.collision_distance;
 
   if (is_obstacle_found) {
     last_obstacle_found_stamp_ = this->now();
@@ -368,26 +374,29 @@ void CollisionDetectorNode::checkCollision(diagnostic_updater::DiagnosticStatusW
     status.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
     status.message = "collision detected";
     if (is_obstacle_found) {
-      stat.addf("Distance to nearest neighbor object", "%lf", nearest_obstacle.get().first);
+      stat.addf("Distance to nearest neighbor object", "%lf", nearest_obstacle->first);
     }
   } else {
     status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   }
 
   stat.summary(status.level, status.message);
+
+  pub_debug_->publish(generate_debug_markers(ego_polygon, nearest_obstacle));
 }
 
-boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacle() const
+std::optional<Obstacle> CollisionDetectorNode::getNearestObstacle(
+  const autoware_utils_geometry::Polygon2d & ego_polygon) const
 {
-  boost::optional<Obstacle> nearest_pointcloud{boost::none};
-  boost::optional<Obstacle> nearest_object{boost::none};
+  std::optional<Obstacle> nearest_pointcloud;
+  std::optional<Obstacle> nearest_object;
 
   if (node_param_.use_pointcloud) {
-    nearest_pointcloud = getNearestObstacleByPointCloud();
+    nearest_pointcloud = getNearestObstacleByPointCloud(ego_polygon);
   }
 
   if (node_param_.use_dynamic_object) {
-    nearest_object = getNearestObstacleByDynamicObject();
+    nearest_object = getNearestObstacleByDynamicObject(ego_polygon);
   }
 
   if (!nearest_pointcloud && !nearest_object) {
@@ -402,11 +411,11 @@ boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacle() const
     return nearest_pointcloud;
   }
 
-  return nearest_pointcloud.get().first < nearest_object.get().first ? nearest_pointcloud
-                                                                     : nearest_object;
+  return nearest_pointcloud->first < nearest_object->first ? nearest_pointcloud : nearest_object;
 }
 
-boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByPointCloud() const
+std::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByPointCloud(
+  const autoware_utils_geometry::Polygon2d & ego_polygon) const
 {
   const auto transform_stamped =
     getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
@@ -418,15 +427,13 @@ boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByPointCloud(
     return {};
   }
 
-  Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.get().transform).cast<float>();
+  Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped->transform).cast<float>();
   pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
   pcl::fromROSMsg(*pointcloud_ptr_, transformed_pointcloud);
   pcl::transformPointCloud(transformed_pointcloud, transformed_pointcloud, isometry);
 
-  const auto ego_polygon = createSelfPolygon(vehicle_info_);
-
   for (const auto & p : transformed_pointcloud) {
-    Point2d boost_point(p.x, p.y);
+    autoware_utils_geometry::Point2d boost_point(p.x, p.y);
 
     const auto distance_to_object = bg::distance(ego_polygon, boost_point);
 
@@ -439,7 +446,8 @@ boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByPointCloud(
   return std::make_pair(minimum_distance, nearest_point);
 }
 
-boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByDynamicObject() const
+std::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByDynamicObject(
+  const autoware_utils_geometry::Polygon2d & ego_polygon) const
 {
   const auto transform_stamped = getTransform(
     filtered_object_ptr_->header.frame_id, "base_link", filtered_object_ptr_->header.stamp, 0.5);
@@ -452,9 +460,7 @@ boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByDynamicObje
   }
 
   tf2::Transform tf_src2target;
-  tf2::fromMsg(transform_stamped.get().transform, tf_src2target);
-
-  const auto ego_polygon = createSelfPolygon(vehicle_info_);
+  tf2::fromMsg(transform_stamped->transform, tf_src2target);
 
   for (const auto & object : filtered_object_ptr_->objects) {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
@@ -491,7 +497,7 @@ boost::optional<Obstacle> CollisionDetectorNode::getNearestObstacleByDynamicObje
   return std::make_pair(minimum_distance, nearest_point);
 }
 
-boost::optional<geometry_msgs::msg::TransformStamped> CollisionDetectorNode::getTransform(
+std::optional<geometry_msgs::msg::TransformStamped> CollisionDetectorNode::getTransform(
   const std::string & source, const std::string & target, const rclcpp::Time & stamp,
   double duration_sec) const
 {


### PR DESCRIPTION
## Description

Required launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1443

## Related links

**Parent Issue:**

- Link

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/L4P-173)


## How was this PR tested?

Psim

I visualize the new debug markers.
- We can see the ego footprint used for collision detection and with the new option the polygon does not extend behind the rear axle.
- When the diagnostic of the `collision_detector` is in the `ERROR` state, the footprint turns red. Otherwise it is green.

In the following video, we can see that once the ego footprint overlaps the object footprint, the footprint becomes red (`ERROR` diagnostic) and becomes extended by the hysteresis. After the obstacle disappear, it takes some time for the diagnostic to go back to the normal state (footprint goes back to the normal size and to the green color).

https://github.com/user-attachments/assets/5d93a27d-8c93-4786-9032-7a7ea21f7af3

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
