### PR TITLE
feat(obstacle_stop_module): maintain larger stop distance for opposing traffic

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/obstacle_cruise_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/obstacle_cruise_module.cpp
@@ -35,19 +35,6 @@ namespace autoware::motion_velocity_planner
 {
 namespace
 {
-double calc_diff_angle_against_trajectory(
-  const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & target_pose)
-{
-  const size_t nearest_idx =
-    autoware::motion_utils::findNearestIndex(traj_points, target_pose.position);
-  const double traj_yaw = tf2::getYaw(traj_points.at(nearest_idx).pose.orientation);
-
-  const double target_yaw = tf2::getYaw(target_pose.orientation);
-
-  const double diff_yaw = autoware_utils::normalize_radian(target_yaw - traj_yaw);
-  return diff_yaw;
-}
-
 std::vector<PredictedPath> resample_highest_confidence_predicted_paths(
   const std::vector<PredictedPath> & predicted_paths, const double time_interval,
   const double time_horizon, const size_t num_paths)
@@ -814,7 +801,7 @@ bool ObstacleCruiseModule::is_obstacle_crossing(
   const std::vector<TrajectoryPoint> & traj_points,
   const std::shared_ptr<PlannerData::Object> object) const
 {
-  const double diff_angle = calc_diff_angle_against_trajectory(
+  const double diff_angle = autoware::motion_utils::calc_diff_angle_against_trajectory(
     traj_points, object->predicted_object.kinematics.initial_pose_with_covariance.pose);
 
   // NOTE: Currently predicted objects does not have orientation availability even


### PR DESCRIPTION
## Description
Adds behaviour to the obstacle stop module so that the ego-vehicle yields to on-coming vehicles

## Related links

**Parent Issue:**

- https://tier4.atlassian.net/browse/RT1-9226

**Design Document:**
https://tier4.atlassian.net/wiki/spaces/~712020794ae44077c44b7e9a5aa2cb085494fb/pages/3565782422/Slowing+Down+for+Opposing+Traffic

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
