### PR TITLE
fix(collision_detector): rename parameters to prevent launch issues

### DIFF
--- a/control/autoware_collision_detector/config/collision_detector.param.yaml
+++ b/control/autoware_collision_detector/config/collision_detector.param.yaml
@@ -16,6 +16,6 @@
       filter_unknown: true
     ignore_behind_rear_axle: true  # If true, collisions detected behind the rear axle of the ego vehicle are ignored
     time_buffer:  # buffer to start or stop publishing the ERROR diagnostic
-      on: 0.2  # [s] minimum consecutive detection time before triggering the ERROR diagnostic
-      off: 5.0  # [s] minimum consecutive time without collision detection (including the hysteresis) before releasing the ERROR diagnostic
+      on_duration: 0.2  # [s] minimum consecutive detection time before triggering the diagnostic
+      off_duration: 5.0  # [s] minimum consecutive time without collision detection (including the hysteresis) before releasing the diagnostic
       off_distance_hysteresis: 1.0  # [m] extra distance used to detect collisions once the diagnostic is triggered

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -158,8 +158,8 @@ CollisionDetectorNode::CollisionDetectorNode(const rclcpp::NodeOptions & node_op
     p.nearby_object_type_filters.filter_pedestrian =
       this->declare_parameter<bool>("nearby_object_type_filters.filter_pedestrian");
     p.ignore_behind_rear_axle = this->declare_parameter<bool>("ignore_behind_rear_axle");
-    p.time_buffer.on = this->declare_parameter<double>("time_buffer.on");
-    p.time_buffer.off = this->declare_parameter<double>("time_buffer.off");
+    p.time_buffer.on = this->declare_parameter<double>("time_buffer.on_duration");
+    p.time_buffer.off = this->declare_parameter<double>("time_buffer.off_duration");
     p.time_buffer.off_distance_hysteresis =
       this->declare_parameter<double>("time_buffer.off_distance_hysteresis");
   }


### PR DESCRIPTION
## Description

There is an error when trying to launch Autoware and I have not found a solution other than renaming some parameters.

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): 'bool' object is not iterable
```

## Related links

Requires to also merge https://github.com/autowarefoundation/autoware_launch/pull/1447

## How was this PR tested?

Evaluator (all pass):
- [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/cf3e136f-c2fe-5e42-9c30-c46600d073e3?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
