### PR TITLE
feat(diagnostic_graph_utils): show the error graph on the terminal only when it changes

### DIFF
--- a/system/autoware_diagnostic_graph_utils/src/node/logging.cpp
+++ b/system/autoware_diagnostic_graph_utils/src/node/logging.cpp
@@ -63,19 +63,29 @@ void LoggingNode::on_timer()
     dump_text_.str("");
     dump_text_.clear(std::stringstream::goodbit);
     dump_unit(root_unit_, 0, "");
+    const auto error_graph_text = dump_text_.str();
 
-    if (enable_terminal_log_) {
-      RCLCPP_WARN_STREAM(get_logger(), prefix_message << std::endl << dump_text_.str());
+    // show on terminal
+    if (enable_terminal_log_ && error_graph_text != prev_error_graph_text_) {
+      RCLCPP_WARN_STREAM(get_logger(), prefix_message << std::endl << error_graph_text);
     }
 
-    autoware_internal_debug_msgs::msg::StringStamped message;
-    message.stamp = now();
-    message.data = dump_text_.str();
-    pub_error_graph_text_->publish(message);
+    // publish debug topic
+    autoware_internal_debug_msgs::msg::StringStamped error_graph_message;
+    error_graph_message.stamp = now();
+    error_graph_message.data = error_graph_text;
+    pub_error_graph_text_->publish(error_graph_message);
+
+    // update previous value
+    prev_error_graph_text_ = error_graph_text;
   } else {
-    autoware_internal_debug_msgs::msg::StringStamped message;
-    message.stamp = now();
-    pub_error_graph_text_->publish(message);
+    // publish debug topic
+    autoware_internal_debug_msgs::msg::StringStamped error_graph_message;
+    error_graph_message.stamp = now();
+    pub_error_graph_text_->publish(error_graph_message);
+
+    // update previous value
+    prev_error_graph_text_ = "";
   }
 }
 

--- a/system/autoware_diagnostic_graph_utils/src/node/logging.hpp
+++ b/system/autoware_diagnostic_graph_utils/src/node/logging.hpp
@@ -46,6 +46,7 @@ private:
   std::string root_path_;
   std::ostringstream dump_text_;
   bool enable_terminal_log_;
+  std::string prev_error_graph_text_;
 };
 
 }  // namespace autoware::diagnostic_graph_utils


### PR DESCRIPTION
## Description

Currently, when the MRM is triggered, the error graph (the cause of the diag triggering MRM) is visualized on the rviz.
However, there is no error message on the terminal, and it's hard to know the cause when we cannot access the rviz for the low-level debugging.

This PR changed the diagnostic_graph_utils package to show the error graph on the terminal only when it changes to suppress the frequent log.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
