### PR TITLE
fix(autoware_ground_segmentation): correct slope threshold global to local

### DIFF
--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/grid_ground_filter.cpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/grid_ground_filter.cpp
@@ -276,7 +276,7 @@ void GridGroundFilter::SegmentDiscontinuousCell(
     // 3. local slope
     const float delta_radius = radius - prev_cell.avg_radius_;
     const float local_slope_threshold = param_.local_slope_max_ratio * delta_radius;
-    if (abs(delta_avg_z) < global_slope_threshold) {
+    if (abs(delta_avg_z) < local_slope_threshold) {
       // this point is ground
       ground_bin.addPoint(radius, height, pt_idx);
       // go to the next point

--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/grid_ground_filter.cpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/grid_ground_filter.cpp
@@ -275,7 +275,7 @@ void GridGroundFilter::SegmentDiscontinuousCell(
     }
     // 3. local slope
     const float delta_radius = radius - prev_cell.avg_radius_;
-    const float global_slope_threshold = param_.local_slope_max_ratio * delta_radius;
+    const float local_slope_threshold = param_.local_slope_max_ratio * delta_radius;
     if (abs(delta_avg_z) < global_slope_threshold) {
       // this point is ground
       ground_bin.addPoint(radius, height, pt_idx);

--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/grid_ground_filter.cpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/grid_ground_filter.cpp
@@ -219,7 +219,7 @@ void GridGroundFilter::SegmentContinuousCell(
 
     // 3. local slope
     const float delta_radius = radius - prev_cell.avg_radius_;
-    if (abs(delta_z) < param_.global_slope_max_ratio * delta_radius) {
+    if (abs(delta_z) < param_.local_slope_max_ratio * delta_radius) {
       // this point is ground
       ground_bin.addPoint(radius, height, pt_idx);
       // go to the next point
@@ -275,7 +275,7 @@ void GridGroundFilter::SegmentDiscontinuousCell(
     }
     // 3. local slope
     const float delta_radius = radius - prev_cell.avg_radius_;
-    const float global_slope_threshold = param_.global_slope_max_ratio * delta_radius;
+    const float global_slope_threshold = param_.local_slope_max_ratio * delta_radius;
     if (abs(delta_avg_z) < global_slope_threshold) {
       // this point is ground
       ground_bin.addPoint(radius, height, pt_idx);

--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/grid_ground_filter.cpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/grid_ground_filter.cpp
@@ -297,7 +297,7 @@ void GridGroundFilter::SegmentDiscontinuousCell(
       continue;
     }
     // 5. obstacle from local slope
-    if (delta_avg_z >= global_slope_threshold) {
+    if (delta_avg_z >= local_slope_threshold) {
       // this point is obstacle
       out_no_ground_indices.indices.push_back(pt_idx);
       // go to the next point


### PR DESCRIPTION
## Description

`global_slope_max_angle_deg` has been implemented in threshold of local slope, which is not intended.

Fix this to use `local_slope_max_angle_deg`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
