### PR TITLE
fix(pid_longitudinal_controller): fix reseting the prev value

### DIFF
--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -726,7 +726,7 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
       m_pid_vel.reset();
       m_lpf_vel_error->reset(0.0);
       // prevent the car from taking a long time to start to move
-      m_prev_ctrl_cmd.acc = std::max(0.0, m_prev_raw_ctrl_cmd.acc);
+      m_prev_raw_ctrl_cmd.acc = std::max(0.0, m_prev_raw_ctrl_cmd.acc);
       return changeControlState(ControlState::DRIVE);
     }
     return;


### PR DESCRIPTION
## Description
Fixed a bug in resetting the previous value for the difference filter.

The design diagram is here: https://github.com/autowarefoundation/autoware_universe/pull/7718
However, a different variable was being reset in the implementation.

## Related links

## How was this PR tested?
engage and stop available in psim

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
