### PR TITLE
feat(mission_planner): print route state when set_route fails

### DIFF
--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -41,7 +41,7 @@ namespace
   case RouteState::state:       \
     return #state;
 
-std::string routeStateToString(const uint8_t state)
+std::string route_state_to_string(const uint8_t state)
 {
   switch (state) {
     ROUTE_STATE_CASE(UNKNOWN)

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -24,6 +24,7 @@
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
+#include <fmt/format.h>
 #include <lanelet2_core/geometry/LineString.h>
 
 #include <algorithm>
@@ -34,6 +35,31 @@
 
 namespace autoware::mission_planner_universe
 {
+namespace
+{
+#define ROUTE_STATE_CASE(state) \
+  case RouteState::state:       \
+    return #state;
+
+std::string routeStateToString(const uint8_t state)
+{
+  switch (state) {
+    ROUTE_STATE_CASE(UNKNOWN)
+    ROUTE_STATE_CASE(INITIALIZING)
+    ROUTE_STATE_CASE(UNSET)
+    ROUTE_STATE_CASE(ROUTING)
+    ROUTE_STATE_CASE(SET)
+    ROUTE_STATE_CASE(REROUTING)
+    ROUTE_STATE_CASE(ARRIVED)
+    ROUTE_STATE_CASE(ABORTED)
+    ROUTE_STATE_CASE(INTERRUPTED)
+    default:
+      return "UNKNOWN(" + std::to_string(static_cast<int>(state)) + ")";
+  }
+}
+
+#undef ROUTE_STATE_CASE
+}  // namespace
 
 MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
 : Node("mission_planner", options),
@@ -241,7 +267,10 @@ void MissionPlanner::on_set_lanelet_route(
 
   if (state_.state != RouteState::UNSET && state_.state != RouteState::SET) {
     throw service_utils::ServiceException(
-      ResponseCode::ERROR_INVALID_STATE, "The route cannot be set in the current state.");
+      ResponseCode::ERROR_INVALID_STATE,
+      fmt::format(
+        "The lanelet route cannot be set in the current state: {}",
+        routeStateToString(state_.state)));
   }
   if (!is_mission_planner_ready_) {
     throw service_utils::ServiceException(
@@ -304,7 +333,10 @@ void MissionPlanner::on_set_waypoint_route(
 
   if (state_.state != RouteState::UNSET && state_.state != RouteState::SET) {
     throw service_utils::ServiceException(
-      ResponseCode::ERROR_INVALID_STATE, "The route cannot be set in the current state.");
+      ResponseCode::ERROR_INVALID_STATE,
+      fmt::format(
+        "The waypoint route cannot be set in the current state: {}",
+        routeStateToString(state_.state)));
   }
   if (!is_mission_planner_ready_) {
     throw service_utils::ServiceException(

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -270,7 +270,7 @@ void MissionPlanner::on_set_lanelet_route(
       ResponseCode::ERROR_INVALID_STATE,
       fmt::format(
         "The lanelet route cannot be set in the current state: {}",
-        routeStateToString(state_.state)));
+        route_state_to_string(state_.state)));
   }
   if (!is_mission_planner_ready_) {
     throw service_utils::ServiceException(
@@ -336,7 +336,7 @@ void MissionPlanner::on_set_waypoint_route(
       ResponseCode::ERROR_INVALID_STATE,
       fmt::format(
         "The waypoint route cannot be set in the current state: {}",
-        routeStateToString(state_.state)));
+        route_state_to_string(state_.state)));
   }
   if (!is_mission_planner_ready_) {
     throw service_utils::ServiceException(

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -37,28 +37,23 @@ namespace autoware::mission_planner_universe
 {
 namespace
 {
-#define ROUTE_STATE_CASE(state) \
-  case RouteState::state:       \
-    return #state;
-
 std::string route_state_to_string(const uint8_t state)
 {
   switch (state) {
-    ROUTE_STATE_CASE(UNKNOWN)
-    ROUTE_STATE_CASE(INITIALIZING)
-    ROUTE_STATE_CASE(UNSET)
-    ROUTE_STATE_CASE(ROUTING)
-    ROUTE_STATE_CASE(SET)
-    ROUTE_STATE_CASE(REROUTING)
-    ROUTE_STATE_CASE(ARRIVED)
-    ROUTE_STATE_CASE(ABORTED)
-    ROUTE_STATE_CASE(INTERRUPTED)
-    default:
-      return "UNKNOWN(" + std::to_string(static_cast<int>(state)) + ")";
+      // clang-format off
+    case RouteState::UNKNOWN:      return "UNKNOWN";
+    case RouteState::INITIALIZING: return "INITIALIZING";
+    case RouteState::UNSET:        return "UNSET";
+    case RouteState::ROUTING:      return "ROUTING";
+    case RouteState::SET:          return "SET";
+    case RouteState::REROUTING:    return "REROUTING";
+    case RouteState::ARRIVED:      return "ARRIVED";
+    case RouteState::ABORTED:      return "ABORTED";
+    case RouteState::INTERRUPTED:  return "INTERRUPTED";
+    default: return "UNKNOWN(" + std::to_string(static_cast<int>(state)) + ")";
+      // clang-format on
   }
 }
-
-#undef ROUTE_STATE_CASE
 }  // namespace
 
 MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)


### PR DESCRIPTION
## Description

print route state when set_route fails

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim

check follwoing in terminal
```
  const auto message = fmt::format("state_.state: {}", routeStateToString(state_.state));
  RCLCPP_INFO(get_logger(), message.c_str());
```


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
