### PR TITLE
fix(autoware_universe_utils): remove unused function

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/ros/marker_helper.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/ros/marker_helper.hpp
@@ -68,9 +68,6 @@ visualization_msgs::msg::Marker createDefaultMarker(
   const int32_t type, const geometry_msgs::msg::Vector3 & scale,
   const std_msgs::msg::ColorRGBA & color);
 
-visualization_msgs::msg::Marker createDeletedDefaultMarker(
-  const rclcpp::Time & now, const std::string & ns, const int32_t id);
-
 void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
   visualization_msgs::msg::MarkerArray * marker_array,

--- a/common/autoware_universe_utils/src/ros/marker_helper.cpp
+++ b/common/autoware_universe_utils/src/ros/marker_helper.cpp
@@ -42,19 +42,6 @@ visualization_msgs::msg::Marker createDefaultMarker(
   return marker;
 }
 
-visualization_msgs::msg::Marker createDeletedDefaultMarker(
-  const rclcpp::Time & now, const std::string & ns, const int32_t id)
-{
-  visualization_msgs::msg::Marker marker;
-
-  marker.header.stamp = now;
-  marker.ns = ns;
-  marker.id = id;
-  marker.action = visualization_msgs::msg::Marker::DELETE;
-
-  return marker;
-}
-
 void appendMarkerArray(
   const visualization_msgs::msg::MarkerArray & additional_marker_array,
   visualization_msgs::msg::MarkerArray * marker_array,


### PR DESCRIPTION
## Description

Removed `createDeletedDefaultMarker` based on cppcheck warning
```
common/autoware_universe_utils/src/ros/marker_helper.cpp:45:0: style: The function 'createDeletedDefaultMarker' is never used. [unusedFunction]
visualization_msgs::msg::Marker createDeletedDefaultMarker(
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
