### PR TITLE
fix(autoware_path_optimizer): remove unused function

### DIFF
--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/utils/trajectory_utils.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/utils/trajectory_utils.hpp
@@ -95,9 +95,6 @@ TrajectoryPoint convertToTrajectoryPoint(const T & point)
   return traj_point;
 }
 
-template <>
-TrajectoryPoint convertToTrajectoryPoint(const ReferencePoint & ref_point);
-
 template <typename T>
 std::vector<TrajectoryPoint> convertToTrajectoryPoints(const std::vector<T> & points)
 {

--- a/planning/autoware_path_optimizer/src/utils/trajectory_utils.cpp
+++ b/planning/autoware_path_optimizer/src/utils/trajectory_utils.cpp
@@ -39,15 +39,6 @@ namespace autoware::path_optimizer
 namespace trajectory_utils
 {
 
-template <>
-TrajectoryPoint convertToTrajectoryPoint(const ReferencePoint & ref_point)
-{
-  TrajectoryPoint traj_point;
-  traj_point.pose = autoware_utils::get_pose(ref_point);
-  traj_point.longitudinal_velocity_mps = autoware_utils::get_longitudinal_velocity(ref_point);
-  return traj_point;
-}
-
 ReferencePoint convertToReferencePoint(const TrajectoryPoint & traj_point)
 {
   ReferencePoint ref_point;


### PR DESCRIPTION
## Description

Removed `convertToTrajectoryPoint` based on cppcheck warning
```
planning/autoware_path_optimizer/src/utils/trajectory_utils.cpp:43:0: style: The function 'convertToTrajectoryPoint' is never used. [unusedFunction]
TrajectoryPoint convertToTrajectoryPoint(const ReferencePoint & ref_point)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
