### PR TITLE
refactor(blockage_diag): split up `filter` function, add doc comments

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/blockage_diag/blockage_diag_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/blockage_diag/blockage_diag_node.hpp
@@ -29,6 +29,7 @@
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
+#include <pcl/PCLPointCloud2.h>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
@@ -46,6 +47,7 @@ namespace autoware::pointcloud_preprocessor
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
 using autoware::point_types::PointXYZIRCAEDT;
+using PCLCloudXYZIRCAEDT = pcl::PointCloud<PointXYZIRCAEDT>;
 
 class BlockageDiagComponent : public autoware::pointcloud_preprocessor::Filter
 {
@@ -71,8 +73,14 @@ protected:
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr blockage_type_pub_;
 
 private:
-  void run_blockage_check(DiagnosticStatusWrapper & stat);
-  void run_dust_check(DiagnosticStatusWrapper & stat);
+  struct DebugInfo {
+    std_msgs::msg::Header input_header;
+    cv::Mat depth_image_16u;
+    cv::Mat blockage_mask_multi_frame;
+  };
+
+  void run_blockage_check(DiagnosticStatusWrapper & stat) const;
+  void run_dust_check(DiagnosticStatusWrapper & stat) const;
 
   /**
    * @brief Get the horizontal bin index of the given azimuth, if within the FoV.
@@ -105,37 +113,152 @@ private:
    */
   cv::Size get_mask_dimensions() const;
 
+  /**
+   * @brief Make a downsampled depth image from the input point cloud, normalized to 0-35565.
+   *
+   * The size of the output is given by `get_mask_dimensions()`.
+   * Close depth values are mapped to higher values, far depth values are mapped to lower values.
+   * The `max_distance_range_` is mapped to 0, and a LiDAR distance of 0 is mapped to UINT16_MAX.
+   *
+   * @param input The input point cloud.
+   * @return cv::Mat The normalized depth image. The data type is `CV_16UC1`.
+   */
+  cv::Mat make_normalized_depth_image(const PCLCloudXYZIRCAEDT & input) const;
+
+  /**
+   * @brief Quantize a 16-bit image to 8-bit.
+   *
+   * The values are scaled by `1.0 / 300` to prevent overflow.
+   *
+   * @param image_16u The input 16-bit image.
+   * @return cv::Mat The quantized 8-bit image. The data type is `CV_8UC1`.
+   */
+  cv::Mat quantize_to_8u(const cv::Mat & image_16u) const;
+
+  /**
+   * @brief Make a no-return mask from the input depth image.
+   *
+   * The mask is a binary image where 255 is no-return and 0 is return.
+   *
+   * @param depth_image The input depth image.
+   * @return cv::Mat The no-return mask. The data type is `CV_8UC1`.
+   */
+  cv::Mat make_no_return_mask(const cv::Mat & depth_image) const;
+
+  /**
+   * @brief Make a binary, cleaned blockage mask from the input no-return mask.
+   * 
+   * @param no_return_mask A mask where 255 is no-return and 0 is return.
+   * @return cv::Mat The blockage mask. The data type is `CV_8UC1`.
+   */
+  cv::Mat make_blockage_mask(const cv::Mat & no_return_mask) const;
+
+  /**
+   * @brief Update the internal blockage mask buffer and return the updated mask.
+   * 
+   * @param blockage_mask The current blockage mask. The data type is `CV_8UC1`.
+   * @return cv::Mat The updated aggregated blockage mask. The data type is `CV_8UC1`.
+   */
+  cv::Mat update_time_series_blockage_mask(const cv::Mat & blockage_mask);
+
+  /**
+   * @brief Segments a given mask into two masks, according to the ground/sky segmentation parameters.
+   * 
+   * @param mask The input mask. The data type is `CV_8UC1`.
+   * @return std::pair<cv::Mat, cv::Mat> The pair {ground_mask, sky_mask}. The data type is `CV_8UC1`.
+   */
+  std::pair<cv::Mat, cv::Mat> segment_into_ground_and_sky(const cv::Mat & mask) const;
+
+  /**
+   * @brief Get the ratio of non-zero pixels in a given mask.
+   * 
+   * @param mask The input mask. The data type is `CV_8UC1`.
+   * @return float The ratio of non-zero pixels (e.g. 1.0 if all are non-zero, 0.0 if all are zero).
+   */
+  static float get_nonzero_ratio(const cv::Mat & mask);
+
+  /**
+   * @brief Update the internal ground blockage info.
+   * 
+   * @param ground_blockage_mask The ground blockage mask. The data type is `CV_8UC1`.
+   */
+  void update_ground_blockage_info(const cv::Mat & ground_blockage_mask);
+
+  /**
+   * @brief Update the internal sky blockage info.
+   * 
+   * @param sky_blockage_mask The sky blockage mask. The data type is `CV_8UC1`.
+   */
+  void update_sky_blockage_info(const cv::Mat & sky_blockage_mask);
+
+  /**
+   * @brief Compute dust diagnostics and update the internal dust info.
+   * 
+   * @param no_return_mask The no-return mask. The data type is `CV_8UC1`.
+   * @param debug_info The debug info to publish if enabled.
+   */
+  void compute_dust_diagnostics(const cv::Mat & no_return_mask, const DebugInfo & debug_info);
+
+  /**
+   * @brief Publish the debug info if enabled.
+   * 
+   * @param debug_info The debug info to publish.
+   */
+  void publish_debug_info(const DebugInfo & debug_info) const;
+
   Updater updater_{this};
+  
+  // Debug parameters
+  bool publish_debug_image_;
+  
+  // LiDAR parameters
+  double max_distance_range_{200.0};
+
+  // Mask size parameters
   int vertical_bins_;
   std::vector<double> angle_range_deg_;
-  int horizontal_ring_id_;
-  float blockage_ratio_threshold_;
-  float dust_ratio_threshold_;
-  float ground_blockage_ratio_ = -1.0f;
-  float sky_blockage_ratio_ = -1.0f;
-  float ground_dust_ratio_ = -1.0f;
-  std::vector<float> ground_blockage_range_deg_ = {0.0f, 0.0f};
-  std::vector<float> sky_blockage_range_deg_ = {0.0f, 0.0f};
-  int blockage_kernel_ = 10;
-  int blockage_frame_count_ = 0;
-  int ground_blockage_count_ = 0;
-  int sky_blockage_count_ = 0;
-  int blockage_count_threshold_;
+  double horizontal_resolution_{0.4};
+
+  // Ground/sky segmentation parameters
   bool is_channel_order_top2down_;
+  int horizontal_ring_id_;
+
+  // Blockage detection parameters
+  float blockage_ratio_threshold_;
+  int blockage_kernel_ = 10;
   int blockage_buffering_frames_;
   int blockage_buffering_interval_;
+  int blockage_count_threshold_;
+
+  // Blockage detection state
+  float ground_blockage_ratio_ = -1.0f;
+  float sky_blockage_ratio_ = -1.0f;
+  int ground_blockage_count_ = 0;
+  int sky_blockage_count_ = 0;
+  std::vector<float> ground_blockage_range_deg_ = {0.0f, 0.0f};
+  std::vector<float> sky_blockage_range_deg_ = {0.0f, 0.0f};
+
+  // Multi-frame blockage detection state
+  int blockage_frame_count_ = 0;
+  boost::circular_buffer<cv::Mat> no_return_mask_buffer{1};
+
+  // Dust detection parameters
   bool enable_dust_diag_;
-  bool publish_debug_image_;
+  float dust_ratio_threshold_;
   int dust_kernel_size_;
   int dust_buffering_frames_;
   int dust_buffering_interval_;
-  int dust_buffering_frame_counter_ = 0;
   int dust_count_threshold_;
+
+  // Dust detection state
+  float ground_dust_ratio_ = -1.0f;
+  
+  // Multi-frame dust detection state
+  int dust_buffering_frame_counter_ = 0;
   int dust_frame_count_ = 0;
-  double max_distance_range_{200.0};
-  double horizontal_resolution_{0.4};
-  boost::circular_buffer<cv::Mat> no_return_mask_buffer{1};
   boost::circular_buffer<cv::Mat> dust_mask_buffer{1};
+
+  
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/blockage_diag/blockage_diag_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/blockage_diag/blockage_diag_node.hpp
@@ -46,8 +46,8 @@ using diagnostic_updater::Updater;
 class BlockageDiagComponent : public autoware::pointcloud_preprocessor::Filter
 {
 protected:
-  virtual void filter(
-    const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output);
+  void filter(
+    const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output) override;
   /** \brief Parameter service callback result : needed to be hold */
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
@@ -67,8 +67,11 @@ protected:
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr blockage_type_pub_;
 
 private:
-  void onBlockageChecker(DiagnosticStatusWrapper & stat);
-  void dustChecker(DiagnosticStatusWrapper & stat);
+  void run_blockage_check(DiagnosticStatusWrapper & stat);
+  void run_dust_check(DiagnosticStatusWrapper & stat);
+
+
+
   Updater updater_{this};
   int vertical_bins_;
   std::vector<double> angle_range_deg_;

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/blockage_diag/blockage_diag_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/blockage_diag/blockage_diag_node.hpp
@@ -15,8 +15,8 @@
 #ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__BLOCKAGE_DIAG__BLOCKAGE_DIAG_NODE_HPP_
 #define AUTOWARE__POINTCLOUD_PREPROCESSOR__BLOCKAGE_DIAG__BLOCKAGE_DIAG_NODE_HPP_
 
-#include "autoware/pointcloud_preprocessor/filter.hpp"
 #include "autoware/point_types/types.hpp"
+#include "autoware/pointcloud_preprocessor/filter.hpp"
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <image_transport/image_transport.hpp>
@@ -29,6 +29,7 @@
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
+
 #include <pcl/PCLPointCloud2.h>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
@@ -44,9 +45,9 @@
 
 namespace autoware::pointcloud_preprocessor
 {
+using autoware::point_types::PointXYZIRCAEDT;
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
-using autoware::point_types::PointXYZIRCAEDT;
 using PCLCloudXYZIRCAEDT = pcl::PointCloud<PointXYZIRCAEDT>;
 
 class BlockageDiagComponent : public autoware::pointcloud_preprocessor::Filter
@@ -73,7 +74,8 @@ protected:
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr blockage_type_pub_;
 
 private:
-  struct DebugInfo {
+  struct DebugInfo
+  {
     std_msgs::msg::Header input_header;
     cv::Mat depth_image_16u;
     cv::Mat blockage_mask_multi_frame;
@@ -147,7 +149,7 @@ private:
 
   /**
    * @brief Make a binary, cleaned blockage mask from the input no-return mask.
-   * 
+   *
    * @param no_return_mask A mask where 255 is no-return and 0 is return.
    * @return cv::Mat The blockage mask. The data type is `CV_8UC1`.
    */
@@ -155,23 +157,25 @@ private:
 
   /**
    * @brief Update the internal blockage mask buffer and return the updated mask.
-   * 
+   *
    * @param blockage_mask The current blockage mask. The data type is `CV_8UC1`.
    * @return cv::Mat The updated aggregated blockage mask. The data type is `CV_8UC1`.
    */
   cv::Mat update_time_series_blockage_mask(const cv::Mat & blockage_mask);
 
   /**
-   * @brief Segments a given mask into two masks, according to the ground/sky segmentation parameters.
-   * 
+   * @brief Segments a given mask into two masks, according to the ground/sky segmentation
+   * parameters.
+   *
    * @param mask The input mask. The data type is `CV_8UC1`.
-   * @return std::pair<cv::Mat, cv::Mat> The pair {ground_mask, sky_mask}. The data type is `CV_8UC1`.
+   * @return std::pair<cv::Mat, cv::Mat> The pair {ground_mask, sky_mask}. The data type is
+   * `CV_8UC1`.
    */
   std::pair<cv::Mat, cv::Mat> segment_into_ground_and_sky(const cv::Mat & mask) const;
 
   /**
    * @brief Get the ratio of non-zero pixels in a given mask.
-   * 
+   *
    * @param mask The input mask. The data type is `CV_8UC1`.
    * @return float The ratio of non-zero pixels (e.g. 1.0 if all are non-zero, 0.0 if all are zero).
    */
@@ -179,21 +183,21 @@ private:
 
   /**
    * @brief Update the internal ground blockage info.
-   * 
+   *
    * @param ground_blockage_mask The ground blockage mask. The data type is `CV_8UC1`.
    */
   void update_ground_blockage_info(const cv::Mat & ground_blockage_mask);
 
   /**
    * @brief Update the internal sky blockage info.
-   * 
+   *
    * @param sky_blockage_mask The sky blockage mask. The data type is `CV_8UC1`.
    */
   void update_sky_blockage_info(const cv::Mat & sky_blockage_mask);
 
   /**
    * @brief Compute dust diagnostics and update the internal dust info.
-   * 
+   *
    * @param no_return_mask The no-return mask. The data type is `CV_8UC1`.
    * @param debug_info The debug info to publish if enabled.
    */
@@ -201,16 +205,16 @@ private:
 
   /**
    * @brief Publish the debug info if enabled.
-   * 
+   *
    * @param debug_info The debug info to publish.
    */
   void publish_debug_info(const DebugInfo & debug_info) const;
 
   Updater updater_{this};
-  
+
   // Debug parameters
   bool publish_debug_image_;
-  
+
   // LiDAR parameters
   double max_distance_range_{200.0};
 
@@ -252,13 +256,11 @@ private:
 
   // Dust detection state
   float ground_dust_ratio_ = -1.0f;
-  
+
   // Multi-frame dust detection state
   int dust_buffering_frame_counter_ = 0;
   int dust_frame_count_ = 0;
   boost::circular_buffer<cv::Mat> dust_mask_buffer{1};
-
-  
 
 public:
   PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/blockage_diag/blockage_diag_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/blockage_diag/blockage_diag_node.hpp
@@ -40,7 +40,7 @@
 
 #include <boost/circular_buffer.hpp>
 
-#include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::pointcloud_preprocessor

--- a/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
@@ -81,13 +81,14 @@ BlockageDiagComponent::BlockageDiagComponent(const rclcpp::NodeOptions & options
   }
 
   updater_.setHardwareID("blockage_diag");
-  updater_.add(
-    std::string(this->get_namespace()) + ": blockage_validation", this,
-    &BlockageDiagComponent::run_blockage_check);
+  updater_.add(std::string(this->get_namespace()) + ": blockage_validation", [this](auto & stat) {
+    run_blockage_check(stat);
+  });
+
   if (enable_dust_diag_) {
-    updater_.add(
-      std::string(this->get_namespace()) + ": dust_validation", this,
-      &BlockageDiagComponent::run_dust_check);
+    updater_.add(std::string(this->get_namespace()) + ": dust_validation", [this](auto & stat) {
+      run_dust_check(stat);
+    });
 
     ground_dust_ratio_pub_ = create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>(
       "blockage_diag/debug/ground_dust_ratio", rclcpp::SensorDataQoS());
@@ -116,7 +117,7 @@ BlockageDiagComponent::BlockageDiagComponent(const rclcpp::NodeOptions & options
     std::bind(&BlockageDiagComponent::param_callback, this, _1));
 }
 
-void BlockageDiagComponent::run_blockage_check(DiagnosticStatusWrapper & stat)
+void BlockageDiagComponent::run_blockage_check(DiagnosticStatusWrapper & stat) const
 {
   stat.add("ground_blockage_ratio", std::to_string(ground_blockage_ratio_));
   stat.add("ground_blockage_count", std::to_string(ground_blockage_count_));
@@ -155,7 +156,7 @@ void BlockageDiagComponent::run_blockage_check(DiagnosticStatusWrapper & stat)
   stat.summary(level, msg);
 }
 
-void BlockageDiagComponent::run_dust_check(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void BlockageDiagComponent::run_dust_check(diagnostic_updater::DiagnosticStatusWrapper & stat) const
 {
   stat.add("ground_dust_ratio", std::to_string(ground_dust_ratio_));
   auto level = DiagnosticStatus::OK;
@@ -220,235 +221,274 @@ std::optional<int> BlockageDiagComponent::get_vertical_bin(uint16_t channel) con
   return {vertical_bins_ - channel - 1};
 }
 
-void BlockageDiagComponent::filter(
-  const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
-  PointCloud2 & output)
+cv::Mat BlockageDiagComponent::make_normalized_depth_image(const PCLCloudXYZIRCAEDT & input) const
 {
-  std::scoped_lock lock(mutex_);
-  int vertical_bins = vertical_bins_;
-  int ideal_horizontal_bins;
-  double compensate_angle = 0.0;
-  // Check the case when angle_range_deg_[1] exceed 360 and shifted the range to 0~360
-  if (angle_range_deg_[0] > angle_range_deg_[1]) {
-    compensate_angle = 360.0;
-  }
-  ideal_horizontal_bins = static_cast<int>(
-    (angle_range_deg_[1] + compensate_angle - angle_range_deg_[0]) / horizontal_resolution_);
-  pcl::PointCloud<PointXYZIRCAEDT>::Ptr pcl_input(new pcl::PointCloud<PointXYZIRCAEDT>);
-  pcl::fromROSMsg(*input, *pcl_input);
-  cv::Mat full_size_depth_map(
-    cv::Size(ideal_horizontal_bins, vertical_bins), CV_16UC1, cv::Scalar(0));
-  cv::Mat lidar_depth_map_8u(
-    cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
-  if (pcl_input->points.empty()) {
-    ground_blockage_ratio_ = 1.0f;
-    sky_blockage_ratio_ = 1.0f;
-    if (ground_blockage_count_ <= 2 * blockage_count_threshold_) {
-      ground_blockage_count_ += 1;
-    }
-    if (sky_blockage_count_ <= 2 * blockage_count_threshold_) {
-      sky_blockage_count_ += 1;
-    }
-    ground_blockage_range_deg_[0] = angle_range_deg_[0];
-    ground_blockage_range_deg_[1] = angle_range_deg_[1];
-    sky_blockage_range_deg_[0] = angle_range_deg_[0];
-    sky_blockage_range_deg_[1] = angle_range_deg_[1];
-  } else {
-    for (const auto p : pcl_input->points) {
-      if (p.channel >= vertical_bins) {
-        RCLCPP_ERROR(
-          this->get_logger(),
-          "p.channel: %d is larger than vertical_bins: %d  .Please check the parameter "
-          "'vertical_bins'.",
-          p.channel, vertical_bins);
-        throw std::runtime_error("Parameter is not valid");
-      }
-      double azimuth_deg = p.azimuth * (180.0 / M_PI);
-      if (
-        ((azimuth_deg > angle_range_deg_[0]) &&
-         (azimuth_deg <= angle_range_deg_[1] + compensate_angle)) ||
-        ((azimuth_deg + compensate_angle > angle_range_deg_[0]) &&
-         (azimuth_deg < angle_range_deg_[1]))) {
-        double current_angle_range = (azimuth_deg + compensate_angle - angle_range_deg_[0]);
-        int horizontal_bin_index = static_cast<int>(current_angle_range / horizontal_resolution_) %
-                                   static_cast<int>(360.0 / horizontal_resolution_);
-        uint16_t depth_intensity =
-          UINT16_MAX * (1.0 - std::min(p.distance / max_distance_range_, 1.0));
-        if (is_channel_order_top2down_) {
-          full_size_depth_map.at<uint16_t>(p.channel, horizontal_bin_index) = depth_intensity;
-        } else {
-          full_size_depth_map.at<uint16_t>(vertical_bins - p.channel - 1, horizontal_bin_index) =
-            depth_intensity;
-        }
-      }
-    }
-  }
-  full_size_depth_map.convertTo(lidar_depth_map_8u, CV_8UC1, 1.0 / 300);
-  cv::Mat no_return_mask(cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
-  cv::inRange(lidar_depth_map_8u, 0, 1, no_return_mask);
-  cv::Mat erosion_dst;
-  cv::Mat blockage_element = cv::getStructuringElement(
-    cv::MORPH_RECT, cv::Size(2 * blockage_kernel_ + 1, 2 * blockage_kernel_ + 1),
-    cv::Point(blockage_kernel_, blockage_kernel_));
-  cv::erode(no_return_mask, erosion_dst, blockage_element);
-  cv::dilate(erosion_dst, no_return_mask, blockage_element);
-  cv::Mat time_series_blockage_result(
-    cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
-  cv::Mat time_series_blockage_mask(
-    cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
-  cv::Mat no_return_mask_binarized(
-    cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
+  auto dimensions = get_mask_dimensions();
+  cv::Mat depth_image(dimensions, CV_16UC1, cv::Scalar(0));
 
+  for (const auto & p : input.points) {
+    auto vertical_bin = get_vertical_bin(p.channel);
+    if (!vertical_bin) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "p.channel: %d is larger than vertical_bins: %d. Please check the parameter "
+        "'vertical_bins'.",
+        p.channel, vertical_bins_);
+      throw std::runtime_error("Parameter is not valid");
+    }
+
+    double azimuth_deg = p.azimuth * (180.0 / M_PI);
+    auto horizontal_bin = get_horizontal_bin(azimuth_deg);
+    if (!horizontal_bin) {
+      continue;
+    }
+
+    // Max distance is mapped to 0, zero-distance is mapped to UINT16_MAX.
+    uint16_t normalized_depth =
+      UINT16_MAX * (1.0 - std::min(p.distance / max_distance_range_, 1.0));
+    depth_image.at<uint16_t>(*vertical_bin, *horizontal_bin) = normalized_depth;
+  }
+
+  return depth_image;
+}
+
+cv::Mat BlockageDiagComponent::quantize_to_8u(const cv::Mat & image_16u) const
+{
+  auto dimensions = get_mask_dimensions();
+  assert(dimensions == image_16u.size());
+  assert(image_16u.type() == CV_16UC1);
+
+  cv::Mat image_8u(dimensions, CV_8UC1, cv::Scalar(0));
+  // FIXME(badai-nguyen): Is the normalization factor correct? `256` would be enough to prevent
+  // overflow.
+  image_16u.convertTo(image_8u, CV_8UC1, 1.0 / 300);
+  return image_8u;
+}
+
+cv::Mat BlockageDiagComponent::make_no_return_mask(const cv::Mat & depth_image) const
+{
+  auto dimensions = get_mask_dimensions();
+  assert(dimensions == depth_image.size());
+  assert(depth_image.type() == CV_8UC1);
+
+  cv::Mat no_return_mask(dimensions, CV_8UC1, cv::Scalar(0));
+  cv::inRange(depth_image, 0, 1, no_return_mask);
+
+  return no_return_mask;
+}
+
+cv::Mat BlockageDiagComponent::make_blockage_mask(const cv::Mat & no_return_mask) const
+{
+  auto dimensions = get_mask_dimensions();
+  assert(dimensions == no_return_mask.size());
+  assert(no_return_mask.type() == CV_8UC1);
+
+  int kernel_size = 2 * blockage_kernel_ + 1;
+  int kernel_center = blockage_kernel_;
+  cv::Mat kernel = cv::getStructuringElement(
+    cv::MORPH_RECT, cv::Size(kernel_size, kernel_size), cv::Point(kernel_center, kernel_center));
+
+  cv::Mat erosion_result(dimensions, CV_8UC1, cv::Scalar(0));
+  cv::erode(no_return_mask, erosion_result, kernel);
+
+  cv::Mat blockage_mask(dimensions, CV_8UC1, cv::Scalar(0));
+  cv::dilate(erosion_result, blockage_mask, kernel);
+
+  return blockage_mask;
+}
+
+cv::Mat BlockageDiagComponent::update_time_series_blockage_mask(const cv::Mat & blockage_mask)
+{
   if (blockage_buffering_interval_ == 0) {
-    no_return_mask.copyTo(time_series_blockage_result);
-  } else {
-    no_return_mask_binarized = no_return_mask / 255;
-    if (blockage_frame_count_ >= blockage_buffering_interval_) {
-      no_return_mask_buffer.push_back(no_return_mask_binarized);
-      blockage_frame_count_ = 0;
-    } else {
-      blockage_frame_count_++;
-    }
-    for (const auto & binary_mask : no_return_mask_buffer) {
-      time_series_blockage_mask += binary_mask;
-    }
-    cv::inRange(
-      time_series_blockage_mask, no_return_mask_buffer.size() - 1, no_return_mask_buffer.size(),
-      time_series_blockage_result);
-  }
-  cv::Mat ground_no_return_mask;
-  cv::Mat sky_no_return_mask;
-  no_return_mask(cv::Rect(0, 0, ideal_horizontal_bins, horizontal_ring_id_))
-    .copyTo(sky_no_return_mask);
-  no_return_mask(
-    cv::Rect(0, horizontal_ring_id_, ideal_horizontal_bins, vertical_bins - horizontal_ring_id_))
-    .copyTo(ground_no_return_mask);
-  ground_blockage_ratio_ =
-    static_cast<float>(cv::countNonZero(ground_no_return_mask)) /
-    static_cast<float>(ideal_horizontal_bins * (vertical_bins - horizontal_ring_id_));
-
-  if (horizontal_ring_id_ == 0) {
-    sky_blockage_ratio_ = 0.0f;
-  } else {
-    sky_blockage_ratio_ = static_cast<float>(cv::countNonZero(sky_no_return_mask)) /
-                          static_cast<float>(ideal_horizontal_bins * horizontal_ring_id_);
+    return blockage_mask.clone();
   }
 
-  if (ground_blockage_ratio_ > blockage_ratio_threshold_) {
-    cv::Rect ground_blockage_bb = cv::boundingRect(ground_no_return_mask);
-    ground_blockage_range_deg_[0] =
-      ground_blockage_bb.x * horizontal_resolution_ + angle_range_deg_[0];
-    ground_blockage_range_deg_[1] =
-      (ground_blockage_bb.x + ground_blockage_bb.width) * horizontal_resolution_ +
-      angle_range_deg_[0];
-    if (ground_blockage_count_ <= 2 * blockage_count_threshold_) {
-      ground_blockage_count_ += 1;
-    }
+  auto dimensions = get_mask_dimensions();
+  assert(dimensions == blockage_mask.size());
+  assert(blockage_mask.type() == CV_8UC1);
+
+  cv::Mat time_series_blockage_result(dimensions, CV_8UC1, cv::Scalar(0));
+  cv::Mat time_series_blockage_mask(dimensions, CV_8UC1, cv::Scalar(0));
+  cv::Mat no_return_mask_binarized(dimensions, CV_8UC1, cv::Scalar(0));
+
+  no_return_mask_binarized = blockage_mask / 255;
+  if (blockage_frame_count_ >= blockage_buffering_interval_) {
+    no_return_mask_buffer.push_back(no_return_mask_binarized);
+    blockage_frame_count_ = 0;
   } else {
+    blockage_frame_count_++;
+  }
+
+  for (const auto & binary_mask : no_return_mask_buffer) {
+    time_series_blockage_mask += binary_mask;
+  }
+
+  cv::inRange(
+    time_series_blockage_mask, no_return_mask_buffer.size() - 1, no_return_mask_buffer.size(),
+    time_series_blockage_result);
+
+  return time_series_blockage_result;
+}
+
+std::pair<cv::Mat, cv::Mat> BlockageDiagComponent::segment_into_ground_and_sky(
+  const cv::Mat & mask) const
+{
+  auto dimensions = get_mask_dimensions();
+  assert(dimensions == mask.size());
+  assert(mask.type() == CV_8UC1);
+
+  cv::Mat sky_mask;
+  mask(cv::Rect(0, 0, dimensions.width, horizontal_ring_id_)).copyTo(sky_mask);
+
+  cv::Mat ground_mask;
+  mask(cv::Rect(0, horizontal_ring_id_, dimensions.width, dimensions.height - horizontal_ring_id_))
+    .copyTo(ground_mask);
+
+  return {ground_mask, sky_mask};
+}
+
+float BlockageDiagComponent::get_nonzero_ratio(const cv::Mat & mask)
+{
+  size_t area = mask.cols * mask.rows;
+  if (area == 0) {
+    return 0.F;
+  }
+
+  return static_cast<float>(cv::countNonZero(mask)) / static_cast<float>(area);
+}
+
+void BlockageDiagComponent::update_ground_blockage_info(const cv::Mat & ground_blockage_mask)
+{
+  if (ground_blockage_ratio_ <= blockage_ratio_threshold_) {
     ground_blockage_count_ = 0;
+    return;
   }
-  if (sky_blockage_ratio_ > blockage_ratio_threshold_) {
-    cv::Rect sky_blockage_bx = cv::boundingRect(sky_no_return_mask);
-    sky_blockage_range_deg_[0] = sky_blockage_bx.x * horizontal_resolution_ + angle_range_deg_[0];
-    sky_blockage_range_deg_[1] =
-      (sky_blockage_bx.x + sky_blockage_bx.width) * horizontal_resolution_ + angle_range_deg_[0];
-    if (sky_blockage_count_ <= 2 * blockage_count_threshold_) {
-      sky_blockage_count_ += 1;
+
+  cv::Rect blockage_bb = cv::boundingRect(ground_blockage_mask);
+  double blockage_start_deg = blockage_bb.x * horizontal_resolution_ + angle_range_deg_[0];
+  double blockage_end_deg =
+    (blockage_bb.x + blockage_bb.width) * horizontal_resolution_ + angle_range_deg_[0];
+
+  ground_blockage_range_deg_[0] = static_cast<float>(blockage_start_deg);
+  ground_blockage_range_deg_[1] = static_cast<float>(blockage_end_deg);
+
+  if (ground_blockage_count_ <= 2 * blockage_count_threshold_) {
+    ground_blockage_count_ += 1;
+  }
+}
+
+void BlockageDiagComponent::update_sky_blockage_info(const cv::Mat & sky_blockage_mask)
+{
+  if (sky_blockage_ratio_ <= blockage_ratio_threshold_) {
+    sky_blockage_count_ = 0;
+    return;
+  }
+
+  cv::Rect blockage_bb = cv::boundingRect(sky_blockage_mask);
+  double blockage_start_deg = blockage_bb.x * horizontal_resolution_ + angle_range_deg_[0];
+  double blockage_end_deg =
+    (blockage_bb.x + blockage_bb.width) * horizontal_resolution_ + angle_range_deg_[0];
+
+  sky_blockage_range_deg_[0] = static_cast<float>(blockage_start_deg);
+  sky_blockage_range_deg_[1] = static_cast<float>(blockage_end_deg);
+
+  if (sky_blockage_count_ <= 2 * blockage_count_threshold_) {
+    sky_blockage_count_ += 1;
+  }
+}
+
+void BlockageDiagComponent::compute_dust_diagnostics(
+  const cv::Mat & no_return_mask, const DebugInfo & debug_info)
+{
+  auto dimensions = get_mask_dimensions();
+  assert(dimensions == no_return_mask.size());
+  assert(no_return_mask.type() == CV_8UC1);
+
+  auto [single_dust_ground_img, sky_blank] = segment_into_ground_and_sky(no_return_mask);
+
+  // It is normal for the sky region to be blank, therefore ignore it.
+  sky_blank.setTo(cv::Scalar(0));
+
+  int kernel_size = 2 * dust_kernel_size_ + 1;
+  int kernel_center = dust_kernel_size_;
+  cv::Mat kernel = cv::getStructuringElement(
+    cv::MORPH_RECT, cv::Size(kernel_size, kernel_size), cv::Point(kernel_center, kernel_center));
+
+  cv::dilate(single_dust_ground_img, single_dust_ground_img, kernel);
+  cv::erode(single_dust_ground_img, single_dust_ground_img, kernel);
+  cv::inRange(single_dust_ground_img, 254, 255, single_dust_ground_img);
+
+  // Re-assemble the processed ground dust image and the sky blank.
+  cv::Mat single_dust_img(dimensions, CV_8UC1, cv::Scalar(0));
+  cv::vconcat(sky_blank, single_dust_ground_img, single_dust_img);
+
+  autoware_internal_debug_msgs::msg::Float32Stamped ground_dust_ratio_msg;
+  ground_dust_ratio_ = static_cast<float>(cv::countNonZero(single_dust_ground_img)) /
+                       (single_dust_ground_img.cols * single_dust_ground_img.rows);
+  ground_dust_ratio_msg.data = ground_dust_ratio_;
+  ground_dust_ratio_msg.stamp = now();
+  ground_dust_ratio_pub_->publish(ground_dust_ratio_msg);
+
+  if (ground_dust_ratio_ > dust_ratio_threshold_) {
+    if (dust_frame_count_ < 2 * dust_count_threshold_) {
+      dust_frame_count_++;
     }
   } else {
-    sky_blockage_count_ = 0;
+    dust_frame_count_ = 0;
   }
-  // dust
-  if (enable_dust_diag_) {
-    cv::Mat ground_depth_map = lidar_depth_map_8u(
-      cv::Rect(0, horizontal_ring_id_, ideal_horizontal_bins, vertical_bins - horizontal_ring_id_));
-    cv::Mat sky_blank(horizontal_ring_id_, ideal_horizontal_bins, CV_8UC1, cv::Scalar(0));
-    cv::Mat ground_blank(
-      vertical_bins - horizontal_ring_id_, ideal_horizontal_bins, CV_8UC1, cv::Scalar(0));
-    cv::Mat single_dust_img(
-      cv::Size(lidar_depth_map_8u.rows, lidar_depth_map_8u.cols), CV_8UC1, cv::Scalar(0));
-    cv::Mat single_dust_ground_img = ground_depth_map.clone();
-    cv::inRange(single_dust_ground_img, 0, 1, single_dust_ground_img);
-    cv::Mat dust_element = getStructuringElement(
-      cv::MORPH_RECT, cv::Size(2 * dust_kernel_size_ + 1, 2 * dust_kernel_size_ + 1),
-      cv::Point(-1, -1));
-    cv::dilate(single_dust_ground_img, single_dust_ground_img, dust_element);
-    cv::erode(single_dust_ground_img, single_dust_ground_img, dust_element);
-    cv::inRange(single_dust_ground_img, 254, 255, single_dust_ground_img);
-    cv::Mat ground_mask(cv::Size(ideal_horizontal_bins, horizontal_ring_id_), CV_8UC1);
-    cv::vconcat(sky_blank, single_dust_ground_img, single_dust_img);
 
-    autoware_internal_debug_msgs::msg::Float32Stamped ground_dust_ratio_msg;
-    ground_dust_ratio_ = static_cast<float>(cv::countNonZero(single_dust_ground_img)) /
-                         (single_dust_ground_img.cols * single_dust_ground_img.rows);
-    ground_dust_ratio_msg.data = ground_dust_ratio_;
-    ground_dust_ratio_msg.stamp = now();
-    ground_dust_ratio_pub_->publish(ground_dust_ratio_msg);
-    if (ground_dust_ratio_ > dust_ratio_threshold_) {
-      if (dust_frame_count_ < 2 * dust_count_threshold_) {
-        dust_frame_count_++;
-      }
+  if (publish_debug_image_) {
+    cv::Mat binarized_dust_mask_(dimensions, CV_8UC1, cv::Scalar(0));
+    cv::Mat multi_frame_dust_mask(dimensions, CV_8UC1, cv::Scalar(0));
+    cv::Mat multi_frame_ground_dust_result(dimensions, CV_8UC1, cv::Scalar(0));
+
+    if (dust_buffering_interval_ == 0) {
+      single_dust_img.copyTo(multi_frame_ground_dust_result);
+      dust_buffering_frame_counter_ = 0;
     } else {
-      dust_frame_count_ = 0;
-    }
-
-    if (publish_debug_image_) {
-      cv::Mat binarized_dust_mask_(
-        cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
-      cv::Mat multi_frame_dust_mask(
-        cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
-      cv::Mat multi_frame_ground_dust_result(
-        cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
-
-      if (dust_buffering_interval_ == 0) {
-        single_dust_img.copyTo(multi_frame_ground_dust_result);
+      binarized_dust_mask_ = single_dust_img / 255;
+      if (dust_buffering_frame_counter_ >= dust_buffering_interval_) {
+        dust_mask_buffer.push_back(binarized_dust_mask_);
         dust_buffering_frame_counter_ = 0;
       } else {
-        binarized_dust_mask_ = single_dust_img / 255;
-        if (dust_buffering_frame_counter_ >= dust_buffering_interval_) {
-          dust_mask_buffer.push_back(binarized_dust_mask_);
-          dust_buffering_frame_counter_ = 0;
-        } else {
-          dust_buffering_frame_counter_++;
-        }
-        for (const auto & binarized_dust_mask : dust_mask_buffer) {
-          multi_frame_dust_mask += binarized_dust_mask;
-        }
-        cv::inRange(
-          multi_frame_dust_mask, dust_mask_buffer.size() - 1, dust_mask_buffer.size(),
-          multi_frame_ground_dust_result);
+        dust_buffering_frame_counter_++;
       }
-      cv::Mat single_frame_ground_dust_colorized(
-        cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC3, cv::Scalar(0, 0, 0));
-      cv::applyColorMap(single_dust_img, single_frame_ground_dust_colorized, cv::COLORMAP_JET);
-      cv::Mat multi_frame_ground_dust_colorized;
-      cv::Mat blockage_dust_merged_img(
-        cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC3, cv::Scalar(0, 0, 0));
-      cv::Mat blockage_dust_merged_mask(
-        cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC1, cv::Scalar(0));
-      blockage_dust_merged_img.setTo(
-        cv::Vec3b(0, 0, 255), time_series_blockage_result);  // red:blockage
-      blockage_dust_merged_img.setTo(
-        cv::Vec3b(0, 255, 255), multi_frame_ground_dust_result);  // yellow:dust
-      sensor_msgs::msg::Image::SharedPtr single_frame_dust_mask_msg =
-        cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", single_frame_ground_dust_colorized)
-          .toImageMsg();
-      single_frame_dust_mask_pub.publish(single_frame_dust_mask_msg);
-      sensor_msgs::msg::Image::SharedPtr multi_frame_dust_mask_msg =
-        cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", multi_frame_ground_dust_colorized)
-          .toImageMsg();
-      multi_frame_dust_mask_pub.publish(multi_frame_dust_mask_msg);
-      cv::Mat blockage_dust_merged_colorized(
-        cv::Size(ideal_horizontal_bins, vertical_bins), CV_8UC3, cv::Scalar(0, 0, 0));
-      blockage_dust_merged_img.copyTo(blockage_dust_merged_colorized);
-      sensor_msgs::msg::Image::SharedPtr blockage_dust_merged_msg =
-        cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", blockage_dust_merged_colorized)
-          .toImageMsg();
-      blockage_dust_merged_msg->header = input->header;
-      blockage_dust_merged_pub.publish(blockage_dust_merged_msg);
+      for (const auto & binarized_dust_mask : dust_mask_buffer) {
+        multi_frame_dust_mask += binarized_dust_mask;
+      }
+      cv::inRange(
+        multi_frame_dust_mask, dust_mask_buffer.size() - 1, dust_mask_buffer.size(),
+        multi_frame_ground_dust_result);
     }
+    cv::Mat single_frame_ground_dust_colorized(dimensions, CV_8UC3, cv::Scalar(0, 0, 0));
+    cv::applyColorMap(single_dust_img, single_frame_ground_dust_colorized, cv::COLORMAP_JET);
+    cv::Mat multi_frame_ground_dust_colorized;
+    cv::Mat blockage_dust_merged_img(dimensions, CV_8UC3, cv::Scalar(0, 0, 0));
+    cv::Mat blockage_dust_merged_mask(dimensions, CV_8UC1, cv::Scalar(0));
+    blockage_dust_merged_img.setTo(
+      cv::Vec3b(0, 0, 255), debug_info.blockage_mask_multi_frame);  // red:blockage
+    blockage_dust_merged_img.setTo(
+      cv::Vec3b(0, 255, 255), multi_frame_ground_dust_result);  // yellow:dust
+    sensor_msgs::msg::Image::SharedPtr single_frame_dust_mask_msg =
+      cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", single_frame_ground_dust_colorized)
+        .toImageMsg();
+    single_frame_dust_mask_pub.publish(single_frame_dust_mask_msg);
+    sensor_msgs::msg::Image::SharedPtr multi_frame_dust_mask_msg =
+      cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", multi_frame_ground_dust_colorized)
+        .toImageMsg();
+    multi_frame_dust_mask_pub.publish(multi_frame_dust_mask_msg);
+    cv::Mat blockage_dust_merged_colorized(dimensions, CV_8UC3, cv::Scalar(0, 0, 0));
+    blockage_dust_merged_img.copyTo(blockage_dust_merged_colorized);
+    sensor_msgs::msg::Image::SharedPtr blockage_dust_merged_msg =
+      cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", blockage_dust_merged_colorized)
+        .toImageMsg();
+    blockage_dust_merged_msg->header = debug_info.input_header;
+    blockage_dust_merged_pub.publish(blockage_dust_merged_msg);
   }
+}
 
+void BlockageDiagComponent::publish_debug_info(const DebugInfo & debug_info) const
+{
   autoware_internal_debug_msgs::msg::Float32Stamped ground_blockage_ratio_msg;
   ground_blockage_ratio_msg.data = ground_blockage_ratio_;
   ground_blockage_ratio_msg.stamp = now();
@@ -458,22 +498,58 @@ void BlockageDiagComponent::filter(
   sky_blockage_ratio_msg.data = sky_blockage_ratio_;
   sky_blockage_ratio_msg.stamp = now();
   sky_blockage_ratio_pub_->publish(sky_blockage_ratio_msg);
+
   if (publish_debug_image_) {
     sensor_msgs::msg::Image::SharedPtr lidar_depth_map_msg =
-      cv_bridge::CvImage(std_msgs::msg::Header(), "mono16", full_size_depth_map).toImageMsg();
-    lidar_depth_map_msg->header = input->header;
+      cv_bridge::CvImage(std_msgs::msg::Header(), "mono16", debug_info.depth_image_16u)
+        .toImageMsg();
+    lidar_depth_map_msg->header = debug_info.input_header;
     lidar_depth_map_pub_.publish(lidar_depth_map_msg);
     cv::Mat blockage_mask_colorized;
-    cv::applyColorMap(time_series_blockage_result, blockage_mask_colorized, cv::COLORMAP_JET);
+    cv::applyColorMap(
+      debug_info.blockage_mask_multi_frame, blockage_mask_colorized, cv::COLORMAP_JET);
     sensor_msgs::msg::Image::SharedPtr blockage_mask_msg =
       cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", blockage_mask_colorized).toImageMsg();
-    blockage_mask_msg->header = input->header;
+    blockage_mask_msg->header = debug_info.input_header;
     blockage_mask_pub_.publish(blockage_mask_msg);
   }
+}
 
-  pcl::toROSMsg(*pcl_input, output);
+void BlockageDiagComponent::filter(
+  const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
+  PointCloud2 & output)
+{
+  std::scoped_lock lock(mutex_);
+
+  PCLCloudXYZIRCAEDT pcl_input;
+  pcl::fromROSMsg(*input, pcl_input);
+
+  cv::Mat depth_image_16u = make_normalized_depth_image(pcl_input);
+  cv::Mat depth_image_8u = quantize_to_8u(depth_image_16u);
+  cv::Mat no_return_mask = make_no_return_mask(depth_image_8u);
+  cv::Mat blockage_mask = make_blockage_mask(no_return_mask);
+  cv::Mat time_series_blockage_result = update_time_series_blockage_mask(blockage_mask);
+
+  auto [ground_blockage_mask, sky_blockage_mask] = segment_into_ground_and_sky(blockage_mask);
+
+  ground_blockage_ratio_ = get_nonzero_ratio(ground_blockage_mask);
+  sky_blockage_ratio_ = get_nonzero_ratio(sky_blockage_mask);
+
+  update_ground_blockage_info(ground_blockage_mask);
+  update_sky_blockage_info(sky_blockage_mask);
+
+  const DebugInfo debug_info = {input->header, depth_image_16u, time_series_blockage_result};
+
+  if (enable_dust_diag_) {
+    compute_dust_diagnostics(no_return_mask, debug_info);
+  }
+
+  publish_debug_info(debug_info);
+
+  pcl::toROSMsg(pcl_input, output);
   output.header = input->header;
 }
+
 rcl_interfaces::msg::SetParametersResult BlockageDiagComponent::param_callback(
   const std::vector<rclcpp::Parameter> & p)
 {

--- a/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
@@ -81,11 +81,11 @@ BlockageDiagComponent::BlockageDiagComponent(const rclcpp::NodeOptions & options
   updater_.setHardwareID("blockage_diag");
   updater_.add(
     std::string(this->get_namespace()) + ": blockage_validation", this,
-    &BlockageDiagComponent::onBlockageChecker);
+    &BlockageDiagComponent::run_blockage_check);
   if (enable_dust_diag_) {
     updater_.add(
       std::string(this->get_namespace()) + ": dust_validation", this,
-      &BlockageDiagComponent::dustChecker);
+      &BlockageDiagComponent::run_dust_check);
 
     ground_dust_ratio_pub_ = create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>(
       "blockage_diag/debug/ground_dust_ratio", rclcpp::SensorDataQoS());
@@ -114,7 +114,7 @@ BlockageDiagComponent::BlockageDiagComponent(const rclcpp::NodeOptions & options
     std::bind(&BlockageDiagComponent::param_callback, this, _1));
 }
 
-void BlockageDiagComponent::onBlockageChecker(DiagnosticStatusWrapper & stat)
+void BlockageDiagComponent::run_blockage_check(DiagnosticStatusWrapper & stat)
 {
   stat.add("ground_blockage_ratio", std::to_string(ground_blockage_ratio_));
   stat.add("ground_blockage_count", std::to_string(ground_blockage_count_));
@@ -153,7 +153,7 @@ void BlockageDiagComponent::onBlockageChecker(DiagnosticStatusWrapper & stat)
   stat.summary(level, msg);
 }
 
-void BlockageDiagComponent::dustChecker(diagnostic_updater::DiagnosticStatusWrapper & stat)
+void BlockageDiagComponent::run_dust_check(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   stat.add("ground_dust_ratio", std::to_string(ground_dust_ratio_));
   auto level = DiagnosticStatus::OK;

--- a/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
@@ -30,25 +30,44 @@ BlockageDiagComponent::BlockageDiagComponent(const rclcpp::NodeOptions & options
 : Filter("BlockageDiag", options)
 {
   {
-    // initialize params:
-    horizontal_ring_id_ = declare_parameter<int>("horizontal_ring_id");
-    blockage_ratio_threshold_ = declare_parameter<float>("blockage_ratio_threshold");
-    vertical_bins_ = declare_parameter<int>("vertical_bins");
+    // LiDAR configuration
+    // Horizontal FoV, expects two values: [min, max]
     angle_range_deg_ = declare_parameter<std::vector<double>>("angle_range");
+    // Whether the channel order is top-down (true) or bottom-up (false)
     is_channel_order_top2down_ = declare_parameter<bool>("is_channel_order_top2down");
-    blockage_count_threshold_ = declare_parameter<int>("blockage_count_threshold");
-    blockage_buffering_frames_ = declare_parameter<int>("blockage_buffering_frames");
-    blockage_buffering_interval_ = declare_parameter<int>("blockage_buffering_interval");
-    publish_debug_image_ = declare_parameter<bool>("publish_debug_image");
+
+    // Blockage mask format configuration
+    // The number of vertical bins in the mask. Has to equal the number of channels of the LiDAR.
+    vertical_bins_ = declare_parameter<int>("vertical_bins");
+    // The angular resolution of the mask, in degrees.
+    horizontal_resolution_ = declare_parameter<double>("horizontal_resolution");
+
+    // Dust detection configuration
     enable_dust_diag_ = declare_parameter<bool>("enable_dust_diag");
     dust_ratio_threshold_ = declare_parameter<float>("dust_ratio_threshold");
     dust_count_threshold_ = declare_parameter<int>("dust_count_threshold");
     dust_kernel_size_ = declare_parameter<int>("dust_kernel_size");
     dust_buffering_frames_ = declare_parameter<int>("dust_buffering_frames");
     dust_buffering_interval_ = declare_parameter<int>("dust_buffering_interval");
-    max_distance_range_ = declare_parameter<double>("max_distance_range");
-    horizontal_resolution_ = declare_parameter<double>("horizontal_resolution");
+
+    // Blockage detection configuration
+    blockage_ratio_threshold_ = declare_parameter<float>("blockage_ratio_threshold");
+    blockage_count_threshold_ = declare_parameter<int>("blockage_count_threshold");
     blockage_kernel_ = declare_parameter<int>("blockage_kernel");
+    blockage_buffering_frames_ = declare_parameter<int>("blockage_buffering_frames");
+    blockage_buffering_interval_ = declare_parameter<int>("blockage_buffering_interval");
+    
+    // Debug configuration
+    publish_debug_image_ = declare_parameter<bool>("publish_debug_image");
+
+    // Depth map configuration
+    // The maximum distance range of the LiDAR, in meters. The depth map is normalized to this value.
+    max_distance_range_ = declare_parameter<double>("max_distance_range");
+
+    // Ground segmentation configuration
+    // The ring ID that coincides with the horizon. Regions below are treated as ground,
+    // regions above are treated as sky.
+    horizontal_ring_id_ = declare_parameter<int>("horizontal_ring_id");
   }
   dust_mask_buffer.set_capacity(dust_buffering_frames_);
   no_return_mask_buffer.set_capacity(blockage_buffering_frames_);

--- a/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
@@ -17,9 +17,9 @@
 #include "autoware/point_types/types.hpp"
 
 #include <algorithm>
-#include <numeric>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::pointcloud_preprocessor

--- a/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/blockage_diag/blockage_diag_node.cpp
@@ -259,9 +259,8 @@ cv::Mat BlockageDiagComponent::quantize_to_8u(const cv::Mat & image_16u) const
   assert(image_16u.type() == CV_16UC1);
 
   cv::Mat image_8u(dimensions, CV_8UC1, cv::Scalar(0));
-  // FIXME(badai-nguyen): Is the normalization factor correct? `256` would be enough to prevent
-  // overflow.
-  image_16u.convertTo(image_8u, CV_8UC1, 1.0 / 300);
+  // UINT16_MAX = 65535, UINT8_MAX = 255, so downscale by ceil(65535 / 255) = 256.
+  image_16u.convertTo(image_8u, CV_8UC1, 1.0 / 256);
   return image_8u;
 }
 


### PR DESCRIPTION
## Description

This PR is the first step to enable blockage mask input from sensors that have blockage detection.
The PR splits up the `filter` function into its logical steps, and cleans up some duplicated and/or verbose code along the way.

Dust detection is largely left untouched for now as the LiDAR blockage input does not interact with it in any special way.

### :green_circle: Self-evaluation

The output of both before and after this PR seems to be exactly the same:

<table>
<tr>
<th>Before</th>
<td>

https://github.com/user-attachments/assets/c7a0472d-9d4c-4839-8d4a-85cd3c0f0c55

</td>
</tr>
<tr>
<th>After</th>
<td>

https://github.com/user-attachments/assets/71bcad3e-30e4-48af-afe6-66c1e6d424c9

</td>
</tr>
</table>

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
