### PR TITLE
fix(path_optimizer): undefined behavior when optimizer failure

### DIFF
--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -391,8 +391,8 @@ std::vector<TrajectoryPoint> PathOptimizer::optimizeTrajectory(const PlannerData
   const bool elapsed_time_over_three_seconds = (elapsed_time > 3.0);
 
   auto optimized_traj_points =
-    optimized_traj_failed && elapsed_time_over_three_seconds ? p.traj_points : std::move(*mpt_traj);
-  is_optimization_failed_ = optimized_traj_failed && elapsed_time_over_three_seconds;
+    optimized_traj_failed || elapsed_time_over_three_seconds ? p.traj_points : std::move(*mpt_traj);
+  is_optimization_failed_ = optimized_traj_failed || elapsed_time_over_three_seconds;
 
   // 3. update velocity
   //    NOTE: When optimization failed or is skipped, velocity in trajectory points must

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -399,7 +399,7 @@ std::vector<TrajectoryPoint> PathOptimizer::optimizeTrajectory(const PlannerData
       return std::move(*mpt_traj);
     }
   }();
-  is_optimization_failed_ = optimized_traj_failed || elapsed_time_over_three_seconds;
+  is_optimization_failed_ = optimized_traj_failed && elapsed_time_over_three_seconds;
 
   // 3. update velocity
   //    NOTE: When optimization failed or is skipped, velocity in trajectory points must

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -391,7 +391,15 @@ std::vector<TrajectoryPoint> PathOptimizer::optimizeTrajectory(const PlannerData
   const bool elapsed_time_over_three_seconds = (elapsed_time > 3.0);
 
   auto optimized_traj_points =
-    optimized_traj_failed || elapsed_time_over_three_seconds ? p.traj_points : std::move(*mpt_traj);
+     auto optimized_traj_points = [&]() {
+    if (optimized_traj_failed && elapsed_time_over_three_seconds) {
+      return p.traj_points;
+    } else if (optimized_traj_failed && !elapsed_time_over_three_seconds) {
+      return getPrevOptimizedTrajectory(p.traj_points);
+    } else {
+      return std::move(*mpt_traj);
+    }
+  }();
   is_optimization_failed_ = optimized_traj_failed || elapsed_time_over_three_seconds;
 
   // 3. update velocity

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -383,22 +383,21 @@ std::vector<TrajectoryPoint> PathOptimizer::optimizeTrajectory(const PlannerData
   //    with model predictive trajectory
   const auto mpt_traj = mpt_optimizer_ptr_->optimizeTrajectory(planner_data);
 
-  const bool optimized_traj_failed = !static_cast<bool>(mpt_traj);
-
-  conditional_timer_->update(optimized_traj_failed);
-
   const double elapsed_time = conditional_timer_->getElapsedTime().count();
   const bool elapsed_time_over_three_seconds = (elapsed_time > 3.0);
 
   auto optimized_traj_points = [&]() {
-    if (optimized_traj_failed && elapsed_time_over_three_seconds) {
-      return p.traj_points;
-    } else if (optimized_traj_failed && !elapsed_time_over_three_seconds) {
-      return getPrevOptimizedTrajectory(p.traj_points);
-    } else {
+    if (mpt_traj) {
       return std::move(*mpt_traj);
     }
+    if (elapsed_time_over_three_seconds) {
+      return p.traj_points;
+    }
+    return getPrevOptimizedTrajectory(p.traj_points);
   }();
+
+  const bool optimized_traj_failed = !static_cast<bool>(mpt_traj);
+  conditional_timer_->update(optimized_traj_failed);
   is_optimization_failed_ = optimized_traj_failed && elapsed_time_over_three_seconds;
 
   // 3. update velocity

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -390,8 +390,7 @@ std::vector<TrajectoryPoint> PathOptimizer::optimizeTrajectory(const PlannerData
   const double elapsed_time = conditional_timer_->getElapsedTime().count();
   const bool elapsed_time_over_three_seconds = (elapsed_time > 3.0);
 
-  auto optimized_traj_points =
-     auto optimized_traj_points = [&]() {
+  auto optimized_traj_points = [&]() {
     if (optimized_traj_failed && elapsed_time_over_three_seconds) {
       return p.traj_points;
     } else if (optimized_traj_failed && !elapsed_time_over_three_seconds) {


### PR DESCRIPTION
## Description

When MPT optimization fails but there is no timeout, `std::move(*mpt_traj)` is executed. But when `mpt_traj` is `std::nullopt`, it will  results in undefined behavior. :cry:
I would like to fix this.

Here is an example stacktrace of undefined behavior.
```
[component_container_mt-36] [WARN 1747301824.459061255] [osqp_interface]: [MPT] Optimization failed due to solved inaccurate                                                                                                                                                                                                                                                                                                             
[component_container_mt-36] [WARN 1747301824.459088904] [planning.scenario_planning.lane_driving.motion_planning.path_optimizer.mpt_optimizer]: return std::nullopt since could not solve qp                                                                                                                                                                                                                                             
[component_container_mt-36] terminate called after throwing an instance of 'std::bad_alloc'                                                                                                                                                                                                                                                                                                                                              
[component_container_mt-36]   what():  std::bad_alloc                                                                                                                                                                                                                                                                                                                                                                                    
[component_container_mt-36] *** Aborted at 1747301824 (unix time) try "date -d @1747301824" if you are using GNU date ***                                                                                                                                                                                                                                                                                                                
[component_container_mt-36] PC: @                0x0 (unknown)                                                                                                                                                                                                                                                                                                                                                                           
[component_container_mt-36] *** SIGABRT (@0x3e800023f69) received by PID 147305 (TID 0x7f50b61f4640) from PID 147305; stack trace: ***                                                                                                                                                                                                                                                                                                   
[component_container_mt-36]     @     0x7f50bbfa24d6 google::(anonymous namespace)::FailureSignalHandler()                                                                                                                                                                                                                                                                                                                               
[component_container_mt-36]     @     0x7f50bb442520 (unknown)                                                                                                                                                                                                                                                                                                                                                                           
[component_container_mt-36]     @     0x7f50bb4969fc pthread_kill                                                                                                                                                                                                                                                                                                                                                                        
[component_container_mt-36]     @     0x7f50bb442476 raise                                                                                                                                                                                                                                                                                                                                                                               
[component_container_mt-36]     @     0x7f50bb4287f3 abort                                                                                                                                                                                                                                                                                                                                                                               
[component_container_mt-36]     @     0x7f50bb8a2b9e (unknown)                                                                                                                                                                                                                                                                                                                                                                           
[component_container_mt-36]     @     0x7f50bb8ae20c (unknown)                                                                                                                                                                                                                                                                                                                                                                           
[component_container_mt-36]     @     0x7f50bb8ae277 std::terminate()                                                                                                                                                                                                                                                                                                                                                                    
[component_container_mt-36]     @     0x7f50bb8ae4d8 __cxa_throw                                                                                                                                                                                                                                                                                                                                                                         
[component_container_mt-36]     @     0x7f50bb8a27ac (unknown)                                                                                                                                                                                                                                                                                                                                                                           
[component_container_mt-36]     @     0x7f50695ecf85 std::vector<>::vector()                                                                                                                                                                                                                                                                                                                                                             
[component_container_mt-36]     @     0x7f50695da7c1 autoware::path_optimizer::PathOptimizer::optimizeTrajectory()                                                                                                                                                                                                                                                                                                                       
[component_container_mt-36]     @     0x7f50695db221 autoware::path_optimizer::PathOptimizer::generateOptimizedTrajectory()                                                                                                                                                                                                                                                                                                              
[component_container_mt-36]     @     0x7f50695dbac6 autoware::path_optimizer::PathOptimizer::onPath()                                                                                                                                                                                                                                                                                                                                   
[component_container_mt-36]     @     0x7f50695f6958 std::_Function_handler<>::_M_invoke()                                                                                                                                                                                                                                                                                                                                               
[component_container_mt-36]     @     0x7f50695f6037 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN22autoware_planning_msgs3msg5Path_ISaIvEEESA_E8dispatchESt10shared_ptrISB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRKSB_EESN_IFvSP_SH_EESN_IFvRKNS5_17SerializedMessageEEESN_IFvSW_SH_EESN_IFvSt10unique_ptrISB_St14default_dele
teISB_EEEESN_IFvS14_SH_EESN_IFvS11_ISU_S12_ISU_EEEESN_IFvS1A_SH_EESN_IFvSD_ISO_EEESN_IFvS1F_SH_EESN_IFvSD_ISV_EEESN_IFvS1K_SH_EESN_IFvRKS1F_EESN_IFvS1Q_SH_EESN_IFvRKS1K_EESN_IFvS1W_SH_EESN_IFvSE_EESN_IFvSE_SH_EESN_IFvSD_ISU_EEESN_IFvS25_SH_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESL_S2B_                                                                                                                          
[component_container_mt-36]     @     0x7f5069623705 rclcpp::Subscription<>::handle_message()                                                                                                                                                                                                                                                                                                                                            
[component_container_mt-36]     @     0x7f50bbd5dba0 rclcpp::Executor::execute_subscription()                                                                                                                                                                                                                                                                                                                                            
[component_container_mt-36]     @     0x7f50bbd5f10e rclcpp::Executor::execute_any_executable()                                                                                                                                                                                                                                                                                                                                          
[component_container_mt-36]     @     0x7f50bbd65432 rclcpp::executors::MultiThreadedExecutor::run()                                                                                                                                                                                                                                                                                                                                     
[component_container_mt-36]     @     0x7f50bb8dc253 (unknown)                                                                                                                                                                                                                                                                                                                                                                           
[component_container_mt-36]     @     0x7f50bb494ac3 (unknown)                                                                                                                                                                                                                                                                                                                                                                           
[component_container_mt-36]     @     0x7f50bb526850 (unknown)     
```

I guess the root cause is that the current logic for handling optimization failure is incorrect. 
I’ve modified it so that a failure is triggered if either a timeout of over 3 seconds **or** an MPT optimization failure occurs.

### reference 
> [!NOTE]
> https://en.cppreference.com/w/cpp/utility/optional/operator%252A.html
> <img src=https://github.com/user-attachments/assets/98a9cc97-5290-4fd4-951f-01f2919a2b83 width=400>


## Related links

**Private Links:**
- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-37240)

## How was this PR tested?

I have confirmed that path_optimizer does not die due to MPT optimization failure.
Before this PR, the node was dead.

![image](https://github.com/user-attachments/assets/a5129f9a-8422-4ffc-9ffa-cd99fc7910d4)
(I intentionally increased the `front_overhang` in `vehicle_info.param.yaml` to force an MPT optimization failure for testing purposes.)

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
