### PR TITLE
chore: remove ported packages in codecov.yaml

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -122,14 +122,10 @@ component_management:
     - component_id: localization-tier-iv-maintained-packages
       name: Localization TIER IV Maintained Packages
       paths:
-        - localization/autoware_gyro_odometer/**
         - localization/autoware_localization_error_monitor/**
-        - localization/autoware_localization_util/**
         - localization/autoware_ndt_scan_matcher/**
         - localization/autoware_pose_initializer/**
         - localization/autoware_pose_instability_detector/**
-        - localization/autoware_stop_filter/**
-        - localization/autoware_twist2accel/**
 
     - component_id: map-tier-iv-maintained-packages
       name: Map TIER IV Maintained Packages
@@ -202,12 +198,10 @@ component_management:
         # - planning/autoware_planning_topic_converter/**
         - planning/autoware_planning_validator/**
         # - planning/autoware_remaining_distance_time_calculator/**
-        - planning/autoware_route_handler/**
         - planning/autoware_rtc_interface/**
         - planning/autoware_scenario_selector/**
         - planning/autoware_static_centerline_generator/**
         - planning/autoware_surround_obstacle_checker/**
-        - planning/autoware_velocity_smoother/**
         ##### behavior_path_planner #####
         # - planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/**
         - planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/**
@@ -228,11 +222,8 @@ component_management:
         # - planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/**
         - planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/**
         # - planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/**
-        - planning/behavior_velocity_planner/autoware_behavior_velocity_planner/**
-        - planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/**
         - planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/**
         # - planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/**
-        - planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/**
         # - planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/**
         - planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/**
         - planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/**


### PR DESCRIPTION
## Description
This removes the packages that are already ported to Core from codecov.yaml
I plan to create a similar system in Autoware Core, but we can remove the packages from Universe first.  

## Related links

- None

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
