### PR TITLE
feat(obstacle_pointcloud_validator): add processing time ms for track…

### DIFF
--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
@@ -324,6 +324,7 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
   const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects,
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud)
 {
+  autoware_utils::StopWatch<std::chrono::milliseconds> stopwatch;
   autoware_perception_msgs::msg::DetectedObjects output, removed_objects;
   output.header = input_objects->header;
   removed_objects.header = input_objects->header;
@@ -387,6 +388,9 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
       .count();
   debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/pipeline_latency_ms", pipeline_latency);
+  const double processing_time_ms = stopwatch.toc();
+  debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+    "debug/processing_time_ms", processing_time_ms);
 }
 
 }  // namespace obstacle_pointcloud

--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
@@ -19,6 +19,7 @@
 
 #include "autoware_utils/ros/debug_publisher.hpp"
 #include "autoware_utils/ros/published_time_publisher.hpp"
+#include "autoware_utils/system/stop_watch.hpp"
 #include "debugger.hpp"
 
 #include <rclcpp/rclcpp.hpp>


### PR DESCRIPTION
## Description

Add a simple stop watch to output processing time for obstacle_pointcloud_based_validator

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

During rosbag replay, check processing time with
```
ros2 topic echo /perception/object_recognition/detection/obstacle_pointcloud_based_validator/debug/processing_time_ms
stamp:
  sec: 1744597162
  nanosec: 819433026
data: 7.653
---
stamp:
  sec: 1744597162
  nanosec: 918416859
data: 6.62
---
stamp:
  sec: 1744597163
  nanosec: 19431801
data: 6.087
---
stamp:
  sec: 1744597163
  nanosec: 118478044
data: 6.05
---
stamp:
  sec: 1744597163
  nanosec: 218440752
data: 7.45
---
stamp:
  sec: 1744597163
  nanosec: 320432754
data: 6.837
``` 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
