### PR TITLE
fix(run_out): guard against decreasing ego trajectory times

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
@@ -93,6 +93,10 @@ double calculate_keep_stop_distance_range(
   std::vector<double> arc_lengths = {0.0};
   for (auto i = 1UL; i < trajectory.size(); ++i) {
     const auto t = rclcpp::Duration(trajectory[i].time_from_start).seconds();
+    if (times.back() >= t) {
+      // we skip trajectory points where the predicted time decreases to avoid interpolation errors
+      continue;
+    }
     const auto arc_length_delta = universe_utils::calcDistance2d(trajectory[i - 1], trajectory[i]);
     times.push_back(t);
     arc_lengths.push_back(arc_lengths.back() + arc_length_delta);


### PR DESCRIPTION
## Description

Fix crashes that can occur when the calculate times along the ego trajectory are decreasing.

## Related links

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-37423)

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
