### PR TITLE
feat(tier4_autoware_api_launch): add tier4 api to replace old api

### DIFF
--- a/launch/tier4_autoware_api_launch/launch/deprecated_api.launch.xml
+++ b/launch/tier4_autoware_api_launch/launch/deprecated_api.launch.xml
@@ -12,10 +12,9 @@
     <include file="$(find-pkg-share autoware_iv_internal_api_adaptor)/launch/internal_api_relay.launch.xml"/>
   </group>
 
-  <!-- autoware api utils -->
+  <!-- tier4 autoware api extension -->
   <group>
-    <push-ros-namespace namespace="autoware_api/utils"/>
-    <include file="$(find-pkg-share autoware_path_distance_calculator)/launch/path_distance_calculator.launch.xml"/>
+    <include file="$(find-pkg-share tier4_autoware_api_extension)/launch/tier4_autoware_api_extension.launch.xml"/>
   </group>
 
   <!-- tier4 deprecated api adapter -->

--- a/launch/tier4_autoware_api_launch/package.xml
+++ b/launch/tier4_autoware_api_launch/package.xml
@@ -15,9 +15,10 @@
   <exec_depend>autoware_default_adapi</exec_depend>
   <exec_depend>autoware_iv_external_api_adaptor</exec_depend>
   <exec_depend>autoware_iv_internal_api_adaptor</exec_depend>
-  <exec_depend>autoware_path_distance_calculator</exec_depend>
   <exec_depend>awapi_awiv_adapter</exec_depend>
   <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>tier4_autoware_api_extension</exec_depend>
+  <exec_depend>tier4_deprecated_api_adapter</exec_depend>
   <exec_depend>topic_tools</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

This is one of the steps of https://github.com/autowarefoundation/autoware/issues/3096.
To remove tier4 api adaptor, we are refactoring our API.
Related to https://github.com/tier4/tier4_ad_api_adaptor/pull/153

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/3096

## How was this PR tested?

Launch planning simulation with `launch_deprecated_api:=true` option.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
