### PR TITLE
fix(mpc): update time from start in the predicted trajectory

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -286,6 +286,8 @@ Trajectory convertToAutowareTrajectory(const MPCTrajectory & input)
     p.pose.orientation = autoware_utils::create_quaternion_from_yaw(input.yaw.at(i));
     p.longitudinal_velocity_mps =
       static_cast<decltype(p.longitudinal_velocity_mps)>(input.vx.at(i));
+    p.time_from_start =
+      rclcpp::Duration::from_seconds(input.relative_time.at(i) - input.relative_time.front());
     output.points.push_back(p);
     if (output.points.size() == output.points.max_size()) {
       break;


### PR DESCRIPTION
## Description

update `time_from_start` variable in MPC's predicted trajectory.

## Related links

**Parent Issue:**

- Link


**Private Links:**

- [TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/878125e8-60db-59e5-9ebe-890b526a680b?project_id=prd_jt)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
