### PR TITLE
feat(autoware_deignostic_graph_utils): throttle warning message

### DIFF
--- a/system/autoware_diagnostic_graph_utils/src/node/logging.cpp
+++ b/system/autoware_diagnostic_graph_utils/src/node/logging.cpp
@@ -67,7 +67,10 @@ void LoggingNode::on_timer()
 
     // show on terminal
     if (enable_terminal_log_ && error_graph_text != prev_error_graph_text_) {
-      RCLCPP_WARN_STREAM(get_logger(), prefix_message << std::endl << error_graph_text);
+      RCLCPP_WARN_STREAM_THROTTLE(
+        get_logger(), *get_clock(), 3000 /* ms */,
+        prefix_message << std::endl
+                       << error_graph_text);
     }
 
     // publish debug topic


### PR DESCRIPTION
## Description
This will make one of the RCLCPP_WARN_STREAM to RCLCPP_WARN_STREAM_THROTTLE to avoid spamming the terminal at start up.

## Related links

none

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Locally built and tested with planning simulator.
Before (warning message is shown at 10 Hz): 
![image](https://github.com/user-attachments/assets/84b26a57-5e7e-451e-8409-675c0842f090)

After (warning is shown once at startup):
![image](https://github.com/user-attachments/assets/5c3be17e-dcee-4f70-9b57-25437f544db3)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
