### PR TITLE
fix(goal_planner): publish debug_objects_extraction_polygon

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -232,7 +232,8 @@ std::optional<Pose> calcClosestPose(
 autoware_perception_msgs::msg::PredictedObjects extract_dynamic_objects(
   const autoware_perception_msgs::msg::PredictedObjects & original_objects,
   const route_handler::RouteHandler & route_handler, const GoalPlannerParameters & parameters,
-  const double vehicle_width, const Pose & ego_pose);
+  const double vehicle_width, const Pose & ego_pose,
+  std::optional<std::reference_wrapper<Polygon2d>> debug_objects_extraction_polygon = std::nullopt);
 
 bool is_goal_reachable_on_path(
   const lanelet::ConstLanelets current_lanes, const route_handler::RouteHandler & route_handler,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -771,7 +771,8 @@ void GoalPlannerModule::updateData()
   // extract static and dynamic objects in extraction polygon for path collision check
   const auto dynamic_target_objects = goal_planner_utils::extract_dynamic_objects(
     *(planner_data_->dynamic_object), *(planner_data_->route_handler), parameters_,
-    planner_data_->parameters.vehicle_width, planner_data_->self_odometry->pose.pose);
+    planner_data_->parameters.vehicle_width, planner_data_->self_odometry->pose.pose,
+    std::ref(debug_data_.objects_extraction_polygon));
   const auto static_target_objects = utils::path_safety_checker::filterObjectsByVelocity(
     dynamic_target_objects, parameters_.th_moving_object_velocity);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -945,7 +945,8 @@ std::optional<Pose> calcClosestPose(
 autoware_perception_msgs::msg::PredictedObjects extract_dynamic_objects(
   const autoware_perception_msgs::msg::PredictedObjects & original_objects,
   const route_handler::RouteHandler & route_handler, const GoalPlannerParameters & parameters,
-  const double vehicle_width, const Pose & ego_pose)
+  const double vehicle_width, const Pose & ego_pose,
+  std::optional<std::reference_wrapper<Polygon2d>> debug_objects_extraction_polygon)
 {
   const bool left_side_parking = parameters.parking_policy == ParkingPolicy::LEFT_SIDE;
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
@@ -954,6 +955,11 @@ autoware_perception_msgs::msg::PredictedObjects extract_dynamic_objects(
   const auto objects_extraction_polygon = goal_planner_utils::generateObjectExtractionPolygon(
     pull_over_lanes, left_side_parking, parameters.detection_bound_offset,
     parameters.margin_from_boundary + parameters.max_lateral_offset + vehicle_width);
+
+  // Store extraction polygon for debugging if the optional parameter is provided
+  if (debug_objects_extraction_polygon && objects_extraction_polygon.has_value()) {
+    debug_objects_extraction_polygon->get() = objects_extraction_polygon.value();
+  }
 
   // Extract objects within the extraction polygon
   PredictedObjects dynamic_target_objects{};


### PR DESCRIPTION
## Description

Currently debug_objects_extraction_polygon(blue polygon) is not published. Fixed this issue in this PR.

![image](https://github.com/user-attachments/assets/9bd9ae66-c94d-4419-b74a-e2d4c75bce6c)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
