### PR TITLE
feat(goal_planner): add param of path_decision_state_controller.check_collision_duration

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
@@ -452,6 +452,12 @@ When ego approached the start of the temporarily selected pull over path within 
 ![state_transition](./images/goal_planner-state-transition.drawio.svg)
 [Open]({{ drawio("/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/images/goal_planner-state-transition.drawio.svg") }})
 
+### Parameters for path decision state controller
+
+| Name                     | Unit | Type   | Description                                                                                                                                                                 | Default value |
+| :----------------------- | :--- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
+| check_collision_duration | [s]  | double | Duration to continuously check collision before transition from DECIDING to DECIDED state. This ensures the path remains safe for a period of time before final commitment. | 1.0           |
+
 ## Unimplemented parts / limitations
 
 - Only shift pull over can be executed concurrently with other modules

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
@@ -48,6 +48,9 @@
         outer_road_detection_offset: 1.0
         inner_road_detection_offset: 0.0
 
+      # path decision state controller
+      path_decision_state_controller:
+        check_collision_duration: 1.0  # Duration to check collision before transition from DECIDING to DECIDED
 
       # pull over
       pull_over:

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_parameters.hpp
@@ -133,6 +133,9 @@ struct GoalPlannerParameters
   // hysteresis parameter
   double hysteresis_factor_expand_rate{0.0};
 
+  // path decision state controller
+  double check_collision_duration{1.0};  // Duration to check collision before deciding path
+
   // path safety checker
   utils::path_safety_checker::EgoPredictedPathParams ego_predicted_path_params{};
   utils::path_safety_checker::ObjectsFilteringParams objects_filtering_params{};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
@@ -422,6 +422,12 @@ GoalPlannerParameters GoalPlannerModuleManager::initGoalPlannerParameters(
     p.print_debug_info = node->declare_parameter<bool>(ns + "print_debug_info");
   }
 
+  // path decision state controller
+  {
+    const std::string ns = base_ns + "path_decision_state_controller.";
+    p.check_collision_duration = node->declare_parameter<double>(ns + "check_collision_duration");
+  }
+
   // validation of parameters
   if (p.shift_sampling_num < 1) {
     RCLCPP_FATAL_STREAM(
@@ -853,6 +859,12 @@ void GoalPlannerModuleManager::updateModuleParams(
   {
     const std::string ns = base_ns + "debug.";
     update_param<bool>(parameters, ns + "print_debug_info", p->print_debug_info);
+  }
+
+  // path decision state controller
+  {
+    const std::string ns = base_ns + "path_decision_state_controller.";
+    update_param<double>(parameters, ns + "check_collision_duration", p->check_collision_duration);
   }
 
   std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {


### PR DESCRIPTION
## Description

currently check_collision_duration of path_decision_state_controller is harcoded. 
this paremter is Duration to check collision before transition from DECIDING to DECIDED
in this PR make this paramters.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

with

```
      # path decision state controller
      path_decision_state_controller:
        check_collision_duration: 5.0  # Duration to check collision before transition from DECIDING to DECIDED
```

![image](https://github.com/user-attachments/assets/0869dd89-bc3f-46ee-abcf-f61957d30357)


2025/06/05 https://evaluation.tier4.jp/evaluation/reports/173d8952-39fc-5336-b629-7899a7720e2d/?project_id=prd_jt
3945/3946



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
