### PR TITLE
feat(autoware_behavior_velocity_traffic_light_module): add v2i

### DIFF
--- a/common/autoware_traffic_light_utils/include/autoware/traffic_light_utils/traffic_light_utils.hpp
+++ b/common/autoware_traffic_light_utils/include/autoware/traffic_light_utils/traffic_light_utils.hpp
@@ -27,6 +27,8 @@
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Transform.h>
 
+#include <vector>
+
 namespace autoware::traffic_light_utils
 {
 
@@ -43,7 +45,8 @@ void setSignalUnknown(tier4_perception_msgs::msg::TrafficLight & signal, float c
  * @return True if a circle-shaped light with the specified color is found, false otherwise.
  */
 bool hasTrafficLightCircleColor(
-  const autoware_perception_msgs::msg::TrafficLightGroup & tl_state, const uint8_t & lamp_color);
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements,
+  const uint8_t & lamp_color);
 
 /**
  * @brief Checks if a traffic light state includes a light with the specified shape.
@@ -55,7 +58,8 @@ bool hasTrafficLightCircleColor(
  * @return True if a light with the specified shape is found, false otherwise.
  */
 bool hasTrafficLightShape(
-  const autoware_perception_msgs::msg::TrafficLightGroup & tl_state, const uint8_t & lamp_shape);
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements,
+  const uint8_t & lamp_shape);
 
 /**
  * @brief Determines if a traffic signal indicates a stop for the given lanelet.

--- a/common/autoware_traffic_light_utils/src/traffic_light_utils.cpp
+++ b/common/autoware_traffic_light_utils/src/traffic_light_utils.cpp
@@ -14,7 +14,10 @@
 
 #include "autoware/traffic_light_utils/traffic_light_utils.hpp"
 
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+
 #include <string>
+#include <vector>
 
 namespace autoware::traffic_light_utils
 {
@@ -26,35 +29,37 @@ void setSignalUnknown(tier4_perception_msgs::msg::TrafficLight & signal, float c
   signal.elements[0].color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
   signal.elements[0].confidence = confidence;
 }
-
 bool hasTrafficLightCircleColor(
-  const autoware_perception_msgs::msg::TrafficLightGroup & tl_state, const uint8_t & lamp_color)
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements,
+  const uint8_t & lamp_color)
 {
   const auto it_lamp =
-    std::find_if(tl_state.elements.begin(), tl_state.elements.end(), [&lamp_color](const auto & x) {
+    std::find_if(elements.begin(), elements.end(), [&lamp_color](const auto & x) {
       return x.shape == autoware_perception_msgs::msg::TrafficLightElement::CIRCLE &&
              x.color == lamp_color;
     });
 
-  return it_lamp != tl_state.elements.end();
+  return it_lamp != elements.end();
 }
 
 bool hasTrafficLightShape(
-  const autoware_perception_msgs::msg::TrafficLightGroup & tl_state, const uint8_t & lamp_shape)
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements,
+  const uint8_t & lamp_shape)
 {
   const auto it_lamp = std::find_if(
-    tl_state.elements.begin(), tl_state.elements.end(),
+    elements.begin(), elements.end(),
     [&lamp_shape](const auto & x) { return x.shape == lamp_shape; });
 
-  return it_lamp != tl_state.elements.end();
+  return it_lamp != elements.end();
 }
 
 bool isTrafficSignalStop(
   const lanelet::ConstLanelet & lanelet,
   const autoware_perception_msgs::msg::TrafficLightGroup & tl_state)
 {
+  const auto & elements = tl_state.elements;
   if (hasTrafficLightCircleColor(
-        tl_state, autoware_perception_msgs::msg::TrafficLightElement::GREEN)) {
+        elements, autoware_perception_msgs::msg::TrafficLightElement::GREEN)) {
     return false;
   }
 
@@ -66,18 +71,18 @@ bool isTrafficSignalStop(
   if (
     turn_direction == "right" &&
     hasTrafficLightShape(
-      tl_state, autoware_perception_msgs::msg::TrafficLightElement::RIGHT_ARROW)) {
+      elements, autoware_perception_msgs::msg::TrafficLightElement::RIGHT_ARROW)) {
     return false;
   }
   if (
     turn_direction == "left" &&
     hasTrafficLightShape(
-      tl_state, autoware_perception_msgs::msg::TrafficLightElement::LEFT_ARROW)) {
+      elements, autoware_perception_msgs::msg::TrafficLightElement::LEFT_ARROW)) {
     return false;
   }
   if (
     turn_direction == "straight" &&
-    hasTrafficLightShape(tl_state, autoware_perception_msgs::msg::TrafficLightElement::UP_ARROW)) {
+    hasTrafficLightShape(elements, autoware_perception_msgs::msg::TrafficLightElement::UP_ARROW)) {
     return false;
   }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
@@ -12,3 +12,9 @@
       restart_suppression:
         min_behind_distance_to_stop: 0.5 #[m]
         max_behind_distance_to_stop: 1.0 #[m]
+
+      v2i:
+        use_remaining_time: false
+        last_time_allowed_to_pass: 2.0 # [s] relative time against at the time of turn to red
+        velocity_threshold: 0.5 # [m/s] change the decision logic whether the current velocity is faster or not
+        required_time_to_departure: 3.0 # [s] prevent low speed pass

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
@@ -50,7 +50,14 @@ TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
     get_or_declare_parameter<double>(node, ns + ".restart_suppression.min_behind_distance_to_stop");
   planner_param_.max_behind_dist_to_stop_for_restart_suppression =
     get_or_declare_parameter<double>(node, ns + ".restart_suppression.max_behind_distance_to_stop");
-
+  planner_param_.v2i_use_remaining_time =
+    get_or_declare_parameter<bool>(node, ns + ".v2i.use_remaining_time");
+  planner_param_.v2i_last_time_allowed_to_pass =
+    get_or_declare_parameter<double>(node, ns + ".v2i.last_time_allowed_to_pass");
+  planner_param_.v2i_velocity_threshold =
+    get_or_declare_parameter<double>(node, ns + ".v2i.velocity_threshold");
+  planner_param_.v2i_required_time_to_departure =
+    get_or_declare_parameter<double>(node, ns + ".v2i.required_time_to_departure");
   pub_tl_state_ = node.create_publisher<autoware_perception_msgs::msg::TrafficLightGroup>(
     "~/output/traffic_signal", 1);
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
@@ -67,6 +67,11 @@ public:
     // Restart Suppression Parameter
     double max_behind_dist_to_stop_for_restart_suppression;
     double min_behind_dist_to_stop_for_restart_suppression;
+    // V2I Parameter
+    bool v2i_use_remaining_time;
+    double v2i_last_time_allowed_to_pass;
+    double v2i_velocity_threshold;
+    double v2i_required_time_to_departure;
   };
 
 public:
@@ -94,6 +99,8 @@ public:
 
 private:
   bool isStopSignal();
+
+  bool willTrafficLightTurnRedBeforeReachingStopLine(const double & distance_to_stop_line) const;
 
   autoware_internal_planning_msgs::msg::PathWithLaneId insertStopPose(
     const autoware_internal_planning_msgs::msg::PathWithLaneId & input,

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.hpp
@@ -25,6 +25,8 @@
 #include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
 
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+
 #include <lanelet2_core/LaneletMap.h>
 
 namespace autoware::behavior_velocity_planner
@@ -76,6 +78,16 @@ auto calcStopPointAndInsertIndex(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & input_path,
   const lanelet::ConstLineString3d & lanelet_stop_lines, const double & offset)
   -> std::optional<std::pair<size_t, Eigen::Vector2d>>;
+
+/**
+ * @brief check if the traffic signal is red stop.
+ * @param lanelet
+ * @param elements
+ * @return true if the traffic signal is red stop, false otherwise.
+ */
+bool isTrafficSignalRedStop(
+  const lanelet::ConstLanelet & lanelet,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & elements);
 
 }  // namespace autoware::behavior_velocity_planner
 


### PR DESCRIPTION
## Description

This function uses the predicted time when the signal color will change, as provided by V2I.

Even if the current signal is GREEN, if it is predicted to change to RED in a few seconds and you cannot cross the stop line before it changes to RED, it is better to plan to stop.

In this PR, I introduced a function that determines whether it is possible to stop at the stop line based on the time remaining until RED when V2I is enabled, and plans to stop if it is not possible to pass.

[V2I.webm](https://github.com/user-attachments/assets/285731c2-7a1c-4fc4-8acc-36b816d1f441)


## Related links

- https://github.com/autowarefoundation/autoware_launch/pull/1482
- https://github.com/tier4/vehicle2infrastructure/pull/140

## How was this PR tested?

I tested it using psim and my own script. The attached video shows the test results.

<details>

<summary>Scripts used for testing</summary>

```python
import argparse

import rclpy
from rclpy.node import Node
from builtin_interfaces.msg import Time
from autoware_perception_msgs.msg import (
    TrafficLightElement,
    TrafficLightGroup,
    TrafficLightGroupArray,
    PredictedTrafficLightState,
)
from autoware_vehicle_msgs.msg import VelocityReport


def append_green_light(group):
    # Append a green light element to the group
    group.elements.append(TrafficLightFactory.green())


def append_amber_light(group):
    # Append an amber light element to the group
    group.elements.append(TrafficLightFactory.amber())


def append_red_light(group):
    # Append a red light element to the group
    group.elements.append(TrafficLightFactory.red())


def get_time_plus_seconds(time_msg: Time, seconds: float) -> Time:
    # Calculate a Time message offset by `seconds` from `time_msg`
    total_ns = (
        int(time_msg.sec) * 1_000_000_000
        + int(time_msg.nanosec)
        + int(seconds * 1_000_000_000)
    )
    result = Time()
    result.sec = int(total_ns // 1_000_000_000)
    result.nanosec = int(total_ns % 1_000_000_000)
    return result


class TrafficLightFactory:
    @staticmethod
    def green():
        return TrafficLightElement(
            color=TrafficLightElement.GREEN,
            shape=TrafficLightElement.CIRCLE,
            status=TrafficLightElement.SOLID_ON,
            confidence=1.0,
        )

    @staticmethod
    def amber():
        return TrafficLightElement(
            color=TrafficLightElement.AMBER,
            shape=TrafficLightElement.CIRCLE,
            status=TrafficLightElement.SOLID_ON,
            confidence=1.0,
        )

    @staticmethod
    def red():
        return TrafficLightElement(
            color=TrafficLightElement.RED,
            shape=TrafficLightElement.CIRCLE,
            status=TrafficLightElement.SOLID_ON,
            confidence=1.0,
        )


class DummyTrafficLightPublisher(Node):
    def __init__(self, traffic_light_group_id, topic_name):
        super().__init__("dummy_traffic_light_publisher")
        self.traffic_light_group_id = traffic_light_group_id
        self.topic_name = topic_name

        # Vehicle velocity [m/s]
        self.vehicle_velocity = 0.0
        # Flag that indicates whether cycling has started
        self._is_started = False
        # ROS2 time at the moment cycling started
        self._start_time = None
        # Current state: "green", "amber", "red", or "final_green"
        self._current_state = "green"

        # Timing constants [seconds]
        self.DURATION_GREEN_PRED = 5.0  # green + predict amber
        self.DURATION_AMBER = 2.0       # amber + predict red
        self.DURATION_RED = 10.0        # red + predict green

        # Publisher and subscription
        self.publisher = self.create_publisher(TrafficLightGroupArray, topic_name, 10)
        self.create_subscription(
            VelocityReport,
            "/vehicle/status/velocity_status",
            self.vehicle_status_callback,
            10,
        )
        # Timer: 10Hz
        self.create_timer(0.1, self.publish_traffic_light)

    def publish_traffic_light(self):
        now = self.get_clock().now()
        group_array = TrafficLightGroupArray()
        group_array.stamp = now.to_msg()

        group = TrafficLightGroup()
        group.traffic_light_group_id = self.traffic_light_group_id

        # Check start condition (velocity threshold) only once
        if not self._is_started:
            self.check_start_condition(now)

        if not self._is_started:
            # Before start: show green, no prediction
            append_green_light(group)
            self.update_state("green")
        else:
            # Compute elapsed time since start in seconds (float)
            elapsed = (now - self._start_time).nanoseconds / 1e9

            # Stage 1: 0 <= elapsed < DURATION_GREEN_PRED
            if elapsed < self.DURATION_GREEN_PRED:
                append_green_light(group)
                predicted_time = get_time_plus_seconds(
                    self._start_time.to_msg(), self.DURATION_GREEN_PRED
                )
                prediction = PredictedTrafficLightState(
                    predicted_stamp=predicted_time,
                    simultaneous_elements=[TrafficLightFactory.amber()],
                    reliability=1.0,
                )
                group.predictions.append(prediction)
                self.update_state("green")

            # Stage 2: DURATION_GREEN_PRED <= elapsed < DURATION_GREEN_PRED + DURATION_AMBER
            elif elapsed < self.DURATION_GREEN_PRED + self.DURATION_AMBER:
                append_amber_light(group)
                next_switch = self.DURATION_GREEN_PRED + self.DURATION_AMBER
                predicted_time = get_time_plus_seconds(
                    self._start_time.to_msg(), next_switch
                )
                prediction = PredictedTrafficLightState(
                    predicted_stamp=predicted_time,
                    simultaneous_elements=[TrafficLightFactory.red()],
                    reliability=1.0,
                )
                group.predictions.append(prediction)
                self.update_state("amber")

            # Stage 3: red stage
            elif elapsed < self.DURATION_GREEN_PRED + self.DURATION_AMBER + self.DURATION_RED:
                append_red_light(group)
                next_switch = (
                    self.DURATION_GREEN_PRED + self.DURATION_AMBER + self.DURATION_RED
                )
                predicted_time = get_time_plus_seconds(
                    self._start_time.to_msg(), next_switch
                )
                prediction = PredictedTrafficLightState(
                    predicted_stamp=predicted_time,
                    simultaneous_elements=[TrafficLightFactory.green()],
                    reliability=1.0,
                )
                group.predictions.append(prediction)
                self.update_state("red")

            # Stage 4: cycle complete
            else:
                append_green_light(group)
                self.update_state("final_green")

        group_array.traffic_light_groups.append(group)
        self.publisher.publish(group_array)

    def update_state(self, new_state):
        # Print only when state actually changes
        if new_state != self._current_state:
            self._current_state = new_state
            print(f"Switched to {new_state}")

    def check_start_condition(self, now):
        # If velocity exceeds 5.0 m/s, mark started and record start time
        if self.vehicle_velocity > 5.0:
            self._is_started = True
            self._start_time = now
            print("Cycling started at", now.to_msg().sec, "sec")

    def vehicle_status_callback(self, msg):
        # Update vehicle velocity from subscription
        self.vehicle_velocity = msg.longitudinal_velocity


def main():
    rclpy.init()
    parser = argparse.ArgumentParser()
    parser.add_argument("--traffic_light_group_id", type=int, default=10001)
    parser.add_argument(
        "--topic_name",
        type=str,
        default="/perception/traffic_light_recognition/traffic_signals",
    )
    args = parser.parse_args()

    node = DummyTrafficLightPublisher(args.traffic_light_group_id, args.topic_name)
    try:
        rclpy.spin(node)
    except KeyboardInterrupt:
        pass
    finally:
        node.destroy_node()
        rclpy.shutdown()


if __name__ == "__main__":
    main()
```
</details>

If the arrow signal is on, do not insert the wall.
Traffic light color transition like this.
```
[Blue, ←] ⇛ [AMBER, ←] ⇛ [RED, ←]
```
[Screencast from 06-13-2025 04:28:31 PM.webm](https://github.com/user-attachments/assets/abff88f4-c87b-4044-9524-ddcd89e948eb)


## Notes for re

viewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
