### PR TITLE
feat(goal_planner): check previous module's stopline when regenerate candidates

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/decision_state.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/decision_state.hpp
@@ -49,7 +49,8 @@ public:
    * @brief update current state and save old current state to prev state
    */
   void transit_state(
-    const std::optional<PullOverPath> & pull_over_path_opt, const rclcpp::Time & now,
+    const std::optional<PullOverPath> & pull_over_path_opt, const bool upstream_module_has_stopline,
+    const rclcpp::Time & now,
     const autoware_perception_msgs::msg::PredictedObjects & static_target_objects,
     const autoware_perception_msgs::msg::PredictedObjects & dynamic_target_objects,
     const std::shared_ptr<const PlannerData> planner_data,
@@ -69,8 +70,9 @@ private:
    * @brief update current state and save old current state to prev state
    */
   PathDecisionState get_next_state(
-    const std::optional<PullOverPath> & pull_over_path_opt, const rclcpp::Time & now,
-    const PredictedObjects & static_target_objects, const PredictedObjects & dynamic_target_objects,
+    const std::optional<PullOverPath> & pull_over_path_opt, const bool upstream_module_has_stopline,
+    const rclcpp::Time & now, const PredictedObjects & static_target_objects,
+    const PredictedObjects & dynamic_target_objects,
     const std::shared_ptr<const PlannerData> planner_data,
     const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
     const bool is_current_safe, const GoalPlannerParameters & parameters,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -122,12 +122,6 @@ bool isOnModifiedGoal(
   const Pose & current_pose, const std::optional<GoalCandidate> & modified_goal_opt,
   const GoalPlannerParameters & parameters);
 
-bool hasPreviousModulePathShapeChanged(
-  const BehaviorModuleOutput & upstream_module_output,
-  const BehaviorModuleOutput & last_upstream_module_output);
-bool hasDeviatedFromPath(
-  const Point & ego_position, const BehaviorModuleOutput & upstream_module_output);
-
 bool needPathUpdate(
   const Pose & current_pose, const double path_update_duration, const rclcpp::Time & now,
   const std::optional<GoalCandidate> & modified_goal,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -246,11 +246,11 @@ bool hasDeviatedFromPath(
   const Point & ego_position, const BehaviorModuleOutput & upstream_module_output);
 
 /**
- * @brief check if stopline existance and position have changed
+ * @brief check if stopline exists execept for the terminal
+ * @note except for terminal, to account for lane change bug that inserts stopline at the end
+ * randomly
  */
-bool has_previous_module_path_velocity_changed(
-  const BehaviorModuleOutput & upstream_module_output,
-  const BehaviorModuleOutput & last_upstream_module_output);
+bool has_stopline_except_terminal(const PathWithLaneId & path);
 
 }  // namespace autoware::behavior_path_planner::goal_planner_utils
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -239,6 +239,19 @@ bool is_goal_reachable_on_path(
   const lanelet::ConstLanelets current_lanes, const route_handler::RouteHandler & route_handler,
   const bool left_side_parking);
 
+bool hasPreviousModulePathShapeChanged(
+  const BehaviorModuleOutput & upstream_module_output,
+  const BehaviorModuleOutput & last_upstream_module_output);
+bool hasDeviatedFromPath(
+  const Point & ego_position, const BehaviorModuleOutput & upstream_module_output);
+
+/**
+ * @brief check if stopline existance and position have changed
+ */
+bool has_previous_module_path_velocity_changed(
+  const BehaviorModuleOutput & upstream_module_output,
+  const BehaviorModuleOutput & last_upstream_module_output);
+
 }  // namespace autoware::behavior_path_planner::goal_planner_utils
 
 #endif  // AUTOWARE__BEHAVIOR_PATH_GOAL_PLANNER_MODULE__UTIL_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -246,7 +246,7 @@ bool hasDeviatedFromPath(
   const Point & ego_position, const BehaviorModuleOutput & upstream_module_output);
 
 /**
- * @brief check if stopline exists execept for the terminal
+ * @brief check if stopline exists except for the terminal
  * @note except for terminal, to account for lane change bug that inserts stopline at the end
  * randomly
  */

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -132,49 +132,6 @@ bool isOnModifiedGoal(
   return isOnModifiedGoal(current_pose, modified_goal_opt.value(), parameters);
 }
 
-bool hasPreviousModulePathShapeChanged(
-  const BehaviorModuleOutput & upstream_module_output,
-  const BehaviorModuleOutput & last_upstream_module_output)
-{
-  // Calculate the lateral distance between each point of the current path and the nearest point of
-  // the last path
-  constexpr double LATERAL_DEVIATION_THRESH = 0.1;
-  for (const auto & p : upstream_module_output.path.points) {
-    const size_t nearest_seg_idx = autoware::motion_utils::findNearestSegmentIndex(
-      last_upstream_module_output.path.points, p.point.pose.position);
-    const auto seg_front = last_upstream_module_output.path.points.at(nearest_seg_idx);
-    const auto seg_back = last_upstream_module_output.path.points.at(nearest_seg_idx + 1);
-    // Check if the target point is within the segment
-    const Eigen::Vector3d segment_vec{
-      seg_back.point.pose.position.x - seg_front.point.pose.position.x,
-      seg_back.point.pose.position.y - seg_front.point.pose.position.y, 0.0};
-    const Eigen::Vector3d target_vec{
-      p.point.pose.position.x - seg_front.point.pose.position.x,
-      p.point.pose.position.y - seg_front.point.pose.position.y, 0.0};
-    const double dot_product = segment_vec.x() * target_vec.x() + segment_vec.y() * target_vec.y();
-    const double segment_length_squared =
-      segment_vec.x() * segment_vec.x() + segment_vec.y() * segment_vec.y();
-    if (dot_product < 0 || dot_product > segment_length_squared) {
-      // p.point.pose.position is not within the segment, skip lateral distance check
-      continue;
-    }
-    const double lateral_distance = std::abs(autoware::motion_utils::calcLateralOffset(
-      last_upstream_module_output.path.points, p.point.pose.position, nearest_seg_idx));
-    if (lateral_distance > LATERAL_DEVIATION_THRESH) {
-      return true;
-    }
-  }
-  return false;
-}
-
-bool hasDeviatedFromPath(
-  const Point & ego_position, const BehaviorModuleOutput & upstream_module_output)
-{
-  constexpr double LATERAL_DEVIATION_THRESH = 0.1;
-  return std::abs(autoware::motion_utils::calcLateralOffset(
-           upstream_module_output.path.points, ego_position)) > LATERAL_DEVIATION_THRESH;
-}
-
 bool needPathUpdate(
   const Pose & current_pose, const double path_update_duration, const rclcpp::Time & now,
   const std::optional<GoalCandidate> & modified_goal,
@@ -343,26 +300,28 @@ void LaneParkingPlanner::onTimer()
           local_planner_data->self_odometry->pose.pose, modified_goal_opt, parameters_)) {
       return false;
     }
-    if (hasDeviatedFromPath(
+    if (goal_planner_utils::hasDeviatedFromPath(
           local_planner_data->self_odometry->pose.pose.position, upstream_module_output)) {
       RCLCPP_DEBUG(getLogger(), "has deviated from current previous module path");
       return false;
     }
-    if (hasPreviousModulePathShapeChanged(
+    if (goal_planner_utils::hasPreviousModulePathShapeChanged(
           upstream_module_output, original_upstream_module_output_)) {
       RCLCPP_DEBUG(getLogger(), "has previous module path shape changed");
       return true;
     }
     if (
-      hasDeviatedFromPath(
+      goal_planner_utils::hasDeviatedFromPath(
         local_planner_data->self_odometry->pose.pose.position, original_upstream_module_output_) &&
       current_state != PathDecisionState::DecisionKind::DECIDED) {
       RCLCPP_DEBUG(getLogger(), "has deviated from last previous module path");
       return true;
     }
-    // TODO(someone): The generated path inherits the velocity of the path of the previous module.
-    // Therefore, if the velocity of the path of the previous module changes (e.g. stop points are
-    // inserted, deleted), the path should be regenerated.
+    if (goal_planner_utils::has_previous_module_path_velocity_changed(
+          upstream_module_output, original_upstream_module_output_)) {
+      RCLCPP_DEBUG(getLogger(), "previous module changed stopline");
+      return true;
+    }
 
     return false;
   });

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -317,17 +317,8 @@ void LaneParkingPlanner::onTimer()
       RCLCPP_DEBUG(getLogger(), "has deviated from last previous module path");
       return true;
     }
-    const auto & upstream_module_path = upstream_module_output.path;
-    const auto stopline_it = std::find_if(
-      upstream_module_path.points.begin(), upstream_module_path.points.end(),
-      [&](const auto & point) { return std::fabs(point.point.longitudinal_velocity_mps) == 0.0; });
-    /*
-      NOTE(soblin): this is a hack for lane_change bug randomly inserting a stopline at the end of
-      the path.
-     */
     const bool upstream_module_has_stopline_except_terminal =
-      static_cast<unsigned>(std::distance(upstream_module_path.points.begin(), stopline_it)) + 1 <
-      upstream_module_path.points.size();
+      goal_planner_utils::has_stopline_except_terminal(upstream_module_output.path);
     if (upstream_module_has_stopline_except_terminal) {
       return true;
     }
@@ -744,17 +735,8 @@ void GoalPlannerModule::updateData()
   const auto static_target_objects = utils::path_safety_checker::filterObjectsByVelocity(
     dynamic_target_objects, parameters_.th_moving_object_velocity);
 
-  const auto & upstream_module_path = getPreviousModuleOutput().path;
-  const auto stopline_it = std::find_if(
-    upstream_module_path.points.begin(), upstream_module_path.points.end(),
-    [&](const auto & point) { return std::fabs(point.point.longitudinal_velocity_mps) == 0.0; });
-  /*
-    NOTE(soblin): this is a hack for lane_change bug randomly inserting a stopline at the end of the
-    path.
-   */
   const bool upstream_module_has_stopline_except_terminal =
-    static_cast<unsigned>(std::distance(upstream_module_path.points.begin(), stopline_it)) + 1 <
-    upstream_module_path.points.size();
+    goal_planner_utils::has_stopline_except_terminal(getPreviousModuleOutput().path);
   path_decision_controller_.transit_state(
     pull_over_path_recv, upstream_module_has_stopline_except_terminal, clock_->now(),
     static_target_objects, dynamic_target_objects, planner_data_, occupancy_grid_map_,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -735,10 +735,17 @@ void GoalPlannerModule::updateData()
   const auto static_target_objects = utils::path_safety_checker::filterObjectsByVelocity(
     dynamic_target_objects, parameters_.th_moving_object_velocity);
 
+  const auto & upstream_module_path = getPreviousModuleOutput().path;
+  const bool upstream_module_has_stopline =
+    std::find_if(
+      upstream_module_path.points.begin(), upstream_module_path.points.end(),
+      [&](const auto & point) {
+        return std::fabs(point.point.longitudinal_velocity_mps) == 0.0;
+      }) != upstream_module_path.points.end();
   path_decision_controller_.transit_state(
-    pull_over_path_recv, clock_->now(), static_target_objects, dynamic_target_objects,
-    planner_data_, occupancy_grid_map_, is_current_safe, parameters_, goal_searcher,
-    debug_data_.ego_polygons_expanded);
+    pull_over_path_recv, upstream_module_has_stopline, clock_->now(), static_target_objects,
+    dynamic_target_objects, planner_data_, occupancy_grid_map_, is_current_safe, parameters_,
+    goal_searcher, debug_data_.ego_polygons_expanded);
   const auto new_decision_state = path_decision_controller_.get_current_state();
 
   auto [lane_parking_response, freespace_parking_response] = syncWithThreads();

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -1101,4 +1101,13 @@ bool has_previous_module_path_velocity_changed(
   return had_stopline_last.has_value();
 }
 
+bool has_stopline_except_terminal(const PathWithLaneId & path)
+{
+  const auto stopline_it = std::find_if(
+    path.points.begin(), path.points.end(),
+    [](const auto & point) { return std::fabs(point.point.longitudinal_velocity_mps) == 0.0; });
+  return static_cast<unsigned>(std::distance(path.points.begin(), stopline_it)) + 1 <
+         path.points.size();
+}
+
 }  // namespace autoware::behavior_path_planner::goal_planner_utils

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -1067,40 +1067,6 @@ bool hasDeviatedFromPath(
            upstream_module_output.path.points, ego_position)) > LATERAL_DEVIATION_THRESH;
 }
 
-bool has_previous_module_path_velocity_changed(
-  const BehaviorModuleOutput & upstream_module_output,
-  const BehaviorModuleOutput & last_upstream_module_output)
-{
-  static constexpr double ZERO_VELOCITY = 0.0;
-  static constexpr double STOPLINE_POSITION_THRESH = 0.1;
-
-  auto find_stopline =
-    [&](const BehaviorModuleOutput & module_output) -> std::optional<geometry_msgs::msg::Point> {
-    for (const auto & p : module_output.path.points) {
-      if (std::fabs(p.point.longitudinal_velocity_mps) == ZERO_VELOCITY) {
-        return p.point.pose.position;
-      }
-    }
-    return std::nullopt;
-  };
-  const auto has_stopline_now = find_stopline(upstream_module_output);
-  const auto had_stopline_last = find_stopline(last_upstream_module_output);
-  if (has_stopline_now) {
-    if (!had_stopline_last) {
-      return true;
-    }
-    if (
-      std::fabs(autoware_utils_geometry::calc_distance3d(*has_stopline_now, *had_stopline_last)) >
-      STOPLINE_POSITION_THRESH) {
-      // stopline position have changed
-      return true;
-    }
-    return false;
-  }
-  // !has_stopline_now
-  return had_stopline_last.has_value();
-}
-
 bool has_stopline_except_terminal(const PathWithLaneId & path)
 {
   const auto stopline_it = std::find_if(


### PR DESCRIPTION
## Description

If upstream module like avoidance and lane_change inserted a stopline during their execution, and goal_planner's thread started candidate generation, goal_planner may keep using the upstream_module path that contains stopline.

Thus, while such stopline exists, goal_planner does not transit to DECIDING, and keep re-generating candidates.

## Related links

- https://tier4.atlassian.net/browse/RT0-35455

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/c11b5a0c-75d7-5f3f-89eb-6f82a4743a5e?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
