### PR TITLE
feat(goal_planner): check pull over lane crossing validity when triggering candidate generation thread

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/decision_state.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/decision_state.hpp
@@ -55,8 +55,8 @@ public:
     const autoware_perception_msgs::msg::PredictedObjects & dynamic_target_objects,
     const std::shared_ptr<const PlannerData> planner_data,
     const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const bool is_current_safe, const GoalPlannerParameters & parameters,
-    const GoalSearcher & goal_searcher,
+    const bool is_current_safe, const bool lane_change_status_changed,
+    const GoalPlannerParameters & parameters, const GoalSearcher & goal_searcher,
     std::vector<autoware_utils::Polygon2d> & ego_polygons_expanded);
 
   PathDecisionState get_current_state() const { return current_state_; }
@@ -75,8 +75,8 @@ private:
     const PredictedObjects & dynamic_target_objects,
     const std::shared_ptr<const PlannerData> planner_data,
     const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const bool is_current_safe, const GoalPlannerParameters & parameters,
-    const GoalSearcher & goal_searcher,
+    const bool is_current_safe, const bool lane_change_status_changed,
+    const GoalPlannerParameters & parameters, const GoalSearcher & goal_searcher,
     std::vector<autoware_utils::Polygon2d> & ego_polygons_expanded) const;
 };
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -178,6 +178,9 @@ private:
   std::atomic<bool> & is_lane_parking_cb_running_;
   rclcpp::Logger logger_;
 
+  // last_lane_change_trigger_time of the request which was used when this was waken-up previously
+  std::optional<rclcpp::Time> last_lane_change_trigger_time_saved_;
+
   std::vector<std::shared_ptr<PullOverPlannerBase>> pull_over_planners_;
   BehaviorModuleOutput
     original_upstream_module_output_;  //<! upstream_module_output used for generating last
@@ -304,6 +307,7 @@ private:
   bool trigger_thread_on_approach_{false};
 
   // signal path generator and state manager to regenerate path candidates and remain NOT_DECIDED
+  std::optional<rclcpp::Time> last_lane_change_trigger_time_{};
   std::optional<bool> prev_lane_change_detected_{};
   bool lane_change_status_changed_{false};
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -302,6 +302,11 @@ private:
   const bool left_side_parking_;
 
   bool trigger_thread_on_approach_{false};
+
+  // signal path generator and state manager to regenerate path candidates and remain NOT_DECIDED
+  std::optional<bool> prev_lane_change_detected_{};
+  bool lane_change_status_changed_{false};
+
   // pre-generate lane parking paths in a separate thread
   rclcpp::TimerBase::SharedPtr lane_parking_timer_;
   rclcpp::CallbackGroup::SharedPtr lane_parking_timer_cb_group_;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/pull_over_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/pull_over_planner_base.hpp
@@ -91,6 +91,8 @@ public:
 
   std::vector<Pose> debug_poses{};
 
+  std::optional<PathWithLaneId> debug_processed_prev_module_path;
+
 private:
   PullOverPath(
     const PullOverPlannerType & type, const size_t id, const Pose & start_pose,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -28,6 +28,17 @@
 namespace autoware::behavior_path_planner
 {
 
+/**
+ * @brief compare the lane_change_trigger timestamp saved in main thread context and background
+ * thread wakeup context. If either of them are null, it means lane change was triggered or
+ * cancelled, so candidate paths must be refreshed. If both of them are null, no lane change has
+ * happened. If the timestamps differ, another lane change has happened after "saved"
+ * @pre if not nullopt, last_lane_change_trigger_time >= last_lane_change_trigger_time_saved
+ */
+bool is_lane_change_context_expired(
+  const std::optional<rclcpp::Time> & last_lane_change_trigger_time_saved,
+  const std::optional<rclcpp::Time> & last_lane_change_trigger_time);
+
 class LaneParkingRequest
 {
 public:
@@ -45,7 +56,8 @@ public:
     const PlannerData & planner_data, const ModuleStatus & current_status,
     const BehaviorModuleOutput & upstream_module_output,
     const std::optional<PullOverPath> & pull_over_path, const PathDecisionState & prev_data,
-    const bool trigger_thread_on_approach, const bool lane_change_status_changed);
+    const bool trigger_thread_on_approach,
+    const std::optional<rclcpp::Time> & last_lane_change_trigger_time);
 
   const autoware_utils::LinearRing2d vehicle_footprint_;
   const GoalCandidates goal_candidates_;
@@ -60,7 +72,10 @@ public:
   const std::optional<PullOverPath> & get_pull_over_path() const { return pull_over_path_; }
   const PathDecisionState & get_prev_data() const { return prev_data_; }
   bool trigger_thread_on_approach() const { return trigger_thread_on_approach_; }
-  bool lane_change_status_changed() const { return lane_change_status_changed_; }
+  const std::optional<rclcpp::Time> & last_lane_change_trigger_time() const
+  {
+    return last_lane_change_trigger_time_;
+  }
 
 private:
   std::shared_ptr<PlannerData> planner_data_;
@@ -69,7 +84,7 @@ private:
   std::optional<PullOverPath> pull_over_path_;  //<! pull over path selected by main thread
   PathDecisionState prev_data_;
   bool trigger_thread_on_approach_{false};
-  bool lane_change_status_changed_{false};
+  std::optional<rclcpp::Time> last_lane_change_trigger_time_;
 };
 
 struct LaneParkingResponse
@@ -77,6 +92,7 @@ struct LaneParkingResponse
   std::vector<PullOverPath> pull_over_path_candidates;
   std::optional<Pose> closest_start_pose;
   std::optional<std::vector<size_t>> sorted_bezier_indices_opt;
+  std::optional<rclcpp::Time> last_lane_change_trigger_time;
 };
 
 class FreespaceParkingRequest

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -45,7 +45,7 @@ public:
     const PlannerData & planner_data, const ModuleStatus & current_status,
     const BehaviorModuleOutput & upstream_module_output,
     const std::optional<PullOverPath> & pull_over_path, const PathDecisionState & prev_data,
-    const bool trigger_thread_on_approach);
+    const bool trigger_thread_on_approach, const bool lane_change_status_changed);
 
   const autoware_utils::LinearRing2d vehicle_footprint_;
   const GoalCandidates goal_candidates_;
@@ -60,6 +60,7 @@ public:
   const std::optional<PullOverPath> & get_pull_over_path() const { return pull_over_path_; }
   const PathDecisionState & get_prev_data() const { return prev_data_; }
   bool trigger_thread_on_approach() const { return trigger_thread_on_approach_; }
+  bool lane_change_status_changed() const { return lane_change_status_changed_; }
 
 private:
   std::shared_ptr<PlannerData> planner_data_;
@@ -68,6 +69,7 @@ private:
   std::optional<PullOverPath> pull_over_path_;  //<! pull over path selected by main thread
   PathDecisionState prev_data_;
   bool trigger_thread_on_approach_{false};
+  bool lane_change_status_changed_{false};
 };
 
 struct LaneParkingResponse

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -252,6 +252,23 @@ bool hasDeviatedFromPath(
  */
 bool has_stopline_except_terminal(const PathWithLaneId & path);
 
+/**
+ * @brief find the lanelet that has changed "laterally" from previous lanelet on the routing graph
+ * @return the lanelet that changed "laterally" if the path is lane changing, otherwise nullopt
+ */
+std::optional<lanelet::ConstLanelet> find_lane_change_completed_lanelet(
+  const PathWithLaneId & path, const lanelet::LaneletMapConstPtr lanelet_map,
+  const lanelet::routing::RoutingGraphConstPtr routing_graph);
+
+/**
+ * @brief generate lanelets with which pull over path is aligned
+ * @note if lane changing path is detected, this returns lanelets aligned with later part of the
+ * lane changing path
+ */
+lanelet::ConstLanelets get_reference_lanelets_for_pullover(
+  const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data,
+  const double backward_length, const double forward_length);
+
 }  // namespace autoware::behavior_path_planner::goal_planner_utils
 
 #endif  // AUTOWARE__BEHAVIOR_PATH_GOAL_PLANNER_MODULE__UTIL_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -262,6 +262,7 @@ void LaneParkingPlanner::onTimer()
     return;
   }
   const auto & local_request = local_request_opt.value();
+
   const auto & goal_candidates = local_request.goal_candidates_;
   const auto & local_planner_data = local_request.get_planner_data();
   const auto & upstream_module_output = local_request.get_upstream_module_output();
@@ -269,7 +270,13 @@ void LaneParkingPlanner::onTimer()
   const auto & prev_data = local_request.get_prev_data();
   const auto trigger_thread_on_approach = local_request.trigger_thread_on_approach();
   const auto use_bus_stop_area = local_request.use_bus_stop_area_;
-  const auto lane_change_status_changed = local_request.lane_change_status_changed();
+  const auto last_lane_change_trigger_time_saved =
+    last_lane_change_trigger_time_saved_;  // NOTE: copy, not reference
+  const auto & last_lane_change_trigger_time_req = local_request.last_lane_change_trigger_time();
+  last_lane_change_trigger_time_saved_ = last_lane_change_trigger_time_req;
+
+  const auto lane_change_status_changed_since_last_wakeup = is_lane_change_context_expired(
+    last_lane_change_trigger_time_saved, last_lane_change_trigger_time_req);
 
   if (!trigger_thread_on_approach) {
     return;
@@ -292,6 +299,13 @@ void LaneParkingPlanner::onTimer()
       if (response_.pull_over_path_candidates.empty()) {
         return true;
       }
+    }
+    if (lane_change_status_changed_since_last_wakeup) {
+      RCLCPP_INFO(
+        getLogger(),
+        "[LaneParkingPlanner]: lane change has been executed or cancelled since last wakeup of "
+        "LaneParking thread, so replan");
+      return true;
     }
     const std::optional<GoalCandidate> modified_goal_opt =
       pull_over_path_opt
@@ -316,10 +330,6 @@ void LaneParkingPlanner::onTimer()
         local_planner_data->self_odometry->pose.pose.position, original_upstream_module_output_) &&
       current_state != PathDecisionState::DecisionKind::DECIDED) {
       RCLCPP_DEBUG(getLogger(), "has deviated from last previous module path");
-      return true;
-    }
-    if (lane_change_status_changed) {
-      RCLCPP_INFO(getLogger(), "[LaneParkingPlanner]: lane_change_status changed, so replan");
       return true;
     }
     const bool upstream_module_has_stopline_except_terminal =
@@ -364,6 +374,7 @@ void LaneParkingPlanner::onTimer()
       getLogger(), "generated %lu pull over path candidates",
       response_.pull_over_path_candidates.size());
     response_.sorted_bezier_indices_opt = std::move(sorted_indices_opt);
+    response_.last_lane_change_trigger_time = last_lane_change_trigger_time_req;
   }
 }
 
@@ -628,7 +639,7 @@ std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::sync
     lane_parking_request_.value().update(
       *planner_data_, getCurrentStatus(), getPreviousModuleOutput(), pull_over_path,
       path_decision_controller_.get_current_state(), trigger_thread_on_approach_,
-      lane_change_status_changed_);
+      last_lane_change_trigger_time_);
     // NOTE: RouteHandler holds several shared pointers in it, so just copying PlannerData as
     // value does not adds the reference counts of RouteHandler.lanelet_map_ptr_ and others. Since
     // behavior_path_planner::run() updates
@@ -640,7 +651,17 @@ std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::sync
     // `planner_data_.is_route_handler_updated` variable is set true by behavior_path_planner
     // (although this flag is not implemented yet). In that case, lane_parking_request members
     // except for route_handler should be copied from planner_data_
-    lane_parking_response = lane_parking_response_;
+    const auto & lane_change_triggered_thread_side =
+      lane_parking_response_.last_lane_change_trigger_time;
+    if (!is_lane_change_context_expired(
+          lane_change_triggered_thread_side, last_lane_change_trigger_time_)) {
+      lane_parking_response = lane_parking_response_;
+    } else {
+      RCLCPP_INFO(
+        getLogger(),
+        "lane change has been executed or cancelled while LaneParking thread was planning. Reject "
+        "the response and wait for LaneParking thread to complete");
+    }
   }
 
   FreespaceParkingResponse freespace_parking_response;
@@ -660,6 +681,7 @@ std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::sync
     // freespace_parking_request_.value().update, and it is shared with goal_planner_module. Next,
     // goal_planner_module update it and pass it to freespace_parking_request.
     occupancy_grid_map_ = freespace_parking_request_.value().get_occupancy_grid_map();
+    // TODO(soblin): should we consider lane change trigger just before ego parks in a freespace ?
     freespace_parking_response = freespace_parking_response_;
   }
   // end of critical section
@@ -699,6 +721,9 @@ void GoalPlannerModule::updateData()
   lane_change_status_changed_ =
     prev_lane_change_detected_ && prev_lane_change_detected_.value() != lane_change_detected;
   prev_lane_change_detected_ = lane_change_detected;
+  if (lane_change_status_changed_) {
+    last_lane_change_trigger_time_ = clock_->now();
+  }
 
   const lanelet::ConstLanelets current_lanes =
     utils::getCurrentLanesFromPath(getPreviousModuleOutput().reference_path, planner_data_);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/bezier_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/bezier_pull_over.cpp
@@ -56,9 +56,8 @@ std::optional<PullOverPath> BezierPullOver::plan(
   [[maybe_unused]] const double jerk_resolution =
     std::abs(max_jerk - min_jerk) / shift_sampling_num;
 
-  const auto road_lanes = utils::getExtendedCurrentLanesFromPath(
-    upstream_module_output.path, planner_data, backward_search_length, forward_search_length,
-    /*forward_only_in_route*/ false);
+  const auto road_lanes = goal_planner_utils::get_reference_lanelets_for_pullover(
+    upstream_module_output.path, planner_data, backward_search_length, forward_search_length);
 
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, backward_search_length, forward_search_length);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -51,9 +51,9 @@ std::optional<PullOverPath> GeometricPullOver::plan(
 
   const auto & goal_pose = modified_goal_pose.goal_pose;
   // prepare road nad shoulder lanes
-  const auto road_lanes = utils::getExtendedCurrentLanes(
-    planner_data, parameters_.backward_goal_search_length, parameters_.forward_goal_search_length,
-    /*forward_only_in_route*/ false);
+  const auto road_lanes = goal_planner_utils::get_reference_lanelets_for_pullover(
+    upstream_module_output.path, planner_data, parameters_.backward_goal_search_length,
+    parameters_.forward_goal_search_length);
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, parameters_.backward_goal_search_length,
     parameters_.forward_goal_search_length);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
@@ -54,9 +54,8 @@ std::optional<PullOverPath> ShiftPullOver::plan(
   const int shift_sampling_num = parameters_.shift_sampling_num;
   const double jerk_resolution = std::abs(max_jerk - min_jerk) / shift_sampling_num;
 
-  const auto road_lanes = utils::getExtendedCurrentLanesFromPath(
-    upstream_module_output.path, planner_data, backward_search_length, forward_search_length,
-    /*forward_only_in_route*/ false);
+  const auto road_lanes = goal_planner_utils::get_reference_lanelets_for_pullover(
+    upstream_module_output.path, planner_data, backward_search_length, forward_search_length);
 
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, backward_search_length, forward_search_length);
@@ -286,6 +285,7 @@ std::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
     return {};
   }
 
+  pull_over_path.debug_processed_prev_module_path = processed_prev_module_path;
   return pull_over_path;
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -23,7 +23,7 @@ void LaneParkingRequest::update(
   const PlannerData & planner_data, const ModuleStatus & current_status,
   const BehaviorModuleOutput & upstream_module_output,
   const std::optional<PullOverPath> & pull_over_path, const PathDecisionState & prev_data,
-  const bool trigger_thread_on_approach)
+  const bool trigger_thread_on_approach, const bool lane_change_status_changed)
 {
   planner_data_ = std::make_shared<PlannerData>(planner_data);
   planner_data_->route_handler = std::make_shared<RouteHandler>(*(planner_data.route_handler));
@@ -32,6 +32,7 @@ void LaneParkingRequest::update(
   pull_over_path_ = pull_over_path;
   prev_data_ = prev_data;
   trigger_thread_on_approach_ = trigger_thread_on_approach;
+  lane_change_status_changed_ = lane_change_status_changed;
 }
 
 void FreespaceParkingRequest::initializeOccupancyGridMap(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -27,7 +27,7 @@ bool is_lane_change_context_expired(
     // when "saved" lane change was not detected but now detected, so expired
     // which means between "saved" and now, lane change was triggered
 
-    // when "saved" lane changes was detected but now not detectecd, so expired
+    // when "saved" lane changes was detected but now not detected, so expired
     // which means between "saved" and now, lane change was cancelled
     return true;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -19,11 +19,32 @@
 namespace autoware::behavior_path_planner
 {
 
+bool is_lane_change_context_expired(
+  const std::optional<rclcpp::Time> & last_lane_change_trigger_time_saved,
+  const std::optional<rclcpp::Time> & last_lane_change_trigger_time)
+{
+  if (last_lane_change_trigger_time_saved.has_value() ^ last_lane_change_trigger_time.has_value()) {
+    // when "saved" lane change was not detected but now detected, so expired
+    // which means between "saved" and now, lane change was triggered
+
+    // when "saved" lane changes was detected but now not detectecd, so expired
+    // which means between "saved" and now, lane change was cancelled
+    return true;
+  }
+  if (!last_lane_change_trigger_time_saved) {
+    // lane change not triggered up to now
+    return false;
+  }
+  return (last_lane_change_trigger_time.value() - last_lane_change_trigger_time_saved.value())
+           .seconds() > 0.0;
+}
+
 void LaneParkingRequest::update(
   const PlannerData & planner_data, const ModuleStatus & current_status,
   const BehaviorModuleOutput & upstream_module_output,
   const std::optional<PullOverPath> & pull_over_path, const PathDecisionState & prev_data,
-  const bool trigger_thread_on_approach, const bool lane_change_status_changed)
+  const bool trigger_thread_on_approach,
+  const std::optional<rclcpp::Time> & last_lane_change_trigger_time)
 {
   planner_data_ = std::make_shared<PlannerData>(planner_data);
   planner_data_->route_handler = std::make_shared<RouteHandler>(*(planner_data.route_handler));
@@ -32,7 +53,7 @@ void LaneParkingRequest::update(
   pull_over_path_ = pull_over_path;
   prev_data_ = prev_data;
   trigger_thread_on_approach_ = trigger_thread_on_approach;
-  lane_change_status_changed_ = lane_change_status_changed;
+  last_lane_change_trigger_time_ = last_lane_change_trigger_time;
 }
 
 void FreespaceParkingRequest::initializeOccupancyGridMap(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -1121,6 +1121,6 @@ lanelet::ConstLanelets get_reference_lanelets_for_pullover(
       /*forward_only_in_route*/ false);
   }
   return planner_data->route_handler->getLaneletSequence(
-    *lane_change_complete_lane, backward_length, forward_length);
+    *lane_change_complete_lane, backward_length, forward_length, false /* extend outward route */);
 }
 }  // namespace autoware::behavior_path_planner::goal_planner_utils


### PR DESCRIPTION
## Description

If lane_change is running when goal_planner's thread is generating path candidates, lane_change can suddenly swerve the path. If ego is still driving on the preferred_lanelets before swerving, and goal_planner still happened to be IDLE, syncWithThreads() is not triggered, thus the backgroud thread keeps using old reference path, which is aligned on the old preferred lanelets. This is problematic when pull over planners process "previous_module_path" w.r.t reference path.

To deal with this issue:
1. added the flag `lane_change_status_changed_` to goal_planner to signal background thread
2. each planner use `get_reference_lanelets_for_pullover` instead of `getPullOverLanes`
 
![image](https://github.com/user-attachments/assets/11b5505a-3289-406b-872c-b5bbe4dc000e)

## Related links

- https://tier4.atlassian.net/browse/RT0-35453

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/7fdf2fc0-e7b0-51ba-b36a-03955607323d?project_id=prd_jt&state=failed

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
