### PR TITLE
feat(multi_object_tracker):  parameters tuned for mahalanobis distance

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -139,7 +139,7 @@ public:
         process_noise.acc_long = const_g * 0.35;
         process_noise.acc_lat = const_g * 0.15;
         process_noise.yaw_rate_min = deg2rad(1.5);
-        process_noise.yaw_rate_max = deg2rad(15.0);
+        process_noise.yaw_rate_max = deg2rad(18.0);
 
         process_limit.acc_long_max = const_g;
         process_limit.acc_lat_max = const_g;
@@ -155,7 +155,7 @@ public:
         // measurement noise model
         measurement_covariance.pos_x = sq(0.5);
         measurement_covariance.pos_y = sq(0.4);
-        measurement_covariance.yaw = sq(deg2rad(20.0));
+        measurement_covariance.yaw = sq(deg2rad(22.0));
         measurement_covariance.vel_long = sq(1.0);
 
         // bicycle motion model
@@ -183,7 +183,7 @@ public:
         process_noise.acc_long = const_g * 0.35;
         process_noise.acc_lat = const_g * 0.15;
         process_noise.yaw_rate_min = deg2rad(1.5);
-        process_noise.yaw_rate_max = deg2rad(15.0);
+        process_noise.yaw_rate_max = deg2rad(18.0);
 
         process_limit.acc_long_max = const_g;
         process_limit.acc_lat_max = const_g;
@@ -199,7 +199,7 @@ public:
         // measurement noise model
         measurement_covariance.pos_x = sq(0.5);
         measurement_covariance.pos_y = sq(0.4);
-        measurement_covariance.yaw = sq(deg2rad(20.0));
+        measurement_covariance.yaw = sq(deg2rad(22.0));
         measurement_covariance.vel_long = sq(kmph2mps(10.0));
 
         // bicycle motion model

--- a/perception/autoware_multi_object_tracker/lib/association/association.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/association.cpp
@@ -268,8 +268,9 @@ double DataAssociation::calculateScore(
     measurement_object.pose.position, tracked_object.pose.position,
     getXYCovariance(tracked_object.pose_covariance));
   constexpr double mahalanobis_dist_threshold =
-    11.62;  // This is a empirical value, around to 99.5% confidence level for 2 degrees of freedom,
-            // chi-square critical value
+    11.62;  // This is an empirical value corresponding to the 99.6% confidence level
+            // for a chi-square distribution with 2 degrees of freedom (critical value).
+
   if (mahalanobis_dist >= mahalanobis_dist_threshold) return 0.0;
 
   // 2d iou gate

--- a/perception/autoware_multi_object_tracker/lib/association/association.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/association.cpp
@@ -268,7 +268,8 @@ double DataAssociation::calculateScore(
     measurement_object.pose.position, tracked_object.pose.position,
     getXYCovariance(tracked_object.pose_covariance));
   constexpr double mahalanobis_dist_threshold =
-    11.62;  // This is a empirical value, around to 99.5% confidence level for 2 degrees of freedom, chi-square critical value
+    11.62;  // This is a empirical value, around to 99.5% confidence level for 2 degrees of freedom,
+            // chi-square critical value
   if (mahalanobis_dist >= mahalanobis_dist_threshold) return 0.0;
 
   // 2d iou gate

--- a/perception/autoware_multi_object_tracker/lib/association/association.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/association.cpp
@@ -268,7 +268,7 @@ double DataAssociation::calculateScore(
     measurement_object.pose.position, tracked_object.pose.position,
     getXYCovariance(tracked_object.pose_covariance));
   constexpr double mahalanobis_dist_threshold =
-    13.816;  // 99.99% confidence level for 2 degrees of freedom, chi-square critical value
+    11.62;  // This is a empirical value, around to 99.5% confidence level for 2 degrees of freedom, chi-square critical value
   if (mahalanobis_dist >= mahalanobis_dist_threshold) return 0.0;
 
   // 2d iou gate


### PR DESCRIPTION
## Description

This is the previous analysis report about this tuning 

- [TIER IV INTERNAL](https://tier4.atlassian.net/wiki/spaces/CT/pages/3573875165/SP)
Since the threshold has already been changed, the performance may not differ much. However, theoretically, this change is more reasonable and helps avoid deviations from the original performance.
## Related links

Previous tuning: https://github.com/autowarefoundation/autoware_universe/pull/10648
**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**



- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?


**Private Links:**

- [TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/a80db83b-4282-5ee2-89cc-e5d30c7fa80b?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
