### PR TITLE
fix(multi_object_tracker): correct area calculation for cylinder shape in getArea function

### DIFF
--- a/perception/autoware_multi_object_tracker/lib/object_model/types.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/types.cpp
@@ -119,7 +119,7 @@ double getArea(const autoware_perception_msgs::msg::Shape & shape)
     case autoware_perception_msgs::msg::Shape::BOUNDING_BOX:
       return shape.dimensions.x * shape.dimensions.y;
     case autoware_perception_msgs::msg::Shape::CYLINDER:
-      return shape.dimensions.x * shape.dimensions.x * M_PI;
+      return shape.dimensions.x * shape.dimensions.x * M_PI * 0.25;
     case autoware_perception_msgs::msg::Shape::POLYGON: {
       double area = 0.0;
       for (size_t i = 0; i < shape.footprint.points.size(); ++i) {


### PR DESCRIPTION
## Description

Previous PR https://github.com/autowarefoundation/autoware_universe/pull/10744 contains area calculation cache.
The function getArea had a bug on area calculation.

- before
```c++
      return shape.dimensions.x * shape.dimensions.x * M_PI;
```
- after
```c++
      return shape.dimensions.x * shape.dimensions.x * M_PI * 0.25;
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
