### PR TITLE
fix(planning_validator): fix conflict between trajectory shift and distance deviation checks

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/README.md
+++ b/planning/planning_validator/autoware_planning_validator/README.md
@@ -179,3 +179,7 @@ The following parameters can be set for the `autoware_planning_validator`:
 | `validity_checks.trajectory_shift.forward_shift_th`  | double | max valid Longitudinal distance between two consecutive trajectories (measured at nearest point to ego) [m] | 1.0           |
 | `validity_checks.trajectory_shift.backward_shift_th` | double | min valid longitudinal distance between two consecutive trajectories (measured at nearest point to ego) [m] | 0.1           |
 | `validity_checks.trajectory_shift.is_critical`       | bool   | if true, will use handling type specified for critical checks                                               | true          |
+
+!!! warning
+
+    When a validity check with `is_critical = true` is triggered, AND `handling_type.critical` is set to apply soft stop on last valid trajectory, THEN any other validity check triggered simultanuously will publish a WARN level diagnostic instead of ERROR level. This is to avoid contradictory behavior for different types of checks.

--- a/planning/planning_validator/autoware_planning_validator/README.md
+++ b/planning/planning_validator/autoware_planning_validator/README.md
@@ -182,4 +182,4 @@ The following parameters can be set for the `autoware_planning_validator`:
 
 !!! warning
 
-    When a validity check with `is_critical = true` is triggered, AND `handling_type.critical` is set to apply soft stop on last valid trajectory, THEN any other validity check triggered simultanuously will publish a WARN level diagnostic instead of ERROR level. This is to avoid contradictory behavior for different types of checks.
+    When a validity check with `is_critical = true` is triggered, AND `handling_type.critical` is set to apply soft stop on last valid trajectory, THEN any other validity check triggered simultaneously will publish a WARN level diagnostic instead of ERROR level. This is to avoid contradictory behavior for different types of checks.

--- a/planning/planning_validator/autoware_planning_validator/src/node.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/node.cpp
@@ -238,7 +238,7 @@ void PlanningValidatorNode::publishDebugInfo()
     shiftPose(
       front_pose, context_->vehicle_info.front_overhang_m + context_->vehicle_info.wheel_base_m);
     auto offset_pose = front_pose;
-    shiftPose(offset_pose, 0.25);
+    shiftPose(offset_pose, 0.5);
     context_->debug_pose_publisher->pushVirtualWall(front_pose);
     const auto status_debug_str = context_->debug_pose_publisher->getStatusDebugString(*status);
     context_->debug_pose_publisher->pushWarningMsg(

--- a/planning/planning_validator/autoware_planning_validator/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/utils.cpp
@@ -72,9 +72,12 @@ Trajectory getStopTrajectory(
   Trajectory soft_stop_traj = trajectory;
   soft_stop_traj.header = trajectory.header;
   double accumulated_distance = 0.0;
+  static constexpr double zero_velocity_th = 0.5;
   for (size_t i = nearest_traj_idx + 1; i < trajectory.points.size(); ++i) {
     accumulated_distance += calc_distance2d(trajectory.points.at(i - 1), trajectory.points.at(i));
-    if (accumulated_distance >= stopping_distance) {
+    if (
+      accumulated_distance >= stopping_distance ||
+      soft_stop_traj.points.at(i - 1).longitudinal_velocity_mps < zero_velocity_th) {
       soft_stop_traj.points.at(i).longitudinal_velocity_mps = 0.0;
       continue;
     }

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -102,52 +102,37 @@ void TrajectoryChecker::setup_diag()
   const auto & status = context_->validation_status;
 
   std::string ns = "trajectory_validation_";
-  // constexpr bool default_critical = false;
-  context_->add_diag(ns + "size", status->is_valid_size, "invalid trajectory size is found");
-  context_->add_diag(ns + "finite", status->is_valid_finite_value, "infinite value is found");
-  context_->add_diag(
-    ns + "interval", status->is_valid_interval, "points interval is too large",
-    params_.interval.is_critical);
-  context_->add_diag(
-    ns + "relative_angle", status->is_valid_relative_angle, "relative angle is too large",
-    params_.relative_angle.is_critical);
-  context_->add_diag(
-    ns + "curvature", status->is_valid_curvature, "curvature is too large",
-    params_.curvature.is_critical);
-  context_->add_diag(
-    ns + "lateral_acceleration", status->is_valid_lateral_acc, "lateral acceleration is too large",
-    params_.lateral_accel.is_critical);
-  context_->add_diag(
-    ns + "acceleration", status->is_valid_longitudinal_max_acc, "acceleration is too large",
-    params_.max_lon_accel.is_critical);
-  context_->add_diag(
-    ns + "deceleration", status->is_valid_longitudinal_min_acc, "deceleration is too large",
-    params_.min_lon_accel.is_critical);
-  context_->add_diag(
-    ns + "steering", status->is_valid_steering, "steering angle is too large",
-    params_.steering.is_critical);
-  context_->add_diag(
-    ns + "steering_rate", status->is_valid_steering_rate, "steering rate is too large",
-    params_.steering_rate.is_critical);
-  context_->add_diag(
-    ns + "velocity_deviation", status->is_valid_velocity_deviation,
-    "velocity deviation is too large", params_.velocity_deviation.is_critical);
-  context_->add_diag(
-    ns + "distance_deviation", status->is_valid_distance_deviation,
-    "distance deviation is too large", params_.distance_deviation.is_critical);
-  context_->add_diag(
-    ns + "longitudinal_distance_deviation", status->is_valid_longitudinal_distance_deviation,
-    "longitudinal distance deviation is too large", params_.lon_distance_deviation.is_critical);
-  context_->add_diag(
-    ns + "yaw_deviation", status->is_valid_yaw_deviation,
-    "difference between vehicle yaw and closest trajectory yaw is too large",
-    params_.yaw_deviation.is_critical);
-  context_->add_diag(
-    ns + "forward_trajectory_length", status->is_valid_forward_trajectory_length,
-    "trajectory length is too short", params_.forward_trajectory_length.is_critical);
-  context_->add_diag(
-    ns + "trajectory_shift", status->is_valid_trajectory_shift,
-    "detected sudden shift in trajectory", params_.trajectory_shift.is_critical);
+  const auto add_diag = [&](
+                          const std::string & name, const bool & status, const std::string & msg) {
+    context_->add_diag(ns + name, status, msg, is_critical_error_);
+  };
+
+  add_diag("size", status->is_valid_size, "invalid trajectory size is found");
+  add_diag("finite", status->is_valid_finite_value, "infinite value is found");
+  add_diag("interval", status->is_valid_interval, "points interval is too large");
+  add_diag("relative_angle", status->is_valid_relative_angle, "relative angle is too large");
+  add_diag("curvature", status->is_valid_curvature, "curvature is too large");
+  add_diag(
+    "lateral_acceleration", status->is_valid_lateral_acc, "lateral acceleration is too large");
+  add_diag("acceleration", status->is_valid_longitudinal_max_acc, "acceleration is too large");
+  add_diag("deceleration", status->is_valid_longitudinal_min_acc, "deceleration is too large");
+  add_diag("steering", status->is_valid_steering, "steering angle is too large");
+  add_diag("steering_rate", status->is_valid_steering_rate, "steering rate is too large");
+  add_diag(
+    "velocity_deviation", status->is_valid_velocity_deviation, "velocity deviation is too large");
+  add_diag(
+    "distance_deviation", status->is_valid_distance_deviation, "distance deviation is too large");
+  add_diag(
+    "longitudinal_distance_deviation", status->is_valid_longitudinal_distance_deviation,
+    "longitudinal distance deviation is too large");
+  add_diag(
+    "yaw_deviation", status->is_valid_yaw_deviation,
+    "difference between vehicle yaw and closest trajectory yaw is too large");
+  add_diag(
+    "forward_trajectory_length", status->is_valid_forward_trajectory_length,
+    "trajectory length is too short");
+  add_diag(
+    "trajectory_shift", status->is_valid_trajectory_shift, "detected sudden shift in trajectory");
 }
 
 void TrajectoryChecker::validate(bool & is_critical)


### PR DESCRIPTION
## Description

When `trajectory_checker` detects a "critical" error, then the appropriate behavior should be executed as specified by planning validator configs.
Currently if `trajectory_checker` detects another "noncritical" error simultaneously, the expected behavior might be overriden by the diagnostics published for the "noncritical" error.

This PR addresses the issue by using one common `is_critical_error_` flag for the trajectory diagnostics update instead of using a separate flag for each error type. Doing so will ensure that the handling method of critical error is prioritized in case multiple errors are detected at the same time

## Related links

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM.
- [Internal TIER IV Evaluator](https://evaluation.tier4.jp/evaluation/reports/626a9dcf-9f23-564f-8ec6-fee5ee192e21?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
