### PR TITLE
feat(planning_validator): implement a collision detection feature for rearward objects of the vehicle

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/debug_marker.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/debug_marker.hpp
@@ -51,6 +51,10 @@ public:
   void pushLaneletPolygonsMarker(
     const lanelet::BasicPolygons2d & polygon, const std::string & ns, int id = 0);
 
+  void pushMarker(const visualization_msgs::msg::Marker & marker);
+
+  void pushMarkers(const visualization_msgs::msg::MarkerArray & marker);
+
   std::string getStatusDebugString(const PlanningValidatorStatus & status) const
   {
     std::stringstream ss;

--- a/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
+++ b/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
@@ -2,6 +2,7 @@
   <arg name="launch_latency_checker" default="true"/>
   <arg name="launch_trajectory_checker" default="true"/>
   <arg name="launch_intersection_collision_checker" default="true"/>
+  <arg name="launch_rear_collision_checker" default="true"/>
   <arg name="launch_modules_list_end" default="&quot;&quot;]"/>
   <arg name="planning_validator_launch_modules" default="["/>
   <let
@@ -19,12 +20,18 @@
     value="$(eval &quot;'$(var planning_validator_launch_modules)' + 'autoware::planning_validator::IntersectionCollisionChecker, '&quot;)"
     if="$(var launch_intersection_collision_checker)"
   />
+  <let
+    name="planning_validator_launch_modules"
+    value="$(eval &quot;'$(var planning_validator_launch_modules)' + 'autoware::planning_validator::RearCollisionChecker, '&quot;)"
+    if="$(var launch_rear_collision_checker)"
+  />
   <let name="planning_validator_launch_modules" value="$(eval &quot;'$(var planning_validator_launch_modules)' + '$(var launch_modules_list_end)'&quot;)"/>
 
   <arg name="planning_validator_param_path" default="$(find-pkg-share autoware_planning_validator)/config/planning_validator.param.yaml"/>
   <arg name="planning_validator_latency_checker_param_path" default="$(find-pkg-share autoware_planning_validator_latency_checker)/config/latency_checker.param.yaml"/>
   <arg name="planning_validator_trajectory_checker_param_path" default="$(find-pkg-share autoware_planning_validator_trajectory_checker)/config/trajectory_checker.param.yaml"/>
   <arg name="planning_validator_intersection_collision_checker_param_path" default="$(find-pkg-share autoware_planning_validator_trajectory_checker)/config/intersection_collision_checker.param.yaml"/>
+  <arg name="planning_validator_rear_collision_checker_param_path" default="$(find-pkg-share autoware_planning_validator_rear_collision_checker)/config/rear_collision_checker.param.yaml"/>
   <arg name="input_trajectory" default="/planning/scenario_planning/velocity_smoother/trajectory"/>
   <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="input_route_topic_name" default="/planning/mission_planning/route"/>
@@ -51,6 +58,7 @@
         <param from="$(var planning_validator_latency_checker_param_path)"/>
         <param from="$(var planning_validator_trajectory_checker_param_path)"/>
         <param from="$(var planning_validator_intersection_collision_checker_param_path)"/>
+        <param from="$(var planning_validator_rear_collision_checker_param_path)"/>
         <extra_arg name="use_intra_process_comms" value="false"/>
       </composable_node>
     </node_container>

--- a/planning/planning_validator/autoware_planning_validator/msg/PlanningValidatorStatus.msg
+++ b/planning/planning_validator/autoware_planning_validator/msg/PlanningValidatorStatus.msg
@@ -20,6 +20,7 @@ bool is_valid_latency
 bool is_valid_yaw_deviation
 bool is_valid_trajectory_shift
 bool is_valid_collision_check
+bool is_valid_rear_collision_check
 
 # values
 int64 trajectory_size

--- a/planning/planning_validator/autoware_planning_validator/src/debug_marker.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/debug_marker.cpp
@@ -130,6 +130,18 @@ void PlanningValidatorDebugMarkerPublisher::pushLaneletPolygonsMarker(
   marker_array_.markers.push_back(marker);
 }
 
+void PlanningValidatorDebugMarkerPublisher::pushMarker(
+  const visualization_msgs::msg::Marker & marker)
+{
+  marker_array_.markers.push_back(marker);
+}
+
+void PlanningValidatorDebugMarkerPublisher::pushMarkers(
+  const visualization_msgs::msg::MarkerArray & markers)
+{
+  autoware_utils::append_marker_array(markers, &marker_array_);
+}
+
 void PlanningValidatorDebugMarkerPublisher::publish()
 {
   debug_viz_pub_->publish(marker_array_);

--- a/planning/planning_validator/autoware_planning_validator/src/node.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/node.cpp
@@ -152,7 +152,7 @@ bool PlanningValidatorNode::isAllValid(const PlanningValidatorStatus & s) const
          s.is_valid_velocity_deviation && s.is_valid_distance_deviation &&
          s.is_valid_longitudinal_distance_deviation && s.is_valid_forward_trajectory_length &&
          s.is_valid_latency && s.is_valid_yaw_deviation && s.is_valid_trajectory_shift &&
-         s.is_valid_collision_check;
+         s.is_valid_collision_check && s.is_valid_rear_collision_check;
 }
 
 void PlanningValidatorNode::publishTrajectory()
@@ -280,6 +280,7 @@ void PlanningValidatorNode::displayStatus()
   warn(s->is_valid_yaw_deviation, "planning trajectory yaw difference from ego yaw is too large!!");
   warn(s->is_valid_trajectory_shift, "planning trajectory had sudden shift!!");
   warn(s->is_valid_collision_check, "planning trajectory leads to collision!!");
+  warn(s->is_valid_rear_collision_check, "planning trajectory leads to collision!! (rear objects)");
 }
 
 }  // namespace autoware::planning_validator

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/CMakeLists.txt
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_planning_validator_rear_collision_checker)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+pluginlib_export_plugin_description_file(autoware_planning_validator plugins.xml)
+
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-error=deprecated-declarations)
+endif()
+
+include_directories(
+  ${autoware_planning_validator_INCLUDE_DIRS}
+)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  DIRECTORY src
+)
+
+generate_parameter_library(rear_collision_checker_node_parameters
+  param/rear_collision_checker_node_parameters.yaml
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${autoware_planning_validator_LIBRARIES}
+  rear_collision_checker_node_parameters
+)
+
+ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     common:
       on_time_buffer: 0.5                           # [s]
-      off_time_buffer: 0.5                          # [s]
+      off_time_buffer: 1.5                          # [s]
 
       pointcloud:
         range:

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
@@ -45,7 +45,6 @@
         max_deceleration: -2.0
 
       ego:
-        footprint_buffer: -0.5
         reaction_time: 1.2
         min_velocity: 1.38                              # [m/s]
         max_velocity: 16.6                              # [m/s]
@@ -53,14 +52,14 @@
         max_deceleration: -4.0
         max_positive_jerk: 5.0
         max_negative_jerk: -5.0
+        nominal_deceleration: -1.5
+        nominal_positive_jerk: 0.6
+        nominal_negative_jerk: -0.6
 
       blind_spot:
         check:
           left: true
           right: false
-        active_distance:
-          start: 20.0
-          end: -10.0
         offset:
           inner: 0.1
           outer: 0.3

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
@@ -1,0 +1,71 @@
+/**:
+  ros__parameters:
+    common:
+      on_time_buffer: 0.5
+      off_time_buffer: 0.5
+
+      pointcloud:
+        range:
+          static: false
+          dead_zone: 0.3
+          forward: 0.0
+          backward: 0.0
+        crop_box_filter:
+          x:
+            max: 10.0
+            min: -100.0
+          z:
+            max: -1.0
+            min: 0.3
+        voxel_grid_filter:
+          x: 0.1
+          y: 0.1
+          z: 0.5
+        clustering:
+          cluster_tolerance: 0.15  #[m]
+          min_cluster_height: 0.1
+          min_cluster_size: 5
+          max_cluster_size: 10000
+        velocity_estimation:
+          observation_time: 0.3
+        latency: 0.3
+
+      filter:
+        min_velocity: 1.0
+        moving_time: 0.5
+
+      vehicle:
+        reaction_time: 1.2
+        max_velocity: 16.6 # 60km/h
+        max_deceleration: -2.0
+
+      vru:
+        reaction_time: 1.2
+        max_velocity: 5.5 # 20km/h
+        max_deceleration: -2.0
+
+      ego:
+        footprint_buffer: -0.5
+        reaction_time: 1.2
+        min_velocity: 1.38                              # [m/s]
+        max_velocity: 16.6                              # [m/s]
+        max_acceleration: 1.5
+        max_deceleration: -4.0
+        max_positive_jerk: 5.0
+        max_negative_jerk: -5.0
+
+      blind_spot:
+        check:
+          left: true
+          right: false
+        active_distance:
+          start: 20.0
+          end: -10.0
+        offset:
+          inner: 0.1
+          outer: 0.3
+
+      adjacent_lane:
+        offset:
+          left: -0.5
+          right: -0.5

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
@@ -6,10 +6,8 @@
 
       pointcloud:
         range:
-          static: false
           dead_zone: 0.3
-          forward: 0.0
-          backward: 0.0
+          buffer: 3.0
         crop_box_filter:
           x:
             max: 10.0

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
@@ -38,7 +38,7 @@
         max_velocity: 16.6                          # [m/s] (60 km/h)
         max_deceleration: -2.0                      # [m/s^2]
 
-      vru:
+      vulnerable_road_user:
         reaction_time: 1.2                          # [s]
         max_velocity: 5.5                           # [m/s] (20 km/h)
         max_deceleration: -2.0                      # [m/s^2]

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
@@ -1,68 +1,69 @@
 /**:
   ros__parameters:
     common:
-      on_time_buffer: 0.5
-      off_time_buffer: 0.5
+      on_time_buffer: 0.5                           # [s]
+      off_time_buffer: 0.5                          # [s]
 
       pointcloud:
         range:
-          dead_zone: 0.3
-          buffer: 3.0
+          dead_zone: 0.3                            # [m]
+          buffer: 3.0                               # [m]
         crop_box_filter:
           x:
-            max: 10.0
-            min: -100.0
+            max: 10.0                               # [m]
+            min: -100.0                             # [m]
           z:
-            max: -1.0
-            min: 0.3
+            max: -1.0                               # [m]
+            min: 0.3                                # [m]
         voxel_grid_filter:
-          x: 0.1
-          y: 0.1
-          z: 0.5
+          x: 0.1                                    # [m]
+          y: 0.1                                    # [m]
+          z: 0.5                                    # [m]
         clustering:
-          cluster_tolerance: 0.15  #[m]
-          min_cluster_height: 0.1
-          min_cluster_size: 5
-          max_cluster_size: 10000
+          cluster_tolerance: 0.15                   # [m]
+          min_cluster_height: 0.1                   # [m]
+          min_cluster_size: 5                       # [points]
+          max_cluster_size: 10000                   # [points]
         velocity_estimation:
-          observation_time: 0.3
-        latency: 0.3
+          observation_time: 0.3                     # [s]
+          max_acceleration: 10.0                    # [m/s^2]
+        latency: 0.3                                # [s]
 
       filter:
-        min_velocity: 1.0
-        moving_time: 0.5
+        min_velocity: 1.0                           # [m/s]
+        moving_time: 0.5                            # [s]
 
       vehicle:
-        reaction_time: 1.2
-        max_velocity: 16.6 # 60km/h
-        max_deceleration: -2.0
+        reaction_time: 1.2                          # [s]
+        max_velocity: 16.6                          # [m/s] (60 km/h)
+        max_deceleration: -2.0                      # [m/s^2]
 
       vru:
-        reaction_time: 1.2
-        max_velocity: 5.5 # 20km/h
-        max_deceleration: -2.0
+        reaction_time: 1.2                          # [s]
+        max_velocity: 5.5                           # [m/s] (20 km/h)
+        max_deceleration: -2.0                      # [m/s^2]
 
       ego:
-        reaction_time: 1.2
-        min_velocity: 1.38                              # [m/s]
-        max_velocity: 16.6                              # [m/s]
-        max_acceleration: 1.5
-        max_deceleration: -4.0
-        max_positive_jerk: 5.0
-        max_negative_jerk: -5.0
-        nominal_deceleration: -1.5
-        nominal_positive_jerk: 0.6
-        nominal_negative_jerk: -0.6
+        reaction_time: 1.2                          # [s]
+        min_velocity: 1.38                          # [m/s]
+        max_velocity: 16.6                          # [m/s]
+        max_acceleration: 1.5                       # [m/s^2]
+        max_deceleration: -4.0                      # [m/s^2]
+        max_positive_jerk: 5.0                      # [m/s^3]
+        max_negative_jerk: -5.0                     # [m/s^3]
+        nominal_deceleration: -1.5                  # [m/s^2]
+        nominal_positive_jerk: 0.6                  # [m/s^3]
+        nominal_negative_jerk: -0.6                 # [m/s^3]
 
       blind_spot:
         check:
           left: true
           right: false
         offset:
-          inner: 0.1
-          outer: 0.3
+          inner: 0.1                                # [m]
+          outer: 0.3                                # [m]
 
       adjacent_lane:
         offset:
-          left: -0.5
-          right: -0.5
+          left: -0.5                                # [m]
+          right: -0.5                               # [m]

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_planning_validator_rear_collision_checker</name>
+  <version>1.0.0</version>
+  <description>The autoware_planning_validator_rear_collision_checker package</description>
+
+  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
+  <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <maintainer email="kyoichi.sugahara@tier4.jp">kyoichi sugahara</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_motion_utils</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_factor_interface</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_planning_test_manager</depend>
+  <depend>autoware_planning_validator</depend>
+  <depend>autoware_route_handler</depend>
+  <depend>autoware_signal_processing</depend>
+  <depend>autoware_utils</depend>
+  <depend>autoware_vehicle_info_utils</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>eigen</depend>
+  <depend>generate_parameter_library</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>pcl_conversions</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tier4_planning_msgs</depend>
+  <depend>visualization_msgs</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
@@ -11,7 +11,7 @@
 
   <license>Apache License 2.0</license>
 
-  <author email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
@@ -65,6 +65,10 @@ rear_collision_checker_node:
           type: double
           validation:
             gt_eq<>: [0.0]
+        max_acceleration:
+          type: double
+          validation:
+            gt_eq<>: [0.0]
       latency:
         type: double
         validation:

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
@@ -105,16 +105,18 @@ rear_collision_checker_node:
         type: double
 
     ego:
-      footprint_buffer:
-        type: double
       reaction_time:
         type: double
         validation:
           gt<>: [0.0]
       min_velocity:
         type: double
+        validation:
+          gt<>: [0.0]
       max_velocity:
         type: double
+        validation:
+          gt<>: [0.0]
       max_acceleration:
         type: double
         validation:
@@ -127,6 +129,14 @@ rear_collision_checker_node:
           gt<>: [0.0]
       max_negative_jerk:
         type: double
+      nominal_deceleration:
+        type: double
+      nominal_positive_jerk:
+        type: double
+        validation:
+          gt<>: [0.0]
+      nominal_negative_jerk:
+        type: double
 
     blind_spot:
       check:
@@ -134,13 +144,6 @@ rear_collision_checker_node:
           type: bool
         right:
           type: bool
-      active_distance:
-        start:
-          type: double
-          validation:
-            gt<>: [0.0]
-        end:
-          type: double
       offset:
         inner:
           type: double

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
@@ -92,7 +92,7 @@ rear_collision_checker_node:
       max_deceleration:
         type: double
 
-    vru:
+    vulnerable_road_user:
       reaction_time:
         type: double
         validation:

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
@@ -15,11 +15,7 @@ rear_collision_checker_node:
           type: double
           validation:
             gt_eq<>: [0.0]
-        forward:
-          type: double
-          validation:
-            gt_eq<>: [0.0]
-        backward:
+        buffer:
           type: double
           validation:
             gt_eq<>: [0.0]

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
@@ -1,0 +1,155 @@
+rear_collision_checker_node:
+  common:
+    on_time_buffer:
+      type: double
+      validation:
+        gt_eq<>: [0.0]
+    off_time_buffer:
+      type: double
+      validation:
+        gt_eq<>: [0.0]
+
+    pointcloud:
+      range:
+        dead_zone:
+          type: double
+          validation:
+            gt_eq<>: [0.0]
+        forward:
+          type: double
+          validation:
+            gt_eq<>: [0.0]
+        backward:
+          type: double
+          validation:
+            gt_eq<>: [0.0]
+      crop_box_filter:
+        x:
+          max:
+            type: double
+          min:
+            type: double
+        z:
+          max:
+            type: double
+          min:
+            type: double
+      voxel_grid_filter:
+        x:
+          type: double
+          validation:
+            gt<>: [0.0]
+        y:
+          type: double
+          validation:
+            gt<>: [0.0]
+        z:
+          type: double
+          validation:
+            gt<>: [0.0]
+      clustering:
+        cluster_tolerance:
+          type: double
+          validation:
+            gt<>: [0.0]
+        min_cluster_height:
+          type: double
+          validation:
+            gt<>: [0.0]
+        min_cluster_size:
+          type: int
+          validation:
+            gt<>: [0]
+        max_cluster_size:
+          type: int
+          validation:
+            gt<>: [0]
+      velocity_estimation:
+        observation_time:
+          type: double
+          validation:
+            gt_eq<>: [0.0]
+      latency:
+        type: double
+        validation:
+          gt_eq<>: [0.0]
+
+    filter:
+      min_velocity:
+        type: double
+      moving_time:
+        type: double
+
+    vehicle:
+      reaction_time:
+        type: double
+        validation:
+          gt<>: [0.0]
+      max_velocity:
+        type: double
+        validation:
+          gt<>: [0.0]
+      max_deceleration:
+        type: double
+
+    vru:
+      reaction_time:
+        type: double
+        validation:
+          gt<>: [0.0]
+      max_velocity:
+        type: double
+        validation:
+          gt<>: [0.0]
+      max_deceleration:
+        type: double
+
+    ego:
+      footprint_buffer:
+        type: double
+      reaction_time:
+        type: double
+        validation:
+          gt<>: [0.0]
+      min_velocity:
+        type: double
+      max_velocity:
+        type: double
+      max_acceleration:
+        type: double
+        validation:
+          gt<>: [0.0]
+      max_deceleration:
+        type: double
+      max_positive_jerk:
+        type: double
+        validation:
+          gt<>: [0.0]
+      max_negative_jerk:
+        type: double
+
+    blind_spot:
+      check:
+        left:
+          type: bool
+        right:
+          type: bool
+      active_distance:
+        start:
+          type: double
+          validation:
+            gt<>: [0.0]
+        end:
+          type: double
+      offset:
+        inner:
+          type: double
+        outer:
+          type: double
+
+    adjacent_lane:
+      offset:
+        left:
+          type: double
+        right:
+          type: double

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/plugins.xml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/plugins.xml
@@ -1,0 +1,3 @@
+<library path="autoware_planning_validator_rear_collision_checker">
+  <class type="autoware::planning_validator::RearCollisionChecker" base_class_type="autoware::planning_validator::PluginInterface"/>
+</library>

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -115,8 +115,8 @@ void RearCollisionChecker::fill_rss_distance(PointCloudObjects & objects) const
 
   for (auto & object : objects) {
     if (object.is_vru) {
-      const auto & delay_object = p.common.vru.reaction_time;
-      const auto & max_deceleration_object = p.common.vru.max_deceleration;
+      const auto & delay_object = p.common.vulnerable_road_user.reaction_time;
+      const auto & max_deceleration_object = p.common.vulnerable_road_user.max_deceleration;
       const auto stop_distance_object =
         delay_object * object.velocity +
         0.5 * std::pow(object.velocity, 2.0) / std::abs(max_deceleration_object);
@@ -126,7 +126,7 @@ void RearCollisionChecker::fill_rss_distance(PointCloudObjects & objects) const
       object.rss_distance = stop_distance_object - stop_distance_ego;
       object.safe = object.rss_distance < object.relative_distance_with_delay_compensation;
       object.ignore = object.moving_time < p.common.filter.moving_time ||
-                      object.velocity > p.common.vru.max_velocity;
+                      object.velocity > p.common.vulnerable_road_user.max_velocity;
     } else {
       const auto & delay_object = p.common.vehicle.reaction_time;
       const auto & max_deceleration_object = p.common.vehicle.max_deceleration;
@@ -450,12 +450,13 @@ auto RearCollisionChecker::get_pointcloud_objects(
   const auto current_velocity = context_->data->current_kinematics->twist.twist.linear.x;
 
   {
-    const auto delay_object = p.common.vru.reaction_time;
-    const auto max_deceleration_object = p.common.vru.max_deceleration;
+    const auto delay_object = p.common.vulnerable_road_user.reaction_time;
+    const auto max_deceleration_object = p.common.vulnerable_road_user.max_deceleration;
 
-    const auto stop_distance_object =
-      delay_object * p.common.vru.max_velocity +
-      0.5 * std::pow(p.common.vru.max_velocity, 2.0) / std::abs(max_deceleration_object);
+    const auto stop_distance_object = delay_object * p.common.vulnerable_road_user.max_velocity +
+                                      0.5 *
+                                        std::pow(p.common.vulnerable_road_user.max_velocity, 2.0) /
+                                        std::abs(max_deceleration_object);
     const auto stop_distance_ego =
       0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
 

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -72,9 +72,6 @@ void RearCollisionChecker::init(
   pub_voxel_pointcloud_ =
     node.create_publisher<PointCloud2>("~/rear_collision_checker/debug/voxel_points", 1);
 
-  pub_debug_marker_ =
-    node.create_publisher<MarkerArray>("~/rear_collision_checker/debug/marker", 20);
-
   pub_string_ = node.create_publisher<StringStamped>("~/rear_collision_checker/debug/state", 1);
 
   pub_debug_processing_time_detail_ = node.create_publisher<autoware_utils::ProcessingTimeDetail>(
@@ -843,13 +840,13 @@ void RearCollisionChecker::publish_marker(const DebugData & debug) const
     add(utils::create_polygon_marker_array(
       debug.hull_polygons, "hull_polygons",
       autoware_utils::create_marker_color(0.0, 0.0, 1.0, 0.999)));
+
+    std::for_each(msg.markers.begin(), msg.markers.end(), [](auto & marker) {
+      marker.lifetime = rclcpp::Duration::from_seconds(0.5);
+    });
+
+    context_->debug_pose_publisher->pushMarkers(msg);
   }
-
-  std::for_each(msg.markers.begin(), msg.markers.end(), [](auto & marker) {
-    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
-  });
-
-  pub_debug_marker_->publish(msg);
 
   if (debug.cluster_points) {
     pub_cluster_pointcloud_->publish(*debug.cluster_points);

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -744,9 +744,10 @@ bool RearCollisionChecker::is_safe(DebugData & debug)
     return true;
   }
 
-  const auto current_lanes = utils::get_current_lanes(
-    context_, predicted_stop_line.value(), p.common.pointcloud.range.forward,
-    p.common.pointcloud.range.backward);
+  constexpr double forward = 100.0;
+  constexpr double backward = 100.0;
+  const auto current_lanes =
+    utils::get_current_lanes(context_, predicted_stop_line.value(), forward, backward);
   {
     debug.current_lanes = current_lanes;
     debug.predicted_front_line = predicted_stop_line.value();

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -169,13 +169,13 @@ void RearCollisionChecker::fill_velocity(PointCloudObject & pointcloud_object)
       return;
     }
 
-    constexpr double assumed_acceleration = 30.0;
     const auto raw_velocity = dx / dt + context_->data->current_kinematics->twist.twist.linear.x;
     const auto is_reliable =
       previous_data.tracking_duration > p.common.pointcloud.velocity_estimation.observation_time;
 
     if (
-      is_reliable && std::abs(raw_velocity - previous_data.velocity) / dt > assumed_acceleration) {
+      is_reliable && std::abs(raw_velocity - previous_data.velocity) / dt >
+                       p.common.pointcloud.velocity_estimation.max_acceleration) {
       // closest point may jumped. don't use the data.
       pointcloud_object.velocity = previous_data.velocity;
       pointcloud_object.tracking_duration = previous_data.tracking_duration;

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -1,0 +1,887 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rear_collision_checker.hpp"
+
+#include "utils.hpp"
+
+#include <autoware/motion_utils/resample/resample.hpp>
+#include <autoware/signal_processing/lowpass_filter_1d.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_lanelet2_extension/visualization/visualization.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/ros/parameter.hpp>
+#include <autoware_utils/ros/update_param.hpp>
+#include <autoware_utils/transform/transforms.hpp>
+#include <magic_enum.hpp>
+
+#include <pcl/filters/crop_hull.h>
+#include <pcl/filters/extract_indices.h>
+#include <pcl/filters/passthrough.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/point_types.h>
+#include <pcl/registration/gicp.h>
+#include <pcl/segmentation/extract_clusters.h>
+#include <pcl/surface/convex_hull.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_eigen/tf2_eigen.h>
+#else
+#include <tf2_eigen/tf2_eigen.hpp>
+#endif
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::planning_validator
+{
+using autoware_utils::get_or_declare_parameter;
+
+void RearCollisionChecker::init(
+  rclcpp::Node & node, const std::string & name,
+  const std::shared_ptr<PlanningValidatorContext> & context)
+{
+  module_name_ = name;
+
+  clock_ = node.get_clock();
+
+  logger_ = node.get_logger();
+
+  context_ = context;
+
+  last_safe_time_ = clock_->now();
+
+  last_unsafe_time_ = clock_->now();
+
+  tf_buffer_ = std::make_shared<tf2_ros::Buffer>(clock_);
+
+  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
+
+  param_listener_ = std::make_unique<rear_collision_checker_node::ParamListener>(
+    node.get_node_parameters_interface());
+
+  pub_obstacle_pointcloud_ =
+    node.create_publisher<PointCloud2>("~/rear_collision_checker/debug/pointcloud", 1);
+
+  pub_debug_marker_ =
+    node.create_publisher<MarkerArray>("~/rear_collision_checker/debug/marker", 20);
+
+  pub_string_ = node.create_publisher<StringStamped>("~/rear_collision_checker/debug/state", 1);
+
+  pub_debug_processing_time_detail_ = node.create_publisher<autoware_utils::ProcessingTimeDetail>(
+    "~/rear_collision_checker/debug/processing_time_detail_ms", 1);
+
+  time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(pub_debug_processing_time_detail_);
+
+  setup_diag();
+}
+
+void RearCollisionChecker::validate(bool & is_critical)
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  const auto start_time = clock_->now();
+
+  DebugData debug_data;
+
+  context_->validation_status->is_no_collision_risk_rear = is_safe(debug_data);
+
+  is_critical = false;
+
+  post_process();
+
+  debug_data.processing_time_detail_ms = (clock_->now() - start_time).seconds() * 1e3;
+
+  publish_marker(debug_data);
+}
+
+void RearCollisionChecker::setup_diag()
+{
+  context_->add_diag(
+    "rear_collision_risk", context_->validation_status->is_no_collision_risk_rear,
+    "obstacle detected behind the vehicle", false);
+}
+
+void RearCollisionChecker::fill_rss_distance(PointCloudObjects & objects) const
+{
+  const auto p = param_listener_->get_params();
+  const auto & max_deceleration_ego = p.common.ego.max_deceleration;
+  const auto & current_velocity = context_->data->current_kinematics->twist.twist.linear.x;
+
+  for (auto & object : objects) {
+    if (object.is_vru) {
+      const auto & delay_object = p.common.vru.reaction_time;
+      const auto & max_deceleration_object = p.common.vru.max_deceleration;
+      const auto stop_distance_object =
+        delay_object * object.velocity +
+        0.5 * std::pow(object.velocity, 2.0) / std::abs(max_deceleration_object);
+      const auto stop_distance_ego =
+        0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
+
+      object.rss_distance = stop_distance_object - stop_distance_ego;
+      object.safe = object.rss_distance < object.relative_distance_with_delay_compensation;
+      object.ignore = object.moving_time < p.common.filter.moving_time ||
+                      object.velocity > p.common.vru.max_velocity;
+    } else {
+      const auto & delay_object = p.common.vehicle.reaction_time;
+      const auto & max_deceleration_object = p.common.vehicle.max_deceleration;
+      const auto stop_distance_object =
+        delay_object * object.velocity +
+        0.5 * std::pow(object.velocity, 2.0) / std::abs(max_deceleration_object);
+      const auto stop_distance_ego =
+        0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
+
+      object.rss_distance = stop_distance_object - stop_distance_ego;
+      object.safe = object.rss_distance < object.relative_distance_with_delay_compensation;
+      object.ignore = object.moving_time < p.common.filter.moving_time ||
+                      object.velocity > p.common.vehicle.max_velocity;
+    }
+  }
+}
+
+void RearCollisionChecker::fill_velocity(PointCloudObject & pointcloud_object)
+{
+  const auto p = param_listener_->get_params();
+
+  const auto update_history = [this](const auto & pointcloud_object) {
+    if (history_.count(pointcloud_object.furthest_lane.id()) == 0) {
+      history_.emplace(pointcloud_object.furthest_lane.id(), pointcloud_object);
+    } else {
+      history_.at(pointcloud_object.furthest_lane.id()) = pointcloud_object;
+    }
+  };
+
+  const auto fill_velocity = [&p, this](auto & pointcloud_object, const auto & previous_data) {
+    const auto dx = previous_data.relative_distance - pointcloud_object.relative_distance;
+    const auto dt = (pointcloud_object.last_update_time - previous_data.last_update_time).seconds();
+
+    if (dt < 1e-6) {
+      pointcloud_object.velocity = previous_data.velocity;
+      pointcloud_object.tracking_duration = previous_data.tracking_duration + dt;
+      pointcloud_object.relative_distance_with_delay_compensation =
+        pointcloud_object.relative_distance -
+        pointcloud_object.velocity * p.common.pointcloud.latency;
+      return;
+    }
+
+    constexpr double assumed_acceleration = 30.0;
+    const auto raw_velocity = dx / dt + context_->data->current_kinematics->twist.twist.linear.x;
+    const auto is_reliable =
+      previous_data.tracking_duration > p.common.pointcloud.velocity_estimation.observation_time;
+
+    if (
+      is_reliable && std::abs(raw_velocity - previous_data.velocity) / dt > assumed_acceleration) {
+      // closest point may jumped. reset tracking history.
+      pointcloud_object.velocity = 0.0;
+      pointcloud_object.tracking_duration = 0.0;
+    } else {
+      // keep tracking.
+      pointcloud_object.velocity =
+        autoware::signal_processing::lowpassFilter(raw_velocity, previous_data.velocity, 0.5);
+      pointcloud_object.tracking_duration = previous_data.tracking_duration + dt;
+    }
+
+    pointcloud_object.relative_distance_with_delay_compensation =
+      pointcloud_object.relative_distance -
+      pointcloud_object.velocity * p.common.pointcloud.latency;
+  };
+
+  const auto fill_moving_time = [&p, this](auto & pointcloud_object, const auto & previous_data) {
+    const auto dt = (pointcloud_object.last_update_time - previous_data.last_update_time).seconds();
+
+    if (pointcloud_object.velocity > p.common.filter.min_velocity) {
+      pointcloud_object.moving_time = previous_data.moving_time + dt;
+      pointcloud_object.last_stop_time = previous_data.last_stop_time;
+    } else {
+      pointcloud_object.moving_time = 0.0;
+      pointcloud_object.last_stop_time = clock_->now();
+    }
+  };
+
+  if (history_.count(pointcloud_object.furthest_lane.id()) == 0) {
+    const auto previous_lanes =
+      context_->data->route_handler->getPreviousLanelets(pointcloud_object.furthest_lane);
+    for (const auto & previous_lane : previous_lanes) {
+      if (history_.count(previous_lane.id()) != 0) {
+        fill_velocity(pointcloud_object, history_.at(previous_lane.id()));
+        fill_moving_time(pointcloud_object, history_.at(previous_lane.id()));
+        update_history(pointcloud_object);
+        return;
+      }
+    }
+
+    update_history(pointcloud_object);
+    return;
+  }
+
+  fill_velocity(pointcloud_object, history_.at(pointcloud_object.furthest_lane.id()));
+  fill_moving_time(pointcloud_object, history_.at(pointcloud_object.furthest_lane.id()));
+  update_history(pointcloud_object);
+}
+
+auto RearCollisionChecker::filter_pointcloud([[maybe_unused]] DebugData & debug) const
+  -> PointCloud::Ptr
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  const auto p = param_listener_->get_params().common.pointcloud;
+
+  auto output = std::make_shared<PointCloud>();
+
+  if (context_->data->obstacle_pointcloud->data.empty()) {
+    return output;
+  }
+
+  {
+    pcl::fromROSMsg(*context_->data->obstacle_pointcloud, *output);
+    debug.pointcloud_nums.push_back(output->size());
+  }
+
+  {
+    autoware_utils::ScopedTimeTrack st("crop_x", *time_keeper_);
+
+    pcl::PassThrough<pcl::PointXYZ> filter;
+    filter.setInputCloud(output);
+    filter.setFilterFieldName("x");
+    filter.setFilterLimits(p.crop_box_filter.x.min, p.crop_box_filter.x.max);
+    filter.filter(*output);
+    debug.pointcloud_nums.push_back(output->size());
+  }
+
+  if (output->empty()) {
+    return output;
+  }
+
+  {
+    autoware_utils::ScopedTimeTrack st("crop_z", *time_keeper_);
+
+    pcl::PassThrough<pcl::PointXYZ> filter;
+    filter.setInputCloud(output);
+    filter.setFilterFieldName("z");
+    filter.setFilterLimits(
+      p.crop_box_filter.z.min, context_->vehicle_info.vehicle_height_m + p.crop_box_filter.z.max);
+    filter.filter(*output);
+    debug.pointcloud_nums.push_back(output->size());
+  }
+
+  if (output->empty()) {
+    return output;
+  }
+
+  {
+    autoware_utils::ScopedTimeTrack st("transform", *time_keeper_);
+
+    geometry_msgs::msg::TransformStamped transform_stamped;
+    try {
+      transform_stamped = tf_buffer_->lookupTransform(
+        "map", context_->data->obstacle_pointcloud->header.frame_id,
+        context_->data->obstacle_pointcloud->header.stamp, rclcpp::Duration::from_seconds(0.1));
+    } catch (tf2::TransformException & e) {
+      RCLCPP_WARN(logger_, "no transform found for no_ground_pointcloud: %s", e.what());
+    }
+
+    Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.transform).cast<float>();
+    autoware_utils::transform_pointcloud(*output, *output, isometry);
+    debug.pointcloud_nums.push_back(output->size());
+  }
+
+  {
+    autoware_utils::ScopedTimeTrack st("voxel_grid_filter", *time_keeper_);
+
+    pcl::VoxelGrid<pcl::PointXYZ> filter;
+    filter.setInputCloud(output);
+    filter.setLeafSize(p.voxel_grid_filter.x, p.voxel_grid_filter.y, p.voxel_grid_filter.z);
+    filter.filter(*output);
+    debug.pointcloud_nums.push_back(output->size());
+  }
+
+  return output;
+}
+
+auto RearCollisionChecker::get_clustered_pointcloud(
+  const PointCloud::Ptr in, DebugData & debug) const -> PointCloud::Ptr
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  const auto p = param_listener_->get_params().common.pointcloud;
+  const auto base_link_z = context_->data->current_kinematics->pose.pose.position.z;
+
+  const auto points_belonging_to_cluster_hulls = std::make_shared<PointCloud>();
+  // eliminate noisy points by only considering points belonging to clusters of at least a certain
+  // size
+  if (in->empty()) return std::make_shared<PointCloud>();
+  const std::vector<pcl::PointIndices> cluster_indices = std::invoke([&]() {
+    std::vector<pcl::PointIndices> cluster_idx;
+    pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
+    tree->setInputCloud(in);
+    pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec;
+    ec.setClusterTolerance(p.clustering.cluster_tolerance);
+    ec.setMinClusterSize(p.clustering.min_cluster_size);
+    ec.setMaxClusterSize(p.clustering.max_cluster_size);
+    ec.setSearchMethod(tree);
+    ec.setInputCloud(in);
+    ec.extract(cluster_idx);
+    return cluster_idx;
+  });
+  for (const auto & indices : cluster_indices) {
+    PointCloud::Ptr cluster(new PointCloud);
+    bool cluster_surpasses_threshold_height{false};
+    for (const auto & index : indices.indices) {
+      const auto & point = (*in)[index];
+      cluster_surpasses_threshold_height |=
+        (point.z - base_link_z) > p.clustering.min_cluster_height;
+      cluster->push_back(point);
+    }
+    if (!cluster_surpasses_threshold_height) continue;
+    // Make a 2d convex hull for the objects
+    pcl::ConvexHull<pcl::PointXYZ> hull;
+    hull.setDimension(2);
+    hull.setInputCloud(cluster);
+    std::vector<pcl::Vertices> polygons;
+    PointCloud::Ptr surface_hull(new PointCloud);
+    hull.reconstruct(*surface_hull, polygons);
+    autoware_utils::Polygon3d hull_polygon;
+    for (const auto & p : *surface_hull) {
+      points_belonging_to_cluster_hulls->push_back(p);
+      const auto point = autoware_utils::Point3d{p.x, p.y, p.z};
+      boost::geometry::append(hull_polygon.outer(), point);
+    }
+    debug.hull_polygons.push_back(hull_polygon);
+  }
+
+  {
+    const auto obstacle_pointcloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    pcl::toROSMsg(*points_belonging_to_cluster_hulls, *obstacle_pointcloud);
+    obstacle_pointcloud->header.stamp = context_->data->obstacle_pointcloud->header.stamp;
+    obstacle_pointcloud->header.frame_id = "map";
+    debug.obstacle_pointcloud = obstacle_pointcloud;
+  }
+
+  return points_belonging_to_cluster_hulls;
+}
+
+auto RearCollisionChecker::get_pointcloud_object(
+  const rclcpp::Time & now, const PointCloud::Ptr & pointcloud_ptr,
+  const DetectionAreas & detection_areas, DebugData & debug) -> std::optional<PointCloudObject>
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  std::optional<PointCloudObject> opt_object = std::nullopt;
+  for (const auto & [polygon, lanes] : detection_areas) {
+    const auto pointcloud =
+      *get_clustered_pointcloud(utils::get_obstacle_points({polygon}, *pointcloud_ptr), debug);
+
+    const auto path = context_->data->route_handler->getCenterLinePath(
+      lanes, 0.0, std::numeric_limits<double>::max());
+    const auto resampled_path = autoware::motion_utils::resamplePath(path, 2.0);
+
+    for (const auto & point : pointcloud) {
+      const auto p_geom = autoware_utils::create_point(point.x, point.y, point.z);
+      const size_t src_seg_idx =
+        autoware::motion_utils::findNearestSegmentIndex(resampled_path.points, p_geom);
+      const double signed_length_src_offset =
+        autoware::motion_utils::calcLongitudinalOffsetToSegment(
+          resampled_path.points, src_seg_idx, p_geom);
+
+      const double obj_arc_length =
+        autoware::motion_utils::calcSignedArcLength(
+          resampled_path.points, src_seg_idx, resampled_path.points.size() - 1) -
+        signed_length_src_offset;
+      const auto pose_on_center_line = autoware::motion_utils::calcLongitudinalOffsetPose(
+        resampled_path.points, src_seg_idx, signed_length_src_offset);
+
+      if (!pose_on_center_line.has_value()) {
+        continue;
+      }
+
+      if (!opt_object.has_value()) {
+        PointCloudObject object;
+        object.last_update_time = now;
+        object.last_stop_time = now;
+        object.pose = pose_on_center_line.value();
+        object.furthest_lane = lanes.back();
+        object.tracking_duration = 0.0;
+        object.absolute_distance = obj_arc_length;
+        object.velocity = 0.0;
+        object.moving_time = 0.0;
+        opt_object = object;
+      } else if (opt_object.value().absolute_distance > obj_arc_length) {
+        opt_object.value().last_update_time = now;
+        opt_object.value().last_stop_time = now;
+        opt_object.value().pose = pose_on_center_line.value();
+        opt_object.value().furthest_lane = lanes.back();
+        opt_object.value().tracking_duration = 0.0;
+        opt_object.value().absolute_distance = obj_arc_length;
+        opt_object.value().velocity = 0.0;
+        opt_object.value().moving_time = 0.0;
+      }
+    }
+  }
+
+  return opt_object;
+}
+
+auto RearCollisionChecker::get_pointcloud_objects(
+  const lanelet::ConstLanelets & current_lanes, const Behavior & shift_behavior,
+  const Behavior & turn_behavior, DebugData & debug) -> PointCloudObjects
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  const auto p = param_listener_->get_params();
+
+  PointCloudObjects objects{};
+
+  const auto obstacle_pointcloud = filter_pointcloud(debug);
+
+  const auto max_deceleration_ego = p.common.ego.max_deceleration;
+  const auto current_velocity = context_->data->current_kinematics->twist.twist.linear.x;
+
+  {
+    const auto delay_object = p.common.vru.reaction_time;
+    const auto max_deceleration_object = p.common.vru.max_deceleration;
+
+    const auto stop_distance_object =
+      delay_object * p.common.vru.max_velocity +
+      0.5 * std::pow(p.common.vru.max_velocity, 2.0) / std::abs(max_deceleration_object);
+    const auto stop_distance_ego =
+      0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
+
+    const auto forward_distance =
+      p.common.pointcloud.range.forward + context_->vehicle_info.max_longitudinal_offset_m;
+    const auto backward_distance = p.common.pointcloud.range.backward -
+                                   context_->vehicle_info.min_longitudinal_offset_m +
+                                   std::max(0.0, stop_distance_object - stop_distance_ego);
+
+    const auto objects_at_blind_spot = get_pointcloud_objects_at_blind_spot(
+      current_lanes, turn_behavior, forward_distance, backward_distance, obstacle_pointcloud,
+      debug);
+    objects.insert(objects.end(), objects_at_blind_spot.begin(), objects_at_blind_spot.end());
+  }
+
+  {
+    const auto delay_object = p.common.vehicle.reaction_time;
+    const auto max_deceleration_object = p.common.vehicle.max_deceleration;
+
+    const auto stop_distance_object =
+      delay_object * p.common.vehicle.max_velocity +
+      0.5 * std::pow(p.common.vehicle.max_velocity, 2.0) / std::abs(max_deceleration_object);
+    const auto stop_distance_ego =
+      0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
+
+    const auto forward_distance =
+      p.common.pointcloud.range.forward + context_->vehicle_info.max_longitudinal_offset_m;
+    const auto backward_distance = p.common.pointcloud.range.backward -
+                                   context_->vehicle_info.min_longitudinal_offset_m +
+                                   std::max(0.0, stop_distance_object - stop_distance_ego);
+
+    const auto objects_on_adjacent_lane = get_pointcloud_objects_on_adjacent_lane(
+      current_lanes, shift_behavior, forward_distance, backward_distance, obstacle_pointcloud,
+      debug);
+    objects.insert(objects.end(), objects_on_adjacent_lane.begin(), objects_on_adjacent_lane.end());
+  }
+
+  return objects;
+}
+
+auto RearCollisionChecker::get_pointcloud_objects_on_adjacent_lane(
+  const lanelet::ConstLanelets & current_lanes, const Behavior & shift_behavior,
+  const double forward_distance, const double backward_distance,
+  const PointCloud::Ptr & obstacle_pointcloud, DebugData & debug) -> PointCloudObjects
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  const auto p = param_listener_->get_params();
+
+  PointCloudObjects objects{};
+
+  if (shift_behavior == Behavior::NONE) {
+    return objects;
+  }
+
+  const auto ego_coordinate_on_arc =
+    lanelet::utils::getArcCoordinates(current_lanes, context_->data->current_kinematics->pose.pose);
+
+  lanelet::ConstLanelets connected_adjacent_lanes{};
+
+  double length = 0.0;
+  for (const auto & lane : current_lanes) {
+    const auto current_lane_length = lanelet::utils::getLaneletLength2d(lane);
+
+    length += current_lane_length;
+
+    const auto ego_to_furthest_point = length - ego_coordinate_on_arc.length;
+    const auto residual_distance = ego_to_furthest_point - forward_distance;
+
+    const auto opt_adjacent_lane = [&lane, &shift_behavior, this]() {
+      const auto is_right = shift_behavior == Behavior::SHIFT_RIGHT;
+      return is_right ? context_->data->route_handler->getRightLanelet(lane, true, true)
+                      : context_->data->route_handler->getLeftLanelet(lane, true, true);
+    }();
+
+    if (opt_adjacent_lane.has_value()) {
+      connected_adjacent_lanes.push_back(opt_adjacent_lane.value());
+    }
+
+    if (!connected_adjacent_lanes.empty() && residual_distance > 0.0) {
+      auto detection_areas = utils::get_previous_polygons_with_lane_recursively(
+        current_lanes, connected_adjacent_lanes, residual_distance,
+        residual_distance + forward_distance + backward_distance, context_->data->route_handler,
+        p.common.adjacent_lane.offset.left, p.common.adjacent_lane.offset.right);
+
+      utils::cut_by_lanelets(current_lanes, detection_areas);
+
+      {
+        debug.detection_areas.insert(
+          debug.detection_areas.end(), detection_areas.begin(), detection_areas.end());
+      }
+
+      time_keeper_->start_track("get_pointcloud_object");
+      auto opt_pointcloud_object = get_pointcloud_object(
+        context_->data->obstacle_pointcloud->header.stamp, obstacle_pointcloud, detection_areas,
+        debug);
+      time_keeper_->end_track("get_pointcloud_object");
+
+      if (!opt_pointcloud_object.has_value()) {
+        return objects;
+      }
+
+      opt_pointcloud_object.value().is_vru = false;
+
+      opt_pointcloud_object.value().relative_distance =
+        opt_pointcloud_object.value().absolute_distance - ego_to_furthest_point -
+        std::abs(context_->vehicle_info.min_longitudinal_offset_m);
+
+      if (
+        opt_pointcloud_object.value().relative_distance <
+        p.common.pointcloud.range.dead_zone - context_->vehicle_info.max_longitudinal_offset_m) {
+        return objects;
+      }
+
+      fill_velocity(opt_pointcloud_object.value());
+
+      objects.push_back(opt_pointcloud_object.value());
+
+      return objects;
+    }
+
+    if (!connected_adjacent_lanes.empty() && !opt_adjacent_lane.has_value()) {
+      auto detection_areas = utils::get_previous_polygons_with_lane_recursively(
+        current_lanes, connected_adjacent_lanes, 0.0,
+        ego_to_furthest_point - current_lane_length + backward_distance,
+        context_->data->route_handler, p.common.adjacent_lane.offset.left,
+        p.common.adjacent_lane.offset.right);
+
+      utils::cut_by_lanelets(current_lanes, detection_areas);
+
+      {
+        debug.detection_areas.insert(
+          debug.detection_areas.end(), detection_areas.begin(), detection_areas.end());
+      }
+
+      connected_adjacent_lanes.clear();
+
+      time_keeper_->start_track("get_pointcloud_object");
+      auto opt_pointcloud_object = get_pointcloud_object(
+        context_->data->obstacle_pointcloud->header.stamp, obstacle_pointcloud, detection_areas,
+        debug);
+      time_keeper_->end_track("get_pointcloud_object");
+
+      if (!opt_pointcloud_object.has_value()) {
+        continue;
+      }
+
+      opt_pointcloud_object.value().is_vru = false;
+
+      opt_pointcloud_object.value().relative_distance =
+        opt_pointcloud_object.value().absolute_distance - ego_to_furthest_point -
+        std::abs(context_->vehicle_info.min_longitudinal_offset_m);
+
+      if (
+        opt_pointcloud_object.value().relative_distance <
+        p.common.pointcloud.range.dead_zone - context_->vehicle_info.max_longitudinal_offset_m) {
+        return objects;
+      }
+
+      fill_velocity(opt_pointcloud_object.value());
+
+      objects.push_back(opt_pointcloud_object.value());
+    }
+  }
+
+  return objects;
+}
+
+auto RearCollisionChecker::get_pointcloud_objects_at_blind_spot(
+  const lanelet::ConstLanelets & current_lanes, const Behavior & turn_behavior,
+  const double forward_distance, const double backward_distance,
+  const PointCloud::Ptr & obstacle_pointcloud, DebugData & debug) -> PointCloudObjects
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  const auto p = param_listener_->get_params();
+
+  PointCloudObjects objects{};
+
+  if (turn_behavior == Behavior::NONE) {
+    return objects;
+  }
+
+  const auto half_lanes = [&current_lanes, &turn_behavior, &p, this]() {
+    const auto is_right = turn_behavior == Behavior::TURN_RIGHT;
+    lanelet::ConstLanelets ret{};
+    for (const auto & lane : current_lanes) {
+      ret.push_back(utils::generate_half_lanelet(
+        lane, is_right,
+        0.5 * context_->vehicle_info.vehicle_width_m + p.common.blind_spot.offset.inner,
+        p.common.blind_spot.offset.outer));
+    }
+    return ret;
+  }();
+  const auto detection_polygon = utils::generate_detection_polygon(
+    half_lanes, context_->data->current_kinematics->pose.pose, forward_distance, backward_distance);
+
+  DetectionAreas detection_areas{};
+  detection_areas.emplace_back(detection_polygon, half_lanes);
+
+  {
+    debug.detection_areas.insert(
+      debug.detection_areas.end(), detection_areas.begin(), detection_areas.end());
+  }
+
+  time_keeper_->start_track("get_pointcloud_object");
+  auto opt_pointcloud_object = get_pointcloud_object(
+    context_->data->obstacle_pointcloud->header.stamp, obstacle_pointcloud, detection_areas, debug);
+  time_keeper_->end_track("get_pointcloud_object");
+
+  if (!opt_pointcloud_object.has_value()) {
+    return objects;
+  }
+
+  opt_pointcloud_object.value().is_vru = true;
+
+  const auto ego_coordinate_on_arc =
+    lanelet::utils::getArcCoordinates(current_lanes, context_->data->current_kinematics->pose.pose);
+
+  const auto ego_to_furthest_point =
+    lanelet::utils::getLaneletLength2d(half_lanes) - ego_coordinate_on_arc.length;
+
+  opt_pointcloud_object.value().relative_distance =
+    opt_pointcloud_object.value().absolute_distance - ego_to_furthest_point -
+    std::abs(context_->vehicle_info.min_longitudinal_offset_m);
+
+  if (
+    opt_pointcloud_object.value().relative_distance <
+    p.common.pointcloud.range.dead_zone - context_->vehicle_info.max_longitudinal_offset_m) {
+    return objects;
+  }
+
+  fill_velocity(opt_pointcloud_object.value());
+
+  objects.push_back(opt_pointcloud_object.value());
+
+  return objects;
+}
+
+bool RearCollisionChecker::is_safe(const PointCloudObjects & objects, DebugData & debug) const
+{
+  autoware_utils::ScopedTimeTrack st("is_safe_pointcloud", *time_keeper_);
+
+  const auto p = param_listener_->get_params();
+
+  {
+    debug.pointcloud_objects = objects;
+  }
+
+  for (const auto & object : objects) {
+    if (object.tracking_duration < p.common.pointcloud.velocity_estimation.observation_time) {
+      continue;
+    }
+
+    if (object.ignore) {
+      continue;
+    }
+
+    if (object.safe) {
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+bool RearCollisionChecker::is_safe(DebugData & debug)
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  const auto p = param_listener_->get_params();
+
+  {
+    const auto obstacle_pointcloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    obstacle_pointcloud->header.stamp = context_->data->obstacle_pointcloud->header.stamp;
+    obstacle_pointcloud->header.frame_id = "map";
+    debug.obstacle_pointcloud = obstacle_pointcloud;
+  }
+
+  const auto predicted_stop_line = utils::calc_predicted_stop_line(context_, p);
+
+  if (!predicted_stop_line.has_value()) {
+    return true;
+  }
+
+  const auto current_lanes = utils::get_current_lanes(
+    context_, predicted_stop_line.value(), p.common.pointcloud.range.forward,
+    p.common.pointcloud.range.backward);
+  {
+    debug.current_lanes = current_lanes;
+    debug.predicted_front_line = predicted_stop_line.value();
+  }
+
+  if (current_lanes.empty()) {
+    debug.text = "EGO CAN'T STOP WITHIN CURRENT LANE.";
+  }
+
+  const auto turn_behavior = utils::check_turn_behavior(current_lanes, context_, p);
+
+  const auto shift_behavior = utils::check_shift_behavior(current_lanes, context_);
+
+  {
+    debug.turn_behavior = turn_behavior;
+    debug.shift_behavior = shift_behavior;
+  }
+
+  if (turn_behavior == Behavior::NONE && shift_behavior == Behavior::NONE) {
+    return true;
+  }
+
+  {
+    debug.is_active = true;
+  }
+
+  PredictedObjects objects_on_target_lane;
+  PointCloudObjects pointcloud_objects{};
+
+  {
+    time_keeper_->start_track("pointcloud_base");
+    pointcloud_objects =
+      get_pointcloud_objects(current_lanes, shift_behavior, turn_behavior, debug);
+    fill_rss_distance(pointcloud_objects);
+    time_keeper_->end_track("pointcloud_base");
+  }
+
+  {
+    const auto now = clock_->now();
+    if (is_safe(pointcloud_objects, debug)) {
+      last_safe_time_ = now;
+      if ((now - last_unsafe_time_).seconds() > p.common.off_time_buffer) {
+        return true;
+      }
+    } else {
+      last_unsafe_time_ = now;
+      RCLCPP_WARN(logger_, "[RCC] Momentary collision risk detected.");
+      if ((now - last_safe_time_).seconds() < p.common.on_time_buffer) {
+        return true;
+      }
+    }
+
+    {
+      RCLCPP_ERROR(logger_, "[RCC] Continuous collision risk detected.");
+      debug.text = "RISK OF COLLISION!!!";
+    }
+  }
+
+  return false;
+}
+
+void RearCollisionChecker::post_process()
+{
+  auto itr = history_.begin();
+  while (itr != history_.end()) {
+    if ((clock_->now() - itr->second.last_update_time).seconds() > 1.0) {
+      itr = history_.erase(itr);
+    } else {
+      itr++;
+    }
+  }
+}
+
+void RearCollisionChecker::publish_marker(const DebugData & debug) const
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  MarkerArray msg;
+
+  const auto add = [&msg](const MarkerArray & added) {
+    autoware_utils::append_marker_array(added, &msg);
+  };
+
+  {
+    add(utils::create_line_marker_array(debug.predicted_front_line, "predicted_front_line"));
+    add(lanelet::visualization::laneletsAsTriangleMarkerArray(
+      "detection_lanes_for_objects", debug.get_detection_lanes(),
+      autoware_utils::create_marker_color(1.0, 0.0, 0.42, 0.2)));
+    add(lanelet::visualization::laneletsAsTriangleMarkerArray(
+      "current_lanes", debug.current_lanes,
+      autoware_utils::create_marker_color(0.16, 1.0, 0.69, 0.2)));
+    add(utils::create_pointcloud_object_marker_array(
+      debug.pointcloud_objects, "pointcloud_objects", param_listener_->get_params()));
+    add(utils::create_polygon_marker_array(
+      debug.get_detection_polygons(), "detection_areas_for_pointcloud",
+      autoware_utils::create_marker_color(1.0, 0.0, 0.42, 0.999)));
+    add(utils::create_polygon_marker_array(
+      debug.hull_polygons, "hull_polygons",
+      autoware_utils::create_marker_color(0.0, 0.0, 1.0, 0.999)));
+  }
+
+  std::for_each(msg.markers.begin(), msg.markers.end(), [](auto & marker) {
+    marker.lifetime = rclcpp::Duration::from_seconds(0.5);
+  });
+
+  pub_debug_marker_->publish(msg);
+
+  if (debug.obstacle_pointcloud) {
+    pub_obstacle_pointcloud_->publish(*debug.obstacle_pointcloud);
+  }
+
+  {
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(2) << std::boolalpha;
+    ss << "ACTIVE:" << debug.is_active << "\n";
+    ss << "SAFE:" << debug.is_safe << "\n";
+    ss << "TURN:" << magic_enum::enum_name(debug.turn_behavior) << "\n";
+    ss << "SHIFT:" << magic_enum::enum_name(debug.shift_behavior) << "\n";
+    ss << "INFO:" << debug.text.c_str() << "\n";
+    ss << "TRACKING OBJECTS:" << debug.pointcloud_objects.size() << "\n";
+    ss << "PC NUM:";
+    for (const auto num : debug.pointcloud_nums) {
+      ss << num << "->";
+    }
+    ss << "\n";
+    ss << "PROCESSING TIME:" << debug.processing_time_detail_ms << "[ms]\n";
+
+    StringStamped string_stamp;
+    string_stamp.stamp = clock_->now();
+    string_stamp.data = ss.str();
+    pub_string_->publish(string_stamp);
+  }
+}
+}  // namespace autoware::planning_validator
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::planning_validator::RearCollisionChecker, autoware::planning_validator::PluginInterface)

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -472,9 +472,8 @@ auto RearCollisionChecker::get_pointcloud_objects(
     const auto stop_distance_ego =
       0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
 
-    const auto forward_distance =
-      p.common.pointcloud.range.forward + context_->vehicle_info.max_longitudinal_offset_m;
-    const auto backward_distance = p.common.pointcloud.range.backward -
+    const auto forward_distance = context_->vehicle_info.max_longitudinal_offset_m;
+    const auto backward_distance = p.common.pointcloud.range.buffer -
                                    context_->vehicle_info.min_longitudinal_offset_m +
                                    std::max(0.0, stop_distance_object - stop_distance_ego);
 
@@ -494,9 +493,8 @@ auto RearCollisionChecker::get_pointcloud_objects(
     const auto stop_distance_ego =
       0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
 
-    const auto forward_distance =
-      p.common.pointcloud.range.forward + context_->vehicle_info.max_longitudinal_offset_m;
-    const auto backward_distance = p.common.pointcloud.range.backward -
+    const auto forward_distance = context_->vehicle_info.max_longitudinal_offset_m;
+    const auto backward_distance = p.common.pointcloud.range.buffer -
                                    context_->vehicle_info.min_longitudinal_offset_m +
                                    std::max(0.0, stop_distance_object - stop_distance_ego);
 

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -744,6 +744,7 @@ bool RearCollisionChecker::is_safe(DebugData & debug)
 
   if (current_lanes.empty()) {
     debug.text = "failed to identify the current driving lane.";
+    return true;
   }
 
   const auto is_unsafe_holding = (now - last_unsafe_time_).seconds() < p.common.off_time_buffer;

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -728,6 +728,7 @@ bool RearCollisionChecker::is_safe(DebugData & debug)
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto p = param_listener_->get_params();
+  const auto now = clock_->now();
 
   {
     const auto obstacle_pointcloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
@@ -745,8 +746,11 @@ bool RearCollisionChecker::is_safe(DebugData & debug)
     debug.text = "failed to identify the current driving lane.";
   }
 
-  const auto turn_behavior = utils::check_turn_behavior(current_lanes, context_, p, debug);
-  const auto shift_behavior = utils::check_shift_behavior(current_lanes, context_, p, debug);
+  const auto is_unsafe_holding = (now - last_unsafe_time_).seconds() < p.common.off_time_buffer;
+  const auto turn_behavior =
+    utils::check_turn_behavior(current_lanes, is_unsafe_holding, context_, p, debug);
+  const auto shift_behavior =
+    utils::check_shift_behavior(current_lanes, is_unsafe_holding, context_, p, debug);
 
   {
     debug.current_lanes = current_lanes;
@@ -774,7 +778,6 @@ bool RearCollisionChecker::is_safe(DebugData & debug)
   }
 
   {
-    const auto now = clock_->now();
     if (is_safe(pointcloud_objects, debug)) {
       last_safe_time_ = now;
       if ((now - last_unsafe_time_).seconds() > p.common.off_time_buffer) {

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -866,7 +866,7 @@ void RearCollisionChecker::publish_marker(const DebugData & debug) const
     ss << "SAFE:" << debug.is_safe << "\n";
     ss << "TURN:" << magic_enum::enum_name(debug.turn_behavior) << "\n";
     ss << "SHIFT:" << magic_enum::enum_name(debug.shift_behavior) << "\n";
-    ss << "INFO:" << debug.text.c_str() << "\n";
+    ss << "INFO:" << debug.text << "\n";
     ss << "TRACKING OBJECTS:" << debug.pointcloud_objects.size() << "\n";
     ss << "PC NUM:";
     for (const auto num : debug.pointcloud_nums) {

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -225,8 +225,7 @@ void RearCollisionChecker::fill_velocity(PointCloudObject & pointcloud_object)
   update_history(pointcloud_object);
 }
 
-auto RearCollisionChecker::filter_pointcloud([[maybe_unused]] DebugData & debug) const
-  -> PointCloud::Ptr
+auto RearCollisionChecker::filter_pointcloud(DebugData & debug) const -> PointCloud::Ptr
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -244,7 +243,7 @@ auto RearCollisionChecker::filter_pointcloud([[maybe_unused]] DebugData & debug)
   }
 
   {
-    autoware_utils::ScopedTimeTrack st("crop_x", *time_keeper_);
+    autoware_utils::ScopedTimeTrack scoped_time_track("crop_x", *time_keeper_);
 
     pcl::PassThrough<pcl::PointXYZ> filter;
     filter.setInputCloud(output);
@@ -259,7 +258,7 @@ auto RearCollisionChecker::filter_pointcloud([[maybe_unused]] DebugData & debug)
   }
 
   {
-    autoware_utils::ScopedTimeTrack st("crop_z", *time_keeper_);
+    autoware_utils::ScopedTimeTrack scoped_time_track("crop_z", *time_keeper_);
 
     pcl::PassThrough<pcl::PointXYZ> filter;
     filter.setInputCloud(output);
@@ -275,7 +274,7 @@ auto RearCollisionChecker::filter_pointcloud([[maybe_unused]] DebugData & debug)
   }
 
   {
-    autoware_utils::ScopedTimeTrack st("transform", *time_keeper_);
+    autoware_utils::ScopedTimeTrack scoped_time_track("transform", *time_keeper_);
 
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
@@ -292,7 +291,7 @@ auto RearCollisionChecker::filter_pointcloud([[maybe_unused]] DebugData & debug)
   }
 
   {
-    autoware_utils::ScopedTimeTrack st("voxel_grid_filter", *time_keeper_);
+    autoware_utils::ScopedTimeTrack scoped_time_track("voxel_grid_filter", *time_keeper_);
 
     pcl::VoxelGrid<pcl::PointXYZ> filter;
     filter.setInputCloud(output);

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -316,7 +316,7 @@ auto RearCollisionChecker::get_clustered_pointcloud(
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  const auto p = param_listener_->get_params().common.pointcloud;
+  const auto parameter = param_listener_->get_params().common.pointcloud;
   const auto base_link_z = context_->data->current_kinematics->pose.pose.position.z;
 
   const auto points_belonging_to_cluster_hulls = std::make_shared<PointCloud>();
@@ -328,9 +328,9 @@ auto RearCollisionChecker::get_clustered_pointcloud(
     pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
     tree->setInputCloud(in);
     pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec;
-    ec.setClusterTolerance(p.clustering.cluster_tolerance);
-    ec.setMinClusterSize(p.clustering.min_cluster_size);
-    ec.setMaxClusterSize(p.clustering.max_cluster_size);
+    ec.setClusterTolerance(parameter.clustering.cluster_tolerance);
+    ec.setMinClusterSize(parameter.clustering.min_cluster_size);
+    ec.setMaxClusterSize(parameter.clustering.max_cluster_size);
     ec.setSearchMethod(tree);
     ec.setInputCloud(in);
     ec.extract(cluster_idx);
@@ -342,7 +342,7 @@ auto RearCollisionChecker::get_clustered_pointcloud(
     for (const auto & index : indices.indices) {
       const auto & point = (*in)[index];
       cluster_surpasses_threshold_height |=
-        (point.z - base_link_z) > p.clustering.min_cluster_height;
+        (point.z - base_link_z) > parameter.clustering.min_cluster_height;
       cluster->push_back(point);
     }
     if (!cluster_surpasses_threshold_height) continue;

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -351,9 +351,8 @@ auto RearCollisionChecker::get_clustered_pointcloud(
     pcl::ConvexHull<pcl::PointXYZ> hull;
     hull.setDimension(2);
     hull.setInputCloud(cluster);
-    std::vector<pcl::Vertices> polygons;
     PointCloud::Ptr surface_hull(new PointCloud);
-    hull.reconstruct(*surface_hull, polygons);
+    hull.reconstruct(*surface_hull);
     autoware_utils::Polygon3d hull_polygon;
     for (const auto & p : *surface_hull) {
       points_belonging_to_cluster_hulls->push_back(p);

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -103,7 +103,7 @@ void RearCollisionChecker::validate(bool & is_critical)
 void RearCollisionChecker::setup_diag()
 {
   context_->add_diag(
-    "rear_collision_risk", context_->validation_status->is_valid_rear_collision_check,
+    "rear_collision_check", context_->validation_status->is_valid_rear_collision_check,
     "obstacle detected behind the vehicle", false);
 }
 

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
@@ -78,8 +78,6 @@ private:
 
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_cluster_pointcloud_;
 
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
-
   rclcpp::Publisher<StringStamped>::SharedPtr pub_string_;
 
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
@@ -1,0 +1,107 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REAR_COLLISION_CHECKER_HPP_
+#define REAR_COLLISION_CHECKER_HPP_
+
+#include "structs.hpp"
+
+#include <autoware/planning_validator/plugin_interface.hpp>
+#include <autoware_utils/system/time_keeper.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <tf2/utils.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace autoware::planning_validator
+{
+
+class RearCollisionChecker : public PluginInterface
+{
+public:
+  void init(
+    rclcpp::Node & node, const std::string & name,
+    const std::shared_ptr<PlanningValidatorContext> & context) override;
+  void validate(bool & is_critical) override;
+  void setup_diag() override;
+  std::string get_module_name() const override { return module_name_; };
+
+private:
+  void fill_rss_distance(PointCloudObjects & objects) const;
+
+  void fill_velocity(PointCloudObject & pointcloud_object);
+
+  auto filter_pointcloud(DebugData & debug_data) const -> PointCloud::Ptr;
+
+  auto get_clustered_pointcloud(const PointCloud::Ptr in, DebugData & debug_data) const
+    -> PointCloud::Ptr;
+
+  auto get_pointcloud_object(
+    const rclcpp::Time & now, const PointCloud::Ptr & pointcloud_ptr,
+    const DetectionAreas & detection_areas, DebugData & debug) -> std::optional<PointCloudObject>;
+
+  auto get_pointcloud_objects(
+    const lanelet::ConstLanelets & current_lanes, const Behavior & shift_behavior,
+    const Behavior & turn_behavior, DebugData & detection_areas) -> PointCloudObjects;
+
+  auto get_pointcloud_objects_on_adjacent_lane(
+    const lanelet::ConstLanelets & current_lanes, const Behavior & shift_behavior,
+    const double forward_distance, const double backward_distance,
+    const PointCloud::Ptr & obstacle_pointcloud, DebugData & debug) -> PointCloudObjects;
+
+  auto get_pointcloud_objects_at_blind_spot(
+    const lanelet::ConstLanelets & current_lanes, const Behavior & turn_behavior,
+    const double forward_distance, const double backward_distance,
+    const PointCloud::Ptr & obstacle_pointcloud, DebugData & debug) -> PointCloudObjects;
+
+  bool is_safe(const PointCloudObjects & objects, DebugData & debug) const;
+
+  bool is_safe(DebugData & debug);
+
+  void post_process();
+
+  void publish_marker(const DebugData & debug) const;
+
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_obstacle_pointcloud_;
+
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
+
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_string_;
+
+  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
+    pub_debug_processing_time_detail_;
+
+  rclcpp::Time last_safe_time_;
+
+  rclcpp::Time last_unsafe_time_;
+
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+
+  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
+
+  std::unique_ptr<rear_collision_checker_node::ParamListener> param_listener_;
+
+  std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
+
+  std::map<lanelet::Id, PointCloudObject> history_;
+};
+
+}  // namespace autoware::planning_validator
+
+#endif  // REAR_COLLISION_CHECKER_HPP_

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
@@ -21,10 +21,6 @@
 #include <autoware_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tf2/utils.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
-
 #include <map>
 #include <memory>
 #include <string>
@@ -92,10 +88,6 @@ private:
   rclcpp::Time last_safe_time_;
 
   rclcpp::Time last_unsafe_time_;
-
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-
-  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
   std::unique_ptr<rear_collision_checker_node::ParamListener> param_listener_;
 

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
@@ -54,7 +54,7 @@ private:
 
   auto get_pointcloud_objects(
     const lanelet::ConstLanelets & current_lanes, const Behavior & shift_behavior,
-    const Behavior & turn_behavior, DebugData & detection_areas) -> PointCloudObjects;
+    const Behavior & turn_behavior, DebugData & debug) -> PointCloudObjects;
 
   auto get_pointcloud_objects_on_adjacent_lane(
     const lanelet::ConstLanelets & current_lanes, const Behavior & shift_behavior,

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
@@ -43,9 +43,9 @@ private:
 
   void fill_velocity(PointCloudObject & pointcloud_object);
 
-  auto filter_pointcloud(DebugData & debug_data) const -> PointCloud::Ptr;
+  auto filter_pointcloud(DebugData & debug) const -> PointCloud::Ptr;
 
-  auto get_clustered_pointcloud(const PointCloud::Ptr in, DebugData & debug_data) const
+  auto get_clustered_pointcloud(const PointCloud::Ptr in, DebugData & debug) const
     -> PointCloud::Ptr;
 
   auto get_pointcloud_object(

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.hpp
@@ -78,7 +78,9 @@ private:
 
   void publish_marker(const DebugData & debug) const;
 
-  rclcpp::Publisher<PointCloud2>::SharedPtr pub_obstacle_pointcloud_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_voxel_pointcloud_;
+
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_cluster_pointcloud_;
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_debug_marker_;
 

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
@@ -1,0 +1,160 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STRUCTS_HPP_
+#define STRUCTS_HPP_
+
+#include <autoware_planning_validator_rear_collision_checker/rear_collision_checker_node_parameters.hpp>
+#include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_core/geometry/Point.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::planning_validator
+{
+
+using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_internal_debug_msgs::msg::StringStamped;
+using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+using geometry_msgs::msg::AccelWithCovarianceStamped;
+using nav_msgs::msg::Odometry;
+using sensor_msgs::msg::PointCloud2;
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
+
+using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
+
+using DetectionArea = std::pair<lanelet::BasicPolygon3d, lanelet::ConstLanelets>;
+
+using DetectionAreas = std::vector<DetectionArea>;
+
+enum class Behavior {
+  NONE = 0,
+  SHIFT_LEFT,
+  SHIFT_RIGHT,
+  TURN_LEFT,
+  TURN_RIGHT,
+};
+
+struct PointCloudObject
+{
+  rclcpp::Time last_update_time;
+
+  rclcpp::Time last_stop_time;
+
+  geometry_msgs::msg::Pose pose;
+
+  lanelet::ConstLanelet furthest_lane;
+
+  double tracking_duration;
+
+  double absolute_distance;
+
+  double relative_distance;
+
+  double relative_distance_with_delay_compensation;
+
+  double rss_distance;
+
+  double velocity;
+
+  double moving_time;
+
+  bool safe;
+
+  bool ignore;
+
+  bool is_vru;
+};
+
+using PointCloudObjects = std::vector<PointCloudObject>;
+
+struct DebugData
+{
+  autoware_utils::LineString3d predicted_front_line;
+
+  lanelet::ConstLanelets current_lanes;
+
+  PointCloudObjects pointcloud_objects;
+
+  DetectionAreas detection_areas;
+
+  sensor_msgs::msg::PointCloud2::SharedPtr obstacle_pointcloud;
+
+  Behavior turn_behavior{Behavior::NONE};
+
+  Behavior shift_behavior{Behavior::NONE};
+
+  std::vector<autoware_utils::Polygon3d> hull_polygons;
+
+  std::vector<size_t> pointcloud_nums{};
+
+  std::string text{"-"};
+
+  double processing_time_detail_ms;
+
+  bool is_active{false};
+
+  bool is_safe{true};
+
+  auto get_detection_polygons() const -> lanelet::BasicPolygons3d
+  {
+    lanelet::BasicPolygons3d ret{};
+    for (const auto & [polygon, lanes] : detection_areas) {
+      ret.push_back(polygon);
+    }
+    return ret;
+  }
+
+  auto get_detection_lanes() const -> lanelet::ConstLanelets
+  {
+    lanelet::ConstLanelets ret{};
+    for (const auto & [polygon, lanes] : detection_areas) {
+      ret.insert(ret.end(), lanes.begin(), lanes.end());
+    }
+    return ret;
+  }
+};
+}  // namespace autoware::planning_validator
+
+#endif  // STRUCTS_HPP_

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
@@ -113,7 +113,9 @@ using PointCloudObjects = std::vector<PointCloudObject>;
 
 struct DebugData
 {
-  autoware_utils::LineString3d predicted_front_line;
+  autoware_utils::LineString3d reachable_line;
+
+  autoware_utils::LineString3d stoppable_line;
 
   lanelet::ConstLanelets current_lanes;
 

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
@@ -105,6 +105,8 @@ struct PointCloudObject
   bool ignore;
 
   bool is_vru;
+
+  std::string detail{""};
 };
 
 using PointCloudObjects = std::vector<PointCloudObject>;
@@ -119,7 +121,9 @@ struct DebugData
 
   DetectionAreas detection_areas;
 
-  sensor_msgs::msg::PointCloud2::SharedPtr obstacle_pointcloud;
+  sensor_msgs::msg::PointCloud2::SharedPtr cluster_points;
+
+  sensor_msgs::msg::PointCloud2::SharedPtr voxel_points;
 
   Behavior turn_behavior{Behavior::NONE};
 

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
@@ -86,25 +86,25 @@ struct PointCloudObject
 
   lanelet::ConstLanelet furthest_lane;
 
-  double tracking_duration;
+  double tracking_duration{0.0};
 
-  double absolute_distance;
+  double absolute_distance{0.0};
 
-  double relative_distance;
+  double relative_distance{0.0};
 
-  double relative_distance_with_delay_compensation;
+  double relative_distance_with_delay_compensation{0.0};
 
-  double rss_distance;
+  double rss_distance{0.0};
 
-  double velocity;
+  double velocity{0.0};
 
-  double moving_time;
+  double moving_time{0.0};
 
-  bool safe;
+  bool safe{true};
 
-  bool ignore;
+  bool ignore{false};
 
-  bool is_vru;
+  bool is_vru{false};
 
   std::string detail{""};
 };

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
@@ -1,0 +1,674 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "utils.hpp"
+
+#include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware/motion_utils/resample/resample.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/unit_conversion.hpp>
+#include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_utils/transform/transforms.hpp>
+#include <magic_enum.hpp>
+
+#include <boost/assert.hpp>
+#include <boost/assign/list_of.hpp>
+#include <boost/format.hpp>
+#include <boost/geometry.hpp>
+#include <boost/geometry/algorithms/area.hpp>
+#include <boost/geometry/algorithms/difference.hpp>
+#include <boost/geometry/algorithms/distance.hpp>
+#include <boost/geometry/algorithms/length.hpp>
+#include <boost/geometry/algorithms/within.hpp>
+#include <boost/geometry/geometries/linestring.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_core/geometry/Point.h>
+#include <lanelet2_routing/RoutingGraphContainer.h>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace autoware::planning_validator::utils
+{
+
+namespace
+{
+std::optional<lanelet::ConstLanelet> get_sibling_straight_lanelet(
+  const lanelet::ConstLanelet assigned_lane,
+  const lanelet::routing::RoutingGraphConstPtr routing_graph_ptr)
+{
+  for (const auto & prev : routing_graph_ptr->previous(assigned_lane)) {
+    for (const auto & following : routing_graph_ptr->following(prev)) {
+      if (std::string(following.attributeOr("turn_direction", "else")) == "straight") {
+        return following;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+bool is_within_lanes(
+  const lanelet::ConstLanelets & lanelets, const autoware_utils::LineString2d & stop_line)
+{
+  const auto combine_lanelet = lanelet::utils::combineLaneletsShape(lanelets);
+
+  return boost::geometry::within(stop_line, combine_lanelet.polygon2d().basicPolygon());
+}
+
+std::pair<lanelet::BasicPoint2d, double> get_smallest_enclosing_circle(
+  const lanelet::BasicPolygon2d & poly)
+{
+  // The `eps` is used to avoid precision bugs in circle inclusion checks.
+  // If the value of `eps` is too small, this function doesn't work well. More than 1e-10 is
+  // recommended.
+  const double eps = 1e-5;
+  lanelet::BasicPoint2d center(0.0, 0.0);
+  double radius_squared = 0.0;
+
+  auto cross = [](const lanelet::BasicPoint2d & p1, const lanelet::BasicPoint2d & p2) -> double {
+    return p1.x() * p2.y() - p1.y() * p2.x();
+  };
+
+  auto make_circle_3 = [&](
+                         const lanelet::BasicPoint2d & p1, const lanelet::BasicPoint2d & p2,
+                         const lanelet::BasicPoint2d & p3) -> void {
+    // reference for circumcenter vector https://en.wikipedia.org/wiki/Circumscribed_circle
+    const double a = (p2 - p3).squaredNorm();
+    const double b = (p3 - p1).squaredNorm();
+    const double c = (p1 - p2).squaredNorm();
+    const double s = cross(p2 - p1, p3 - p1);
+    if (std::abs(s) < eps) return;
+    center = (a * (b + c - a) * p1 + b * (c + a - b) * p2 + c * (a + b - c) * p3) / (4 * s * s);
+    radius_squared = (center - p1).squaredNorm() + eps;
+  };
+
+  auto make_circle_2 =
+    [&](const lanelet::BasicPoint2d & p1, const lanelet::BasicPoint2d & p2) -> void {
+    center = (p1 + p2) * 0.5;
+    radius_squared = (center - p1).squaredNorm() + eps;
+  };
+
+  auto in_circle = [&](const lanelet::BasicPoint2d & p) -> bool {
+    return (center - p).squaredNorm() <= radius_squared;
+  };
+
+  // mini disc
+  for (size_t i = 1; i < poly.size(); i++) {
+    const auto p1 = poly[i];
+    if (in_circle(p1)) continue;
+
+    // mini disc with point
+    const auto p0 = poly[0];
+    make_circle_2(p0, p1);
+    for (size_t j = 0; j < i; j++) {
+      const auto p2 = poly[j];
+      if (in_circle(p2)) continue;
+
+      // mini disc with two points
+      make_circle_2(p1, p2);
+      for (size_t k = 0; k < j; k++) {
+        const auto p3 = poly[k];
+        if (in_circle(p3)) continue;
+
+        // mini disc with tree points
+        make_circle_3(p1, p2, p3);
+      }
+    }
+  }
+
+  return std::make_pair(center, radius_squared);
+}
+}  // namespace
+
+auto calc_predicted_stop_line(
+  const std::shared_ptr<PlanningValidatorContext> & context,
+  const rear_collision_checker_node::Params & parameters)
+  -> std::optional<autoware_utils::LineString3d>
+{
+  const auto & points = context->data->current_trajectory->points;
+  const auto & ego_pose = context->data->current_kinematics->pose.pose;
+  const auto & current_velocity = context->data->current_kinematics->twist.twist.linear.x;
+  const auto & current_acceleration = context->data->current_acceleration->accel.accel.linear.x;
+  const auto & vehicle_info = context->vehicle_info;
+
+  constexpr double target_velocity = 0.0;
+  const auto & max_deceleration = parameters.common.ego.max_deceleration;
+  const auto & max_positive_jerk = parameters.common.ego.max_positive_jerk;
+  const auto & max_negative_jerk = parameters.common.ego.max_negative_jerk;
+
+  autoware_utils::LineString3d stop_line;
+
+  const auto stop_distance = autoware::motion_utils::calcDecelDistWithJerkAndAccConstraints(
+    current_velocity, target_velocity, current_acceleration, max_deceleration, max_positive_jerk,
+    max_negative_jerk);
+
+  if (!stop_distance.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto p_future = autoware::motion_utils::calcLongitudinalOffsetPose(
+    points, ego_pose.position, vehicle_info.max_longitudinal_offset_m + stop_distance.value());
+
+  if (!p_future.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto p1 = autoware_utils::calc_offset_pose(
+    p_future.value(), 0.0, 0.5 * vehicle_info.vehicle_width_m, 0.0);
+  const auto p2 = autoware_utils::calc_offset_pose(
+    p_future.value(), 0.0, -0.5 * vehicle_info.vehicle_width_m, 0.0);
+  stop_line.emplace_back(p1.position.x, p1.position.y, ego_pose.position.z);
+  stop_line.emplace_back(p2.position.x, p2.position.y, ego_pose.position.z);
+  return stop_line;
+}
+
+auto check_shift_behavior(
+  const lanelet::ConstLanelets & lanelets,
+  const std::shared_ptr<PlanningValidatorContext> & context) -> Behavior
+{
+  const auto & points = context->data->current_trajectory->points;
+  const auto & ego_pose = context->data->current_kinematics->pose.pose;
+  const auto & vehicle_width = context->vehicle_info.vehicle_width_m;
+
+  const auto combine_lanelet = lanelet::utils::combineLaneletsShape(lanelets);
+  const auto nearest_idx =
+    autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(points, ego_pose);
+  {
+    const auto p1 = autoware_utils::calc_offset_pose(ego_pose, 0.0, 0.5 * vehicle_width, 0.0);
+    const auto p2 = autoware_utils::calc_offset_pose(ego_pose, 0.0, -0.5 * vehicle_width, 0.0);
+    autoware_utils::LineString2d axle;
+    axle.emplace_back(p1.position.x, p1.position.y);
+    axle.emplace_back(p2.position.x, p2.position.y);
+
+    const auto is_left_shift = boost::geometry::intersects(
+      axle, lanelet::utils::to2D(combine_lanelet.leftBound()).basicLineString());
+    if (is_left_shift) {
+      return Behavior::NONE;
+    }
+
+    const auto is_right_shift = boost::geometry::intersects(
+      axle, lanelet::utils::to2D(combine_lanelet.rightBound()).basicLineString());
+    if (is_right_shift) {
+      return Behavior::NONE;
+    }
+  }
+
+  for (size_t i = 0; i < points.size(); i++) {
+    const auto p1 = autoware_utils::calc_offset_pose(
+      autoware_utils::get_pose(points.at(i)), 0.0, 0.5 * vehicle_width, 0.0);
+    const auto p2 = autoware_utils::calc_offset_pose(
+      autoware_utils::get_pose(points.at(i)), 0.0, -0.5 * vehicle_width, 0.0);
+    autoware_utils::LineString2d axle;
+    axle.emplace_back(p1.position.x, p1.position.y);
+    axle.emplace_back(p2.position.x, p2.position.y);
+
+    const auto is_left_shift = boost::geometry::intersects(
+      axle, lanelet::utils::to2D(combine_lanelet.leftBound()).basicLineString());
+    if (is_left_shift && std::abs(points.at(i).longitudinal_velocity_mps) > 1e-3) {
+      return i < nearest_idx ? Behavior::NONE : Behavior::SHIFT_LEFT;
+    }
+
+    const auto is_right_shift = boost::geometry::intersects(
+      axle, lanelet::utils::to2D(combine_lanelet.rightBound()).basicLineString());
+    if (is_right_shift && std::abs(points.at(i).longitudinal_velocity_mps) > 1e-3) {
+      return i < nearest_idx ? Behavior::NONE : Behavior::SHIFT_RIGHT;
+    }
+  }
+
+  return Behavior::NONE;
+}
+
+auto check_turn_behavior(
+  const lanelet::ConstLanelets & lanelets,
+  const std::shared_ptr<PlanningValidatorContext> & context,
+  const rear_collision_checker_node::Params & parameters) -> Behavior
+{
+  const auto & points = context->data->current_trajectory->points;
+  const auto & ego_pose = context->data->current_kinematics->pose.pose;
+  const auto & route_handler = context->data->route_handler;
+  const auto & vehicle_info = context->vehicle_info;
+
+  const auto ego_coordinate_on_arc = lanelet::utils::getArcCoordinates(lanelets, ego_pose);
+
+  const auto distance_to_stop_point =
+    autoware::motion_utils::calcDistanceToForwardStopPoint(points, ego_pose);
+
+  constexpr double buffer = 0.5;
+
+  const auto routing_graph_ptr = route_handler->getRoutingGraphPtr();
+
+  const auto conflict_point = [&points, &vehicle_info](
+                                const auto & sibling_straight_lanelet,
+                                const auto is_right) -> std::optional<geometry_msgs::msg::Point> {
+    const auto bound =
+      is_right ? sibling_straight_lanelet.rightBound() : sibling_straight_lanelet.leftBound();
+    for (const auto & p : points) {
+      const auto p1 = autoware_utils::calc_offset_pose(
+        autoware_utils::get_pose(p), 0.0, 0.5 * vehicle_info.vehicle_width_m, 0.0);
+      const auto p2 = autoware_utils::calc_offset_pose(
+        autoware_utils::get_pose(p), 0.0, -0.5 * vehicle_info.vehicle_width_m, 0.0);
+      autoware_utils::LineString2d axle;
+      axle.emplace_back(p1.position.x, p1.position.y);
+      axle.emplace_back(p2.position.x, p2.position.y);
+
+      if (boost::geometry::intersects(axle, lanelet::utils::to2D(bound.basicLineString()))) {
+        return autoware_utils::get_point(p);
+      }
+    }
+
+    return std::nullopt;
+  };
+
+  const auto & p = parameters.common.blind_spot;
+
+  const auto exceed_dead_line = [&points, &ego_pose, &p, &conflict_point, &vehicle_info](
+                                  const auto & sibling_straight_lanelet, const auto distance,
+                                  const auto is_right) {
+    if (!sibling_straight_lanelet.has_value()) {
+      return distance < p.active_distance.end;
+    }
+
+    if (!sibling_straight_lanelet.has_value()) {
+      return distance < p.active_distance.end;
+    }
+
+    const auto dead_line_point = conflict_point(sibling_straight_lanelet.value(), is_right);
+    if (!dead_line_point.has_value()) {
+      return distance < p.active_distance.end;
+    }
+
+    return autoware::motion_utils::calcSignedArcLength(
+             points, ego_pose.position, dead_line_point.value()) -
+             vehicle_info.max_longitudinal_offset_m <
+           0.0;
+  };
+
+  double total_length = 0.0;
+  for (const auto & lane : lanelets) {
+    const auto distance =
+      total_length - ego_coordinate_on_arc.length - vehicle_info.max_longitudinal_offset_m;
+    const std::string turn_direction = lane.attributeOr("turn_direction", "none");
+
+    total_length += lanelet::utils::getLaneletLength2d(lane);
+
+    if (turn_direction == "left" && p.check.left) {
+      const auto sibling_straight_lanelet = get_sibling_straight_lanelet(lane, routing_graph_ptr);
+
+      if (exceed_dead_line(sibling_straight_lanelet, distance, false)) {
+        continue;
+      }
+
+      if (!distance_to_stop_point.has_value()) {
+        return distance < p.active_distance.start ? Behavior::TURN_LEFT : Behavior::NONE;
+      }
+      if (distance_to_stop_point.value() < distance + buffer) {
+        return Behavior::NONE;
+      }
+      return distance < p.active_distance.start ? Behavior::TURN_LEFT : Behavior::NONE;
+    }
+
+    if (turn_direction == "right" && p.check.right) {
+      const auto sibling_straight_lanelet = get_sibling_straight_lanelet(lane, routing_graph_ptr);
+
+      if (exceed_dead_line(sibling_straight_lanelet, distance, true)) {
+        continue;
+      }
+
+      if (!distance_to_stop_point.has_value()) {
+        return distance < p.active_distance.start ? Behavior::TURN_RIGHT : Behavior::NONE;
+      }
+      if (distance_to_stop_point.value() < distance + buffer) {
+        return Behavior::NONE;
+      }
+      return distance < p.active_distance.start ? Behavior::TURN_RIGHT : Behavior::NONE;
+    }
+  }
+
+  return Behavior::NONE;
+}
+
+void cut_by_lanelets(const lanelet::ConstLanelets & lanelets, DetectionAreas & detection_areas)
+{
+  const auto combine_lanelet = lanelet::utils::combineLaneletsShape(lanelets);
+
+  for (auto & [original, lanelets] : detection_areas) {
+    if (original.empty()) {
+      continue;
+    }
+
+    lanelet::BasicPolygons2d polygons2d;
+    boost::geometry::difference(
+      lanelet::utils::to2D(original), combine_lanelet.polygon2d().basicPolygon(), polygons2d);
+
+    if (polygons2d.empty()) {
+      continue;
+    }
+
+    lanelet::BasicPolygon3d polygon3d;
+    for (const auto & p : polygons2d.front()) {
+      polygon3d.push_back(lanelet::BasicPoint3d(p.x(), p.y(), original.front().z()));
+    }
+
+    original = polygon3d;
+  }
+}
+
+auto get_current_lanes(
+  const std::shared_ptr<PlanningValidatorContext> & context,
+  const autoware_utils::LineString3d & stop_line, const double forward_distance,
+  const double backward_distance) -> lanelet::ConstLanelets
+{
+  const auto & ego_pose = context->data->current_kinematics->pose.pose;
+  const auto & route_handler = context->data->route_handler;
+  const auto & vehicle_info = context->vehicle_info;
+
+  lanelet::ConstLanelet closest_lanelet;
+  if (!route_handler->getClosestLaneletWithinRoute(ego_pose, &closest_lanelet)) {
+    return {};
+  }
+
+  const auto current_lanes = route_handler->getLaneletSequence(
+    closest_lanelet, ego_pose, backward_distance, forward_distance);
+
+  autoware_utils::LineString2d stop_line_2d{stop_line.front().to_2d(), stop_line.back().to_2d()};
+
+  if (is_within_lanes(current_lanes, stop_line_2d)) {
+    return current_lanes;
+  }
+
+  const auto start_pose = route_handler->getOriginalStartPose();
+  const auto pull_out_start_lane_opt =
+    route_handler->getPullOutStartLane(start_pose, vehicle_info.vehicle_width_m);
+  if (!pull_out_start_lane_opt.has_value()) {
+    return {};
+  }
+
+  const auto road_shoulder_lanes =
+    route_handler->getShoulderLaneletSequence(pull_out_start_lane_opt.value(), start_pose);
+  if (is_within_lanes(road_shoulder_lanes, stop_line_2d)) {
+    return road_shoulder_lanes;
+  }
+
+  return {};
+}
+
+auto get_previous_polygons_with_lane_recursively(
+  const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes,
+  const double s1, const double s2,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const double left_offset, const double right_offset) -> DetectionAreas
+{
+  DetectionAreas ret{};
+
+  if (target_lanes.empty()) {
+    return ret;
+  }
+
+  if (route_handler->getPreviousLanelets(target_lanes.front()).empty()) {
+    const auto total_length = lanelet::utils::getLaneletLength2d(target_lanes);
+    const auto expand_lanelets =
+      lanelet::utils::getExpandedLanelets(target_lanes, left_offset, -1.0 * right_offset);
+    const auto polygon = lanelet::utils::getPolygonFromArcLength(
+      expand_lanelets, total_length - s2, total_length - s1);
+    ret.emplace_back(polygon.basicPolygon(), target_lanes);
+    return ret;
+  }
+
+  for (const auto & prev_lane : route_handler->getPreviousLanelets(target_lanes.front())) {
+    {
+      const auto overlap_current_lanes = std::any_of(
+        current_lanes.begin(), current_lanes.end(),
+        [&prev_lane](const auto & lane) { return lane.id() == prev_lane.id(); });
+      const auto total_length = lanelet::utils::getLaneletLength2d(target_lanes);
+      if (overlap_current_lanes) {
+        const auto expand_lanelets =
+          lanelet::utils::getExpandedLanelets(target_lanes, left_offset, -1.0 * right_offset);
+        const auto polygon = lanelet::utils::getPolygonFromArcLength(
+          expand_lanelets, total_length - s2, total_length - s1);
+        ret.emplace_back(polygon.basicPolygon(), target_lanes);
+
+        continue;
+      }
+    }
+
+    lanelet::ConstLanelets pushed_lanes = target_lanes;
+    pushed_lanes.insert(pushed_lanes.begin(), prev_lane);
+
+    {
+      const auto total_length = lanelet::utils::getLaneletLength2d(pushed_lanes);
+      if (total_length > s2) {
+        const auto expand_lanelets =
+          lanelet::utils::getExpandedLanelets(pushed_lanes, left_offset, -1.0 * right_offset);
+        const auto polygon = lanelet::utils::getPolygonFromArcLength(
+          expand_lanelets, total_length - s2, total_length - s1);
+        ret.emplace_back(polygon.basicPolygon(), pushed_lanes);
+      } else {
+        const auto polygons = get_previous_polygons_with_lane_recursively(
+          current_lanes, pushed_lanes, s1, s2, route_handler, left_offset, right_offset);
+        ret.insert(ret.end(), polygons.begin(), polygons.end());
+      }
+    }
+  }
+
+  return ret;
+}
+
+auto get_obstacle_points(const lanelet::BasicPolygons3d & polygons, const PointCloud & points)
+  -> PointCloud::Ptr
+{
+  PointCloud ret;
+  for (const auto & polygon : polygons) {
+    const auto circle = get_smallest_enclosing_circle(lanelet::utils::to2D(polygon));
+    for (const auto & p : points) {
+      const double squared_dist = (circle.first.x() - p.x) * (circle.first.x() - p.x) +
+                                  (circle.first.y() - p.y) * (circle.first.y() - p.y);
+      if (squared_dist > circle.second) {
+        continue;
+      }
+      if (boost::geometry::within(
+            autoware_utils::Point2d{p.x, p.y}, lanelet::utils::to2D(polygon))) {
+        ret.push_back(p);
+      }
+    }
+  }
+  return std::make_shared<PointCloud>(ret);
+}
+
+auto generate_detection_polygon(
+  const lanelet::ConstLanelets & lanelets, const geometry_msgs::msg::Pose & ego_pose,
+  const double forward_distance, const double backward_distance) -> lanelet::BasicPolygon3d
+{
+  const auto ego_coordinate_on_arc = lanelet::utils::getArcCoordinates(lanelets, ego_pose).length;
+  const auto polygon = lanelet::utils::getPolygonFromArcLength(
+    lanelets, ego_coordinate_on_arc - backward_distance, ego_coordinate_on_arc + forward_distance);
+  return polygon.basicPolygon();
+}
+
+auto generate_half_lanelet(
+  const lanelet::ConstLanelet lanelet, const bool is_right,
+  const double ignore_width_from_centerline, const double expand_width_from_bound)
+  -> lanelet::ConstLanelet
+{
+  lanelet::Points3d lefts, rights;
+
+  const double offset = !is_right ? ignore_width_from_centerline : -ignore_width_from_centerline;
+  const auto offset_centerline = lanelet::utils::getCenterlineWithOffset(lanelet, offset);
+
+  const auto original_left_bound =
+    !is_right ? lanelet::utils::getLeftBoundWithOffset(lanelet, expand_width_from_bound)
+              : offset_centerline;
+  const auto original_right_bound =
+    !is_right ? offset_centerline
+              : lanelet::utils::getRightBoundWithOffset(lanelet, expand_width_from_bound);
+
+  for (const auto & pt : original_left_bound) {
+    lefts.emplace_back(pt);
+  }
+  for (const auto & pt : original_right_bound) {
+    rights.emplace_back(pt);
+  }
+  const auto left_bound = lanelet::LineString3d(lanelet::InvalId, std::move(lefts));
+  const auto right_bound = lanelet::LineString3d(lanelet::InvalId, std::move(rights));
+  auto half_lanelet = lanelet::Lanelet(lanelet::InvalId, left_bound, right_bound);
+  return half_lanelet;
+}
+
+auto create_polygon_marker_array(
+  const std::vector<autoware_utils::Polygon3d> & polygons, const std::string & ns,
+  const std_msgs::msg::ColorRGBA & color) -> MarkerArray
+{
+  MarkerArray msg;
+
+  size_t i = 0;
+  for (const auto & polygon : polygons) {
+    auto marker = autoware_utils::create_default_marker(
+      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, i++, Marker::LINE_STRIP,
+      autoware_utils::create_marker_scale(0.05, 0.0, 0.0), color);
+
+    for (const auto & p : polygon.outer()) {
+      marker.points.push_back(autoware_utils::create_point(p.x(), p.y(), p.z()));
+    }
+    if (!marker.points.empty()) {
+      marker.points.push_back(marker.points.front());
+    }
+    msg.markers.push_back(marker);
+  }
+
+  return msg;
+}
+
+auto create_polygon_marker_array(
+  const lanelet::BasicPolygons3d & polygons, const std::string & ns,
+  const std_msgs::msg::ColorRGBA & color) -> MarkerArray
+{
+  MarkerArray msg;
+
+  size_t i = 0;
+  for (const auto & polygon : polygons) {
+    auto marker = autoware_utils::create_default_marker(
+      "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, i++, Marker::LINE_STRIP,
+      autoware_utils::create_marker_scale(0.2, 0.0, 0.0), color);
+
+    for (const auto & p : polygon) {
+      marker.points.push_back(autoware_utils::create_point(p.x(), p.y(), p.z()));
+    }
+    if (!marker.points.empty()) {
+      marker.points.push_back(marker.points.front());
+    }
+    msg.markers.push_back(marker);
+  }
+
+  return msg;
+}
+
+auto create_pointcloud_object_marker_array(
+  const PointCloudObjects & objects, const std::string & ns,
+  const rear_collision_checker_node::Params & parameters) -> MarkerArray
+{
+  MarkerArray msg;
+
+  size_t i = 0L;
+  for (const auto & object : objects) {
+    const auto sphere_color = [&object, &parameters]() {
+      if (
+        object.tracking_duration <
+        parameters.common.pointcloud.velocity_estimation.observation_time) {
+        return autoware_utils::create_marker_color(1.0, 1.0, 1.0, 0.999);
+      }
+      if (
+        object.velocity > parameters.common.filter.min_velocity &&
+        object.moving_time < parameters.common.filter.moving_time) {
+        return autoware_utils::create_marker_color(1.0, 0.67, 0.0, 0.999);
+      }
+      if (object.ignore) {
+        return autoware_utils::create_marker_color(0.5, 0.5, 0.5, 0.999);
+      }
+      return object.safe ? autoware_utils::create_marker_color(0.16, 1.0, 0.69, 0.999)
+                         : autoware_utils::create_marker_color(1.0, 0.0, 0.42, 0.999);
+    }();
+
+    {
+      auto marker = autoware_utils::create_default_marker(
+        "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns + "_sphere", i++, Marker::SPHERE,
+        autoware_utils::create_marker_scale(1.0, 1.0, 1.0), sphere_color);
+      marker.pose = object.pose;
+      msg.markers.push_back(marker);
+    }
+
+    {
+      const auto x_scale = object.velocity * 0.36;
+      auto marker = autoware_utils::create_default_marker(
+        "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns + "_arrow", i++, Marker::ARROW,
+        autoware_utils::create_marker_scale(x_scale, 0.3, 0.3), sphere_color);
+      marker.pose = object.pose;
+      msg.markers.push_back(marker);
+    }
+
+    {
+      auto marker = autoware_utils::create_default_marker(
+        "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns + "_text", i++, Marker::TEXT_VIEW_FACING,
+        autoware_utils::create_marker_scale(0.5, 0.5, 0.5),
+        autoware_utils::create_marker_color(1.0, 1.0, 1.0, 0.999));
+
+      std::ostringstream ss;
+      ss << std::fixed << std::setprecision(2);
+      ss << "TrackingDuration:" << object.tracking_duration
+         << "[s]\nMovingTime:" << object.moving_time
+         << "[s]\nRelativeDistance(w/DC):" << object.relative_distance
+         << "[m]\nRelativeDistance(w/oDC):" << object.relative_distance_with_delay_compensation
+         << "[m]\nVelocity:" << object.velocity << "[m/s]\nRSSDistance" << object.rss_distance
+         << "[m]\nFurthestLaneID:" << object.furthest_lane.id();
+
+      marker.text = ss.str();
+      marker.pose = object.pose;
+      marker.pose.position.z += 1.0;
+      msg.markers.push_back(marker);
+    }
+  }
+
+  return msg;
+}
+
+auto create_line_marker_array(const autoware_utils::LineString3d & line, const std::string & ns)
+  -> MarkerArray
+{
+  MarkerArray msg;
+
+  if (line.size() < 2) {
+    return msg;
+  }
+
+  auto marker = autoware_utils::create_default_marker(
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), ns, 0L, Marker::LINE_STRIP,
+    autoware_utils::create_marker_scale(0.3, 0.1, 0.1),
+    autoware_utils::create_marker_color(1.0, 0.0, 0.42, 0.999));
+  marker.points.push_back(autoware_utils::to_msg(line.front()));
+  marker.points.push_back(autoware_utils::to_msg(line.back()));
+
+  msg.markers.push_back(marker);
+  return msg;
+}
+}  // namespace autoware::planning_validator::utils

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
@@ -400,7 +400,7 @@ void cut_by_lanelets(const lanelet::ConstLanelets & lanelets, DetectionAreas & d
 {
   const auto combine_lanelet = lanelet::utils::combineLaneletsShape(lanelets);
 
-  for (auto & [original, lanelets] : detection_areas) {
+  for (auto & [original, _] : detection_areas) {
     if (original.empty()) {
       continue;
     }

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
@@ -331,7 +331,7 @@ auto check_turn_behavior(
   }
 
   const auto exceed_dead_line =
-    [&points, &ego_pose, &p, &conflict_point, &stoppable_point, &vehicle_info](
+    [&points, &ego_pose, &conflict_point, &stoppable_point, &vehicle_info](
       const auto & sibling_straight_lanelet, const auto distance, const auto is_right) {
       if (!sibling_straight_lanelet.has_value()) {
         return distance < stoppable_point.value().second;

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
@@ -637,10 +637,10 @@ auto create_pointcloud_object_marker_array(
       ss << std::fixed << std::setprecision(2);
       ss << "TrackingDuration:" << object.tracking_duration
          << "[s]\nMovingTime:" << object.moving_time
-         << "[s]\nRelativeDistance(w/DC):" << object.relative_distance
-         << "[m]\nRelativeDistance(w/oDC):" << object.relative_distance_with_delay_compensation
+         << "[s]\nRelativeDistance(RAW):" << object.relative_distance
+         << "[m]\nRelativeDistance(w/DC):" << object.relative_distance_with_delay_compensation
          << "[m]\nVelocity:" << object.velocity << "[m/s]\nRSSDistance" << object.rss_distance
-         << "[m]\nFurthestLaneID:" << object.furthest_lane.id();
+         << "[m]\nFurthestLaneID:" << object.furthest_lane.id() << "\nDetail:" << object.detail;
 
       marker.text = ss.str();
       marker.pose = object.pose;

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.hpp
@@ -27,12 +27,12 @@
 namespace autoware::planning_validator::utils
 {
 auto check_shift_behavior(
-  const lanelet::ConstLanelets & lanelets,
+  const lanelet::ConstLanelets & lanelets, const bool is_unsafe_holding,
   const std::shared_ptr<PlanningValidatorContext> & context,
   const rear_collision_checker_node::Params & parameters, DebugData & debug) -> Behavior;
 
 auto check_turn_behavior(
-  const lanelet::ConstLanelets & lanelets,
+  const lanelet::ConstLanelets & lanelets, const bool is_unsafe_holding,
   const std::shared_ptr<PlanningValidatorContext> & context,
   const rear_collision_checker_node::Params & parameters, DebugData & debug) -> Behavior;
 

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.hpp
@@ -1,0 +1,85 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS_HPP_
+#define UTILS_HPP_
+
+#include "structs.hpp"
+
+#include <autoware/planning_validator/types.hpp>
+#include <autoware/route_handler/route_handler.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::planning_validator::utils
+{
+
+auto calc_predicted_stop_line(
+  const std::shared_ptr<PlanningValidatorContext> & context,
+  const rear_collision_checker_node::Params & parameters)
+  -> std::optional<autoware_utils::LineString3d>;
+
+auto check_shift_behavior(
+  const lanelet::ConstLanelets & lanelets,
+  const std::shared_ptr<PlanningValidatorContext> & context) -> Behavior;
+
+auto check_turn_behavior(
+  const lanelet::ConstLanelets & lanelets,
+  const std::shared_ptr<PlanningValidatorContext> & context,
+  const rear_collision_checker_node::Params & parameters) -> Behavior;
+
+void cut_by_lanelets(const lanelet::ConstLanelets & lanelets, DetectionAreas & detection_areas);
+
+auto generate_half_lanelet(
+  const lanelet::ConstLanelet lanelet, const bool is_right,
+  const double ignore_width_from_centerline, const double expand_width_from_bound)
+  -> lanelet::ConstLanelet;
+
+auto get_current_lanes(
+  const std::shared_ptr<PlanningValidatorContext> & context,
+  const autoware_utils::LineString3d & stop_line, const double forward_distance,
+  const double backward_distance) -> lanelet::ConstLanelets;
+
+auto get_obstacle_points(const lanelet::BasicPolygons3d & polygons, const PointCloud & points)
+  -> PointCloud::Ptr;
+
+auto get_previous_polygons_with_lane_recursively(
+  const lanelet::ConstLanelets & current_lanes, const lanelet::ConstLanelets & target_lanes,
+  const double s1, const double s2,
+  const std::shared_ptr<autoware::route_handler::RouteHandler> & route_handler,
+  const double left_offset, const double right_offset) -> DetectionAreas;
+
+auto generate_detection_polygon(
+  const lanelet::ConstLanelets & lanelets, const geometry_msgs::msg::Pose & ego_pose,
+  const double forward_distance, const double backward_distance) -> lanelet::BasicPolygon3d;
+
+auto create_polygon_marker_array(
+  const std::vector<autoware_utils::Polygon3d> & polygons, const std::string & ns,
+  const std_msgs::msg::ColorRGBA & color) -> MarkerArray;
+
+auto create_polygon_marker_array(
+  const lanelet::BasicPolygons3d & polygons, const std::string & ns,
+  const std_msgs::msg::ColorRGBA & color) -> MarkerArray;
+
+auto create_pointcloud_object_marker_array(
+  const PointCloudObjects & objects, const std::string & ns,
+  const rear_collision_checker_node::Params & parameters) -> MarkerArray;
+
+auto create_line_marker_array(const autoware_utils::LineString3d & line, const std::string & ns)
+  -> MarkerArray;
+}  // namespace autoware::planning_validator::utils
+
+#endif  // UTILS_HPP_

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.hpp
@@ -26,20 +26,15 @@
 
 namespace autoware::planning_validator::utils
 {
-
-auto calc_predicted_stop_line(
-  const std::shared_ptr<PlanningValidatorContext> & context,
-  const rear_collision_checker_node::Params & parameters)
-  -> std::optional<autoware_utils::LineString3d>;
-
 auto check_shift_behavior(
   const lanelet::ConstLanelets & lanelets,
-  const std::shared_ptr<PlanningValidatorContext> & context) -> Behavior;
+  const std::shared_ptr<PlanningValidatorContext> & context,
+  const rear_collision_checker_node::Params & parameters, DebugData & debug) -> Behavior;
 
 auto check_turn_behavior(
   const lanelet::ConstLanelets & lanelets,
   const std::shared_ptr<PlanningValidatorContext> & context,
-  const rear_collision_checker_node::Params & parameters) -> Behavior;
+  const rear_collision_checker_node::Params & parameters, DebugData & debug) -> Behavior;
 
 void cut_by_lanelets(const lanelet::ConstLanelets & lanelets, DetectionAreas & detection_areas);
 
@@ -49,8 +44,7 @@ auto generate_half_lanelet(
   -> lanelet::ConstLanelet;
 
 auto get_current_lanes(
-  const std::shared_ptr<PlanningValidatorContext> & context,
-  const autoware_utils::LineString3d & stop_line, const double forward_distance,
+  const std::shared_ptr<PlanningValidatorContext> & context, const double forward_distance,
   const double backward_distance) -> lanelet::ConstLanelets;
 
 auto get_obstacle_points(const lanelet::BasicPolygons3d & polygons, const PointCloud & points)
@@ -78,8 +72,9 @@ auto create_pointcloud_object_marker_array(
   const PointCloudObjects & objects, const std::string & ns,
   const rear_collision_checker_node::Params & parameters) -> MarkerArray;
 
-auto create_line_marker_array(const autoware_utils::LineString3d & line, const std::string & ns)
-  -> MarkerArray;
+auto create_line_marker_array(
+  const autoware_utils::LineString3d & line, const std::string & ns,
+  const std_msgs::msg::ColorRGBA & color) -> MarkerArray;
 }  // namespace autoware::planning_validator::utils
 
 #endif  // UTILS_HPP_


### PR DESCRIPTION
## Description

This update introduces a new plugin called rear_collision_checker, which is responsible for detecting potential rear-end collisions based on predicted object motion and the ego vehicle's planned trajectory. The plugin is specifically designed to enhance safety when the vehicle is about to change lanes or merge into an adjacent lane, where rear-approaching vehicles may pose a threat. Key features include:

LIDAR-based obstacle detection: Directly analyzes raw point cloud data to identify rear-approaching objects not yet recognized by perception.

Nearest-point velocity estimation: Calculates relative velocity of closest rear obstacle points for more accurate collision prediction.

RSS-based risk metrics: Computes collision risk using estimated velocity and spatial-temporal proximity.

Dynamic object filtering: Ignores static or irrelevant objects based on motion and direction filtering.

These changes contribute to safer and more robust trajectory validation, especially in lane-change or merging scenarios. The goal is to mitigate risks in situations where object recognition is lost or when the planning module makes incorrect decisions.

This scenario represents an obstacle avoidance case where a vehicle is approaching from behind in the adjacent lane. The obstacle avoidance module detects the rear vehicle as well and, when there is a potential risk of collision, it avoids performing an evasive maneuver. Instead, it waits for the vehicle in the adjacent lane to pass before executing the avoidance. In this case, the module does not activate.

https://github.com/user-attachments/assets/62e0163c-4638-415f-a8d4-0a273c2b6ba9

On the other hand, if the avoidance module fails to operate correctly and performs a lane change in such a situation, this module detects the potential collision as shown below. (In this case, we deliberately disabled the safety check functionality of the avoidance module to intentionally simulate a situation where the planning module fails to make the correct decision.)

https://github.com/user-attachments/assets/9b99228e-11d9-476e-924e-21b34bb9c9d3

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [TIER IV INTERNAL SCENARIOS (disconnect MRM)](https://evaluation.tier4.jp/evaluation/reports/2b7d94a6-8b8e-5158-9ad8-4f2629b8eb42?project_id=prd_jt)
- [x] [TIER IV INTERNAL SCENARIOS (connect MRM)](https://evaluation.tier4.jp/evaluation/reports/f1712149-6b08-53ff-9244-be975634230e?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
