### PR TITLE
fix(planning_validator): fix the lateral distance calculation

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/README.md
+++ b/planning/planning_validator/autoware_planning_validator/README.md
@@ -151,14 +151,14 @@ The following parameters can be set for the `autoware_planning_validator`:
 
 #### Deviation Check
 
-| Name                                        | Type   | Description                                                                  | Default value |
-| :------------------------------------------ | :----- | :--------------------------------------------------------------------------- | :------------ |
-| `validity_checks.deviation.enable`          | bool   | flag to enable/disable deviation validation check                            | true          |
-| `validity_checks.deviation.velocity_th`     | double | max valid velocity deviation between ego and nearest trajectory point [m/s]  | 100.0         |
-| `validity_checks.deviation.distance_th`     | double | max valid euclidean distance between ego and nearest trajectory point [m]    | 100.0         |
-| `validity_checks.deviation.lon_distance_th` | double | max valid longitudinal distance between ego and nearest trajectory point [m] | 2.0           |
-| `validity_checks.deviation.yaw_th`          | double | max valid yaw deviation between ego and nearest trajectory point [rad]       | 1.5708        |
-| `validity_checks.deviation.is_critical`     | bool   | if true, will use handling type specified for critical checks                | false         |
+| Name                                        | Type   | Description                                                                   | Default value |
+| :------------------------------------------ | :----- | :---------------------------------------------------------------------------- | :------------ |
+| `validity_checks.deviation.enable`          | bool   | flag to enable/disable deviation validation check                             | true          |
+| `validity_checks.deviation.velocity_th`     | double | max valid velocity deviation between ego and nearest trajectory point [m/s]   | 100.0         |
+| `validity_checks.deviation.distance_th`     | double | max valid lateral distance between ego and the nearest trajectory segment [m] | 100.0         |
+| `validity_checks.deviation.lon_distance_th` | double | max valid longitudinal distance between ego and nearest trajectory point [m]  | 2.0           |
+| `validity_checks.deviation.yaw_th`          | double | max valid yaw deviation between ego and nearest trajectory point [rad]        | 1.5708        |
+| `validity_checks.deviation.is_critical`     | bool   | if true, will use handling type specified for critical checks                 | false         |
 
 #### Forward Trajectory Length Check
 

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker_diag.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker_diag.cpp
@@ -489,7 +489,6 @@ TEST(TrajectoryCheckerModule, DiagCheckDistanceDeviation)
 
   // Larger distance deviation than threshold -> must be NG
   const auto error_distance = test_utils::THRESHOLD_DISTANCE_DEVIATION * scale_margin;
-  test(error_distance, 0.0, false);
   test(0.0, error_distance, false);
   test(0.0, -error_distance, false);
   test(error_distance, error_distance, false);
@@ -497,6 +496,10 @@ TEST(TrajectoryCheckerModule, DiagCheckDistanceDeviation)
 
   // Smaller distance deviation than threshold -> must be OK
   const auto ok_distance = test_utils::THRESHOLD_DISTANCE_DEVIATION / scale_margin;
+  // Longitudinal error does not cause failure
+  test(error_distance, 0.0, true);
+  test(error_distance, ok_distance, true);
+  test(error_distance, -ok_distance, true);
   test(ok_distance, 0.0, true);
   test(0.0, ok_distance, true);
   test(0.0, -ok_distance, true);


### PR DESCRIPTION
## Description

Distance deviation was incorrectly calculated as Euclidian distance from the nearest trajectory _point_ instead of lateral distance from nearest segment.
This PR fixes that.

Example impact:
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/5a0781d0-dbad-415a-b233-4faffabbc750) | ![image](https://github.com/user-attachments/assets/99938dc1-8686-4b85-95cb-78e71d33b37d) |

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-10026)
## How was this PR tested?

Psim
Perception reproducer

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
