### PR TITLE
fix(autoware_static_obstacle_avoidance): fix classification method of unstable object

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
@@ -144,6 +144,8 @@
         merging_vehicle:
           th_overhang_distance: 0.0                     # [m]
 
+        unstable_classification_time: 2.0                # [s] If the object is classified as UNKNOWN type for less than unstable_classification_time seconds, it is probably not an unknown type.
+
         # params for avoidance of vehicle type objects that are ambiguous as to whether they are parked.
         avoidance_for_ambiguous_vehicle:
           # policy for ego behavior for ambiguous vehicle.

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -277,6 +277,8 @@ struct AvoidanceParameters
   // lost_count and the registered object will be removed when the count exceeds this max count.
   double object_last_seen_threshold{0.0};
 
+  double unstable_classification_time{0.0};
+
   // The avoidance path generation is performed when the shift distance of the
   // avoidance points is greater than this threshold.
   // In multiple targets case: if there are multiple vehicles in a row to be avoided, no new
@@ -390,6 +392,10 @@ struct ObjectData  // avoidance target
 
   // distance factor for perception noise (0.0~1.0)
   double distance_factor{0.0};
+
+  // Objects that have not been classified as UNKNOWN for a certain period of time may not be
+  // UNKNOWN.
+  bool is_classification_unstable{false};
 
   // count up when object disappeared. Removed when it exceeds threshold.
   rclcpp::Time last_seen{rclcpp::Clock(RCL_ROS_TIME).now()};

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -485,6 +485,8 @@ private:
   // TODO(Satoshi OTA) remove this variable.
   mutable ObjectDataArray stopped_objects_;
 
+  mutable std::unordered_map<std::string, rclcpp::Time> unknown_type_object_first_seen_time_map_;
+
   mutable size_t safe_count_{0};
 
   mutable DebugData debug_data_;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp
@@ -20,6 +20,8 @@
 #include "autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp"
 
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -190,6 +192,17 @@ void fillObjectEnvelopePolygon(
 void fillObjectMovingTime(
   ObjectData & object_data, ObjectDataArray & stopped_objects,
   const std::shared_ptr<AvoidanceParameters> & parameters);
+
+/**
+ * @brief update classification unstable objects.
+ * @param current detected object.
+ * @param unknown type object first seen time map.
+ * @param unstable classification time.
+ */
+void updateClassificationUnstableObjects(
+  ObjectData & object_data,
+  std::unordered_map<std::string, rclcpp::Time> & unknown_type_object_first_seen_time_map,
+  const double unstable_classification_time);
 
 /**
  * @brief check whether ego has to avoid the objects.

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
@@ -886,6 +886,7 @@
             "object_check_goal_distance",
             "object_check_return_pose_distance",
             "max_compensation_time",
+            "unstable_classification_time",
             "detection_area",
             "merging_vehicle",
             "parked_vehicle",

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
@@ -689,6 +689,11 @@
               "description": "For the compensation of the detection lost. The object is registered once it is observed as an avoidance target. When the detection loses, the timer will start and the object will be un-registered when the time exceeds this limit.",
               "default": 2.0
             },
+            "unstable_classification_time": {
+              "type": "number",
+              "description": "If the object is classified as UNKNOWN type for less than unstable_classification_time seconds, it is probably not an unknown type.",
+              "default": 2.0
+            },
             "detection_area": {
               "type": "object",
               "properties": {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
@@ -106,6 +106,8 @@ void StaticObstacleAvoidanceModuleManager::updateModuleParams(
     update_param<double>(
       parameters, ns + "object_check_return_pose_distance", p->object_check_return_pose_distance);
     update_param<double>(parameters, ns + "max_compensation_time", p->object_last_seen_threshold);
+    update_param<double>(
+      parameters, ns + "unstable_classification_time", p->unstable_classification_time);
   }
 
   {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -454,6 +454,11 @@ ObjectData StaticObstacleAvoidanceModule::createObjectData(
   utils::static_obstacle_avoidance::fillObjectMovingTime(
     object_data, stopped_objects_, parameters_);
 
+  // Update classification unstable objects.
+  utils::static_obstacle_avoidance::updateClassificationUnstableObjects(
+    object_data, unknown_type_object_first_seen_time_map_,
+    parameters_->unstable_classification_time);
+
   // Calc lateral deviation from path to target object.
   object_data.direction = calc_lateral_deviation(object_closest_pose, object_pose.position) > 0.0
                             ? Direction::LEFT

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -23,6 +23,7 @@
 
 #include <Eigen/Dense>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
 
 #include <boost/geometry/algorithms/buffer.hpp>
 #include <boost/geometry/algorithms/convex_hull.hpp>
@@ -37,6 +38,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -1678,6 +1680,26 @@ void fillObjectMovingTime(
   }
 }
 
+void updateClassificationUnstableObjects(
+  ObjectData & object_data,
+  std::unordered_map<std::string, rclcpp::Time> & unknown_type_object_first_seen_time_map,
+  const double unstable_classification_time)
+{
+  // std::cout << "map size: " << unknown_type_object_first_seen_time_map.size() << std::endl;
+  if (filtering_utils::isUnknownTypeObject(object_data)) {
+    auto now = rclcpp::Clock(RCL_ROS_TIME).now();
+    std::string object_id = to_hex_string(object_data.object.object_id);
+    if (
+      unknown_type_object_first_seen_time_map.find(object_id) ==
+      unknown_type_object_first_seen_time_map.end()) {
+      unknown_type_object_first_seen_time_map[object_id] = now;
+    }
+    auto elapsed_time = (now - unknown_type_object_first_seen_time_map[object_id]).seconds();
+
+    object_data.is_classification_unstable = elapsed_time < unstable_classification_time;
+  }
+}
+
 void fillAvoidanceNecessity(
   ObjectData & object_data, const ObjectDataArray & registered_objects, const double vehicle_width,
   const std::shared_ptr<AvoidanceParameters> & parameters)
@@ -1975,11 +1997,7 @@ void filterTargetObjects(
     o.to_road_shoulder_distance = filtering_utils::getRoadShoulderDistance(o, data, planner_data);
 
     if (filtering_utils::isUnknownTypeObject(o)) {
-      // TARGET: UNKNOWN
-
-      // TODO(Satoshi Ota) parametrize stop time threshold if need.
-      constexpr double STOP_TIME_THRESHOLD = 3.0;  // [s]
-      if (o.stop_time < STOP_TIME_THRESHOLD) {
+      if (o.is_classification_unstable) {
         o.info = ObjectInfo::UNSTABLE_OBJECT;
         data.other_objects.push_back(o);
         continue;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1689,11 +1689,7 @@ void updateClassificationUnstableObjects(
   if (filtering_utils::isUnknownTypeObject(object_data)) {
     auto now = rclcpp::Clock(RCL_ROS_TIME).now();
     std::string object_id = to_hex_string(object_data.object.object_id);
-    if (
-      unknown_type_object_first_seen_time_map.find(object_id) ==
-      unknown_type_object_first_seen_time_map.end()) {
-      unknown_type_object_first_seen_time_map[object_id] = now;
-    }
+    unknown_type_object_first_seen_time_map.try_emplace(object_id, now);
     auto elapsed_time = (now - unknown_type_object_first_seen_time_map[object_id]).seconds();
 
     object_data.is_classification_unstable = elapsed_time < unstable_classification_time;


### PR DESCRIPTION
## Description

Until now, move_time was used to classify objects as UNSTABLE. In this PR, I changed it to use the first time classified as UNKNOWN instead of move_time. By doing so, we made it more robust against perception noise.

## Related links

- https://github.com/autowarefoundation/autoware_launch/pull/1492

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/362d34b8-3034-54e2-b7e8-f48f7d1bac59/tests/f9b42ba6-bd36-561e-adc6-7768c2ef7b49?project_id=prd_jt&state=failed

![Screenshot from 2025-06-13 19-59-42](https://github.com/user-attachments/assets/a202235a-0735-418e-9a12-65d35f8e2aa4)

## Notes for re
viewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
