### PR TITLE
feat(virtual_traffic_light): improve log message

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.cpp
@@ -119,7 +119,7 @@ void VirtualTrafficLightModuleManager::modifyPathVelocity(
   //       of virtual traffic light states is set here.
   const auto virtual_traffic_light_states = sub_virtual_traffic_light_states_->take_data();
   for (const auto & scene_module : scene_modules_) {
-    scene_module->setVirtualTrafficLightStates(virtual_traffic_light_states);
+    scene_module->setCorrespondingVirtualTrafficLightState(virtual_traffic_light_states);
   }
 
   SceneModuleManagerInterface<VirtualTrafficLightModule>::modifyPathVelocity(path);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -228,7 +228,6 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
     return true;
   }
 
-  // Find corresponding state
   // Stop at stop_line if no message received
   if (!virtual_traffic_light_state_) {
     setModuleState<State::REQUESTING>();

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -68,8 +68,8 @@ VirtualTrafficLightModule::VirtualTrafficLightModule(
     map_data_.end_lines = toAutowarePoints(reg_elem_.getEndLines());
 
     // Set stop line ID for logging (safe to use in log messages)
-    map_data_.stop_line_id_for_log =
-      reg_elem_.getStopLine() ? std::to_string(reg_elem_.getStopLine()->id()) : "none";
+    const auto stop_line = reg_elem_.getStopLine();
+    map_data_.stop_line_id_for_log = stop_line ? std::to_string(stop_line->id()) : "none";
   }
 
   // Custom tags

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -47,7 +47,8 @@ VirtualTrafficLightModule::VirtualTrafficLightModule(
   lane_id_(lane_id),
   reg_elem_(reg_elem),
   lane_(lane),
-  planner_param_(planner_param)
+  planner_param_(planner_param),
+  base_logger_(logger)
 {
   // Get map data
   const auto instrument = reg_elem_.getVirtualTrafficLight();
@@ -65,6 +66,10 @@ VirtualTrafficLightModule::VirtualTrafficLightModule(
     map_data_.stop_line = toAutowarePoints(reg_elem_.getStopLine());
     map_data_.start_line = toAutowarePoints(reg_elem_.getStartLine());
     map_data_.end_lines = toAutowarePoints(reg_elem_.getEndLines());
+
+    // Set stop line ID for logging (safe to use in log messages)
+    map_data_.stop_line_id_for_log =
+      reg_elem_.getStopLine() ? std::to_string(reg_elem_.getStopLine()->id()) : "none";
   }
 
   // Custom tags
@@ -95,8 +100,81 @@ VirtualTrafficLightModule::VirtualTrafficLightModule(
   command_.id = map_data_.instrument_id;
   command_.custom_tags = map_data_.custom_tags;
 
-  // Add instrument information to the logger
-  logger_ = logger_.get_child((map_data_.instrument_type + "_" + map_data_.instrument_id).c_str());
+  // Set up base logger with instrument information
+  base_logger_ =
+    base_logger_.get_child((map_data_.instrument_type + "_" + map_data_.instrument_id).c_str());
+  updateLoggerWithState();
+}
+
+void VirtualTrafficLightModule::setModuleState(
+  const State new_state, const std::optional<int64_t> end_line_id)
+{
+  // +----------+
+  // |   NONE   |
+  // +----------+
+  //      |
+  //      | vehicle is before start line
+  //      v
+  // +----------+
+  // |REQUESTING|
+  // +----------+
+  //      |
+  //      | vehicle has passed stop line
+  //      v
+  // +----------+
+  // | PASSING  |
+  // +----------+
+  //      |
+  //      +-------------------------------------------+
+  //      | - vehicle is near end line                | vehicle has passed end line
+  //      | - finalization isn't completed            |
+  //      v                                           v
+  // +----------+                                 +-----------+
+  // |FINALIZING|                                 | FINALIZED |
+  // +----------+                                 +-----------+
+
+  if (state_ == new_state) {
+    return;
+  }
+
+  // NONE -> REQUESTING
+  if (state_ == State::NONE && new_state == State::REQUESTING) {
+    logInfo(
+      "State transition: NONE -> REQUESTING as vehicle is before start line (ID: %ld)",
+      reg_elem_.getStartLine().id());
+  }
+
+  // REQUESTING -> PASSING
+  if (state_ == State::REQUESTING && new_state == State::PASSING) {
+    logInfo(
+      "State transition: REQUESTING -> PASSING as vehicle has passed stop line (ID: %s)",
+      map_data_.stop_line_id_for_log.c_str());
+  }
+
+  // PASSING -> FINALIZING
+  if (state_ == State::PASSING && new_state == State::FINALIZING) {
+    if (end_line_id.has_value()) {
+      logInfo(
+        "State transition: PASSING -> FINALIZING as vehicle is near end line (ID: %ld)",
+        end_line_id.value());
+    } else {
+      logInfo("State transition: PASSING -> FINALIZING as vehicle is near end line");
+    }
+  }
+
+  // PASSING -> FINALIZED
+  if (state_ == State::PASSING && new_state == State::FINALIZED) {
+    if (end_line_id.has_value()) {
+      logInfo(
+        "State transition: PASSING -> FINALIZED as vehicle has passed end line (ID: %ld)",
+        end_line_id.value());
+    } else {
+      logInfo("State transition: PASSING -> FINALIZED as vehicle has passed end line");
+    }
+  }
+
+  state_ = new_state;
+  updateLoggerWithState();
 }
 
 bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
@@ -114,51 +192,60 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
   // Calculate path index of end line
   // NOTE: In order to deal with u-turn or self-crossing path, only start/stop lines before the end
   // line are used when whether the ego is before/after the start/stop/end lines is calculated.
-  const auto opt_end_line_idx = getPathIndexOfFirstEndLine();
-  if (!opt_end_line_idx) {
+  const auto opt_end_line_result = getPathIndexOfFirstEndLine();
+  if (!opt_end_line_result) {
     return true;
   }
-  const size_t end_line_idx = opt_end_line_idx.value();
+  const size_t end_line_idx = opt_end_line_result->first;
+  const int64_t end_line_id = opt_end_line_result->second;
 
   // Do nothing if vehicle is before start line
   if (isBeforeStartLine(end_line_idx)) {
-    RCLCPP_DEBUG(logger_, "before start_line");
-    state_ = State::NONE;
+    logDebug("before start_line");
+    setModuleState<State::NONE>();
+    updateInfrastructureCommand();
+    return true;
+  }
+
+  // Do nothing if state is already FINALIZED
+  if (state_ == State::FINALIZED) {
+    logInfoThrottle(5000, "state is already FINALIZED");
     updateInfrastructureCommand();
     return true;
   }
 
   // Do nothing if vehicle is after any end line
-  if (isAfterAnyEndLine(end_line_idx) || state_ == State::FINALIZED) {
-    RCLCPP_DEBUG(logger_, "after end_line");
-    state_ = State::FINALIZED;
+  if (isAfterAnyEndLine(end_line_idx)) {
+    setModuleState<State::FINALIZED>(end_line_id);
     updateInfrastructureCommand();
     return true;
   }
 
-  // Set state
-  state_ = State::REQUESTING;
-
   // Don't need to stop if there is no stop_line
-  if (!map_data_.stop_line) {
+  if (!map_data_.stop_line || !reg_elem_.getStopLine()) {
+    logWarnThrottle(5000, "no stop line is found, do nothing in this module");
     updateInfrastructureCommand();
     return true;
   }
 
   // Find corresponding state
-  const auto virtual_traffic_light_state = findCorrespondingState();
-
   // Stop at stop_line if no message received
-  if (!virtual_traffic_light_state) {
-    RCLCPP_DEBUG(logger_, "no message received");
+  if (!virtual_traffic_light_state_) {
+    setModuleState<State::REQUESTING>();
+    logInfoThrottle(
+      5000, "no message received for instrument (ID: %s), stop at stop line (ID: %s)",
+      map_data_.instrument_id.c_str(), map_data_.stop_line_id_for_log.c_str());
     insertStopVelocityAtStopLine(path, end_line_idx);
     updateInfrastructureCommand();
     return true;
   }
 
   // Stop at stop_line if no right is given
-  if (!hasRightOfWay(*virtual_traffic_light_state)) {
-    RCLCPP_DEBUG(logger_, "no right is given");
+  if (!hasRightOfWay(*virtual_traffic_light_state_)) {
+    setModuleState<State::REQUESTING>();
+    logInfoThrottle(
+      5000, "no right of way for instrument (ID: %s) is given, stop at stop line (ID: %s)",
+      map_data_.instrument_id.c_str(), map_data_.stop_line_id_for_log.c_str());
     insertStopVelocityAtStopLine(path, end_line_idx);
     updateInfrastructureCommand();
     return true;
@@ -166,8 +253,11 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
 
   // Stop at stop_line if state is timeout before stop_line
   if (isBeforeStopLine(end_line_idx)) {
-    if (isStateTimeout(*virtual_traffic_light_state)) {
-      RCLCPP_DEBUG(logger_, "state is timeout before stop line");
+    setModuleState<State::REQUESTING>();
+    if (isStateTimeout(*virtual_traffic_light_state_)) {
+      logWarnThrottle(
+        5000, "virtual traffic light state is timeout, stop at stop line (ID: %s)",
+        map_data_.stop_line_id_for_log.c_str());
       insertStopVelocityAtStopLine(path, end_line_idx);
     }
 
@@ -176,24 +266,33 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
   }
 
   // After stop_line
-  state_ = State::PASSING;
+  if (state_ == State::REQUESTING) {
+    setModuleState<State::PASSING>();
+  }
 
   // Check timeout after stop_line if the option is on
   if (
-    planner_param_.check_timeout_after_stop_line && isStateTimeout(*virtual_traffic_light_state)) {
-    RCLCPP_DEBUG(logger_, "state is timeout after stop line");
+    planner_param_.check_timeout_after_stop_line && isStateTimeout(*virtual_traffic_light_state_)) {
+    setModuleState<State::PASSING>();
+    logWarnThrottle(
+      5000,
+      "virtual traffic light state is timeout after stop line, insert stop velocity at stop line "
+      "(ID: %s)",
+      map_data_.stop_line_id_for_log.c_str());
     insertStopVelocityAtStopLine(path, end_line_idx);
     updateInfrastructureCommand();
     return true;
   }
 
   // Stop at stop_line if finalization isn't completed
-  if (!virtual_traffic_light_state->is_finalized) {
-    RCLCPP_DEBUG(logger_, "finalization isn't completed");
+  if (!virtual_traffic_light_state_->is_finalized) {
+    logInfoThrottle(
+      5000, "finalization isn't completed, insert stop velocity at end line (ID: %s)",
+      map_data_.stop_line_id_for_log.c_str());
     insertStopVelocityAtEndLine(path, end_line_idx);
 
     if (isNearAnyEndLine(end_line_idx) && planner_data_->isVehicleStopped()) {
-      state_ = State::FINALIZING;
+      setModuleState<State::FINALIZING>(end_line_id);
     }
   }
 
@@ -208,10 +307,15 @@ void VirtualTrafficLightModule::updateInfrastructureCommand()
   setInfrastructureCommand(command_);
 }
 
-std::optional<size_t> VirtualTrafficLightModule::getPathIndexOfFirstEndLine()
+std::optional<std::pair<size_t, int64_t>> VirtualTrafficLightModule::getPathIndexOfFirstEndLine()
 {
-  std::optional<size_t> min_seg_idx;
-  for (const auto & end_line : map_data_.end_lines) {
+  std::optional<std::pair<size_t, int64_t>> min_result;
+  const auto original_end_lines = reg_elem_.getEndLines();
+
+  for (size_t i = 0; i < map_data_.end_lines.size() && i < original_end_lines.size(); ++i) {
+    const auto & end_line = map_data_.end_lines[i];
+    const auto & original_end_line = original_end_lines[i];
+
     geometry_msgs::msg::Point end_line_p1;
     end_line_p1.x = end_line.front().x();
     end_line_p1.y = end_line.front().y();
@@ -232,13 +336,14 @@ std::optional<size_t> VirtualTrafficLightModule::getPathIndexOfFirstEndLine()
 
     const size_t collision_seg_idx = collision->first;
 
-    if (!min_seg_idx || collision_seg_idx < min_seg_idx.value()) {
-      min_seg_idx =
-        collision_seg_idx + 1;  // NOTE: In order that min_seg_idx will be after the end line
+    if (!min_result || collision_seg_idx < min_result->first) {
+      min_result = std::make_pair(
+        collision_seg_idx + 1,  // NOTE: In order that min_seg_idx will be after the end line
+        original_end_line.id());
     }
   }
 
-  return min_seg_idx;
+  return min_result;
 }
 
 bool VirtualTrafficLightModule::isBeforeStartLine(const size_t end_line_idx)
@@ -336,29 +441,12 @@ bool VirtualTrafficLightModule::isNearAnyEndLine(const size_t end_line_idx)
   return std::abs(signed_arc_length) < planner_param_.near_line_distance;
 }
 
-std::optional<tier4_v2x_msgs::msg::VirtualTrafficLightState>
-VirtualTrafficLightModule::findCorrespondingState()
-{
-  // Note: This variable is set by virtual traffic light's manager.
-  if (!virtual_traffic_light_states_) {
-    return {};
-  }
-
-  for (const auto & state : virtual_traffic_light_states_->states) {
-    if (state.id == map_data_.instrument_id) {
-      return state;
-    }
-  }
-
-  return {};
-}
-
 bool VirtualTrafficLightModule::isStateTimeout(
   const tier4_v2x_msgs::msg::VirtualTrafficLightState & state)
 {
   const auto delay = (clock_->now() - rclcpp::Time(state.stamp)).seconds();
   if (delay > planner_param_.max_delay_sec) {
-    RCLCPP_DEBUG(logger_, "delay=%f, max_delay=%f", delay, planner_param_.max_delay_sec);
+    logDebug("delay=%f, max_delay=%f", delay, planner_param_.max_delay_sec);
     return true;
   }
 
@@ -481,10 +569,68 @@ void VirtualTrafficLightModule::setInfrastructureCommand(
   infrastructure_command_ = command;
 }
 
-void VirtualTrafficLightModule::setVirtualTrafficLightStates(
+void VirtualTrafficLightModule::setCorrespondingVirtualTrafficLightState(
   const tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr
     virtual_traffic_light_states)
 {
-  virtual_traffic_light_states_ = virtual_traffic_light_states;
+  if (!virtual_traffic_light_states) {
+    return;
+  }
+
+  for (const auto & state : virtual_traffic_light_states->states) {
+    if (state.id != map_data_.instrument_id) {
+      continue;
+    }
+
+    const bool has_previous_state = virtual_traffic_light_state_.has_value();
+
+    const bool prev_has_right_of_way =
+      has_previous_state ? hasRightOfWay(*virtual_traffic_light_state_) : false;
+    const bool has_right_of_way = hasRightOfWay(state);
+    if (!prev_has_right_of_way && has_right_of_way) {
+      logInfo(
+        "received message for instrument (ID: %s) is updated : right of way is given, approval: "
+        "true, finalized: %s, stamp: %ld.%09ld",
+        state.id.c_str(), state.is_finalized ? "true" : "false", state.stamp.sec,
+        state.stamp.nanosec);
+    }
+
+    const bool prev_finalized =
+      has_previous_state ? virtual_traffic_light_state_->is_finalized : false;
+    const bool current_finalized = state.is_finalized;
+    if (!prev_finalized && current_finalized) {
+      logInfo(
+        "received message for instrument (ID: %s) is updated : finalization is completed, "
+        "approval: %s, finalized: true, stamp: %ld.%09ld",
+        state.id.c_str(), state.approval ? "true" : "false", state.stamp.sec, state.stamp.nanosec);
+    }
+
+    virtual_traffic_light_state_ = state;
+    return;
+  }
+}
+
+std::string VirtualTrafficLightModule::stateToString(State state) const
+{
+  switch (state) {
+    case State::NONE:
+      return "NONE";
+    case State::REQUESTING:
+      return "REQUESTING";
+    case State::PASSING:
+      return "PASSING";
+    case State::FINALIZING:
+      return "FINALIZING";
+    case State::FINALIZED:
+      return "FINALIZED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+void VirtualTrafficLightModule::updateLoggerWithState()
+{
+  const std::string state_name = stateToString(state_);
+  logger_ = base_logger_.get_child(("state: " + state_name).c_str());
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -284,7 +284,7 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
     return true;
   }
 
-  // Stop at stop_line if finalization isn't completed
+  // Stop at end_line if finalization isn't completed
   if (!virtual_traffic_light_state_->is_finalized) {
     logInfoThrottle(
       5000, "finalization isn't completed, insert stop velocity at end line (ID: %s)",

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -105,8 +105,6 @@ public:
     const tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr
       virtual_traffic_light_states);
 
-  State getState() const;
-
   void updateLoggerWithState();
 
   std::vector<int64_t> getRegulatoryElementIds() const override { return {reg_elem_.id()}; }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -32,8 +32,11 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 
+#include <functional>
 #include <memory>
+#include <optional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner
@@ -58,6 +61,7 @@ public:
     std::optional<autoware_utils::LineString3d> stop_line{};
     autoware_utils::LineString3d start_line{};
     std::vector<autoware_utils::LineString3d> end_lines{};
+    std::string stop_line_id_for_log{};
   };
 
   struct ModuleData
@@ -97,25 +101,70 @@ public:
   void setInfrastructureCommand(
     const std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> & command);
 
-  void setVirtualTrafficLightStates(
+  void setCorrespondingVirtualTrafficLightState(
     const tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr
       virtual_traffic_light_states);
+
+  State getState() const;
+
+  void updateLoggerWithState();
+
+  std::vector<int64_t> getRegulatoryElementIds() const override { return {reg_elem_.id()}; }
+  std::vector<int64_t> getLaneletIds() const override { return {lane_id_}; }
+  std::vector<int64_t> getLineIds() const override
+  {
+    std::vector<int64_t> line_ids;
+
+    line_ids.push_back(reg_elem_.getStartLine().id());
+
+    if (reg_elem_.getStopLine()) {
+      line_ids.push_back(reg_elem_.getStopLine()->id());
+    }
+
+    for (const auto & end_line : reg_elem_.getEndLines()) {
+      line_ids.push_back(end_line.id());
+    }
+
+    return line_ids;
+  }
 
 private:
   const int64_t lane_id_;
   const lanelet::autoware::VirtualTrafficLight & reg_elem_;
   const lanelet::ConstLanelet lane_;
   const PlannerParam planner_param_;
-  tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr virtual_traffic_light_states_;
+  std::optional<tier4_v2x_msgs::msg::VirtualTrafficLightState> virtual_traffic_light_state_;
   State state_{State::NONE};
   tier4_v2x_msgs::msg::InfrastructureCommand command_;
   std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> infrastructure_command_;
   MapData map_data_;
   ModuleData module_data_;
+  rclcpp::Logger base_logger_;
+
+  void setModuleState(
+    const State new_state, const std::optional<int64_t> end_line_id = std::nullopt);
+
+  template <State StateValue>
+  void setModuleState()
+  {
+    static_assert(
+      StateValue != State::FINALIZING && StateValue != State::FINALIZED,
+      "FINALIZING and FINALIZED states require end_line_id parameter");
+    setModuleState(StateValue);
+  }
+
+  template <State StateValue>
+  void setModuleState(const int64_t end_line_id)
+  {
+    static_assert(
+      StateValue == State::FINALIZING || StateValue == State::FINALIZED,
+      "This overload is only for FINALIZING and FINALIZED states");
+    setModuleState(StateValue, end_line_id);
+  }
 
   void updateInfrastructureCommand();
 
-  std::optional<size_t> getPathIndexOfFirstEndLine();
+  std::optional<std::pair<size_t, int64_t>> getPathIndexOfFirstEndLine();
 
   bool isBeforeStartLine(const size_t end_line_idx);
 
@@ -124,8 +173,6 @@ private:
   bool isAfterAnyEndLine(const size_t end_line_idx);
 
   bool isNearAnyEndLine(const size_t end_line_idx);
-
-  std::optional<tier4_v2x_msgs::msg::VirtualTrafficLightState> findCorrespondingState();
 
   bool isStateTimeout(const tier4_v2x_msgs::msg::VirtualTrafficLightState & state);
 
@@ -136,6 +183,8 @@ private:
 
   void insertStopVelocityAtEndLine(
     autoware_internal_planning_msgs::msg::PathWithLaneId * path, const size_t end_line_idx);
+
+  std::string stateToString(State state) const;
 };
 }  // namespace autoware::behavior_velocity_planner
 #endif  // SCENE_HPP_


### PR DESCRIPTION
## Description

- Add module state, module ID, Regulatory Element ID, Lane ID, Start/Stop/End Line ID to log message
- Print state transition and remarkable events

1) ego passes start_line

> [component_container_mt-34] [INFO 1749815272.230217083] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.virtual_traffic_light_module.intersection_coordination_9971.state: NONE]: [Module ID: 43][Reg: 9972][Lane: 43][Line: 9965, 9962, 9945] State transition: NONE -> REQUESTING as vehicle is before start line (ID: 9965)



2) no instrument message is received

> [component_container_mt-34] [INFO 1749815302.430467509] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.virtual_traffic_light_module.intersection_coordination_9971.state: REQUESTING]: [Module ID: 43][Reg: 9972][Lane: 43][Line: 9965, 9962, 9945] no message received for instrument (ID: 9971), stop at stop line (ID: 9962)


![image](https://github.com/user-attachments/assets/b8e2b54a-3339-478b-81b2-e3e440687e5f)


3) approval:false message is received 

```
sec=$(($(date +%s) + 30)); ros2 topic pub /awapi/tmp/virtual_traffic_light_states tier4_v2x_msgs/msg/VirtualTrafficLightStateArray "{stamp: {sec: $sec, nanosec: 999999999}, states: [{stamp: {sec: $sec, nanosec: 999999999}, type: 'dummy_infrastructure', id: '9971', approval: false, is_finalized: true}]}" -1
```

> [component_container_mt-34] [INFO 1749817047.335571649] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.virtual_traffic_light_module.intersection_coordination_9971.state: REQUESTING]: [Module ID: 43][Reg: 9972][Lane: 43][Line: 9965, 9962, 9945] no right of way for instrument (ID: 9971) is given, stop at stop line (ID: 9962)

![image](https://github.com/user-attachments/assets/7f5d3c1a-1b22-4c45-89c8-78ff4417abdc)


4) apprroval: true message is received

```
sec=$(($(date +%s) + 30)); ros2 topic pub /awapi/tmp/virtual_traffic_light_states tier4_v2x_msgs/msg/VirtualTrafficLightStateArray "{stamp: {sec: $sec, nanosec: 999999999}, states: [{stamp: {sec: $sec, nanosec: 999999999}, type: 'dummy_infrastructure', id: '9971', approval: true, is_finalized: true}]}" -1
```

> [component_container_mt-34] [INFO 1749821377.898143238] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.virtual_traffic_light_module.intersection_coordination_9971.state: REQUESTING]: [Module ID: 43][Reg: 9972][Lane: 43][Line: 9965, 9962, 9945] received message for instrument (ID: 9971) is updated : right of way is given, approval: true, finalized: true, stamp: 1749821406.999999999


> [component_container_mt-34] [INFO 1749817607.076714490] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.virtual_traffic_light_module.intersection_coordination_9971.state: REQUESTING]: [Module ID: 43][Reg: 9972][Lane: 43][Line: 9965, 9962, 9945] State transition: REQUESTING -> PASSING as vehicle has passed stop line (ID: 9962) 

5)  ego passes end line

> [component_container_mt-34] [INFO 1749821359.498892368] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.virtual_traffic_light_module.intersection_coordination_9971.state: NONE]: [Module ID: 43][Reg: 9972][Lane: 43][Line: 9965, 9962, 9945] received message for instrument (ID: 9971) is updated : finalization is completed, approval: false, finalized: true, stamp: 1749821388.999999999

> [component_container_mt-34] [INFO 1749817607.076714490] [planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.virtual_traffic_light_module.intersection_coordination_9971.state: PASSING]: [Module ID: 43][Reg: 9972][Lane: 43][Line: 9965, 9962, 9945] State transition: PASSING -> FINALIZED as vehicle has passed end line (ID: 9945)



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim

2025/06/13 https://evaluation.tier4.jp/evaluation/reports/a594e8c5-bcb9-5969-92c6-0eb8c621e38f/?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
