### PR TITLE
fix(segmentation_pointcloud_fusion): add missing context 

### DIFF
--- a/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
+++ b/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
@@ -45,7 +45,7 @@ class SegmentationPointcloudFusion:
         approximate_camera_projection = []
         rois_timestamp_noise_window = []
         point_project_to_unrectified_image = []
-        image_topic_name = LaunchConfiguration("image_topic_name")
+        image_topic_name = LaunchConfiguration("image_topic_name").perform(context)
 
         for index, camera_id in enumerate(self.camera_ids):
             mask_timestamp_offsets.append(


### PR DESCRIPTION
## Description

This PR resolves that `segmentation_pointcloud_fusion` could not be launched with `debug_mode` enabled.

## Related links

**Parent Issue:**

- Nothing

## How was this PR tested?

I have confirmed that the node does not crash when launched with `segmentation_based_filter` and `debug_mode` enabled.
> `image_topic_name` is only referenced when `debug_mode` is set to true.

```
# set debug_mode TRUE for image_projection_based_fusion
sed -i '26s/.*/    debug_mode: true/' src/launcher/autoware_launch/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/fusion_common.param.yaml

# launch 
ros2 launch autoware_launch logging_simulator.launch.xml \
  map_path:=$HOME/autoware_map/sample-map-rosbag/ \
  vehicle_model:=sample_vehicle \
  sensor_model:=sample_sensor_kit \
  use_image_segmentation_based_filter:=true \
  perception_mode:=camera_lidar_fusion
```

Before this PR, segmentation based filter crashed due to invalid parameters.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
