### PR TITLE
fix(intersection): fix path lanelets generation

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
@@ -165,9 +165,9 @@ void IntersectionModule::updateObjectInfoManagerCollision(
   }
 
   const double passing_time = time_distance_array.back().first;
-  const auto & concat_lanelets = path_lanelets.all;
+  const auto & concat_lanelets = lanelet::utils::combineLaneletsShape(path_lanelets.all);
   const auto closest_arc_coords =
-    lanelet::utils::getArcCoordinates(concat_lanelets, planner_data_->current_odometry->pose);
+    lanelet::utils::getArcCoordinates({concat_lanelets}, planner_data_->current_odometry->pose);
   const auto & ego_lane = path_lanelets.ego_or_entry2exit;
   debug_data_.ego_lane = ego_lane.polygon3d();
   const auto ego_poly = ego_lane.polygon2d().basicPolygon();
@@ -316,7 +316,7 @@ void IntersectionModule::updateObjectInfoManagerCollision(
           planner_data_->vehicle_info_.max_longitudinal_offset_m,
         lanelet::utils::getLaneletLength2d(concat_lanelets));
       const auto trimmed_ego_polygon = lanelet::utils::getPolygonFromArcLength(
-        concat_lanelets, ego_start_arc_length, ego_end_arc_length);
+        {concat_lanelets}, ego_start_arc_length, ego_end_arc_length);
       if (trimmed_ego_polygon.empty()) {
         continue;
       }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
@@ -264,9 +264,12 @@ Result<IntersectionModule::BasicData, InternalError> IntersectionModule::prepare
   const auto lanelets_on_path =
     planning_utils::getLaneletsOnPath(*path, lanelet_map_ptr, current_pose);
   // see the doc for struct PathLanelets
+  const auto closest_idx_ip = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+    path_ip.points, current_pose, planner_data_->ego_nearest_dist_threshold,
+    planner_data_->ego_nearest_yaw_threshold);
   const auto path_lanelets_opt = generatePathLanelets(
     lanelets_on_path, interpolated_path_info, first_conflicting_area, conflicting_area,
-    first_attention_area_opt, intersection_lanelets.attention_area(), closest_idx);
+    first_attention_area_opt, intersection_lanelets.attention_area(), closest_idx_ip);
   if (!path_lanelets_opt.has_value()) {
     return make_err<IntersectionModule::BasicData, InternalError>(
       "failed to generate PathLanelets");


### PR DESCRIPTION
## Description

`generatePathLanelets` generate a Lanelet which 
- start from ego position
- end at the exit of the intersection
from the given `path`.

Previous implementation was passing `interpolated_path` as `path` but `closest_idx` was the index for not interpolated path.

I fixed to pass `closest_idx_ip`, which is the `closest_idx` for `inrterpolated_path`.

## Related links

https://github.com/autowarefoundation/autoware_launch/pull/1501

## How was this PR tested?

see the videos in https://github.com/autowarefoundation/autoware_launch/pull/1501

https://evaluation.tier4.jp/evaluation/reports/28f21a85-06b8-50ad-8b45-7db47595373c?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
