### PR TITLE
feat!: replace autoware_internal_localization_msgs with autoware_localization_msgs for InitializeLocalization service

### DIFF
--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/localization.hpp
@@ -18,7 +18,7 @@
 #include <rclcpp/qos.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
-#include <autoware_internal_localization_msgs/srv/initialize_localization.hpp>
+#include <autoware_localization_msgs/srv/initialize_localization.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
@@ -27,7 +27,7 @@ namespace autoware::component_interface_specs_universe::localization
 
 struct Initialize
 {
-  using Service = autoware_internal_localization_msgs::srv::InitializeLocalization;
+  using Service = autoware_localization_msgs::srv::InitializeLocalization;
   static constexpr char name[] = "/localization/initialize";
 };
 

--- a/common/autoware_component_interface_specs_universe/package.xml
+++ b/common/autoware_component_interface_specs_universe/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_internal_localization_msgs</depend>
+  <depend>autoware_localization_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/system/autoware_default_adapi_universe/src/utils/localization_conversion.cpp
+++ b/system/autoware_default_adapi_universe/src/utils/localization_conversion.cpp
@@ -23,8 +23,7 @@ InternalInitializeRequest convert_request(const ExternalInitializeRequest & exte
 {
   auto internal = std::make_shared<InternalInitializeRequest::element_type>();
   internal->pose_with_covariance = external->pose;
-  internal->method =
-    autoware_localization_msgs::srv::InitializeLocalization::Request::AUTO;
+  internal->method = autoware_localization_msgs::srv::InitializeLocalization::Request::AUTO;
   return internal;
 }
 

--- a/system/autoware_default_adapi_universe/src/utils/localization_conversion.cpp
+++ b/system/autoware_default_adapi_universe/src/utils/localization_conversion.cpp
@@ -24,7 +24,7 @@ InternalInitializeRequest convert_request(const ExternalInitializeRequest & exte
   auto internal = std::make_shared<InternalInitializeRequest::element_type>();
   internal->pose_with_covariance = external->pose;
   internal->method =
-    autoware_internal_localization_msgs::srv::InitializeLocalization::Request::AUTO;
+    autoware_localization_msgs::srv::InitializeLocalization::Request::AUTO;
   return internal;
 }
 

--- a/system/autoware_default_adapi_universe/src/utils/localization_conversion.hpp
+++ b/system/autoware_default_adapi_universe/src/utils/localization_conversion.hpp
@@ -18,7 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_adapi_v1_msgs/srv/initialize_localization.hpp>
-#include <autoware_internal_localization_msgs/srv/initialize_localization.hpp>
+#include <autoware_localization_msgs/srv/initialize_localization.hpp>
 
 namespace autoware::default_adapi::localization_conversion
 {
@@ -26,7 +26,7 @@ namespace autoware::default_adapi::localization_conversion
 using ExternalInitializeRequest =
   autoware_adapi_v1_msgs::srv::InitializeLocalization::Request::SharedPtr;
 using InternalInitializeRequest =
-  autoware_internal_localization_msgs::srv::InitializeLocalization::Request::SharedPtr;
+  autoware_localization_msgs::srv::InitializeLocalization::Request::SharedPtr;
 InternalInitializeRequest convert_request(const ExternalInitializeRequest & external);
 
 using ExternalResponse = autoware_adapi_v1_msgs::msg::ResponseStatus;


### PR DESCRIPTION
## Description
This replaces autoware_internal_localization_msgs with autoware_localization_msgs to treat it as component interface.
This is required to use this interface from AD API.
This means that the topic will have stricter version control after this modification.

This should be merged with https://github.com/autowarefoundation/autoware_core/pull/542

## Related links

**Parent Issue:**

- [Link](https://github.com/autowarefoundation/autoware_core/issues/541)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I have tested with AWSIM that localization works even after the interface change
![image](https://github.com/user-attachments/assets/de49e0e7-0ccd-49a2-a9e8-5735b943ff9b)


## Notes for reviewers

None.
## Interface changes
### Topic changes

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Service | `/localization/initialize` | `autoware_localization_msgs::srv::InitializeLocalization`  |
| New     | Service | `/localizaation/initialize` | `autoware_localization_msgs::srv::InitializeLocalization`  |

## Effects on system behavior

None.
