### PR TITLE
fix(autoware_bevfusion): fix clang-tidy errors by removing unused fields

### DIFF
--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_node.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_node.hpp
@@ -75,7 +75,6 @@ private:
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
 
   DetectionClassRemapper detection_class_remapper_;
-  float score_threshold_{0.0};
   std::vector<std::string> class_names_;
   std::optional<std::string> lidar_frame_;
   float max_camera_lidar_delay_;

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/preprocess/pointcloud_densification.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/preprocess/pointcloud_densification.hpp
@@ -63,7 +63,7 @@ struct PointCloudWithTransform
 class PointCloudDensification
 {
 public:
-  explicit PointCloudDensification(const DensificationParam & param, cudaStream_t stream);
+  explicit PointCloudDensification(const DensificationParam & param);
 
   bool enqueuePointCloud(
     const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & msg_ptr,
@@ -99,7 +99,6 @@ private:
   double current_timestamp_{0.0};
   Eigen::Affine3f affine_world2current_;
   std::list<PointCloudWithTransform> pointcloud_cache_;
-  cudaStream_t stream_;
 };
 
 }  // namespace autoware::bevfusion

--- a/perception/autoware_bevfusion/lib/preprocess/pointcloud_densification.cpp
+++ b/perception/autoware_bevfusion/lib/preprocess/pointcloud_densification.cpp
@@ -54,9 +54,8 @@ Eigen::Affine3f transformToEigen(const geometry_msgs::msg::Transform & t)
 namespace autoware::bevfusion
 {
 
-PointCloudDensification::PointCloudDensification(
-  const DensificationParam & param, cudaStream_t stream)
-: param_(param), stream_(stream)
+PointCloudDensification::PointCloudDensification(const DensificationParam & param)
+: param_(param)
 {
 }
 

--- a/perception/autoware_bevfusion/lib/preprocess/voxel_generator.cpp
+++ b/perception/autoware_bevfusion/lib/preprocess/voxel_generator.cpp
@@ -31,7 +31,7 @@ VoxelGenerator::VoxelGenerator(
   cudaStream_t stream)
 : config_(config), stream_(stream)
 {
-  pd_ptr_ = std::make_unique<PointCloudDensification>(densification_param, stream_);
+  pd_ptr_ = std::make_unique<PointCloudDensification>(densification_param);
 
   pre_ptr_ = std::make_unique<PreprocessCuda>(config_, stream_, false);
 


### PR DESCRIPTION
## Description

This PR removes unused fields

- `score_threshold_` (in bevfusion_node.hpp)
- `stream_` (in pointcloud_densification.hpp)

which causes errors in the current clang-tidy CI.
https://github.com/autowarefoundation/autoware_universe/actions/runs/15732756500/job/44384333773?pr=10841

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Checked that build passes locally

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
