### PR TITLE
feat(command_mode_decider): reflect message porting

### DIFF
--- a/system/autoware_command_mode_decider/package.xml
+++ b/system/autoware_command_mode_decider/package.xml
@@ -13,6 +13,7 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_command_mode_types</depend>
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_system_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>diagnostic_updater</depend>
   <depend>pluginlib</depend>

--- a/system/autoware_command_mode_decider/src/command_mode_decider_base.hpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_base.hpp
@@ -26,13 +26,13 @@
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_internal_debug_msgs/msg/int32_multi_array_stamped.hpp>
+#include <autoware_system_msgs/srv/change_autoware_control.hpp>
+#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <tier4_system_msgs/msg/command_mode_availability.hpp>
 #include <tier4_system_msgs/msg/command_mode_request.hpp>
 #include <tier4_system_msgs/msg/command_mode_status.hpp>
 #include <tier4_system_msgs/msg/mode_change_available.hpp>
-#include <tier4_system_msgs/srv/change_autoware_control.hpp>
-#include <tier4_system_msgs/srv/change_operation_mode.hpp>
 
 #include <memory>
 #include <vector>
@@ -44,14 +44,14 @@ using autoware_adapi_v1_msgs::msg::MrmState;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_common_msgs::msg::ResponseStatus;
 using autoware_internal_debug_msgs::msg::Int32MultiArrayStamped;
+using autoware_system_msgs::srv::ChangeAutowareControl;
+using autoware_system_msgs::srv::ChangeOperationMode;
 using autoware_vehicle_msgs::msg::ControlModeReport;
 using tier4_system_msgs::msg::CommandModeAvailability;
 using tier4_system_msgs::msg::CommandModeRequest;
 using tier4_system_msgs::msg::CommandModeRequestItem;
 using tier4_system_msgs::msg::CommandModeStatus;
 using tier4_system_msgs::msg::ModeChangeAvailable;
-using tier4_system_msgs::srv::ChangeAutowareControl;
-using tier4_system_msgs::srv::ChangeOperationMode;
 
 class CommandModeDeciderBase : public rclcpp::Node
 {

--- a/system/autoware_command_mode_decider_plugins/src/command_mode_decider.cpp
+++ b/system/autoware_command_mode_decider_plugins/src/command_mode_decider.cpp
@@ -18,7 +18,7 @@
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <tier4_system_msgs/srv/change_operation_mode.hpp>
+#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 
 #include <vector>
 
@@ -28,7 +28,7 @@ namespace autoware::command_mode_decider
 namespace modes = autoware::command_mode_types::modes;
 using autoware_adapi_v1_msgs::msg::MrmState;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
-using tier4_system_msgs::srv::ChangeOperationMode;
+using autoware_system_msgs::srv::ChangeOperationMode;
 
 uint16_t CommandModeDecider::from_operation_mode(uint16_t operation_mode)
 {


### PR DESCRIPTION
## Description

Apply message change by https://github.com/autowarefoundation/autoware_universe/pull/10842.
(Ideally it should be changed to reference the specs package.)

## Related links

https://github.com/autowarefoundation/autoware_universe/pull/10842

## How was this PR tested?

Launch planning simulation with use_control_command_gate option and https://github.com/autowarefoundation/autoware_launch/pull/1332

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
