### PR TITLE
feat(tier4_state_rviz_plugin): display unknown value

### DIFF
--- a/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -558,6 +558,7 @@ void AutowareStatePanel::onRoute(const RouteState::ConstSharedPtr msg)
     default:
       state = None;
       bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
+      route_state = QString("Routing | Unknown(%1)").arg(msg->state);
       break;
   }
 
@@ -610,6 +611,7 @@ void AutowareStatePanel::onLocalization(const LocalizationInitializationState::C
     default:
       state = None;
       bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
+      localization_state = QString("Localization | Unknown(%1)").arg(msg->state);
       break;
   }
 
@@ -656,6 +658,7 @@ void AutowareStatePanel::onMotion(const MotionState::ConstSharedPtr msg)
     default:
       state = Danger;
       bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
+      motion_state = QString("Motion | Unknown(%1)").arg(msg->state);
       break;
   }
 
@@ -714,7 +717,7 @@ void AutowareStatePanel::onMRMState(const MRMState::ConstSharedPtr msg)
     default:
       state = None;
       bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
-      mrm_state = "MRM State | Unknown";
+      mrm_state = QString("MRM State | Unknown(%1)").arg(msg->state);
       break;
   }
 
@@ -758,7 +761,7 @@ void AutowareStatePanel::onMRMState(const MRMState::ConstSharedPtr msg)
       default:
         behavior_state = Crash;
         behavior_bgColor = QColor(autoware::state_rviz_plugin::colors::default_colors.info.c_str());
-        mrm_behavior = "MRM Behavior | Unknown";
+        mrm_behavior = QString("MRM Behavior | Unknown(%1)").arg(msg->behavior);
         break;
     }
 


### PR DESCRIPTION
## Description

Show the original value when the state is unknown.

## Related links

None

## How was this PR tested?

Launch RViz.
```
rviz2 -d src/launcher/autoware_launch/autoware_launch/rviz/autoware.rviz
```

Check unknown state using following commands
```
ros2 topic pub /api/routing/state autoware_adapi_v1_msgs/msg/RouteState "{state: 111}"
ros2 topic pub /api/localization/initialization_state autoware_adapi_v1_msgs/msg/LocalizationInitializationState "{state: 222}"
ros2 topic pub /api/fail_safe/mrm_state autoware_adapi_v1_msgs/msg/MrmState "{state: 333, behavior: 444}"
```
![Screenshot from 2025-06-20 13-01-02](https://github.com/user-attachments/assets/b7bad97b-3a57-44ea-ba51-cd9c5849dc9f)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
