### PR TITLE
fix(boundary_departure_prevention): add processing time/time keeper

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
@@ -216,9 +216,10 @@ private:
     const lanelet::ConstLanelets & candidate_lanelets,
     const std::vector<LinearRing2d> & vehicle_footprints) const;
 
-  static SegmentRtree extractUncrossableBoundaries(
+  SegmentRtree extractUncrossableBoundaries(
     const lanelet::LaneletMap & lanelet_map, const geometry_msgs::msg::Point & ego_point,
-    const double max_search_length, const std::vector<std::string> & boundary_types_to_detect);
+    const double max_search_length,
+    const std::vector<std::string> & boundary_types_to_detect) const;
 
   bool willCrossBoundary(
     const std::vector<LinearRing2d> & vehicle_footprints,

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -63,6 +63,8 @@ tl::expected<AbnormalitiesData, std::string> BoundaryDepartureChecker::get_abnor
   const geometry_msgs::msg::PoseWithCovariance & curr_pose_with_cov,
   const SteeringReport & current_steering)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   if (predicted_traj.empty()) {
     return tl::make_unexpected("Ego predicted trajectory is empty");
   }
@@ -106,6 +108,8 @@ tl::expected<BoundarySideWithIdx, std::string>
 BoundaryDepartureChecker::get_boundary_segments_from_side(
   const EgoSides & ego_sides_from_footprints)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   if (!lanelet_map_ptr_) {
     return tl::make_unexpected(std::string(__func__) + ": invalid lanelet_map_ptr");
   }
@@ -167,6 +171,8 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
   const Abnormalities<ProjectionsToBound> & projections_to_bound, const SideKey side_key)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   const auto & abnormality_to_check = param_ptr_->abnormality_types_to_compensate;
 
   if (abnormality_to_check.empty()) {
@@ -258,6 +264,8 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries(
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
   const Abnormalities<ProjectionsToBound> & projections_to_bound)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   ClosestProjectionsToBound min_to_bound;
 
   for (const auto side_key : g_side_keys) {
@@ -297,6 +305,8 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries(
 Side<DeparturePoints> BoundaryDepartureChecker::get_departure_points(
   const ClosestProjectionsToBound & projections_to_bound, const double lon_offset_m)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   const auto th_dist_hysteresis_m = param_ptr_->th_dist_hysteresis_m;
 
   Side<DeparturePoints> departure_points;
@@ -312,6 +322,7 @@ BoundaryDepartureChecker::build_uncrossable_boundaries_tree(
   const lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   if (!lanelet_map_ptr) {
     return tl::make_unexpected("lanelet_map_ptr is null");
   }
@@ -326,8 +337,10 @@ BoundaryDepartureChecker::build_uncrossable_boundaries_tree(
 
 SegmentRtree BoundaryDepartureChecker::extractUncrossableBoundaries(
   const lanelet::LaneletMap & lanelet_map, const geometry_msgs::msg::Point & ego_point,
-  const double max_search_length, const std::vector<std::string> & boundary_types_to_detect)
+  const double max_search_length, const std::vector<std::string> & boundary_types_to_detect) const
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   const auto has_types =
     [](const lanelet::ConstLineString3d & ls, const std::vector<std::string> & types) {
       constexpr auto no_type = "";

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -45,7 +45,7 @@ void BoundaryDeparturePreventionModule::init(
 
   subscribe_topics(node);
   publish_topics(node);
-  // time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(processing_time_detail_pub_);
+  time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(processing_time_detail_pub_);
 
   updater_ptr_ = std::make_unique<diagnostic_updater::Updater>(&node);
   updater_ptr_->setHardwareID("motion_velocity_boundary_departure_prevention");
@@ -72,7 +72,7 @@ void BoundaryDeparturePreventionModule::init(
 void BoundaryDeparturePreventionModule::update_parameters(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  // autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   using autoware_utils::update_param;
   auto & pp = node_param_;
@@ -162,8 +162,6 @@ void BoundaryDeparturePreventionModule::update_parameters(
 
 void BoundaryDeparturePreventionModule::subscribe_topics(rclcpp::Node & node)
 {
-  // autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   sub_ego_pred_traj_ = node.create_subscription<Trajectory>(
     "/control/trajectory_follower/lateral/predicted_trajectory", rclcpp::QoS{1},
     [&](const Trajectory::ConstSharedPtr msg) { ego_pred_traj_ptr_ = msg; });
@@ -182,8 +180,6 @@ void BoundaryDeparturePreventionModule::subscribe_topics(rclcpp::Node & node)
 
 void BoundaryDeparturePreventionModule::publish_topics(rclcpp::Node & node)
 {
-  // autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   const std::string ns = "boundary_departure_prevention";
 
   debug_publisher_ =
@@ -195,7 +191,7 @@ void BoundaryDeparturePreventionModule::publish_topics(rclcpp::Node & node)
     "~/debug/processing_time_detail_ms/" + ns, 1);
 
   processing_time_publisher_ =
-    node.create_publisher<Float64Stamped>("~/debug/obstacle_slow_down/processing_time_ms", 1);
+    node.create_publisher<Float64Stamped>("~/debug/" + ns + "/processing_time_ms", 1);
 }
 
 VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
@@ -203,7 +199,7 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
   [[maybe_unused]] const TrajectoryPoints & smoothed_trajectory_points,
   const std::shared_ptr<const PlannerData> planner_data)
 {
-  // autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   StopWatch<std::chrono::milliseconds> stopwatch_ms;
   stopwatch_ms.tic("plan");
 
@@ -241,7 +237,7 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
 bool BoundaryDeparturePreventionModule::is_data_ready(
   [[maybe_unused]] std::unordered_map<std::string, double> & processing_times)
 {
-  // autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (!ego_pred_traj_ptr_) {
     RCLCPP_INFO_THROTTLE(
@@ -260,7 +256,7 @@ bool BoundaryDeparturePreventionModule::is_data_ready(
 
 bool BoundaryDeparturePreventionModule::is_data_valid() const
 {
-  // autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (ego_pred_traj_ptr_->points.empty()) {
     RCLCPP_INFO_THROTTLE(
@@ -272,7 +268,7 @@ bool BoundaryDeparturePreventionModule::is_data_valid() const
 
 bool BoundaryDeparturePreventionModule::is_data_timeout(const Odometry & odom) const
 {
-  // autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto now = clock_ptr_->now();
   const auto time_diff_s = (rclcpp::Time(odom.header.stamp) - now).seconds();
@@ -316,7 +312,7 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
   const TrajectoryPoints & raw_trajectory_points,
   const std::shared_ptr<const PlannerData> & planner_data)
 {
-  // autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto & vehicle_info = planner_data->vehicle_info_;
   const auto & curr_odom = planner_data->current_odometry;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -207,8 +207,8 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
   const auto & ll_map_ptr = planner_data->route_handler->getLaneletMapPtr();
 
   if (!boundary_departure_checker_ptr_) {
-    boundary_departure_checker_ptr_ =
-      std::make_unique<BoundaryDepartureChecker>(ll_map_ptr, vehicle_info, node_param_.bdc_param);
+    boundary_departure_checker_ptr_ = std::make_unique<BoundaryDepartureChecker>(
+      ll_map_ptr, vehicle_info, node_param_.bdc_param, time_keeper_);
   }
 
   if (!slow_down_interpolator_ptr_) {
@@ -474,6 +474,8 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
 std::unordered_map<DepartureType, bool> BoundaryDeparturePreventionModule::get_diagnostics(
   const double curr_vel, const double dist_with_offset_m)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   std::unordered_map<DepartureType, bool> diag{
     {DepartureType::NEAR_BOUNDARY, false},
     {DepartureType::APPROACHING_DEPARTURE, false},


### PR DESCRIPTION
## Description

Fix minor namespace and adds time keeper

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. PSIM. Run autoware and test boundary departure.
2. Run
```
ros2 topic echo /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/debug/boundary_departure_prevention/processing_time_ms
```
3. In another terminal, run
```
ros2 topic echo /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/debug/processing_time_detail_ms/boundary_departure_prevention
```


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
