### PR TITLE
feat(autoware_behavior_velocity_traffic_light_module): enhance rviz for v2i

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/debug.cpp
@@ -36,7 +36,11 @@ autoware::motion_utils::VirtualWalls TrafficLightModule::createVirtualWalls()
 {
   autoware::motion_utils::VirtualWalls virtual_walls;
   autoware::motion_utils::VirtualWall wall;
-  wall.text = "traffic_light";
+  if (debug_data_.is_remaining_time_used) {
+    wall.text = "traffic_light(V2I)";
+  } else {
+    wall.text = "traffic_light";
+  }
   wall.ns = std::to_string(module_id_) + "_";
 
   wall.style = autoware::motion_utils::VirtualWallType::deadline;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -126,9 +126,15 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
         : 0.0;
     bool to_be_stopped =
       is_stop_signal && (is_prev_state_stop_ || time_diff > planner_param_.stop_time_hysteresis);
+
+    debug_data_.is_remaining_time_used = false;
     if (planner_param_.v2i_use_remaining_time) {
       const bool will_traffic_light_turn_red_before_reaching_stop_line =
         willTrafficLightTurnRedBeforeReachingStopLine(signed_arc_length_to_stop_point);
+      if (will_traffic_light_turn_red_before_reaching_stop_line && !is_stop_signal) {
+        debug_data_.is_remaining_time_used = true;
+      }
+
       to_be_stopped = to_be_stopped || will_traffic_light_turn_red_before_reaching_stop_line;
     }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
@@ -54,6 +54,7 @@ public:
     std::vector<geometry_msgs::msg::Point> traffic_light_points;
     std::optional<geometry_msgs::msg::Point> highest_confidence_traffic_light_point = {
       std::nullopt};
+    bool is_remaining_time_used{false};
   };
 
   struct PlannerParam


### PR DESCRIPTION
## Description

When inserting a stop even if the signal is green, the following message is displayed.

[Screencast from 06-20-2025 04:33:19 PM.webm](https://github.com/user-attachments/assets/77df4b90-edd4-4e92-a6a3-81c70ce03ce3)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
