### PR TITLE
feat(static_obstacle_avoidance): support separate lateral jerk constraints for avoidance and return maneuvers

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
@@ -299,7 +299,9 @@
         lateral:
           velocity: [1.39, 4.17, 11.1]                   # [m/s]
           max_accel_values: [0.5, 0.5, 0.5]             # [m/ss]
-          min_jerk_values: [0.2, 0.2, 0.2]              # [m/sss]
+          min_jerk_values:
+            avoid: [0.2, 0.2, 0.2]                      # [m/sss]
+            return: [0.2, 0.2, 0.2]                     # [m/sss]
           max_jerk_values: [1.0, 1.0, 1.0]              # [m/sss]
 
         # longitudinal constraints

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -325,10 +325,10 @@ struct AvoidanceParameters
   // target velocity matrix
   std::vector<double> velocity_map;
 
-  // Minimum lateral jerk limitation map.
+  // Minimum lateral jerk limitation map for avoidance maneuver.
   std::vector<double> avoid_lateral_min_jerk_map;
 
-  // Minimum lateral jerk limitation map.
+  // Minimum lateral jerk limitation map for return maneuver.
   std::vector<double> return_lateral_min_jerk_map;
 
   // Maximum lateral jerk limitation map.

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -326,7 +326,10 @@ struct AvoidanceParameters
   std::vector<double> velocity_map;
 
   // Minimum lateral jerk limitation map.
-  std::vector<double> lateral_min_jerk_map;
+  std::vector<double> avoid_lateral_min_jerk_map;
+
+  // Minimum lateral jerk limitation map.
+  std::vector<double> return_lateral_min_jerk_map;
 
   // Maximum lateral jerk limitation map.
   std::vector<double> lateral_max_jerk_map;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
@@ -75,7 +75,7 @@ public:
     return 0 < idx ? idx - 1 : 0;
   }
 
-  double getLateralMinJerkLimit() const
+  double getAvoidanceLateralMinJerkLimit() const
   {
     const auto idx = getConstraintsMapIndex(getEgoSpeed(), parameters_->velocity_map);
     return parameters_->avoid_lateral_min_jerk_map.at(idx);
@@ -150,7 +150,7 @@ public:
   double getMaxAvoidanceDistance(const double shift_length) const
   {
     const auto distance_from_jerk = autoware::motion_utils::calc_longitudinal_dist_from_jerk(
-      shift_length, getLateralMinJerkLimit(), getAvoidanceEgoSpeed());
+      shift_length, getAvoidanceLateralMinJerkLimit(), getAvoidanceEgoSpeed());
     return std::max(getNominalAvoidanceDistance(shift_length), distance_from_jerk);
   }
 
@@ -254,7 +254,7 @@ public:
     const auto max_shift_length = std::max(
       std::abs(parameters_->max_right_shift_length), std::abs(parameters_->max_left_shift_length));
     const auto dynamic_distance = autoware::motion_utils::calc_longitudinal_dist_from_jerk(
-      max_shift_length, getLateralMinJerkLimit(), speed);
+      max_shift_length, getAvoidanceLateralMinJerkLimit(), speed);
 
     return std::clamp(
       1.5 * dynamic_distance + getNominalPrepareDistance(),

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
@@ -78,7 +78,13 @@ public:
   double getLateralMinJerkLimit() const
   {
     const auto idx = getConstraintsMapIndex(getEgoSpeed(), parameters_->velocity_map);
-    return parameters_->lateral_min_jerk_map.at(idx);
+    return parameters_->avoid_lateral_min_jerk_map.at(idx);
+  }
+
+  double getReturnLateralMinJerkLimit() const
+  {
+    const auto idx = getConstraintsMapIndex(getEgoSpeed(), parameters_->velocity_map);
+    return parameters_->return_lateral_min_jerk_map.at(idx);
   }
 
   double getLateralMaxJerkLimit() const
@@ -119,7 +125,17 @@ public:
     const auto & p = parameters_;
     const auto nominal_speed = std::max(getEgoSpeed(), p->nominal_avoidance_speed);
     const auto nominal_jerk =
-      p->lateral_min_jerk_map.at(getConstraintsMapIndex(nominal_speed, p->velocity_map));
+      p->avoid_lateral_min_jerk_map.at(getConstraintsMapIndex(nominal_speed, p->velocity_map));
+    return autoware::motion_utils::calc_longitudinal_dist_from_jerk(
+      shift_length, nominal_jerk, nominal_speed);
+  }
+
+  double getNominalReturnDistance(const double shift_length) const
+  {
+    const auto & p = parameters_;
+    const auto nominal_speed = std::max(getEgoSpeed(), p->nominal_avoidance_speed);
+    const auto nominal_jerk =
+      p->return_lateral_min_jerk_map.at(getConstraintsMapIndex(nominal_speed, p->velocity_map));
     return autoware::motion_utils::calc_longitudinal_dist_from_jerk(
       shift_length, nominal_jerk, nominal_speed);
   }
@@ -136,6 +152,13 @@ public:
     const auto distance_from_jerk = autoware::motion_utils::calc_longitudinal_dist_from_jerk(
       shift_length, getLateralMinJerkLimit(), getAvoidanceEgoSpeed());
     return std::max(getNominalAvoidanceDistance(shift_length), distance_from_jerk);
+  }
+
+  double getMaxReturnDistance(const double shift_length) const
+  {
+    const auto distance_from_jerk = autoware::motion_utils::calc_longitudinal_dist_from_jerk(
+      shift_length, getReturnLateralMinJerkLimit(), getAvoidanceEgoSpeed());
+    return std::max(getNominalReturnDistance(shift_length), distance_from_jerk);
   }
 
   double getSharpAvoidanceDistance(const double shift_length) const

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
@@ -369,8 +369,10 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
     p.velocity_map = get_or_declare_parameter<std::vector<double>>(*node, ns + "velocity");
     p.lateral_max_accel_map =
       get_or_declare_parameter<std::vector<double>>(*node, ns + "max_accel_values");
-    p.lateral_min_jerk_map =
-      get_or_declare_parameter<std::vector<double>>(*node, ns + "min_jerk_values");
+    p.avoid_lateral_min_jerk_map =
+      get_or_declare_parameter<std::vector<double>>(*node, ns + "min_jerk_values.avoid");
+    p.return_lateral_min_jerk_map =
+      get_or_declare_parameter<std::vector<double>>(*node, ns + "min_jerk_values.return");
     p.lateral_max_jerk_map =
       get_or_declare_parameter<std::vector<double>>(*node, ns + "max_jerk_values");
 
@@ -382,7 +384,11 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
       throw std::domain_error("inconsistency among the constraints map.");
     }
 
-    if (p.velocity_map.size() != p.lateral_min_jerk_map.size()) {
+    if (p.velocity_map.size() != p.avoid_lateral_min_jerk_map.size()) {
+      throw std::domain_error("inconsistency among the constraints map.");
+    }
+
+    if (p.velocity_map.size() != p.return_lateral_min_jerk_map.size()) {
       throw std::domain_error("inconsistency among the constraints map.");
     }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
@@ -1385,9 +1385,21 @@
                   "default": [0.5, 0.5, 0.5]
                 },
                 "min_jerk_values": {
-                  "type": "array",
-                  "description": "Avoidance path is generated with this jerk when there is enough distance from ego.",
-                  "default": [0.2, 0.2, 0.2]
+                  "type": "object",
+                  "properties": {
+                    "avoid": {
+                      "type": "array",
+                      "description": "Minimum lateral jerk constraint when laterally shifting to avoid an obstacle.",
+                      "default": [0.2, 0.2, 0.2]
+                    },
+                    "return": {
+                      "type": "array",
+                      "description": "Minimum lateral jerk constraint when laterally shifting to return to the original lane.",
+                      "default": [0.2, 0.2, 0.2]
+                    }
+                  },
+                  "required": ["avoid", "return"],
+                  "additionalProperties": false
                 },
                 "max_jerk_values": {
                   "type": "array",

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
@@ -232,8 +232,12 @@ void StaticObstacleAvoidanceModuleManager::updateModuleParams(
     update_param<std::vector<double>>(parameters, ns + "velocity", velocity_map);
     std::vector<double> lateral_max_accel_map;
     update_param<std::vector<double>>(parameters, ns + "max_accel_values", lateral_max_accel_map);
-    std::vector<double> lateral_min_jerk_map;
-    update_param<std::vector<double>>(parameters, ns + "min_jerk_values", lateral_min_jerk_map);
+    std::vector<double> avoid_lateral_min_jerk_map;
+    update_param<std::vector<double>>(
+      parameters, ns + "min_jerk_values.avoid", avoid_lateral_min_jerk_map);
+    std::vector<double> return_lateral_min_jerk_map;
+    update_param<std::vector<double>>(
+      parameters, ns + "min_jerk_values.return", return_lateral_min_jerk_map);
     std::vector<double> lateral_max_jerk_map;
     update_param<std::vector<double>>(parameters, ns + "max_jerk_values", lateral_max_jerk_map);
 
@@ -245,8 +249,12 @@ void StaticObstacleAvoidanceModuleManager::updateModuleParams(
       p->lateral_max_accel_map = lateral_max_accel_map;
     }
 
-    if (!velocity_map.empty() && velocity_map.size() == lateral_min_jerk_map.size()) {
-      p->lateral_min_jerk_map = lateral_min_jerk_map;
+    if (!velocity_map.empty() && velocity_map.size() == avoid_lateral_min_jerk_map.size()) {
+      p->avoid_lateral_min_jerk_map = avoid_lateral_min_jerk_map;
+    }
+
+    if (!velocity_map.empty() && velocity_map.size() == return_lateral_min_jerk_map.size()) {
+      p->return_lateral_min_jerk_map = return_lateral_min_jerk_map;
     }
 
     if (!velocity_map.empty() && velocity_map.size() == lateral_max_jerk_map.size()) {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -1772,7 +1772,7 @@ void StaticObstacleAvoidanceModule::insertReturnDeadLine(
 
   // insert slow down speed.
   const double current_target_velocity = autoware::motion_utils::calc_feasible_velocity_from_jerk(
-    shift_length, helper_->getLateralMinJerkLimit(), to_stop_line);
+    shift_length, helper_->getAvoidanceLateralMinJerkLimit(), to_stop_line);
   if (current_target_velocity < getEgoSpeed()) {
     RCLCPP_DEBUG(getLogger(), "current velocity exceeds target slow down speed.");
     return;
@@ -1791,7 +1791,7 @@ void StaticObstacleAvoidanceModule::insertReturnDeadLine(
 
     // target speed with nominal jerk limits.
     const double v_target = autoware::motion_utils::calc_feasible_velocity_from_jerk(
-      shift_length, helper_->getLateralMinJerkLimit(), shift_longitudinal_distance);
+      shift_length, helper_->getAvoidanceLateralMinJerkLimit(), shift_longitudinal_distance);
     const double v_original = shifted_path.path.points.at(i).point.longitudinal_velocity_mps;
     const double v_insert =
       std::max(v_target - parameters_->buf_slow_down_speed, parameters_->min_slow_down_speed);
@@ -1985,7 +1985,7 @@ void StaticObstacleAvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_
 
   // insert slow down speed.
   const double current_target_velocity = autoware::motion_utils::calc_feasible_velocity_from_jerk(
-    shift_length, helper_->getLateralMinJerkLimit(), distance_to_object);
+    shift_length, helper_->getAvoidanceLateralMinJerkLimit(), distance_to_object);
   if (current_target_velocity + parameters_->buf_slow_down_speed < getEgoSpeed()) {
     utils::static_obstacle_avoidance::insertDecelPoint(
       getEgoPosition(), decel_distance, parameters_->velocity_map.front(), shifted_path.path,
@@ -2006,7 +2006,7 @@ void StaticObstacleAvoidanceModule::insertPrepareVelocity(ShiftedPath & shifted_
 
     // target speed with nominal jerk limits.
     const double v_target = autoware::motion_utils::calc_feasible_velocity_from_jerk(
-      shift_length, helper_->getLateralMinJerkLimit(), shift_longitudinal_distance);
+      shift_length, helper_->getAvoidanceLateralMinJerkLimit(), shift_longitudinal_distance);
     const double v_original = shifted_path.path.points.at(i).point.longitudinal_velocity_mps;
     const double v_insert = std::max(v_target - parameters_->buf_slow_down_speed, lower_speed);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
@@ -320,7 +320,7 @@ AvoidOutlines ShiftLineGenerator::generateAvoidOutline(
 
     // use absolute dist for return-to-center, relative dist from current for avoiding.
     const auto feasible_return_distance =
-      helper_->getMaxAvoidanceDistance(feasible_shift_profile.value().first);
+      helper_->getMaxReturnDistance(feasible_shift_profile.value().first);
 
     AvoidLine al_avoid;
     {
@@ -1176,7 +1176,7 @@ AvoidLineArray ShiftLineGenerator::addReturnShiftLine(
   const auto & arclength_from_ego = data.arclength_from_ego;
 
   const auto nominal_prepare_distance = helper_->getNominalPrepareDistance();
-  const auto nominal_avoid_distance = helper_->getMaxAvoidanceDistance(last_sl.end_shift_length);
+  const auto nominal_avoid_distance = helper_->getMaxReturnDistance(last_sl.end_shift_length);
 
   if (arclength_from_ego.empty()) {
     return ret;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
@@ -95,7 +95,8 @@ auto get_parameters() -> std::shared_ptr<AvoidanceParameters>
   parameters.max_prepare_time = 3.0;
   parameters.nominal_avoidance_speed = 8.0;
   parameters.velocity_map = {1.0, 3.0, 10.0};
-  parameters.lateral_min_jerk_map = {0.1, 1.0, 10.0};
+  parameters.avoid_lateral_min_jerk_map = {0.1, 1.0, 10.0};
+  parameters.return_lateral_min_jerk_map = {0.1, 1.0, 10.0};
   parameters.lateral_max_jerk_map = {0.4, 1.5, 15.0};
   parameters.lateral_max_accel_map = {0.7, 0.8, 0.9};
 


### PR DESCRIPTION
## Description

This PR introduces support for separately configuring the minimum lateral jerk constraints used during:

- Obstacle avoidance
- Returning to the original lane

Previously, the min_jerk_values parameter applied a single jerk constraint for both phases. In real-world driving, however, the dynamic characteristics required for avoiding an obstacle and smoothly returning to the lane can differ. This PR resolves that limitation by separating the parameters and applying each one appropriately in the planning logic.

```yaml
min_jerk_values:
  avoid:  [0.2, 0.2, 0.2]  # Used during obstacle avoidance
  return: [0.2, 0.2, 0.2]  # Used when returning to original lane
```

https://github.com/user-attachments/assets/89f83f8c-3024-488c-afe9-aeb919849bdc

```yaml
min_jerk_values:
  avoid:  [0.2, 0.2, 0.2]  # Used during obstacle avoidance
  return: [0.9, 0.9, 0.9]  # Used when returning to original lane
```

https://github.com/user-attachments/assets/7a1d3be7-e2fe-4852-9353-2b1942a02a93

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_launch/pull/1506

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/3d764f1c-cf21-5121-9e60-192ab0f3541e?project_id=prd_jt&state=failed)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
