### PR TITLE
fix(cpu monitor): read /proc/stat directly instead of executing mpstat

### DIFF
--- a/system/autoware_system_monitor/CMakeLists.txt
+++ b/system/autoware_system_monitor/CMakeLists.txt
@@ -70,6 +70,7 @@ message(STATUS "GPU PLATFORM: " ${CMAKE_GPU_PLATFORM})
 set(CPU_MONITOR_SOURCE
   src/cpu_monitor/cpu_monitor_base.cpp
   src/cpu_monitor/${CMAKE_CPU_PLATFORM}_cpu_monitor.cpp
+  src/cpu_monitor/cpu_usage_statistics.cpp
 )
 
 ament_auto_add_library(cpu_monitor_lib SHARED
@@ -207,7 +208,6 @@ if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_cpu_monitor
     test/src/cpu_monitor/test_${CMAKE_CPU_PLATFORM}_cpu_monitor.cpp
     ${CPU_MONITOR_SOURCE}
-    TIMEOUT 120
   )
 
   ament_auto_add_executable(mpstat1

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_information.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_information.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * @file cpu_information.h
+ * @file cpu_information.hpp
  * @brief information about CPUs/cores
  */
 
@@ -85,7 +85,7 @@ struct UsageData
 
   struct CpuUsage
   {
-    std::string label;
+    std::string label;  // "all", "0", "1", etc. : short enough for "short string optimization"
     int status;
     float usr;
     float nice;

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp
@@ -21,6 +21,7 @@
 #define SYSTEM_MONITOR__CPU_MONITOR__CPU_MONITOR_BASE_HPP_
 
 #include "system_monitor/cpu_monitor/cpu_information.hpp"
+#include "system_monitor/cpu_monitor/cpu_usage_statistics.hpp"
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -173,7 +174,6 @@ protected:
   std::vector<int> usage_warn_check_count_;  //!< @brief CPU list for usage over warn check counter
   std::vector<int>
     usage_error_check_count_;  //!< @brief CPU list for usage over error check counter
-  bool mpstat_exists_;         //!< @brief Check if mpstat command exists
   // Though node parameters are read-only after initialization, unit tests modify them.
   // Therefore, they should be protected with mutex_context_, too.
   float usage_warn_;       //!< @brief CPU usage(%) to generate warning
@@ -205,6 +205,11 @@ protected:
    */
   const std::map<int, const char *> thermal_dictionary_ = {
     {DiagStatus::OK, "OK"}, {DiagStatus::WARN, "unused"}, {DiagStatus::ERROR, "throttling"}};
+
+  /**
+   * @brief Class instance for collecting CPU usage statistics
+   */
+  CpuUsageStatistics cpu_usage_statistics_;
 
   // Publisher
   rclcpp::Publisher<tier4_external_api_msgs::msg::CpuUsage>::SharedPtr pub_cpu_usage_;

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_usage_statistics.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_usage_statistics.hpp
@@ -1,0 +1,136 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file cpu_usage_statistics.hpp
+ * @brief CPU usage statistics collection and calculation
+ */
+
+#ifndef SYSTEM_MONITOR__CPU_MONITOR__CPU_USAGE_STATISTICS_HPP_
+#define SYSTEM_MONITOR__CPU_MONITOR__CPU_USAGE_STATISTICS_HPP_
+
+#include <string>
+#include <vector>
+
+class CpuUsageStatistics {
+public:
+  CpuUsageStatistics();
+  ~CpuUsageStatistics() = default;
+
+  // Structure to hold detailed CPU information for each core
+  struct CoreUsageInfo {
+    std::string name;  // "all", "0", "1", etc. : short enough for "short string optimization"
+    float user_percent;         // Percentage of time spent in user mode
+    float nice_percent;         // Percentage of time spent in nice mode
+    float system_percent;       // Percentage of time spent in system mode
+    float idle_percent;         // Percentage of time spent idle
+    float iowait_percent;       // Percentage of time spent waiting for I/O
+    float irq_percent;          // Percentage of time spent handling IRQs
+    float softirq_percent;      // Percentage of time spent handling soft IRQs
+    float steal_percent;        // Percentage of time stolen by other VMs
+    float guest_percent;        // Percentage of time spent running a virtual CPU
+    float guest_nice_percent;   // Percentage of time spent running a virtual CPU in nice mode
+    float total_usage_percent;  // Total CPU usage percentage (100% - idle%)
+
+    // Constructor with default values
+    CoreUsageInfo() :
+      name(""),
+      user_percent(0.0f),
+      nice_percent(0.0f),
+      system_percent(0.0f),
+      idle_percent(0.0f),
+      iowait_percent(0.0f),
+      irq_percent(0.0f),
+      softirq_percent(0.0f),
+      steal_percent(0.0f),
+      guest_percent(0.0f),
+      guest_nice_percent(0.0f),
+      total_usage_percent(0.0f) {}
+  };
+
+  /**
+   * @brief Update CPU statistics data
+   */
+  void update_cpu_statistics();
+
+  /**
+   * @brief Get the number of cores including the "all" core
+   * @return The number of cores
+   */
+  int32_t get_num_cores() const;
+
+  /**
+   * @brief Get the CPU usage information for a specific core
+   * @param [in] core_index The index of the core
+   * @return The CPU usage information for the specified core
+   */
+  CoreUsageInfo get_core_usage_info(int32_t core_index) const;
+
+private:
+  /**
+   * @brief Swap the current and previous statistics
+   */
+  void swap_statistics();
+
+  // Internal structure to hold raw CPU statistics from /proc/stat
+  struct CpuStatistics {
+    std::string name;  // "all", "0", "1", etc. : short enough for "short string optimization"
+    uint64_t user;
+    uint64_t nice;
+    uint64_t system;
+    uint64_t idle;
+    uint64_t iowait;
+    uint64_t irq;
+    uint64_t softirq;
+    uint64_t steal;
+    uint64_t guest;
+    uint64_t guest_nice;
+
+    // Calculate total time (excluding idle)
+    uint64_t total() const {
+      return user + nice + system + iowait + irq + softirq + steal;
+    }
+
+    // Calculate total time including idle
+    uint64_t total_all() const {
+      return total() + idle;
+    }
+
+    // Calculate CPU usage percentage
+    float usage_percent(const CpuStatistics & previous_statistics) const {
+      uint64_t total_delta = total() - previous_statistics.total();
+      uint64_t total_all_delta = total_all() - previous_statistics.total_all();
+
+      if (total_all_delta == 0) {
+        return 0.0f;
+      }
+      return (static_cast<float>(total_delta) / static_cast<float>(total_all_delta)) * 100.0f;
+    }
+  };
+
+  bool first_call_;  // Flag to indicate first call of update_cpu_statistics().
+  std::vector<CpuStatistics> statistics_1_;  // Previous CPU statistics
+  std::vector<CpuStatistics> statistics_2_;  // Previous CPU statistics
+  std::vector<CpuStatistics> & current_statistics_;   // Current CPU statistics
+  std::vector<CpuStatistics> & previous_statistics_;  // Previous CPU statistics
+
+  /**
+   * @brief Vector of CPU usage statistics for each core
+   * @note Allocated on heap and won't be reallocated during the lifetime of the instance.
+   */
+  std::vector<CpuUsageStatistics::CoreUsageInfo> core_usage_info_{};
+
+};
+
+#endif  // SYSTEM_MONITOR__CPU_MONITOR__CPU_USAGE_STATISTICS_HPP_

--- a/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -20,12 +20,10 @@
 #include "system_monitor/cpu_monitor/cpu_monitor_base.hpp"
 
 #include "system_monitor/cpu_monitor/cpu_information.hpp"
+#include "system_monitor/cpu_monitor/cpu_usage_statistics.hpp"
 #include "system_monitor/system_monitor_utility.hpp"
 
 #include <boost/filesystem.hpp>
-#include <boost/process.hpp>
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <boost/thread.hpp>
 
 #include <fmt/format.h>
@@ -38,9 +36,7 @@
 #include <utility>
 #include <vector>
 
-namespace bp = boost::process;
 namespace fs = boost::filesystem;
-namespace pt = boost::property_tree;
 
 CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::NodeOptions & options)
 : Node(node_name, options),
@@ -49,7 +45,6 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
   num_cores_(0),
   temperatures_(),
   frequencies_(),
-  mpstat_exists_(false),
   usage_warn_(declare_parameter<float>(
     "usage_warn", 0.96,
     rcl_interfaces::msg::ParameterDescriptor().set__read_only(true).set__description(
@@ -90,10 +85,6 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
   num_cores_ = boost::thread::hardware_concurrency();
   usage_warn_check_count_.resize(num_cores_ + 2);   // 2 = all + dummy
   usage_error_check_count_.resize(num_cores_ + 2);  // 2 = all + dummy
-
-  // Check if command exists
-  fs::path p = bp::search_path("mpstat");
-  mpstat_exists_ = (p.empty()) ? false : true;
 
   updater_.setHardwareID(hostname_);
   // Update diagnostic data collected by the timer callback.
@@ -229,167 +220,52 @@ void CPUMonitorBase::checkUsage()
   // Remember start time to measure elapsed time
   const auto t_start = std::chrono::high_resolution_clock::now();
 
-  bool usage_average = false;
-  {  // Start of critical section
-    std::lock_guard<std::mutex> lock_context(mutex_context_);
-    usage_average = usage_average_;  // Copy to local variable for later use.
-    if (!mpstat_exists_) {
-      // Note that the mutex_context_ is locked.
-      std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
-      usage_data_.clear();
-      usage_data_.summary_status = DiagStatus::ERROR;
-      usage_data_.summary_message = "mpstat error";
-      usage_data_.elapsed_ms = 0.0f;
-      usage_data_.error_key = "mpstat";
-      usage_data_.error_value =
-        "Command 'mpstat' not found, but can be installed with: sudo apt install sysstat";
-      return;
-    }
-  }  // End of critical section
-
-  // Get CPU Usage
-
-  // boost::process create file descriptor without O_CLOEXEC required for multithreading.
-  // So create file descriptor with O_CLOEXEC and pass it to boost::process.
-  int out_fd[2];
-  if (pipe2(out_fd, O_CLOEXEC) != 0) {
-    std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
-    usage_data_.clear();
-    usage_data_.summary_status = DiagStatus::ERROR;
-    usage_data_.summary_message = "pipe2 error";
-    usage_data_.elapsed_ms = 0.0f;
-    usage_data_.error_key = "pipe2";
-    usage_data_.error_value = strerror(errno);
-    return;
-  }
-  bp::pipe out_pipe{out_fd[0], out_fd[1]};
-  bp::ipstream is_out{std::move(out_pipe)};
-
-  int err_fd[2];
-  if (pipe2(err_fd, O_CLOEXEC) != 0) {
-    std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
-    usage_data_.clear();
-    usage_data_.summary_status = DiagStatus::ERROR;
-    usage_data_.summary_message = "pipe2 error";
-    usage_data_.elapsed_ms = 0.0f;
-    usage_data_.error_key = "pipe2";
-    usage_data_.error_value = strerror(errno);
-    return;
-  }
-  bp::pipe err_pipe{err_fd[0], err_fd[1]};
-  bp::ipstream is_err{std::move(err_pipe)};
-
-  int level = DiagStatus::OK;
-  int whole_level = DiagStatus::OK;
-  std::vector<UsageData::CpuUsage> temporary_core_data{};
-
-  pt::ptree pt;
-  try {
-    // Execution of mpstat command takes 1 second.
-    // On failure, it will throw an exception or return non-zero exit code.
-    bp::child c("mpstat -P ALL 1 1 -o JSON", bp::std_out > is_out, bp::std_err > is_err);
-    c.wait();
-    if (c.exit_code() != 0) {
-      std::ostringstream os;
-      is_err >> os.rdbuf();
-      std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
-      usage_data_.clear();
-      usage_data_.summary_status = DiagStatus::ERROR;
-      usage_data_.summary_message = "mpstat error";
-      usage_data_.elapsed_ms = 0.0f;
-      usage_data_.error_key = "mpstat";
-      usage_data_.error_value = os.str();
-      return;
-    }
-    // Analyze JSON output
-    read_json(is_out, pt);
-
-    for (const pt::ptree::value_type & child1 : pt.get_child("sysstat.hosts")) {
-      const pt::ptree & hosts = child1.second;
-
-      for (const pt::ptree::value_type & child2 : hosts.get_child("statistics")) {
-        const pt::ptree & statistics = child2.second;
-
-        for (const pt::ptree::value_type & child3 : statistics.get_child("cpu-load")) {
-          const pt::ptree & cpu_load = child3.second;
-          bool get_cpu_name = false;
-
-          std::string cpu_name;
-          float usr{0.0f};
-          float nice{0.0f};
-          float sys{0.0f};
-          float iowait{0.0f};
-          float idle{0.0f};
-          float usage{0.0f};
-          float total{0.0f};
-
-          if (boost::optional<std::string> v = cpu_load.get_optional<std::string>("cpu")) {
-            cpu_name = v.get();
-            get_cpu_name = true;
-          }
-          if (boost::optional<float> v = cpu_load.get_optional<float>("usr")) {
-            usr = v.get();
-          }
-          if (boost::optional<float> v = cpu_load.get_optional<float>("nice")) {
-            nice = v.get();
-          }
-          if (boost::optional<float> v = cpu_load.get_optional<float>("sys")) {
-            sys = v.get();
-          }
-          if (boost::optional<float> v = cpu_load.get_optional<float>("idle")) {
-            idle = v.get();
-          }
-
-          total = 100.0f - iowait - idle;
-          usage = total * 1e-2;
-          if (get_cpu_name) {
-            level = CpuUsageToLevel(cpu_name, usage);
-          } else {
-            level = CpuUsageToLevel(std::string("err"), usage);
-          }
-
-          // Use local variable to avoid mutual exclusion.
-          if (usage_average == true) {
-            if (cpu_name == "all") {
-              whole_level = level;
-            }
-          } else {
-            whole_level = std::max(whole_level, level);
-          }
-
-          temporary_core_data.emplace_back(
-            UsageData::CpuUsage{cpu_name, level, usr, nice, sys, iowait, idle, total});
-        }
-      }
-    }
-  } catch (const std::exception & e) {
-    {
-      std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
-      usage_data_.clear();
-      usage_data_.summary_status = DiagStatus::ERROR;
-      usage_data_.summary_message = "mpstat exception";
-      usage_data_.elapsed_ms = 0.0f;
-      usage_data_.error_key = "mpstat";
-      usage_data_.error_value = e.what();
-      usage_data_.core_data.clear();
-    }
-    {
-      std::lock_guard<std::mutex> lock_context(mutex_context_);
-      std::fill(usage_warn_check_count_.begin(), usage_warn_check_count_.end(), 0);
-      std::fill(usage_error_check_count_.begin(), usage_error_check_count_.end(), 0);
-    }
-    return;
-  }
+  cpu_usage_statistics_.update_cpu_statistics();  // May take a while.
 
   std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
-  usage_data_.clear();
-  usage_data_.core_data = temporary_core_data;
+  usage_data_.clear();  // The vector is cleared, but the allocated memory won't be reallocated.
+
+  int whole_level = DiagStatus::OK;
+
+  int32_t num_cores = cpu_usage_statistics_.get_num_cores();
+  for (int32_t core_index = 0; core_index < num_cores; ++core_index) {
+    CpuUsageStatistics::CoreUsageInfo usage = cpu_usage_statistics_.get_core_usage_info(core_index);
+    UsageData::CpuUsage cpu_usage;
+    cpu_usage.label = usage.name;
+    cpu_usage.usr = usage.user_percent;
+    cpu_usage.nice = usage.nice_percent;
+    cpu_usage.sys = usage.system_percent;
+    cpu_usage.iowait = usage.iowait_percent;
+    cpu_usage.idle = usage.idle_percent;
+    cpu_usage.total = usage.total_usage_percent;
+    // Some of the members of CpuUsageStatistics::CoreUsageInfo are not used.
+
+    // CpuUsageToLevel() converts usage to warning and error levels.
+    // It also counts occurrence of warning and error in addition to conversion.
+    float total_usage = usage.total_usage_percent * 1e-2;
+    int level;
+    if (!usage.name.empty()) {
+      level = CpuUsageToLevel(usage.name, total_usage);
+    } else {
+      level = CpuUsageToLevel(std::string("err"), total_usage);
+    }
+    cpu_usage.status = level;
+
+    if (usage_average_ == true) {
+      if (usage.name == "all") {
+        whole_level = level;
+      }
+    } else {
+      whole_level = std::max(whole_level, level);
+    }
+    usage_data_.core_data.push_back(cpu_usage);
+  }
   usage_data_.summary_status = whole_level;
   usage_data_.summary_message = load_dictionary_.at(whole_level);
   usage_data_.error_key = "";
   usage_data_.error_value = "";
 
-  // Measure elapsed time since start time and report
+  // Measure elapsed time since start time for reporting.
   const auto t_end = std::chrono::high_resolution_clock::now();
   const float elapsed_ms = std::chrono::duration<float, std::milli>(t_end - t_start).count();
   usage_data_.elapsed_ms = elapsed_ms;
@@ -544,7 +420,7 @@ void CPUMonitorBase::checkLoad()
   load_data_.load_average[1] = load_average[1] * 1e2;
   load_data_.load_average[2] = load_average[2] * 1e2;
 
-  // Measure elapsed time since start time and report
+  // Measure elapsed time since start time for reporting.
   const auto t_end = std::chrono::high_resolution_clock::now();
   const float elapsed_ms = std::chrono::duration<float, std::milli>(t_end - t_start).count();
   load_data_.elapsed_ms = elapsed_ms;
@@ -635,7 +511,7 @@ void CPUMonitorBase::checkFrequency()
   frequency_data_.summary_status = DiagStatus::OK;
   frequency_data_.summary_message = "OK";
 
-  // Measure elapsed time since start time and report
+  // Measure elapsed time since start time for reporting.
   const auto t_end = std::chrono::high_resolution_clock::now();
   const float elapsed_ms = std::chrono::duration<float, std::milli>(t_end - t_start).count();
   frequency_data_.elapsed_ms = elapsed_ms;

--- a/system/autoware_system_monitor/src/cpu_monitor/cpu_usage_statistics.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/cpu_usage_statistics.cpp
@@ -1,0 +1,165 @@
+// Copyright 2025 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file cpu_usage_statistics.cpp
+ * @brief CPU usage statistics collection and calculation implementation
+ */
+
+#include "system_monitor/cpu_monitor/cpu_usage_statistics.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+CpuUsageStatistics::CpuUsageStatistics()
+  : first_call_(true), statistics_1_(), statistics_2_(),
+    current_statistics_(statistics_1_), previous_statistics_(statistics_2_)
+{
+}
+
+void CpuUsageStatistics::update_cpu_statistics()
+{
+  core_usage_info_.clear();
+  // The vector is cleared, but the allocated memory won't be released.
+
+  std::ifstream stat_file("/proc/stat");
+  if (!stat_file.is_open()) {
+    return;
+  }
+
+  current_statistics_.clear();  // Allocated memory area won't be released.
+
+  std::string line;
+  while (std::getline(stat_file, line)) {
+    try {
+      std::istringstream iss(line);
+      std::string cpu_name;
+      iss >> cpu_name;
+
+      // Skip lines that don't start with "cpu"
+      if (cpu_name.substr(0, 3) != "cpu") {
+        continue;
+      }
+      if (cpu_name == "cpu") {
+        cpu_name = "all";
+      } else {
+        cpu_name = cpu_name.substr(3);
+      }
+
+      CpuStatistics statistics;
+      iss >> statistics.user >> statistics.nice >> statistics.system >> statistics.idle
+        >> statistics.iowait >> statistics.irq >> statistics.softirq >> statistics.steal
+        >> statistics.guest >> statistics.guest_nice;
+
+      statistics.name = cpu_name;
+      current_statistics_.push_back(statistics);
+    } catch (const std::exception& e) {
+      // Log error but continue processing other lines
+      continue;
+    }
+  }
+  stat_file.close();
+
+  // If this is the first call, just store the current statistics.
+  if (first_call_) {
+    swap_statistics();
+    first_call_ = false;
+    return;
+  }
+
+  // Process each CPU's statistics
+  for (const auto & core_info : current_statistics_) {
+    const std::string & cpu_name = core_info.name;
+    const CpuStatistics & stats = core_info;
+
+    // Skip if we don't have previous stats for this CPU
+    auto prev_iter =
+      std::find_if(previous_statistics_.begin(), previous_statistics_.end(),
+        [cpu_name](const CpuStatistics & statistics) { return statistics.name == cpu_name; });
+    if (prev_iter == previous_statistics_.end()) {
+      continue;
+    }
+
+    // Calculate deltas
+    uint64_t user_delta = stats.user - prev_iter->user;
+    uint64_t nice_delta = stats.nice - prev_iter->nice;
+    uint64_t system_delta = stats.system - prev_iter->system;
+    uint64_t idle_delta = stats.idle - prev_iter->idle;
+    uint64_t iowait_delta = stats.iowait - prev_iter->iowait;
+    uint64_t irq_delta = stats.irq - prev_iter->irq;
+    uint64_t softirq_delta = stats.softirq - prev_iter->softirq;
+    uint64_t steal_delta = stats.steal - prev_iter->steal;
+    uint64_t guest_delta = stats.guest - prev_iter->guest;
+    uint64_t guest_nice_delta = stats.guest_nice - prev_iter->guest_nice;
+
+    // Calculate total time delta
+    uint64_t total_delta = user_delta + nice_delta + system_delta +
+                          iowait_delta + irq_delta + softirq_delta + steal_delta;
+    uint64_t total_all_delta = total_delta + idle_delta;
+
+    // Skip if total time delta is zero
+    if (total_all_delta == 0) {
+      continue;
+    }
+
+    float total_all_delta_float = static_cast<float>(total_all_delta);
+    CoreUsageInfo core_usage;
+    core_usage.name = cpu_name;
+    core_usage.user_percent = (static_cast<float>(user_delta) / total_all_delta_float) * 100.0f;
+    core_usage.nice_percent = (static_cast<float>(nice_delta) / total_all_delta_float) * 100.0f;
+    core_usage.system_percent = (static_cast<float>(system_delta) / total_all_delta_float) * 100.0f;
+    core_usage.idle_percent = (static_cast<float>(idle_delta) / total_all_delta_float) * 100.0f;
+    core_usage.iowait_percent = (static_cast<float>(iowait_delta) / total_all_delta_float) * 100.0f;
+    core_usage.irq_percent = (static_cast<float>(irq_delta) / total_all_delta_float) * 100.0f;
+    core_usage.softirq_percent = (static_cast<float>(softirq_delta) / total_all_delta_float) * 100.0f;
+    core_usage.steal_percent = (static_cast<float>(steal_delta) / total_all_delta_float) * 100.0f;
+    core_usage.guest_percent = (static_cast<float>(guest_delta) / total_all_delta_float) * 100.0f;
+    core_usage.guest_nice_percent = (static_cast<float>(guest_nice_delta) / total_all_delta_float) * 100.0f;
+    core_usage.total_usage_percent = 100.0f - core_usage.idle_percent;
+
+    // Add to CPU info
+    core_usage_info_.push_back(core_usage);
+  }
+
+  // Store current stats for next call
+  swap_statistics();
+}
+
+void CpuUsageStatistics::swap_statistics()
+{
+  std::swap(current_statistics_, previous_statistics_);
+}
+
+int32_t CpuUsageStatistics::get_num_cores() const
+{
+  return core_usage_info_.size();
+}
+
+CpuUsageStatistics::CoreUsageInfo CpuUsageStatistics::get_core_usage_info(int32_t core_index) const
+{
+  if (core_index < 0 || static_cast<size_t>(core_index) >= core_usage_info_.size()) {
+    // To avoid unexpected segmentation fault, return empty data.
+    CoreUsageInfo empty_info{};
+    return empty_info;
+  }
+  return core_usage_info_[core_index];
+}

--- a/system/autoware_system_monitor/test/src/cpu_monitor/test_arm_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/test/src/cpu_monitor/test_arm_cpu_monitor.cpp
@@ -77,12 +77,6 @@ public:
     frequencies_.clear();
   }
 
-  void setMpstatExists(bool mpstat_exists)
-  {
-    std::lock_guard<std::mutex> lock_context(mutex_context_);
-    mpstat_exists_ = mpstat_exists;
-  }
-
   void changeUsageWarn(float usage_warn)
   {
     std::lock_guard<std::mutex> lock_context(mutex_context_);
@@ -149,26 +143,15 @@ public:
     // Get directory of executable
     const fs::path exe_path(argv_[0]);
     exe_dir_ = exe_path.parent_path().generic_string();
-    // Get dummy executable path
-    mpstat_ = exe_dir_ + "/mpstat";
-    // Save environment variable PATH for restoration
-    auto env = boost::this_process::environment();
-    original_path_ = env["PATH"].to_string();
   }
 
 protected:
   std::unique_ptr<TestCPUMonitor> monitor_;
   rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_;
   std::string exe_dir_;
-  std::string mpstat_;
-  std::string original_path_;
 
   void SetUp()
   {
-    // The environment variable PATH should be restored
-    // before creating an instance of TestCPUMonitor.
-    restorePath();
-
     using std::placeholders::_1;
     rclcpp::init(0, nullptr);
     rclcpp::NodeOptions node_options;
@@ -191,11 +174,6 @@ protected:
     if (fs::exists(TEST_FILE, error_code)) {
       fs::remove(TEST_FILE, error_code);
     }
-    // mpstat_ is a symbolic link.
-    // fs::exists() tests existence of the destination file, not the symbolic link.
-    if (fs::is_symlink(mpstat_, error_code)) {
-      fs::remove(mpstat_, error_code);
-    }
   }
 
   void TearDown()
@@ -206,13 +184,7 @@ protected:
     if (fs::exists(TEST_FILE, error_code)) {
       fs::remove(TEST_FILE, error_code);
     }
-    // mpstat_ is a symbolic link.
-    // fs::exists() tests existence of the destination file, not the symbolic link.
-    if (fs::is_symlink(mpstat_, error_code)) {
-      fs::remove(mpstat_, error_code);
-    }
     rclcpp::shutdown();
-    restorePath();
   }
 
   bool findValue(const DiagStatus status, const std::string & key, std::string & value)  // NOLINT
@@ -224,21 +196,6 @@ protected:
       }
     }
     return false;
-  }
-
-  void modifyPath()
-  {
-    // Modify PATH temporarily
-    auto env = boost::this_process::environment();
-    std::string new_path = env["PATH"].to_string();
-    new_path.insert(0, fmt::format("{}:", exe_dir_));
-    env["PATH"] = new_path;
-  }
-
-  void restorePath()
-  {
-    auto env = boost::this_process::environment();
-    env["PATH"] = original_path_;
   }
 
   void updatePublishSubscribe()
@@ -468,25 +425,6 @@ TEST_F(CPUMonitorTestSuite, usageErrorTest)
   }
 }
 
-TEST_F(CPUMonitorTestSuite, usageMpstatNotFoundTest)
-{
-  // Set flag false
-  monitor_->setMpstatExists(false);
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat error");
-  ASSERT_TRUE(findValue(status, "mpstat", value));
-  ASSERT_STREQ(
-    value.c_str(),
-    "Command 'mpstat' not found, but can be installed with: sudo apt install sysstat");
-}
-
 // Warning/Error about CPU load average used to be implemented,
 // but they were removed to avoid false alarms.
 #ifdef ENABLE_LOAD_AVERAGE_DIAGNOSTICS
@@ -607,45 +545,6 @@ TEST_F(CPUMonitorTestSuite, freqFrequencyFilesNotFoundTest)
 
   ASSERT_EQ(status.level, DiagStatus::ERROR);
   ASSERT_STREQ(status.message.c_str(), "frequency files not found");
-}
-
-TEST_F(CPUMonitorTestSuite, usageMpstatErrorTest)
-{
-  // Symlink mpstat1 to mpstat
-  fs::create_symlink(exe_dir_ + "/mpstat1", mpstat_);
-
-  // Modify PATH temporarily
-  modifyPath();
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat error");
-  ASSERT_TRUE(findValue(status, "mpstat", value));
-}
-
-TEST_F(CPUMonitorTestSuite, usageMpstatExceptionTest)
-{
-  // Symlink mpstat2 to mpstat
-  fs::create_symlink(exe_dir_ + "/mpstat2", mpstat_);
-
-  // Modify PATH temporarily
-  modifyPath();
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat exception");
 }
 
 // for coverage

--- a/system/autoware_system_monitor/test/src/cpu_monitor/test_intel_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/test/src/cpu_monitor/test_intel_cpu_monitor.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <thread>
 
 namespace fs = std::filesystem;
 using DiagStatus = diagnostic_msgs::msg::DiagnosticStatus;
@@ -86,12 +87,6 @@ public:
   {
     std::lock_guard<std::mutex> lock_context(mutex_context_);
     frequencies_.clear();
-  }
-
-  void setMpstatExists(bool mpstat_exists)
-  {
-    std::lock_guard<std::mutex> lock_context(mutex_context_);
-    mpstat_exists_ = mpstat_exists;
   }
 
   void changeUsageWarn(float usage_warn)
@@ -160,26 +155,15 @@ public:
     // Get directory of executable
     const fs::path exe_path(argv_[0]);
     exe_dir_ = exe_path.parent_path().generic_string();
-    // Get dummy executable path
-    mpstat_ = exe_dir_ + "/mpstat";
-    // Save environment variable PATH for restoration
-    auto env = boost::this_process::environment();
-    original_path_ = env["PATH"].to_string();
   }
 
 protected:
   std::unique_ptr<TestCPUMonitor> monitor_;
   rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_;
   std::string exe_dir_;
-  std::string mpstat_;
-  std::string original_path_;
 
   void SetUp()
   {
-    // The environment variable PATH should be restored
-    // before creating an instance of TestCPUMonitor.
-    restorePath();
-
     using std::placeholders::_1;
     rclcpp::init(0, nullptr);
     rclcpp::NodeOptions node_options;
@@ -202,11 +186,6 @@ protected:
     if (fs::exists(TEST_FILE, error_code)) {
       fs::remove(TEST_FILE, error_code);
     }
-    // mpstat_ is a symbolic link.
-    // fs::exists() tests existence of the destination file, not the symbolic link.
-    if (fs::is_symlink(mpstat_, error_code)) {
-      fs::remove(mpstat_, error_code);
-    }
   }
 
   void TearDown()
@@ -217,13 +196,7 @@ protected:
     if (fs::exists(TEST_FILE, error_code)) {
       fs::remove(TEST_FILE, error_code);
     }
-    // mpstat_ is a symbolic link.
-    // fs::exists() tests existence of the destination file, not the symbolic link.
-    if (fs::is_symlink(mpstat_, error_code)) {
-      fs::remove(mpstat_, error_code);
-    }
     rclcpp::shutdown();
-    restorePath();
   }
 
   bool findValue(const DiagStatus status, const std::string & key, std::string & value)  // NOLINT
@@ -235,21 +208,6 @@ protected:
       }
     }
     return false;
-  }
-
-  void modifyPath()
-  {
-    // Modify PATH temporarily
-    auto env = boost::this_process::environment();
-    std::string new_path = env["PATH"].to_string();
-    new_path.insert(0, fmt::format("{}:", exe_dir_));
-    env["PATH"] = new_path;
-  }
-
-  void restorePath()
-  {
-    auto env = boost::this_process::environment();
-    env["PATH"] = original_path_;
   }
 
   void updatePublishSubscribe()
@@ -622,25 +580,6 @@ TEST_F(CPUMonitorTestSuite, usageErrorTest)
   }
 }
 
-TEST_F(CPUMonitorTestSuite, usageMpstatNotFoundTest)
-{
-  // Set flag false
-  monitor_->setMpstatExists(false);
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat error");
-  ASSERT_TRUE(findValue(status, "mpstat", value));
-  ASSERT_STREQ(
-    value.c_str(),
-    "Command 'mpstat' not found, but can be installed with: sudo apt install sysstat");
-}
-
 // Warning/Error about CPU load average used to be implemented,
 // but they were removed to avoid false alarms.
 #ifdef ENABLE_LOAD_AVERAGE_DIAGNOSTICS
@@ -885,45 +824,6 @@ TEST_F(CPUMonitorTestSuite, freqFrequencyFilesNotFoundTest)
 
   ASSERT_EQ(status.level, DiagStatus::ERROR);
   ASSERT_STREQ(status.message.c_str(), "frequency files not found");
-}
-
-TEST_F(CPUMonitorTestSuite, usageMpstatErrorTest)
-{
-  // Symlink mpstat1 to mpstat
-  fs::create_symlink(exe_dir_ + "/mpstat1", mpstat_);
-
-  // Modify PATH temporarily
-  modifyPath();
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat error");
-  ASSERT_TRUE(findValue(status, "mpstat", value));
-}
-
-TEST_F(CPUMonitorTestSuite, usageMpstatExceptionTest)
-{
-  // Symlink mpstat2 to mpstat
-  fs::create_symlink(exe_dir_ + "/mpstat2", mpstat_);
-
-  // Modify PATH temporarily
-  modifyPath();
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat exception");
 }
 
 // for coverage

--- a/system/autoware_system_monitor/test/src/cpu_monitor/test_raspi_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/test/src/cpu_monitor/test_raspi_cpu_monitor.cpp
@@ -77,12 +77,6 @@ public:
     frequencies_.clear();
   }
 
-  void setMpstatExists(bool mpstat_exists)
-  {
-    std::lock_guard<std::mutex> lock_context(mutex_context_);
-    mpstat_exists_ = mpstat_exists;
-  }
-
   void changeUsageWarn(float usage_warn)
   {
     std::lock_guard<std::mutex> lock_context(mutex_context_);
@@ -149,26 +143,15 @@ public:
     // Get directory of executable
     const fs::path exe_path(argv_[0]);
     exe_dir_ = exe_path.parent_path().generic_string();
-    // Get dummy executable path
-    mpstat_ = exe_dir_ + "/mpstat";
-    // Save environment variable PATH for restoration
-    auto env = boost::this_process::environment();
-    original_path_ = env["PATH"].to_string();
   }
 
 protected:
   std::unique_ptr<TestCPUMonitor> monitor_;
   rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_;
   std::string exe_dir_;
-  std::string mpstat_;
-  std::string original_path_;
 
   void SetUp()
   {
-    // The environment variable PATH should be restored
-    // before creating an instance of TestCPUMonitor.
-    restorePath();
-
     using std::placeholders::_1;
     rclcpp::init(0, nullptr);
     rclcpp::NodeOptions node_options;
@@ -191,11 +174,6 @@ protected:
     if (fs::exists(TEST_FILE, error_code)) {
       fs::remove(TEST_FILE, error_code);
     }
-    // mpstat_ is a symbolic link.
-    // fs::exists() tests existence of the destination file, not the symbolic link.
-    if (fs::is_symlink(mpstat_, error_code)) {
-      fs::remove(mpstat_, error_code);
-    }
   }
 
   void TearDown()
@@ -206,13 +184,7 @@ protected:
     if (fs::exists(TEST_FILE, error_code)) {
       fs::remove(TEST_FILE, error_code);
     }
-    // mpstat_ is a symbolic link.
-    // fs::exists() tests existence of the destination file, not the symbolic link.
-    if (fs::is_symlink(mpstat_, error_code)) {
-      fs::remove(mpstat_, error_code);
-    }
     rclcpp::shutdown();
-    restorePath();
   }
 
   bool findValue(const DiagStatus status, const std::string & key, std::string & value)  // NOLINT
@@ -224,21 +196,6 @@ protected:
       }
     }
     return false;
-  }
-
-  void modifyPath()
-  {
-    // Modify PATH temporarily
-    auto env = boost::this_process::environment();
-    std::string new_path = env["PATH"].to_string();
-    new_path.insert(0, fmt::format("{}:", exe_dir_));
-    env["PATH"] = new_path;
-  }
-
-  void restorePath()
-  {
-    auto env = boost::this_process::environment();
-    env["PATH"] = original_path_;
   }
 
   void updatePublishSubscribe()
@@ -467,26 +424,6 @@ TEST_F(CPUMonitorTestSuite, usageErrorTest)
   }
 }
 
-// Warning/Error about CPU usage used to be implemented,
-TEST_F(CPUMonitorTestSuite, usageMpstatNotFoundTest)
-{
-  // Set flag false
-  monitor_->setMpstatExists(false);
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat error");
-  ASSERT_TRUE(findValue(status, "mpstat", value));
-  ASSERT_STREQ(
-    value.c_str(),
-    "Command 'mpstat' not found, but can be installed with: sudo apt install sysstat");
-}
-
 // Warning/Error about CPU load average used to be implemented,
 // but they were removed to avoid false alarms.
 #ifdef ENABLE_LOAD_AVERAGE_DIAGNOSTICS
@@ -612,45 +549,6 @@ TEST_F(CPUMonitorTestSuite, freqFrequencyFilesNotFoundTest)
 
   ASSERT_EQ(status.level, DiagStatus::ERROR);
   ASSERT_STREQ(status.message.c_str(), "frequency files not found");
-}
-
-TEST_F(CPUMonitorTestSuite, usageMpstatErrorTest)
-{
-  // Symlink mpstat1 to mpstat
-  fs::create_symlink(exe_dir_ + "/mpstat1", mpstat_);
-
-  // Modify PATH temporarily
-  modifyPath();
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat error");
-  ASSERT_TRUE(findValue(status, "mpstat", value));
-}
-
-TEST_F(CPUMonitorTestSuite, usageMpstatExceptionTest)
-{
-  // Symlink mpstat2 to mpstat
-  fs::create_symlink(exe_dir_ + "/mpstat2", mpstat_);
-
-  // Modify PATH temporarily
-  modifyPath();
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat exception");
 }
 
 // for coverage

--- a/system/autoware_system_monitor/test/src/cpu_monitor/test_tegra_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/test/src/cpu_monitor/test_tegra_cpu_monitor.cpp
@@ -78,12 +78,6 @@ public:
     frequencies_.clear();
   }
 
-  void setMpstatExists(bool mpstat_exists)
-  {
-    std::lock_guard<std::mutex> lock_context(mutex_context_);
-    mpstat_exists_ = mpstat_exists;
-  }
-
   void changeUsageWarn(float usage_warn)
   {
     std::lock_guard<std::mutex> lock_context(mutex_context_);
@@ -150,26 +144,15 @@ public:
     // Get directory of executable
     const fs::path exe_path(argv_[0]);
     exe_dir_ = exe_path.parent_path().generic_string();
-    // Get dummy executable path
-    mpstat_ = exe_dir_ + "/mpstat";
-    // Save environment variable PATH for restoration
-    auto env = boost::this_process::environment();
-    original_path_ = env["PATH"].to_string();
   }
 
 protected:
   std::unique_ptr<TestCPUMonitor> monitor_;
   rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_;
   std::string exe_dir_;
-  std::string mpstat_;
-  std::string original_path_;
 
   void SetUp()
   {
-    // The environment variable PATH should be restored
-    // before creating an instance of TestCPUMonitor.
-    restorePath();
-
     using std::placeholders::_1;
     rclcpp::init(0, nullptr);
     rclcpp::NodeOptions node_options;
@@ -192,11 +175,6 @@ protected:
     if (fs::exists(TEST_FILE, error_code)) {
       fs::remove(TEST_FILE, error_code);
     }
-    // mpstat_ is a symbolic link.
-    // fs::exists() tests existence of the destination file, not the symbolic link.
-    if (fs::is_symlink(mpstat_, error_code)) {
-      fs::remove(mpstat_, error_code);
-    }
   }
 
   void TearDown()
@@ -207,13 +185,7 @@ protected:
     if (fs::exists(TEST_FILE, error_code)) {
       fs::remove(TEST_FILE, error_code);
     }
-    // mpstat_ is a symbolic link.
-    // fs::exists() tests existence of the destination file, not the symbolic link.
-    if (fs::is_symlink(mpstat_, error_code)) {
-      fs::remove(mpstat_, error_code);
-    }
     rclcpp::shutdown();
-    restorePath();
   }
 
   bool findValue(const DiagStatus status, const std::string & key, std::string & value)  // NOLINT
@@ -225,21 +197,6 @@ protected:
       }
     }
     return false;
-  }
-
-  void modifyPath()
-  {
-    // Modify PATH temporarily
-    auto env = boost::this_process::environment();
-    std::string new_path = env["PATH"].to_string();
-    new_path.insert(0, fmt::format("{}:", exe_dir_));
-    env["PATH"] = new_path;
-  }
-
-  void restorePath()
-  {
-    auto env = boost::this_process::environment();
-    env["PATH"] = original_path_;
   }
 
   void updatePublishSubscribe()
@@ -469,25 +426,6 @@ TEST_F(CPUMonitorTestSuite, usageErrorTest)
   }
 }
 
-TEST_F(CPUMonitorTestSuite, usageMpstatNotFoundTest)
-{
-  // Set flag false
-  monitor_->setMpstatExists(false);
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat error");
-  ASSERT_TRUE(findValue(status, "mpstat", value));
-  ASSERT_STREQ(
-    value.c_str(),
-    "Command 'mpstat' not found, but can be installed with: sudo apt install sysstat");
-}
-
 // Warning/Error about CPU load average used to be implemented,
 // but they were removed to avoid false alarms.
 #ifdef ENABLE_LOAD_AVERAGE_DIAGNOSTICS
@@ -598,45 +536,6 @@ TEST_F(CPUMonitorTestSuite, freqFrequencyFilesNotFoundTest)
 
   ASSERT_EQ(status.level, DiagStatus::ERROR);
   ASSERT_STREQ(status.message.c_str(), "frequency files not found");
-}
-
-TEST_F(CPUMonitorTestSuite, usageMpstatErrorTest)
-{
-  // Symlink mpstat1 to mpstat
-  fs::create_symlink(exe_dir_ + "/mpstat1", mpstat_);
-
-  // Modify PATH temporarily
-  modifyPath();
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat error");
-  ASSERT_TRUE(findValue(status, "mpstat", value));
-}
-
-TEST_F(CPUMonitorTestSuite, usageMpstatExceptionTest)
-{
-  // Symlink mpstat2 to mpstat
-  fs::create_symlink(exe_dir_ + "/mpstat2", mpstat_);
-
-  // Modify PATH temporarily
-  modifyPath();
-
-  updatePublishSubscribe();
-
-  // Verify
-  DiagStatus status;
-  std::string value;
-
-  ASSERT_TRUE(monitor_->findDiagStatus("CPU Usage", status));
-  ASSERT_EQ(status.level, DiagStatus::ERROR);
-  ASSERT_STREQ(status.message.c_str(), "mpstat exception");
 }
 
 // for coverage


### PR DESCRIPTION
## Description
As reported on issue #10554 , the "cpu_monitor" node executes the command line "mpstat -P ALL 1 1 -o JSON" to collect load information of CPU cores.
This implementation has 2 problems:
* "mpstat 1 1" sleeps for 1 second in it.
* Spawning of "mpstat" process with boost::process::child() introduces non-negligible amount of CPU load.
  * "cpu_monitor" itself need to wait for spawning of "mpstat" process every second.
  * Other processes may suffer from delay of task switching in the kernel when a new process is added to the task queue and the kernel context is locked.

This PR makes the following changes:
* "Cpu_monitor" does not execute "mpstat" command any more.
* Instead, "cpu_monitor" reads CPU load information directly from "/proc/stat".
* Unit tests about "mpstat" are removed because "mpstat" is not used.

Both of this PR and another preceding PR #10545 are needed to fix the issue #10554.

## Related links

**Parent Issue:**

- [The "cpu_monitor" node takes more than 1 second for publishing while it is expected to publish /diagnostics topic with 1 second intervals. #10554](https://github.com/autowarefoundation/autoware_universe/issues/10554)

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-9621)

## How was this PR tested?
- All PR CI tests passed.
- The source code can be built for different CPU platforms.
- Testing on other CPU platforms than Intel is being conducted in parallel to this PR.
  - Other CPU platforms also employs Linux as their OS and they have "/proc/stat" file.
  - The pseudo files for measuring CPU temperature and monitoring thermal throttling status are different among platforms.
- The number of entries and their values in "/diagnostics" topic published by the "cpu_monitor" node are same as before.
- All of unit tests passed.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.

### Improvement on system behavior
With this PR, "cpu_monitor" can publish CPU diagnostics every second as expected, with much lighter CPU load.
