### PR TITLE
feat(control_validator): 2 thresholds for the yaw deviation (warn/error)

### DIFF
--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -18,6 +18,7 @@ The listed features below does not always correspond to the latest implementatio
 - **Lateral jerk** : invalid when the lateral jerk exceeds the configured threshold. The validation uses the vehicle's velocity and steering angle rate to calculate the resulting lateral jerk. The calculation assumes constant velocity (acceleration is zero).
 - **Deviation check between reference trajectory and predicted trajectory** : invalid when the largest deviation between the predicted trajectory and reference trajectory is greater than the given threshold.
 - **Yaw deviation**: invalid when the difference between the yaw of the ego vehicle and the nearest (interpolated) trajectory yaw is greater than the given threshold.
+  - 2 thresholds are implemented, one to trigger a warning diagnostic, and one to trigger an error diagnostic.
 
 ![trajectory_deviation](./image/trajectory_deviation.drawio.svg)
 
@@ -73,4 +74,5 @@ The input trajectory is detected as invalid if the index exceeds the following t
 | `thresholds.will_overrun_stop_point_dist` | double | threshold distance to overrun stop point [m]                                                                | 1.0           |
 | `thresholds.assumed_limit_acc`            | double | assumed acceleration for over run estimation [m]                                                            | 5.0           |
 | `thresholds.assumed_delay_time`           | double | assumed delay for over run estimation [m]                                                                   | 0.2           |
-| `thresholds.yaw_deviation`                | double | threshold angle to validate the vehicle yaw related to the nearest trajectory yaw [rad]                     | 1.0           |
+| `thresholds.yaw_deviation_error`          | double | threshold angle to validate the vehicle yaw related to the nearest trajectory yaw [rad]                     | 1.0           |
+| `thresholds.yaw_deviation_warn`           | double | threshold angle to trigger a WARN diagnostic [rad]                                                          | 0.5           |

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -20,7 +20,8 @@
       assumed_limit_acc: 5.0
       assumed_delay_time: 0.2
       nominal_latency: 0.01
-      yaw_deviation: 1.0
+      yaw_deviation_error: 1.0
+      yaw_deviation_warn: 0.5
 
     acc_lpf_gain: 0.97 # Time constant 1.11s
     vel_lpf_gain: 0.9 # Time constant 0.33

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -206,14 +206,18 @@ class YawValidator
 {
 public:
   explicit YawValidator(rclcpp::Node & node)
-  : yaw_deviation_th_{get_or_declare_parameter<double>(node, "thresholds.yaw_deviation")} {};
+  : yaw_deviation_error_th_{get_or_declare_parameter<double>(
+      node, "thresholds.yaw_deviation_error")},
+    yaw_deviation_warn_th_{
+      get_or_declare_parameter<double>(node, "thresholds.yaw_deviation_warn")} {};
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & reference_trajectory,
-    const Odometry & kinematics);
+    const Odometry & kinematics) const;
 
 private:
-  const double yaw_deviation_th_;
+  const double yaw_deviation_error_th_;
+  const double yaw_deviation_warn_th_;
 };
 
 /**

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -10,6 +10,7 @@ bool has_overrun_stop_point
 bool will_overrun_stop_point
 bool is_valid_latency
 bool is_valid_yaw
+bool is_warn_yaw
 
 # values
 float64 max_distance_deviation

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -317,6 +317,7 @@ void ControlValidator::setup_diag()
   d.add(ns + "yaw_deviation", [&](auto & stat) {
     set_status(
       stat, validation_status_.is_valid_yaw, "The vehicle yaw has deviated from the trajectory.");
+    // TODO(someone): implement the dual thresholds for WARN/ERROR for the other metrics
     if (validation_status_.is_valid_yaw && validation_status_.is_warn_yaw) {
       stat.summary(
         DiagnosticStatus::WARN, "The vehicle yaw is deviating but is still under the error value.");

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -188,14 +188,15 @@ void OverrunValidator::validate(
 
 void YawValidator::validate(
   ControlValidatorStatus & res, const Trajectory & reference_trajectory,
-  const Odometry & kinematics)
+  const Odometry & kinematics) const
 {
   const auto interpolated_trajectory_point =
     motion_utils::calcInterpolatedPoint(reference_trajectory, kinematics.pose.pose);
   res.yaw_deviation = std::abs(angles::shortest_angular_distance(
     tf2::getYaw(interpolated_trajectory_point.pose.orientation),
     tf2::getYaw(kinematics.pose.pose.orientation)));
-  res.is_valid_yaw = res.yaw_deviation <= yaw_deviation_th_;
+  res.is_valid_yaw = res.yaw_deviation <= yaw_deviation_error_th_;
+  res.is_warn_yaw = res.yaw_deviation > yaw_deviation_warn_th_;
 }
 
 ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)
@@ -311,6 +312,15 @@ void ControlValidator::setup_diag()
     set_status(
       stat, validation_status_.is_valid_lateral_jerk,
       "The lateral jerk is larger than expected value.");
+  });
+
+  d.add(ns + "yaw_deviation", [&](auto & stat) {
+    set_status(
+      stat, validation_status_.is_valid_yaw, "The vehicle yaw has deviated from the trajectory.");
+    if (validation_status_.is_valid_yaw && validation_status_.is_warn_yaw) {
+      stat.summary(
+        DiagnosticStatus::WARN, "The vehicle yaw is deviating but is still under the error value.");
+    }
   });
 }
 


### PR DESCRIPTION
## Description

Add a 2nd threshold for the `yaw_deviation` metric allowing publishing of a warning instead of an error.

Requires the launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1508

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-10098)

## How was this PR tested?

Psim

Example with default parameters (threshold of `0.5` for `WARN` and `1.0` for `ERROR`).

https://github.com/user-attachments/assets/6050ad79-92a3-4219-b454-3b93eef4d6c7



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
