### PR TITLE
feat(mission_planner): print set route api type

### DIFF
--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -122,15 +122,24 @@ void MissionPlanner::publish_processing_time(
   pub_processing_time_->publish(processing_time_msg);
 }
 
-void MissionPlanner::publish_pose_log(const Pose & pose, const std::string & pose_type)
+void MissionPlanner::print_pose_log(
+  const std::string & route_type, const Pose & initial_pose, const Pose & goal_pose)
 {
-  const auto & p = pose.position;
+  RCLCPP_INFO(this->get_logger(), "Route set via %s", route_type.c_str());
+
+  const auto & ip = initial_pose.position;
+  RCLCPP_INFO(this->get_logger(), "Initial pose - x: %f, y: %f, z: %f", ip.x, ip.y, ip.z);
+  const auto & iq = initial_pose.orientation;
   RCLCPP_INFO(
-    this->get_logger(), "%s pose - x: %f, y: %f, z: %f", pose_type.c_str(), p.x, p.y, p.z);
-  const auto & quaternion = pose.orientation;
+    this->get_logger(), "Initial orientation - qx: %f, qy: %f, qz: %f, qw: %f", iq.x, iq.y, iq.z,
+    iq.w);
+
+  const auto & gp = goal_pose.position;
+  RCLCPP_INFO(this->get_logger(), "Goal pose - x: %f, y: %f, z: %f", gp.x, gp.y, gp.z);
+  const auto & gq = goal_pose.orientation;
   RCLCPP_INFO(
-    this->get_logger(), "%s orientation - qx: %f, qy: %f, qz: %f, qw: %f", pose_type.c_str(),
-    quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+    this->get_logger(), "Goal orientation - qx: %f, qy: %f, qz: %f, qw: %f", gq.x, gq.y, gq.z,
+    gq.w);
 }
 
 void MissionPlanner::check_initialization()
@@ -316,8 +325,7 @@ void MissionPlanner::on_set_lanelet_route(
   change_state(RouteState::SET);
   res->status.success = true;
 
-  publish_pose_log(odometry_->pose.pose, "initial");
-  publish_pose_log(req->goal_pose, "goal");
+  print_pose_log("set_lanelet_route", odometry_->pose.pose, req->goal_pose);
 }
 
 void MissionPlanner::on_set_waypoint_route(
@@ -377,8 +385,7 @@ void MissionPlanner::on_set_waypoint_route(
   change_state(RouteState::SET);
   res->status.success = true;
 
-  publish_pose_log(odometry_->pose.pose, "initial");
-  publish_pose_log(req->goal_pose, "goal");
+  print_pose_log("set_waypoint_route", odometry_->pose.pose, req->goal_pose);
 }
 
 void MissionPlanner::change_route()

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.hpp
@@ -131,7 +131,8 @@ private:
     const Header & header, const std::vector<Pose> & waypoints, const Pose & start_pose,
     const Pose & goal_pose, const UUID & uuid, const bool allow_goal_modification);
 
-  void publish_pose_log(const Pose & pose, const std::string & pose_type);
+  void print_pose_log(
+    const std::string & route_type, const Pose & initial_pose, const Pose & goal_pose);
 
   rclcpp::TimerBase::SharedPtr data_check_timer_;
   void check_initialization();


### PR DESCRIPTION
## Description

Be able to tell which api is being used.

`/api/routing/set_route`
`/api/routing/set_route_points`

```
[component_container_mt-38] [INFO 1750921150.530228097] [planning.planning_validator]: waiting for current_trajectory (operator()() at /home/kosuke55/pilot-auto/src/autoware/universe/planning/planning_validator/autoware_planning_validator/src/node.cpp:96)
[component_container_mt-29] [INFO 1750921150.643507229] [route_handler]: getMainLanelets: lanelet_sequence = [ids: 361 363 788 369 1197 176394 176399 176423 176432 176437 176443 1185 309 389 391 314 316 178801 318 176376 322 1182 1481 1485 1364 175955 175960 175965 176640 176670 176046 179318 ] (getMainLanelets() at /home/kosuke55/pilot-auto/src/autoware/core/planning/autoware_route_handler/src/route_handler.cpp:2182)
[component_container_mt-29] [INFO 1750921150.646590786] [planning.mission_planning.mission_planner]: Route set via set_waypoint_route (print_pose_log() at ../../src/autoware/universe/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp:128)
[component_container_mt-29] [INFO 1750921150.646610951] [planning.mission_planning.mission_planner]: Initial pose - x: 89632.812500, y: 43026.433594, z: 6.074000 (print_pose_log() at ../../src/autoware/universe/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp:131)
[component_container_mt-29] [INFO 1750921150.646624355] [planning.mission_planning.mission_planner]: Initial orientation - qx: -0.002265, qy: 0.007242, qz: 0.298513, qw: 0.954375 (print_pose_log() at ../../src/autoware/universe/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp:133)
[component_container_mt-29] [INFO 1750921150.646632569] [planning.mission_planning.mission_planner]: Goal pose - x: 89418.750000, y: 43212.714844, z: 0.000000 (print_pose_log() at ../../src/autoware/universe/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp:138)
[component_container_mt-29] [INFO 1750921150.646641346] [planning.mission_planning.mission_planner]: Goal orientation - qx: 0.000000, qy: 0.000000, qz: 0.873475, qw: 0.486869 (print_pose_log() at ../../src/autoware/universe/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp:140)
```


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
