### PR TITLE
fix(goal_planner): return route lanelet sequence for road side pull over

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -199,7 +199,15 @@ lanelet::ConstLanelets getPullOverLanes(
     return route_handler.get_shoulder_lanelet_sequence(
       outermost_lane, backward_distance_with_buffer, forward_distance);
   }
-  return {outermost_lane};
+
+  const auto & route_lane_sequence = route_handler.getLaneletSequence(
+    outermost_lane, backward_distance_with_buffer, forward_distance);
+
+  if (route_lane_sequence.empty()) {
+    return {outermost_lane};
+  }
+
+  return route_lane_sequence;
 }
 
 static double getOffsetToLanesBoundary(


### PR DESCRIPTION
## Description

Closes https://github.com/autowarefoundation/autoware_universe/issues/10885

When trying to pull over to road side, if the goal lane is shorter than ego vehicle, goal_planner module can not generate candidate path. This issue mostly observed when ego is a big vehicle such as bus or truck.

**Before**


https://github.com/user-attachments/assets/39da5c5e-5260-45f8-b1a9-afac4a124f62

**After**


https://github.com/user-attachments/assets/571e7a6a-1191-4846-be10-858de876f81c


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

PSim and scenario simulation

## Notes for reviewers

Following scenario can be used.
[goal_planner_small_lane_pullover.zip](https://github.com/user-attachments/files/20924815/goal_planner_small_lane_pullover.zip)
.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
