### PR TITLE
feat(run_out): add planning factors

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/decision.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/decision.hpp
@@ -23,6 +23,8 @@
 #include <cstdio>
 #include <optional>
 #include <sstream>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::motion_velocity_planner::run_out
@@ -62,8 +64,10 @@ DecisionType calculate_decision_type(
 /// @brief update objects that did not have a decision at the given time
 void update_objects_without_decisions(
   ObjectDecisionsTracker & decisions_tracker, const rclcpp::Time & now);
-/// @brief calculate current decisions for the objects and update the decision tracker accordingly
-void calculate_decisions(
+/// @brief calculate current decisions for the objects, update the decision tracker accordingly, and
+/// return the safety factor of each object
+std::unordered_map<std::string, autoware_internal_planning_msgs::msg::SafetyFactor>
+calculate_decisions(
   ObjectDecisionsTracker & decisions_tracker, const std::vector<Object> & objects,
   const rclcpp::Time & now, const double keep_stop_distance_range, const Parameters & params);
 }  // namespace autoware::motion_velocity_planner::run_out

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
@@ -163,6 +163,9 @@ void RunOutModule::add_planning_factors(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const VelocityPlanningResult & result)
 {
+  if (trajectory.empty()) {
+    return;
+  }
   geometry_msgs::msg::Pose p;
   for (const auto & slowdown : result.slowdown_intervals) {
     p.position = slowdown.from;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.hpp
@@ -62,6 +62,7 @@ public:
     required_subscription_info.predicted_objects = true;
     return required_subscription_info;
   }
+  void publish_planning_factor() override { planning_factor_interface_->publish(); };
 
 private:
   inline static const std::string ns_ = "run_out";
@@ -86,6 +87,10 @@ private:
   void publish_debug_trajectory(
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
     const VelocityPlanningResult & planning_result);
+  /// @brief populate the planning factors based on the module's planning result
+  void add_planning_factors(
+    const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+    const VelocityPlanningResult & result);
 };
 }  // namespace autoware::motion_velocity_planner
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.hpp
@@ -35,6 +35,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::motion_velocity_planner
@@ -90,7 +91,9 @@ private:
   /// @brief populate the planning factors based on the module's planning result
   void add_planning_factors(
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
-    const VelocityPlanningResult & result);
+    const run_out::RunOutResult & result,
+    const std::unordered_map<std::string, autoware_internal_planning_msgs::msg::SafetyFactor> &
+      safety_factor_per_object);
 };
 }  // namespace autoware::motion_velocity_planner
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.cpp
@@ -151,23 +151,25 @@ std::optional<SlowdownInterval> calculate_slowdown_interval(
   return interval;
 }
 
-VelocityPlanningResult calculate_slowdowns(
+RunOutResult calculate_slowdowns(
   ObjectDecisionsTracker & decision_tracker,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const double current_velocity, std::optional<double> & unfeasible_stop_deceleration,
   const Parameters & params)
 {
-  VelocityPlanningResult result;
+  RunOutResult result;
   for (auto & [object, history] : decision_tracker.history_per_object) {
     const auto stop_position = calculate_stop_position(
       history, trajectory, current_velocity, unfeasible_stop_deceleration, params);
     if (stop_position) {
-      result.stop_points.push_back(*stop_position);
+      result.velocity_planning_result.stop_points.push_back(*stop_position);
+      result.stop_objects.push_back(object);
     }
     const auto slowdown_interval =
       calculate_slowdown_interval(history, trajectory, current_velocity, params);
     if (slowdown_interval) {
-      result.slowdown_intervals.push_back(*slowdown_interval);
+      result.velocity_planning_result.slowdown_intervals.push_back(*slowdown_interval);
+      result.slowdown_objects.push_back(object);
     }
   }
   return result;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.hpp
@@ -71,8 +71,8 @@ std::optional<SlowdownInterval> calculate_slowdown_interval(
 /// @param [in] current_velocity [m/s] current ego velocity
 /// @param [inout] unfeasible_stop_deceleration maximum deceleration found that breaks the limit
 /// @param [in] params module parameters
-/// @return result with the calculated stop point and slowdown intervals
-VelocityPlanningResult calculate_slowdowns(
+/// @return result with the calculated stop point and slowdown intervals and their safety factors
+RunOutResult calculate_slowdowns(
   ObjectDecisionsTracker & decision_tracker,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const double current_velocity, std::optional<double> & unfeasible_stop_deceleration,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/types.hpp
@@ -20,6 +20,7 @@
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <rclcpp/time.hpp>
 
+#include <autoware_internal_planning_msgs/msg/safety_factor_array.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 
 #include <boost/geometry.hpp>
@@ -315,6 +316,14 @@ struct FilteringData
   SegmentRtree cut_predicted_paths_rtree;
 };
 using FilteringDataPerLabel = std::vector<FilteringData>;
+
+/// @brief run out results including the factors for the stops and slowdowns
+struct RunOutResult
+{
+  VelocityPlanningResult velocity_planning_result;
+  std::vector<std::string> stop_objects;      // target object uuid for each stop result
+  std::vector<std::string> slowdown_objects;  // target object uuid for each slowdown result
+};
 
 }  // namespace autoware::motion_velocity_planner::run_out
 


### PR DESCRIPTION
## Description

Add publishing of the planning factors in the `run_out` module of the `motion_velocity_planner`.

## Related links

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
