### PR TITLE
feat(intersection): adjust collision stopline position to be ahead of ego by braking distance

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/intersection_stoplines.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/intersection_stoplines.hpp
@@ -38,6 +38,11 @@ struct IntersectionStopLines
   std::optional<size_t> default_stopline{std::nullopt};
 
   /**
+   * collision_stopline is ahead of closest_idx by the braking distance
+   */
+  size_t collision_stopline{0};
+
+  /**
    * first_attention_stopline is null if ego footprint along the path does not intersect with
    * attention area. if path[0] satisfies the condition, it is 0
    */

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -333,7 +333,8 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
 
   const bool is_over_default_stopline = util::isOverTargetIndex(
     *path, closest_idx, planner_data_->current_odometry->pose, default_stopline_idx);
-  const auto collision_stopline_idx = is_over_default_stopline ? closest_idx : default_stopline_idx;
+  const auto collision_stopline_idx =
+    is_over_default_stopline ? intersection_stoplines.collision_stopline : default_stopline_idx;
 
   // ==========================================================================================
   // pseudo collision detection on green light

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -331,10 +331,9 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
       "attention lane, which is dangerous.";
   }
 
-  const bool is_over_default_stopline = util::isOverTargetIndex(
-    *path, closest_idx, planner_data_->current_odometry->pose, default_stopline_idx);
+  const bool can_stop_at_default_stopline = can_smoothly_stop_at(default_stopline_idx);
   const auto collision_stopline_idx =
-    is_over_default_stopline ? intersection_stoplines.collision_stopline : default_stopline_idx;
+    can_stop_at_default_stopline ? default_stopline_idx : intersection_stoplines.collision_stopline;
 
   // ==========================================================================================
   // pseudo collision detection on green light

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -331,9 +331,10 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
       "attention lane, which is dangerous.";
   }
 
-  const bool can_stop_at_default_stopline = can_smoothly_stop_at(default_stopline_idx);
+  const bool is_over_default_stopline = util::isOverTargetIndex(
+    *path, closest_idx, planner_data_->current_odometry->pose, default_stopline_idx);
   const auto collision_stopline_idx =
-    can_stop_at_default_stopline ? default_stopline_idx : intersection_stoplines.collision_stopline;
+    is_over_default_stopline ? intersection_stoplines.collision_stopline : default_stopline_idx;
 
   // ==========================================================================================
   // pseudo collision detection on green light


### PR DESCRIPTION
## Description

If sudden collision is detected after ego passed default stopline, current module inserts stopline at current position. This causes `will overrun` MRM because such braking is impossible. the stopline is inserted ahead of ego by braking distance after this PR (collision_stopline).

### before this PR

intersection stopline appears just in front of ego (at [00:08])

https://github.com/user-attachments/assets/a8ec8ec6-d688-4a9d-9239-59635b70b1d1

### after this PR

intersection stopline appears a bit ahead of ego

https://github.com/user-attachments/assets/258aacd1-5ed2-455c-a9ff-c26c877d737a


## Related links

https://tier4.atlassian.net/browse/RT1-10480

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/1374ee58-5ce8-5cb5-95c5-89448e791f17?project_id=prd_jt
https://evaluation.tier4.jp/evaluation/reports/9325a091-648e-5b28-b44b-5f3babad8511?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
