### PR TITLE
fix(static_obstacle_avoidance): ensure sufficient avoidance margin on high-curvature paths for parked vehicle avoidance

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -425,6 +425,10 @@ struct ObjectData  // avoidance target
   // envelope polygon centroid
   Point2d centroid{};
 
+  // Adds extra margin for objects near highly curved sections of the path
+  // to prevent the vehicle's front from getting too close to obstacles.
+  double curvature_based_margin{0.0};
+
   // lateral distance from overhang to the road shoulder
   double to_road_shoulder_distance{0.0};
 
@@ -553,6 +557,9 @@ struct AvoidancePlanningData
   // arclength vector of the reference_path from ego.
   // If the point is behind ego_pose, the value is negative.
   std::vector<double> arclength_from_ego;
+
+  // Lateral distance from the vehicle's front corner to the path centerline at each path point.
+  std::vector<double> front_corner_offsets;
 
   // current driving lanelet
   lanelet::ConstLanelets current_lanelets;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp
@@ -46,6 +46,17 @@ static constexpr const char * logger_namespace =
 bool isOnRight(const ObjectData & obj);
 
 /**
+ * @brief Calculate lateral distances between the vehicle's front corner and the path centerline
+ *        for each point along the given path.
+ * @param path The reference path with lane IDs.
+ * @param planner_data Shared data containing vehicle parameters and current state.
+ * @return A vector of lateral offsets for the front corner at each path point.
+ */
+auto calc_front_corner_offsets(
+  const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data)
+  -> std::vector<double>;
+
+/**
  * @brief calculate shift length from centerline of current lane.
  * @param object offset direction.
  * @param distance between object polygon and centerline of current lane. (signed)
@@ -108,6 +119,21 @@ void fillLongitudinalAndLengthByClosestEnvelopeFootprint(
  */
 std::vector<std::pair<double, Point>> calcEnvelopeOverhangDistance(
   const ObjectData & object_data, const PathWithLaneId & path);
+
+/**
+ * @brief Calculate additional safety margin based on the curvature of the path
+ *        near the object's position to avoid close proximity of the vehicle's front.
+ * @param object_data Detected object information.
+ * @param front_corner_offsets Lateral distances from the vehicle's front corner to the path
+ * centerline at each path point.
+ * @param path The planned path with lane IDs.
+ * @param ego_pos Current position of the ego vehicle.
+ * @param base_link2front Distance from base_link to the front edge of the vehicle.
+ * @return Extra margin value to apply near the object based on curvature.
+ */
+double calc_curvature_based_margin(
+  const ObjectData & object_data, const std::vector<double> & front_corner_offsets,
+  const PathWithLaneId & path, const Point & ego_pos, const double base_link2front);
 
 void setEndData(
   AvoidLine & al, const double length, const geometry_msgs::msg::Pose & end, const size_t end_idx,

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -301,6 +301,9 @@ void StaticObstacleAvoidanceModule::fillFundamentalData(
     data.reference_path, 0, data.reference_path.points.size(),
     autoware::motion_utils::calcSignedArcLength(data.reference_path.points, getEgoPosition(), 0));
 
+  data.front_corner_offsets = utils::static_obstacle_avoidance::calc_front_corner_offsets(
+    data.reference_path_rough, planner_data_);
+
   data.is_allowed_goal_modification =
     utils::isAllowedGoalModification(planner_data_->route_handler);
   data.distance_to_red_traffic_light = utils::traffic_light::calcDistanceToRedTrafficLight(

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1471,6 +1471,19 @@ std::vector<std::pair<double, Point>> calcEnvelopeOverhangDistance(
   std::sort(overhang_points.begin(), overhang_points.end(), [&](const auto & a, const auto & b) {
     return isOnRight(object_data) ? b.first < a.first : a.first < b.first;
   });
+  if (overhang_points.size() > 1) {
+    const auto p1 = overhang_points.at(0).second;
+    const auto p2 = overhang_points.at(1).second;
+    const auto point = autoware_utils::create_point(0.5 * (p1.x + p2.x), 0.5 * (p1.y + p2.y), 0.0);
+    // TODO(someone): search around first position where the ego should avoid the object.
+    const auto idx = autoware::motion_utils::findNearestIndex(path.points, point);
+    const auto lateral =
+      calc_lateral_deviation(autoware_utils::get_pose(path.points.at(idx)), point);
+    overhang_points.emplace_back(lateral, point);
+  }
+  std::sort(overhang_points.begin(), overhang_points.end(), [&](const auto & a, const auto & b) {
+    return isOnRight(object_data) ? b.first < a.first : a.first < b.first;
+  });
   return overhang_points;
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1089,8 +1089,10 @@ std::optional<double> getAvoidMargin(
                                      : object_parameter.lateral_hard_margin;
 
   const auto max_avoid_margin = lateral_hard_margin * object.distance_factor +
-                                object_parameter.lateral_soft_margin + 0.5 * vehicle_width;
-  const auto min_avoid_margin = lateral_hard_margin + 0.5 * vehicle_width;
+                                object_parameter.lateral_soft_margin +
+                                object.curvature_based_margin + 0.5 * vehicle_width;
+  const auto min_avoid_margin =
+    lateral_hard_margin + object.curvature_based_margin + 0.5 * vehicle_width;
   const auto soft_lateral_distance_limit =
     object.to_road_shoulder_distance - parameters->soft_drivable_bound_margin - 0.5 * vehicle_width;
   const auto hard_lateral_distance_limit =
@@ -1205,6 +1207,49 @@ double calcShiftLength(
   const auto shift_length =
     is_object_on_right ? (overhang_dist + avoid_margin) : (overhang_dist - avoid_margin);
   return std::fabs(shift_length) > 1e-3 ? shift_length : 0.0;
+}
+
+auto calc_front_corner_offsets(
+  const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data)
+  -> std::vector<double>
+{
+  std::vector<double> ret;
+
+  lanelet::BasicLineString3d linestring{};
+  std::for_each(path.points.begin(), path.points.end(), [&](const auto & p) {
+    const auto point = autoware_utils::get_point(p);
+    linestring.emplace_back(point.x, point.y, point.z);
+  });
+
+  const auto vehicle_info = planner_data->parameters.vehicle_info;
+  const auto front_left_corner = autoware_utils::Point2d(
+    vehicle_info.max_longitudinal_offset_m, 0.5 * vehicle_info.vehicle_width_m);
+  const auto front_right_corner = autoware_utils::Point2d(
+    vehicle_info.max_longitudinal_offset_m, -0.5 * vehicle_info.vehicle_width_m);
+
+  const auto curvatures = autoware::motion_utils::calcCurvature(path.points);
+  for (size_t i = 0; i < path.points.size(); i++) {
+    const auto transform =
+      autoware_utils::pose2transform(autoware_utils::get_pose(path.points.at(i)));
+
+    if (curvatures.at(i) > 0.0) {
+      const auto transformed_front_right =
+        autoware_utils::transform_point(front_right_corner, transform);
+      const auto curvature_based_margin =
+        boost::geometry::distance(transformed_front_right, lanelet::utils::to2D(linestring)) -
+        0.5 * vehicle_info.vehicle_width_m;
+      ret.push_back(std::max(0.0, curvature_based_margin));
+    } else {
+      const auto transformed_front_left =
+        autoware_utils::transform_point(front_left_corner, transform);
+      const auto curvature_based_margin =
+        boost::geometry::distance(transformed_front_left, lanelet::utils::to2D(linestring)) -
+        0.5 * vehicle_info.vehicle_width_m;
+      ret.push_back(std::max(0.0, curvature_based_margin));
+    }
+  }
+
+  return ret;
 }
 
 bool isWithinLanes(
@@ -1379,6 +1424,35 @@ void fillLongitudinalAndLengthByClosestEnvelopeFootprint(
   }
   obj.longitudinal = min_distance;
   obj.length = max_distance - min_distance;
+}
+
+double calc_curvature_based_margin(
+  const ObjectData & object_data, const std::vector<double> & front_corner_offsets,
+  const PathWithLaneId & path, const Point & ego_pos, const double base_link2front)
+{
+  if (front_corner_offsets.size() != path.points.size()) {
+    throw std::logic_error(
+      "size mismatch: vectors front_corner_offsets and path points must have the same length.");
+  }
+
+  const auto backward_distance =
+    autoware::motion_utils::calcSignedArcLength(path.points, 0L, ego_pos);
+  double curvature_based_margin = 0.0;
+  for (size_t i = 0; i < path.points.size(); i++) {
+    const auto d =
+      autoware::motion_utils::calcSignedArcLength(path.points, 0L, i) - backward_distance;
+    if (d + base_link2front < object_data.longitudinal) {
+      continue;
+    }
+
+    curvature_based_margin = std::max(curvature_based_margin, front_corner_offsets.at(i));
+
+    if (d > object_data.longitudinal + object_data.length) {
+      break;
+    }
+  }
+
+  return curvature_based_margin;
 }
 
 std::vector<std::pair<double, Point>> calcEnvelopeOverhangDistance(
@@ -2031,8 +2105,12 @@ void filterTargetObjects(
     }
 
     // Find the footprint point closest to the path, set to object_data.overhang_distance.
+    const auto & ego_pos = planner_data->self_odometry->pose.pose.position;
     o.overhang_points =
       utils::static_obstacle_avoidance::calcEnvelopeOverhangDistance(o, data.reference_path);
+    o.curvature_based_margin = calc_curvature_based_margin(
+      o, data.front_corner_offsets, data.reference_path_rough, ego_pos,
+      planner_data->parameters.vehicle_info.max_longitudinal_offset_m);
     o.to_road_shoulder_distance = filtering_utils::getRoadShoulderDistance(o, data, planner_data);
 
     if (filtering_utils::isUnknownTypeObject(o)) {

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1232,6 +1232,13 @@ auto calc_front_corner_offsets(
     const auto transform =
       autoware_utils::pose2transform(autoware_utils::get_pose(path.points.at(i)));
 
+    if (
+      autoware::motion_utils::calcSignedArcLength(path.points, i, path.points.size() - 1) <
+      vehicle_info.max_longitudinal_offset_m) {
+      ret.push_back(0.0);
+      continue;
+    }
+
     if (curvatures.at(i) > 0.0) {
       const auto transformed_front_right =
         autoware_utils::transform_point(front_right_corner, transform);

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
@@ -990,12 +990,13 @@ TEST(TestUtils, calcEnvelopeOverhangDistance)
 
     const auto output = calcEnvelopeOverhangDistance(object_data, path);
 
-    ASSERT_EQ(output.size(), 5);
+    ASSERT_EQ(output.size(), 6);
     EXPECT_NEAR(output.at(0).first, -0.5, epsilon);
     EXPECT_NEAR(output.at(1).first, -0.5, epsilon);
     EXPECT_NEAR(output.at(2).first, -0.5, epsilon);
-    EXPECT_NEAR(output.at(3).first, 2.5, epsilon);
+    EXPECT_NEAR(output.at(3).first, -0.5, epsilon);
     EXPECT_NEAR(output.at(4).first, 2.5, epsilon);
+    EXPECT_NEAR(output.at(5).first, 2.5, epsilon);
   }
 
   {
@@ -1008,12 +1009,13 @@ TEST(TestUtils, calcEnvelopeOverhangDistance)
 
     const auto output = calcEnvelopeOverhangDistance(object_data, path);
 
-    ASSERT_EQ(output.size(), 5);
+    ASSERT_EQ(output.size(), 6);
     EXPECT_NEAR(output.at(0).first, 0.5, epsilon);
     EXPECT_NEAR(output.at(1).first, 0.5, epsilon);
-    EXPECT_NEAR(output.at(2).first, -2.5, epsilon);
+    EXPECT_NEAR(output.at(2).first, 0.5, epsilon);
     EXPECT_NEAR(output.at(3).first, -2.5, epsilon);
     EXPECT_NEAR(output.at(4).first, -2.5, epsilon);
+    EXPECT_NEAR(output.at(5).first, -2.5, epsilon);
   }
 }
 


### PR DESCRIPTION
## Description

### https://github.com/autowarefoundation/autoware_universe/pull/10902/commits/06d38d9dcd39358f0a95a415e0b0dd20dd4de13f

This PR introduces a curvature-based safety margin to improve obstacle avoidance behavior, particularly on high-curvature paths. A new field `curvature_based_margin` is added to `ObjectData`, which represents an extra lateral buffer to prevent the front of the ego vehicle from approaching too closely to roadside obstacles. This margin is calculated using a newly implemented function `calc_curvature_based_margin`, which evaluates the lateral offset between the vehicle's front corner and the path centerline across the object's longitudinal range. To support this, another utility function `calc_front_corner_offsets` computes the lateral distances of the front corners along the path. By incorporating this additional margin into the avoidance logic, the system can generate safer trajectories in curved sections of the road.

### https://github.com/autowarefoundation/autoware_universe/pull/10902/commits/862f218c146fee179d39142b860f9a87ed7cbcf9

Added logic to insert a midpoint between the first two overhang points to improve the accuracy of calculating the lateral distance to the road boundary, especially on high-curvature paths. This helps guide the ego vehicle to initiate avoidance at a more appropriate location.

After the change

https://github.com/user-attachments/assets/b6370dfb-00e1-432a-bba6-bb6e29f710fe

Before the change

https://github.com/user-attachments/assets/20753410-861f-490c-bdae-bae73bce19ea


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/tables/new?catalog_id=095ae8b3-a23b-4a08-8674-10a681449693&filter=git_branch%3Amain+git_branch%3Atest%2Ftest-branch&job_id=1ef91e2d-7ea4-545c-a828-2ef21de6b56a&project_id=prd_jt&table_config=date)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
