### PR TITLE
Feat(accel brake map calibrator node) change timeout sec  to be a parameter

### DIFF
--- a/vehicle/autoware_accel_brake_map_calibrator/config/accel_brake_map_calibrator.param.yaml
+++ b/vehicle/autoware_accel_brake_map_calibrator/config/accel_brake_map_calibrator.param.yaml
@@ -14,6 +14,7 @@
     min_accel: -5.0
     max_data_count: 100
     precision: 3
+    message_timeout: 0.1
     update_method: "update_offset_four_cell_around" # or "update_offset_each_cell", "update_offset_total", "update_offset_four_cell_around"
     update_suggest_thresh: 0.7 # threshold of rmse rate that update suggest flag becomes true. ( rmse_rate: [rmse of update map] / [rmse of original map] )
     progress_file_output: false # flag to output log file

--- a/vehicle/autoware_accel_brake_map_calibrator/include/autoware_accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
+++ b/vehicle/autoware_accel_brake_map_calibrator/include/autoware_accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
@@ -160,6 +160,7 @@ private:
   double max_accel_;
   double min_accel_;
   double pedal_to_accel_delay_;
+  double timeout_sec_;
   int precision_;
   std::string csv_calibrated_map_dir_;
   std::string output_accel_file_;
@@ -170,7 +171,6 @@ private:
   const double dif_pedal_time_ = 0.16;  // 160ms
   const std::size_t twist_vec_max_size_ = 100;
   const std::size_t pedal_vec_max_size_ = 100;
-  const double timeout_sec_ = 0.1;
   int max_data_count_;
   const int max_data_save_num_ = 10000;
   const double map_resolution_ = 0.1;

--- a/vehicle/autoware_accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/autoware_accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -51,6 +51,7 @@ AccelBrakeMapCalibrator::AccelBrakeMapCalibrator(const rclcpp::NodeOptions & nod
   pedal_accel_graph_output_ = declare_parameter<bool>("pedal_accel_graph_output", false);
   progress_file_output_ = declare_parameter<bool>("progress_file_output", false);
   precision_ = static_cast<int>(declare_parameter("precision", 3));
+  timeout_sec_ = declare_parameter<double>("message_timeout", 0.1);
   const auto get_pitch_method_str = declare_parameter("get_pitch_method", std::string("tf"));
   if (get_pitch_method_str == std::string("tf")) {
     get_pitch_method_ = GET_PITCH_METHOD::TF;


### PR DESCRIPTION
## Description

This PR introduces a new ROS parameter `message_timeout` to the `autoware_accel_brake_map_calibrator` node.  
The parameter allows users to configure the timeout threshold (in seconds) for input message freshness checks.  
The default value remains `0.1` seconds, but it can now be set via launch or parameter files.

## How was this PR tested?

- Built and launched the node with the new parameter.
- Confirmed that the node accepts the `message_timeout` parameter via launch and parameter YAML.
- Verified that the timeout logic works as before, and the value can be changed at runtime.

#### Additions

| Change type | Parameter Name     | Type    | Default Value | Description                                 |
|:------------|:------------------|:--------|:--------------|:---------------------------------------------|
| Added       | `message_timeout` | double  | `0.1`         | Timeout (in seconds) for message freshness.  |

## Effects on system behavior

None.  
This change only makes the timeout configurable; it does not alter the default logic or introduce new topics, services, or side effects.
