### PR TITLE
fix(planning_validator_trajectory_checker): set is_critical_error flag to false at start of validation

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -173,6 +173,7 @@ void TrajectoryChecker::validate(bool & is_critical)
       "trajectory has invalid value (NaN, Inf, etc). Stop validation process, raise an error.");
   }
 
+  is_critical_error_ = false;
   status->is_valid_interval = check_valid_interval(data, status);
   status->is_valid_longitudinal_max_acc = check_valid_max_longitudinal_acceleration(data, status);
   status->is_valid_longitudinal_min_acc = check_valid_min_longitudinal_acceleration(data, status);


### PR DESCRIPTION
## Description

The flag `is_critical_error_` is not reset to false at the start of validation. If a "critical" anomaly is detected at any point during operation, and the flag is set to true, it will remain true forever, causing unexpected behavior when another "noncritical" anomaly is detected later on.

This PR fixes the issue by properly setting the flag to false at the start of validation.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
