### PR TITLE
feat(out_of_lane): add objects.extra_width parameter

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/README.md
@@ -63,6 +63,7 @@ In the debug visualization, the filtered predicted paths are shown in green and 
 ### 5. Time to collisions
 
 For each out of lane area, we calculate the times when a dynamic object will overlap the area based on its filtered predicted paths.
+To make it more likely to detect collision in the other lanes, the width of the dynamic object can be increased using the parameter `objects.extra_width`.
 
 In the case where parameter `mode` is set to `threshold` and the calculated time is less than `threshold.time_threshold` parameter, then we decide to avoid the out of lane area.
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -17,6 +17,7 @@
         cut_predicted_paths_beyond_red_lights: true # if true, predicted paths are cut beyond the stop line of red traffic lights
         ignore_behind_ego: false # if true, objects behind the ego vehicle are ignored
         validate_predicted_paths_on_lanelets: true  # if true, an out of lane collision is only considered if the predicted path fully follows a sequence of lanelets that include the out of lane lanelet
+        extra_width: 1.0  # [m] extra width around detected objects, making it more likely to detect an out of lane collision
 
       action:  # action to insert in the trajectory if an object causes a conflict at an overlap
         use_map_stop_lines: true  # if true, try to stop at stop lines defined in the vector map

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
@@ -219,13 +219,15 @@ void calculate_object_path_time_collisions(
 void calculate_objects_time_collisions(
   OutOfLaneData & out_of_lane_data,
   const std::vector<autoware_perception_msgs::msg::PredictedObject> & objects,
-  const route_handler::RouteHandler & route_handler,
-  const bool validate_predicted_paths_on_lanelets)
+  const route_handler::RouteHandler & route_handler, const PlannerParam & params)
 {
   for (const auto & object : objects) {
+    auto shape = object.shape;
+    shape.dimensions.y += params.objects_extra_width * 0.5;
     for (const auto & path : object.kinematics.predicted_paths) {
       calculate_object_path_time_collisions(
-        out_of_lane_data, path, object.shape, route_handler, validate_predicted_paths_on_lanelets);
+        out_of_lane_data, path, object.shape, route_handler,
+        params.validate_predicted_paths_on_lanelets);
     }
   }
 }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
@@ -40,8 +40,7 @@ void calculate_object_path_time_collisions(
 void calculate_objects_time_collisions(
   OutOfLaneData & out_of_lane_data,
   const std::vector<autoware_perception_msgs::msg::PredictedObject> & objects,
-  const route_handler::RouteHandler & route_handler,
-  const bool validate_predicted_paths_on_lanelets);
+  const route_handler::RouteHandler & route_handler, const PlannerParam & params);
 
 /// @brief calculate the collisions to avoid
 /// @details either uses the time to collision or just the time when the object will arrive at the

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -62,6 +62,7 @@ struct PlannerParam
     validate_predicted_paths_on_lanelets;  // if true, an out of lane collision is only considered
                                            // if the predicted path fully follows a sequence of
                                            // lanelets that include the out of lane lanelet
+  double objects_extra_width;              // [m] extra width to apply to the object footprints
 
   // action to insert in the trajectory if an object causes a collision at an overlap
   double lon_dist_buffer;      // [m] safety distance buffer to keep in front of the ego vehicle
@@ -148,7 +149,7 @@ struct SlowdownPose
 
   SlowdownPose() = default;
   SlowdownPose(
-    const double arc_length, const rclcpp::Time start_time, const geometry_msgs::msg::Pose & pose,
+    const double arc_length, const rclcpp::Time & start_time, const geometry_msgs::msg::Pose & pose,
     const bool is_active)
   : arc_length(arc_length), start_time(start_time), pose(pose), is_active(is_active)
   {


### PR DESCRIPTION
## Description

Add a parameter to make the dynamic object footprints wider, making it more likely to detect `out_of_lane` collisions.
Required launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1537

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-37954)

## How was this PR tested?

Psim
Rosbags

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `objects.extra_width`   | `double` | `1.0`         | [m] extra width around detected objects, making it more likely to detect an out of lane collision |



## Effects on system behavior

Can tune the `out_of_lane` collision detection.
