### PR TITLE
fix(image_projection_based_fusion): loosen rois_number check

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/fusion_matching_strategy.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_matching_strategy.cpp
@@ -162,7 +162,7 @@ AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>::AdvancedMatchingStrategy(
       "matching_strategy.rois_timestamp_noise_window");
 
   auto rois_number = id_to_offset_map_.size();
-  if (rois_timestamp_noise_window.size() != rois_number) {
+  if (rois_timestamp_noise_window.size() < rois_number) {
     throw std::runtime_error(
       "Mismatch: rois_number (" + std::to_string(rois_number) +
       ") does not match rois_timestamp_noise_window size (" +

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -72,7 +72,7 @@ FusionNode<Msg3D, Msg2D, ExportObj>::FusionNode(
   rois_timeout_sec_ = declare_parameter<double>("rois_timeout_sec");
 
   auto rois_timestamp_offsets = declare_parameter<std::vector<double>>("rois_timestamp_offsets");
-  if (rois_timestamp_offsets.size() != rois_number_) {
+  if (rois_timestamp_offsets.size() < rois_number_) {
     throw std::runtime_error(
       "Mismatch: rois_number (" + std::to_string(rois_number_) +
       ") does not match rois_timestamp_offsets size (" +
@@ -234,7 +234,7 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::initialize_det2d_status(std::size_t ro
   }
   std::vector<bool> approximate_camera_projection =
     declare_parameter<std::vector<bool>>("approximate_camera_projection");
-  if (rois_number != approximate_camera_projection.size()) {
+  if (rois_number > approximate_camera_projection.size()) {
     const std::size_t current_size = approximate_camera_projection.size();
     throw std::runtime_error(
       "The number of elements in approximate_camera_projection should be the same as rois_number_. "


### PR DESCRIPTION
## Description

- To allow some fusion_node use the number of camera less than the number of camera availabe from sensing.

## Related links

**Parent Issue:**

- [TIER IV Internal Link](https://star4.slack.com/archives/CRUE57C30/p1751596295840199?thread_ts=1751587293.599969&cid=CRUE57C30)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Tested with logging-simulator when `approximate_camera_projection`, `point_project_to_unrectified_image`, `rois_timestamp_offsets` size are setup 9, while [image_number=6](https://github.com/autowarefoundation/autoware_universe/blob/fd22133897b536155004c27d9b0a71bffb0fb3e7/launch/tier4_perception_launch/launch/perception.launch.xml#L116)
```
autoware@npc2201009-ubuntu22:~/autoware.proj$ ros2 node info /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion
/perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion
  Subscribers:
    /clock: rosgraph_msgs/msg/Clock
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/object_recognition/detection/clustering/clusters: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /perception/object_recognition/detection/rois0: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /perception/object_recognition/detection/rois1: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /perception/object_recognition/detection/rois2: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /perception/object_recognition/detection/rois3: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /perception/object_recognition/detection/rois4: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /perception/object_recognition/detection/rois5: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /sensing/camera/camera0/camera_info: sensor_msgs/msg/CameraInfo
    /sensing/camera/camera1/camera_info: sensor_msgs/msg/CameraInfo
    /sensing/camera/camera2/camera_info: sensor_msgs/msg/CameraInfo
    /sensing/camera/camera3/camera_info: sensor_msgs/msg/CameraInfo
    /sensing/camera/camera4/camera_info: sensor_msgs/msg/CameraInfo
    /sensing/camera/camera5/camera_info: sensor_msgs/msg/CameraInfo
  Publishers:
    /diagnostics: diagnostic_msgs/msg/DiagnosticArray
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/object_recognition/detection/clustering/camera_lidar_fusion/clusters: tier4_perception_msgs/msg/DetectedObjectsWithFeature
    /rosout: rcl_interfaces/msg/Log
  Service Servers:
    /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion/get_parameters: rcl_interfaces/srv/GetParameters
    /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion/list_parameters: rcl_interfaces/srv/ListParameters
    /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion/set_parameters: rcl_interfaces/srv/SetParameters
    /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
  Service Clients:

  Action Servers:

  Action Clients:

autoware@npc2201009-ubuntu22:~/autoware.proj$ ros2 param dump /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion
/perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion:
  ros__parameters:
    approximate_camera_projection:
    - true
    - true
    - true
    - true
    - true
    - true
    - true
    - true
    - true
    approximation_grid_cell_height: 1.0
    approximation_grid_cell_width: 1.0
    collector_debug_mode: false
    debug_mode: false
    diagnostic_updater:
      period: 1.0
      use_fqn: false
    filter_scope_max_x: 100.0
    filter_scope_max_y: 100.0
    filter_scope_max_z: 100.0
    filter_scope_min_x: -100.0
    filter_scope_min_y: -100.0
    filter_scope_min_z: -100.0
    fusion_distance: 100.0
    input/camera_info0: /sensing/camera/camera0/camera_info
    input/camera_info1: /sensing/camera/camera1/camera_info
    input/camera_info2: /sensing/camera/camera2/camera_info
    input/camera_info3: /sensing/camera/camera3/camera_info
    input/camera_info4: /sensing/camera/camera4/camera_info
    input/camera_info5: /sensing/camera/camera5/camera_info
    input/rois0: /perception/object_recognition/detection/rois0
    input/rois1: /perception/object_recognition/detection/rois1
    input/rois2: /perception/object_recognition/detection/rois2
    input/rois3: /perception/object_recognition/detection/rois3
    input/rois4: /perception/object_recognition/detection/rois4
    input/rois5: /perception/object_recognition/detection/rois5
    iou_threshold: 0.65
    matching_strategy:
      type: advanced
    msg3d_timeout_sec: 0.05
    only_allow_inside_cluster: false
    point_project_to_unrectified_image:
    - false
    - false
    - false
    - false
    - false
    - false
    - true
    - true
    - true
    publish_previous_but_late_output_msg: false
    publish_processing_time_detail: false
    qos_overrides:
      /clock:
        subscription:
          depth: 1
          durability: volatile
          history: keep_last
          reliability: best_effort
      /parameter_events:
        publisher:
          depth: 1000
          durability: volatile
          history: keep_last
          reliability: reliable
    remove_unknown: false
    roi_scale_factor: 1.1
    rois_number: 6
    rois_timeout_sec: 0.5
    rois_timestamp_offsets:
    - -0.01
    - 0.015
    - 0.065
    - 0.04
    - 0.04
    - 0.04
    - 0.04
    - 0.0733
    - 0.0067
    rosbag_length: 10.0
    rough_iou_match_mode: iou_x
    strict_iou_fusion_distance: 100.0
    strict_iou_match_mode: iou
    unknown_iou_threshold: 0.1
    use_cluster_semantic_type: false
    use_sim_time: true

```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
