### PR TITLE
fix(autoware_control_validator): prevent division by zero in time calculation

### DIFF
--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -66,8 +66,9 @@ void LateralJerkValidator::validate(
   rclcpp::Time prev_time(prev_control_cmd_->stamp);
   const double dt = (current_time - prev_time).seconds();
 
-  // Prevent division by zero or extremely small dt which can cause instability
-  if (dt <= 1e-6) {
+  // Only perform calculation if the time difference is greater than or equal to 1 msec.
+  // This avoids instability due to too small dt and prevents division by zero.
+  if (dt < 1e-3) {
     prev_control_cmd_ = std::make_unique<Control>(control_cmd);
     return;
   }

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -66,6 +66,12 @@ void LateralJerkValidator::validate(
   rclcpp::Time prev_time(prev_control_cmd_->stamp);
   const double dt = (current_time - prev_time).seconds();
 
+  // Prevent division by zero or extremely small dt which can cause instability
+  if (dt <= 1e-6) {
+    prev_control_cmd_ = std::make_unique<Control>(control_cmd);
+    return;
+  }
+
   const double prev_steering_cmd = prev_control_cmd_->lateral.steering_tire_angle;
   const double steering_rate = (steering_cmd - prev_steering_cmd) / dt;
 


### PR DESCRIPTION
## Description

This PR adds a safeguard to prevent division by zero in the `LateralJerkValidator::validate` function.  
If the time difference `dt` is zero or extremely small, the calculation is skipped to ensure numerical stability.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] PASS TIERIV INTERNAL SCENARIOS
  - [BASIC SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/7be1f2e8-64c6-5f4a-9838-c7986224ec55?project_id=prd_jt)
  - [FUNC VERIFICATION SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/65acb71c-6039-50b7-b30a-6889e2eca3c6?project_id=prd_jt)
  - [DLR SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/37e8d792-20bf-50a3-a8bb-6a58be6e7ad9?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
