### PR TITLE
feat(behavior_path_planner_common): ignore the turn signals when using the zebra zone

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/turn_signal_decider.hpp
@@ -179,7 +179,7 @@ private:
     return start_shift_length < threshold && end_shift_length < threshold;
   };
 
-  inline bool shiftSideOnlyHatchedRoadMarking(
+  inline bool isAdjacentToHatchedRoadMarking(
     const double start_shift_length, const double end_shift_length,
     const bool left_hatched_road_marking_only, const bool right_hatched_road_marking_only,
     const double threshold) const

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/turn_signal_decider.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/turn_signal_decider.hpp
@@ -179,31 +179,32 @@ private:
     return start_shift_length < threshold && end_shift_length < threshold;
   };
 
-  inline bool existShiftSideLane(
-    const double start_shift_length, const double end_shift_length, const bool no_left_lanes,
-    const bool no_right_lanes, const double threshold) const
+  inline bool shiftSideOnlyHatchedRoadMarking(
+    const double start_shift_length, const double end_shift_length,
+    const bool left_hatched_road_marking_only, const bool right_hatched_road_marking_only,
+    const double threshold) const
   {
     const auto relative_shift_length = end_shift_length - start_shift_length;
     if (isAvoidShift(start_shift_length, end_shift_length, threshold)) {
       // Left avoid. But there is no adjacent lane. No need blinker.
-      if (relative_shift_length > 0.0 && no_left_lanes) {
+      if (relative_shift_length > 0.0 && left_hatched_road_marking_only) {
         return false;
       }
 
       // Right avoid. But there is no adjacent lane. No need blinker.
-      if (relative_shift_length < 0.0 && no_right_lanes) {
+      if (relative_shift_length < 0.0 && right_hatched_road_marking_only) {
         return false;
       }
     }
 
     if (isReturnShift(start_shift_length, end_shift_length, threshold)) {
       // Right return. But there is no adjacent lane. No need blinker.
-      if (relative_shift_length > 0.0 && no_right_lanes) {
+      if (relative_shift_length > 0.0 && right_hatched_road_marking_only) {
         return false;
       }
 
       // Left return. But there is no adjacent lane. No need blinker.
-      if (relative_shift_length < 0.0 && no_left_lanes) {
+      if (relative_shift_length < 0.0 && left_hatched_road_marking_only) {
         return false;
       }
     }
@@ -211,12 +212,12 @@ private:
     if (isLeftMiddleShift(start_shift_length, end_shift_length, threshold)) {
       // Left avoid. But there is no adjacent lane. No need blinker.
 
-      if (relative_shift_length > 0.0 && no_left_lanes) {
+      if (relative_shift_length > 0.0 && left_hatched_road_marking_only) {
         return false;
       }
 
       // Left return. But there is no adjacent lane. No need blinker.
-      if (relative_shift_length < 0.0 && no_left_lanes) {
+      if (relative_shift_length < 0.0 && left_hatched_road_marking_only) {
         return false;
       }
     }
@@ -224,12 +225,12 @@ private:
     if (isRightMiddleShift(start_shift_length, end_shift_length, threshold)) {
       // Right avoid. But there is no adjacent lane. No need blinker.
 
-      if (relative_shift_length < 0.0 && no_right_lanes) {
+      if (relative_shift_length < 0.0 && right_hatched_road_marking_only) {
         return false;
       }
 
       // Left avoid. But there is no adjacent lane. No need blinker.
-      if (relative_shift_length > 0.0 && no_right_lanes) {
+      if (relative_shift_length > 0.0 && right_hatched_road_marking_only) {
         return false;
       }
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/package.xml
@@ -49,6 +49,7 @@
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_objects_of_interest_marker_interface</depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -799,7 +799,7 @@ std::pair<TurnSignalInfo, bool> TurnSignalDecider::getBehaviorTurnSignalInfo(
 
   if (
     (!is_pull_out && !is_lane_change && !is_pull_over) &&
-    !shiftSideOnlyHatchedRoadMarking(
+    !isAdjacentToHatchedRoadMarking(
       start_shift_length, end_shift_length, left_hatched_road_marking_only,
       right_hatched_road_marking_only, p.turn_signal_shift_length_threshold)) {
     return std::make_pair(TurnSignalInfo(p_path_start, p_path_end), true);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 
+#include <autoware/lanelet2_utils/hatched_road_markings.hpp>
 #include <autoware/motion_utils/constants.hpp>
 #include <autoware/motion_utils/resample/resample.hpp>
 #include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
@@ -783,15 +784,24 @@ std::pair<TurnSignalInfo, bool> TurnSignalDecider::getBehaviorTurnSignalInfo(
   const auto left_opposite_lanes = rh->getLeftOppositeLanelets(lanelet);
   const auto right_same_direction_lane = rh->getRightLanelet(lanelet, true, true);
   const auto right_opposite_lanes = rh->getRightOppositeLanelets(lanelet);
-  const auto has_left_lane = left_same_direction_lane.has_value() || !left_opposite_lanes.empty();
-  const auto has_right_lane =
+  const bool has_left_lane = left_same_direction_lane.has_value() || !left_opposite_lanes.empty();
+  const bool has_right_lane =
     right_same_direction_lane.has_value() || !right_opposite_lanes.empty();
+
+  const auto adjacent_hatched_road_markings =
+    autoware::experimental::lanelet2_utils::get_adjacent_hatched_road_markings(
+      {lanelet}, rh->getLaneletMapPtr());
+
+  const bool left_hatched_road_marking_only =
+    !adjacent_hatched_road_markings.left.empty() && !has_left_lane;
+  const bool right_hatched_road_marking_only =
+    !adjacent_hatched_road_markings.right.empty() && !has_right_lane;
 
   if (
     (!is_pull_out && !is_lane_change && !is_pull_over) &&
-    !existShiftSideLane(
-      start_shift_length, end_shift_length, !has_left_lane, !has_right_lane,
-      p.turn_signal_shift_length_threshold)) {
+    !shiftSideOnlyHatchedRoadMarking(
+      start_shift_length, end_shift_length, left_hatched_road_marking_only,
+      right_hatched_road_marking_only, p.turn_signal_shift_length_threshold)) {
     return std::make_pair(TurnSignalInfo(p_path_start, p_path_end), true);
   }
 


### PR DESCRIPTION
## Description

When avoidance is performed using only the zebra zone, it is not necessary to output a turn signal. Previously, if there were no lanelets on either side of the current lanelet, it was assumed that a zebra zone was being used, and the turn signal was not output. However, this logic caused the turn signal not to be output even when there were neither adjacent lanelets nor zebra zones. In this PR, the logic has been updated to explicitly check for the presence of zebra zones on either side, and the turn signal is now suppressed only when avoidance is performed solely using zebra zones.

### before

[turn_signal_before.webm](https://github.com/user-attachments/assets/601c5672-3a81-45ef-9b0f-501256597496)

### after

[Screencast from 07-07-2025 05:13:16 PM.webm](https://github.com/user-attachments/assets/e7f989f2-4058-4352-a7ac-53e95391af4d)

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/565
- https://star4.slack.com/archives/C03QW0GU6P7/p1751018455659809

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/8ea91a15-8580-51da-ae50-9d08eb492d02?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
