### PR TITLE
fix(simple object merger): handle when tf could not get properly

### DIFF
--- a/perception/autoware_simple_object_merger/include/autoware/simple_object_merger/simple_object_merger_base.hpp
+++ b/perception/autoware_simple_object_merger/include/autoware/simple_object_merger/simple_object_merger_base.hpp
@@ -80,7 +80,6 @@ protected:
   typename rclcpp::Publisher<ObjsMsgType>::SharedPtr pub_objects_{};
 
   std::shared_ptr<autoware_utils::TransformListener> transform_listener_;
-  geometry_msgs::msg::TransformStamped::ConstSharedPtr transform_;
 
   // Data Buffer
   std::vector<typename ObjsMsgType::ConstSharedPtr> objects_data_{};

--- a/perception/autoware_simple_object_merger/src/simple_detected_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/src/simple_detected_object_merger_node.cpp
@@ -38,18 +38,23 @@ void SimpleDetectedObjectMergerNode::approximateMerger(
   const DetectedObjects::ConstSharedPtr & object_msg0,
   const DetectedObjects::ConstSharedPtr & object_msg1)
 {
-  transform_ = transform_listener_->get_transform(
+  auto transform0 = transform_listener_->get_transform(
     node_param_.new_frame_id, object_msg0->header.frame_id, object_msg0->header.stamp,
     rclcpp::Duration::from_seconds(0.01));
+  if (!transform0) {
+    return;
+  }
   DetectedObjects::SharedPtr transformed_objects0 =
-    getTransformedObjects(object_msg0, node_param_.new_frame_id, transform_);
+    getTransformedObjects(object_msg0, node_param_.new_frame_id, transform0);
 
-  // input1
-  transform_ = transform_listener_->get_transform(
+  auto transform1 = transform_listener_->get_transform(
     node_param_.new_frame_id, object_msg1->header.frame_id, object_msg1->header.stamp,
     rclcpp::Duration::from_seconds(0.01));
+  if (!transform1) {
+    return;
+  }
   DetectedObjects::SharedPtr transformed_objects1 =
-    getTransformedObjects(object_msg1, node_param_.new_frame_id, transform_);
+    getTransformedObjects(object_msg1, node_param_.new_frame_id, transform1);
 
   DetectedObjects output_objects;
   output_objects.header = object_msg0->header;
@@ -86,12 +91,14 @@ void SimpleDetectedObjectMergerNode::onTimer()
     double time_diff = rclcpp::Time(objects_data_.at(i)->header.stamp).seconds() -
                        rclcpp::Time(objects_data_.at(0)->header.stamp).seconds();
     if (std::abs(time_diff) < node_param_.timeout_threshold) {
-      transform_ = transform_listener_->get_transform(
+      auto transform = transform_listener_->get_transform(
         node_param_.new_frame_id, objects_data_.at(i)->header.frame_id,
         objects_data_.at(i)->header.stamp, rclcpp::Duration::from_seconds(0.01));
-
+      if (!transform) {
+        continue;
+      }
       typename DetectedObjects::SharedPtr transformed_objects =
-        getTransformedObjects(objects_data_.at(i), node_param_.new_frame_id, transform_);
+        getTransformedObjects(objects_data_.at(i), node_param_.new_frame_id, transform);
 
       output_objects.objects.insert(
         output_objects.objects.end(), std::begin(transformed_objects->objects),

--- a/perception/autoware_simple_object_merger/src/simple_detected_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/src/simple_detected_object_merger_node.cpp
@@ -38,23 +38,31 @@ void SimpleDetectedObjectMergerNode::approximateMerger(
   const DetectedObjects::ConstSharedPtr & object_msg0,
   const DetectedObjects::ConstSharedPtr & object_msg1)
 {
-  auto transform0 = transform_listener_->get_transform(
-    node_param_.new_frame_id, object_msg0->header.frame_id, object_msg0->header.stamp,
-    rclcpp::Duration::from_seconds(0.01));
-  if (!transform0) {
-    return;
+  DetectedObjects::SharedPtr transformed_objects0;
+  if (node_param_.new_frame_id == object_msg0->header.frame_id) {
+    transformed_objects0 = std::make_shared<DetectedObjects>(*object_msg0);
+  } else {
+    auto transform0 = transform_listener_->get_transform(
+      node_param_.new_frame_id, object_msg0->header.frame_id, object_msg0->header.stamp,
+      rclcpp::Duration::from_seconds(0.01));
+    if (!transform0) {
+      return;
+    }
+    transformed_objects0 = getTransformedObjects(object_msg0, node_param_.new_frame_id, transform0);
   }
-  DetectedObjects::SharedPtr transformed_objects0 =
-    getTransformedObjects(object_msg0, node_param_.new_frame_id, transform0);
 
-  auto transform1 = transform_listener_->get_transform(
-    node_param_.new_frame_id, object_msg1->header.frame_id, object_msg1->header.stamp,
-    rclcpp::Duration::from_seconds(0.01));
-  if (!transform1) {
-    return;
+  DetectedObjects::SharedPtr transformed_objects1;
+  if (node_param_.new_frame_id == object_msg1->header.frame_id) {
+    transformed_objects1 = std::make_shared<DetectedObjects>(*object_msg1);
+  } else {
+    auto transform1 = transform_listener_->get_transform(
+      node_param_.new_frame_id, object_msg1->header.frame_id, object_msg1->header.stamp,
+      rclcpp::Duration::from_seconds(0.01));
+    if (!transform1) {
+      return;
+    }
+    transformed_objects1 = getTransformedObjects(object_msg1, node_param_.new_frame_id, transform1);
   }
-  DetectedObjects::SharedPtr transformed_objects1 =
-    getTransformedObjects(object_msg1, node_param_.new_frame_id, transform1);
 
   DetectedObjects output_objects;
   output_objects.header = object_msg0->header;
@@ -91,15 +99,19 @@ void SimpleDetectedObjectMergerNode::onTimer()
     double time_diff = rclcpp::Time(objects_data_.at(i)->header.stamp).seconds() -
                        rclcpp::Time(objects_data_.at(0)->header.stamp).seconds();
     if (std::abs(time_diff) < node_param_.timeout_threshold) {
-      auto transform = transform_listener_->get_transform(
-        node_param_.new_frame_id, objects_data_.at(i)->header.frame_id,
-        objects_data_.at(i)->header.stamp, rclcpp::Duration::from_seconds(0.01));
-      if (!transform) {
-        continue;
+      DetectedObjects::SharedPtr transformed_objects;
+      if (node_param_.new_frame_id == objects_data_.at(i)->header.frame_id) {
+        transformed_objects = std::make_shared<DetectedObjects>(*objects_data_.at(i));
+      } else {
+        auto transform = transform_listener_->get_transform(
+          node_param_.new_frame_id, objects_data_.at(i)->header.frame_id,
+          objects_data_.at(i)->header.stamp, rclcpp::Duration::from_seconds(0.01));
+        if (!transform) {
+          continue;
+        }
+        transformed_objects =
+          getTransformedObjects(objects_data_.at(i), node_param_.new_frame_id, transform);
       }
-      typename DetectedObjects::SharedPtr transformed_objects =
-        getTransformedObjects(objects_data_.at(i), node_param_.new_frame_id, transform);
-
       output_objects.objects.insert(
         output_objects.objects.end(), std::begin(transformed_objects->objects),
         std::end(transformed_objects->objects));

--- a/perception/autoware_simple_object_merger/src/simple_tracked_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/src/simple_tracked_object_merger_node.cpp
@@ -94,23 +94,31 @@ void SimpleTrackedObjectMergerNode::approximateMerger(
   const TrackedObjects::ConstSharedPtr & object_msg0,
   const TrackedObjects::ConstSharedPtr & object_msg1)
 {
-  auto transform0 = transform_listener_->get_transform(
-    node_param_.new_frame_id, object_msg0->header.frame_id, object_msg0->header.stamp,
-    rclcpp::Duration::from_seconds(0.01));
-  if (!transform0) {
-    return;
+  TrackedObjects::SharedPtr transformed_objects0;
+  if (node_param_.new_frame_id == object_msg0->header.frame_id) {
+    transformed_objects0 = std::make_shared<TrackedObjects>(*object_msg0);
+  } else {
+    auto transform0 = transform_listener_->get_transform(
+      node_param_.new_frame_id, object_msg0->header.frame_id, object_msg0->header.stamp,
+      rclcpp::Duration::from_seconds(0.01));
+    if (!transform0) {
+      return;
+    }
+    transformed_objects0 = getTransformedObjects(object_msg0, node_param_.new_frame_id, transform0);
   }
-  TrackedObjects::SharedPtr transformed_objects0 =
-    getTransformedObjects(object_msg0, node_param_.new_frame_id, transform0);
 
-  auto transform1 = transform_listener_->get_transform(
-    node_param_.new_frame_id, object_msg1->header.frame_id, object_msg1->header.stamp,
-    rclcpp::Duration::from_seconds(0.01));
-  if (!transform1) {
-    return;
+  TrackedObjects::SharedPtr transformed_objects1;
+  if (node_param_.new_frame_id == object_msg1->header.frame_id) {
+    transformed_objects1 = std::make_shared<TrackedObjects>(*object_msg1);
+  } else {
+    auto transform1 = transform_listener_->get_transform(
+      node_param_.new_frame_id, object_msg1->header.frame_id, object_msg1->header.stamp,
+      rclcpp::Duration::from_seconds(0.01));
+    if (!transform1) {
+      return;
+    }
+    transformed_objects1 = getTransformedObjects(object_msg1, node_param_.new_frame_id, transform1);
   }
-  TrackedObjects::SharedPtr transformed_objects1 =
-    getTransformedObjects(object_msg1, node_param_.new_frame_id, transform1);
 
   TrackedObjects output_objects;
   output_objects.header = object_msg0->header;
@@ -154,20 +162,23 @@ void SimpleTrackedObjectMergerNode::onTimer()
     double time_diff = rclcpp::Time(objects_data_.at(i)->header.stamp).seconds() -
                        rclcpp::Time(objects_data_.at(0)->header.stamp).seconds();
     if (std::abs(time_diff) < node_param_.timeout_threshold) {
-      auto transform = transform_listener_->get_transform(
-        node_param_.new_frame_id, objects_data_.at(i)->header.frame_id,
-        objects_data_.at(i)->header.stamp, rclcpp::Duration::from_seconds(0.01));
-      if (!transform) {
-        continue;
+      TrackedObjects::SharedPtr transformed_objects;
+      if (node_param_.new_frame_id == objects_data_.at(i)->header.frame_id) {
+        transformed_objects = std::make_shared<TrackedObjects>(*objects_data_.at(i));
+      } else {
+        auto transform = transform_listener_->get_transform(
+          node_param_.new_frame_id, objects_data_.at(i)->header.frame_id,
+          objects_data_.at(i)->header.stamp, rclcpp::Duration::from_seconds(0.01));
+        if (!transform) {
+          continue;
+        }
+        transformed_objects =
+          getTransformedObjects(objects_data_.at(i), node_param_.new_frame_id, transform);
       }
-      typename TrackedObjects::SharedPtr transformed_objects =
-        getTransformedObjects(objects_data_.at(i), node_param_.new_frame_id, transform);
-
       for (auto & object : transformed_objects->objects) {
         mapUUID(object, i);
         output_objects.objects.push_back(object);
       }
-
     } else if (shouldLogThrottle(i, now, last_log_times, throttle_interval)) {
       RCLCPP_INFO(
         get_logger(), "Topic of %s is timeout by %f sec", node_param_.topic_names.at(i).c_str(),


### PR DESCRIPTION
## Description

When tf is not obtained properly, the transform becomes null pointer.

https://github.com/autowarefoundation/autoware_universe/blob/4d0d0ec40afb827eb87d0a3ca23e4760ced6bbc4/common/autoware_universe_utils/include/autoware/universe_utils/ros/transform_listener.hpp#L60-L75

This PR is to handle this exemption properly.

- if the target frame is the same as the input frame, skip the transform process
- if the obtained transform is nullptr, skip the process

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
