### PR TITLE
feat(control_validator): enhance trajectory validation with previous reference trajectory

### DIFF
--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -36,6 +36,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -85,10 +86,11 @@ public:
 
   void validate(
     ControlValidatorStatus & res, const Trajectory & predicted_trajectory,
-    const Trajectory & reference_trajectory) const;
+    const Trajectory & reference_trajectory);
 
 private:
   const double max_distance_deviation_threshold;
+  std::optional<Trajectory> prev_reference_trajectory_;
 };
 
 /**

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -41,12 +41,35 @@ void LatencyValidator::validate(
 
 void TrajectoryValidator::validate(
   ControlValidatorStatus & res, const Trajectory & predicted_trajectory,
-  const Trajectory & reference_trajectory) const
+  const Trajectory & reference_trajectory)
 {
-  res.max_distance_deviation =
-    calc_max_lateral_distance(reference_trajectory, predicted_trajectory);
-  res.is_valid_max_distance_deviation =
-    res.max_distance_deviation <= max_distance_deviation_threshold;
+  // First, check with the current reference_trajectory
+  double max_dist_current = calc_max_lateral_distance(reference_trajectory, predicted_trajectory);
+  bool is_valid_current = max_dist_current <= max_distance_deviation_threshold;
+
+  // Note: The reason for comparing with the previous reference_trajectory is that
+  // the predicted_trajectory of the current cycle may not have been generated based on
+  // the reference_trajectory of the current cycle, but rather on the reference_trajectory of the
+  // previous cycle. Therefore, also check the deviation with the previous reference_trajectory.
+  // Only if the threshold is exceeded, also check with the previous reference_trajectory
+  bool is_valid_prev = true;
+  double max_dist_prev = 0.0;
+  if (!is_valid_current && prev_reference_trajectory_.has_value()) {
+    max_dist_prev =
+      calc_max_lateral_distance(prev_reference_trajectory_.value(), predicted_trajectory);
+    is_valid_prev = max_dist_prev <= max_distance_deviation_threshold;
+  }
+
+  // Only if both exceed the threshold, it is judged as abnormal
+  res.max_distance_deviation = std::max(max_dist_current, max_dist_prev);
+  res.is_valid_max_distance_deviation = is_valid_current || is_valid_prev;
+
+  // Save the previous reference_trajectory only if the timestamp is different from the current one
+  if (
+    !prev_reference_trajectory_.has_value() ||
+    prev_reference_trajectory_->header.stamp != reference_trajectory.header.stamp) {
+    prev_reference_trajectory_ = reference_trajectory;
+  }
 }
 
 void LateralJerkValidator::validate(

--- a/control/autoware_control_validator/test/test_control_validator.cpp
+++ b/control/autoware_control_validator/test/test_control_validator.cpp
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 #include <tf2/LinearMath/Quaternion.h>
 
+#include <cmath>
 #include <memory>
 #include <tuple>
 
@@ -135,7 +136,7 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_tuple(
       make_linear_trajectory(make_trajectory_point(0, 0), make_trajectory_point(10, 0), 11, 1.0),
       make_linear_trajectory(make_trajectory_point(0, 0), make_trajectory_point(10, 1.01), 11, 1.0),
-      1.01, false),
+      1.01, true),
 
     std::make_tuple(
       make_linear_trajectory(make_trajectory_point(0, 0), make_trajectory_point(10, 0), 11, -1.0),
@@ -152,7 +153,7 @@ INSTANTIATE_TEST_SUITE_P(
       make_linear_trajectory(make_trajectory_point(0, 0), make_trajectory_point(10, 0), 11, -1.0),
       make_linear_trajectory(
         make_trajectory_point(0, 0), make_trajectory_point(10, 1.01), 11, -1.0),
-      1.01, false),
+      1.01, true),
 
     std::make_tuple(
       make_linear_trajectory(make_trajectory_point(0, 0), make_trajectory_point(10, 0), 11, 1.0),


### PR DESCRIPTION
## Description

This PR improves the robustness of the trajectory validation logic in the control validator module.

- The maximum lateral deviation check now compares the predicted trajectory not only with the current reference trajectory, but also with the previous cycle's reference trajectory if the threshold is exceeded.
- The previous reference trajectory is only stored if its timestamp is different from the current one.
- The reason for this logic is that the predicted trajectory of the current cycle may have been generated based on the previous cycle's reference trajectory, not the current one.

These changes help prevent false positives in trajectory deviation detection due to timing mismatches between reference and predicted trajectories.


## Related links


**Private Links:**

- [TIERIV internal link](https://tier4.atlassian.net/browse/RT0-36791)

## How was this PR tested?

- [x] PASS TIERIV INTERNAL SCENARIOS
  - https://evaluation.tier4.jp/evaluation/reports/30c0b88b-60d6-5fb4-83ee-e1fb71e7d3d1?project_id=prd_jt
  - https://evaluation.tier4.jp/evaluation/reports/929d95a4-dfd2-5859-bcd1-f1c22c5731b8?project_id=prd_jt
  - https://evaluation.tier4.jp/evaluation/reports/b337be59-96dc-55a7-9944-2f979c59fe56?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
