### PR TITLE
fix(behavior_path_static_obstacle_avoidance_module): fix isWithinLanes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -23,6 +23,7 @@
 
 #include <Eigen/Dense>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 
 #include <boost/geometry/algorithms/buffer.hpp>
@@ -1213,9 +1214,14 @@ bool isWithinLanes(
 {
   const auto & rh = planner_data->route_handler;
   const auto & ego_pose = planner_data->self_odometry->pose.pose;
+  double vehicle_width = planner_data->parameters.vehicle_info.vehicle_width_m;
+  autoware_utils_geometry::Point2d p1(0.0, -vehicle_width / 2.0);
+  autoware_utils_geometry::Point2d p2(0.0, vehicle_width / 2.0);
+  autoware_utils_geometry::LineString2d line;
+  line.push_back(p1);
+  line.push_back(p2);
   const auto transform = autoware_utils::pose2transform(ego_pose);
-  const auto footprint = autoware_utils::transform_vector(
-    planner_data->parameters.vehicle_info.createFootprint(), transform);
+  const auto vehicle_baselink_line = autoware_utils::transform_vector(line, transform);
 
   if (!closest_lanelet.has_value()) {
     return true;
@@ -1242,7 +1248,7 @@ bool isWithinLanes(
 
   const auto combine_lanelet = lanelet::utils::combineLaneletsShape(concat_lanelets);
 
-  return boost::geometry::within(footprint, combine_lanelet.polygon2d().basicPolygon());
+  return boost::geometry::within(vehicle_baselink_line, combine_lanelet.polygon2d().basicPolygon());
 }
 
 bool isShiftNecessary(const bool & is_object_on_right, const double & shift_length)

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1214,7 +1214,7 @@ bool isWithinLanes(
 {
   const auto & rh = planner_data->route_handler;
   const auto & ego_pose = planner_data->self_odometry->pose.pose;
-  double vehicle_width = planner_data->parameters.vehicle_info.vehicle_width_m;
+  const double vehicle_width = planner_data->parameters.vehicle_info.vehicle_width_m;
   autoware_utils_geometry::Point2d p1(0.0, -vehicle_width / 2.0);
   autoware_utils_geometry::Point2d p2(0.0, vehicle_width / 2.0);
   autoware_utils_geometry::LineString2d line;


### PR DESCRIPTION
## Description

This pull request modifies the logic of the isWithinLanes function to improve its robustness on curved paths.

Previously, the check used the vehicle's full footprint, including its front corners. On sharp curves, this could result in a part of the footprint protruding beyond the lane boundary, causing isWithinLanes to return false even when the vehicle is reasonably within the drivable area.

To address this issue, the check has been updated to use only a line segment connecting the left and right sides of the vehicle's base_link (i.e., a line orthogonal to the vehicle's longitudinal axis), instead of the full footprint. This provides a more conservative and stable representation of the vehicle's lane occupancy, especially on curved trajectories.


## Related links

This PR solves the following issue.

- https://github.com/autowarefoundation/autoware_universe/issues/10285

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/efbd2b07-e787-522f-94bb-7a3c8557326a?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/5abbfb79-92b0-54af-bd20-fc2f491929b5?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
