### PR TITLE
feat(out_of_lane): cut trajectory footprints behind the current ego front

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/calculate_slowdown_points.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/calculate_slowdown_points.cpp
@@ -36,6 +36,17 @@
 namespace autoware::motion_velocity_planner::out_of_lane
 {
 
+lanelet::BasicPolygon2d project_to_pose(
+  const autoware_utils::Polygon2d & base_footprint, const geometry_msgs::msg::Pose & pose)
+{
+  const auto angle = tf2::getYaw(pose.orientation);
+  const auto rotated_footprint = autoware_utils::rotate_polygon(base_footprint, angle);
+  lanelet::BasicPolygon2d footprint;
+  for (const auto & p : rotated_footprint.outer())
+    footprint.emplace_back(p.x() + pose.position.x, p.y() + pose.position.y);
+  return footprint;
+}
+
 std::optional<geometry_msgs::msg::Pose> calculate_last_avoiding_pose(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const autoware_utils::Polygon2d & footprint, const lanelet::BasicPolygons2d & polygons_to_avoid,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/debug.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/debug.cpp
@@ -259,7 +259,7 @@ visualization_msgs::msg::MarkerArray create_debug_marker_array(
   base_marker.color = autoware_utils::create_marker_color(1.0, 1.0, 1.0, 1.0);
   // TODO(Maxime): move the debug marker publishing AFTER the trajectory generation
   // disabled to prevent performance issues when publishing the debug markers
-  add_polygons_markers(debug_marker_array, base_marker, ego_data.trajectory_footprints);
+  // add_polygons_markers(debug_marker_array, base_marker, ego_data.trajectory_footprints);
   add_out_lanelets(debug_marker_array, base_marker, ego_data.out_lanelets);
   add_out_of_lane_overlaps(
     debug_marker_array, base_marker, out_of_lane_data.outside_points, ego_data.trajectory_points);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/debug.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/debug.cpp
@@ -65,6 +65,9 @@ void add_polygons_markers(
   auto debug_marker = base_marker;
   debug_marker.type = visualization_msgs::msg::Marker::LINE_LIST;
   for (const auto & f : polygons) {
+    if (f.empty()) {
+      continue;
+    }
     boost::geometry::for_each_segment(f, [&](const auto & s) {
       const auto & [p1, p2] = s;
       debug_marker.points.push_back(autoware_utils::create_marker_position(p1.x(), p1.y(), 0.0));
@@ -256,7 +259,7 @@ visualization_msgs::msg::MarkerArray create_debug_marker_array(
   base_marker.color = autoware_utils::create_marker_color(1.0, 1.0, 1.0, 1.0);
   // TODO(Maxime): move the debug marker publishing AFTER the trajectory generation
   // disabled to prevent performance issues when publishing the debug markers
-  // add_polygons_markers(debug_marker_array, base_marker, ego_data.trajectory_footprints);
+  add_polygons_markers(debug_marker_array, base_marker, ego_data.trajectory_footprints);
   add_out_lanelets(debug_marker_array, base_marker, ego_data.out_lanelets);
   add_out_of_lane_overlaps(
     debug_marker_array, base_marker, out_of_lane_data.outside_points, ego_data.trajectory_points);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/footprint.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/footprint.cpp
@@ -15,14 +15,20 @@
 #include "footprint.hpp"
 
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
+#include <tf2/utils.hpp>
 
+#include <autoware_planning_msgs/msg/detail/trajectory_point__struct.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/detail/intersects/interface.hpp>
 
 #include <lanelet2_core/geometry/Polygon.h>
-#include <tf2/utils.h>
 
+#include <algorithm>
 #include <vector>
 
 namespace autoware::motion_velocity_planner::out_of_lane
@@ -43,32 +49,66 @@ autoware_utils::Polygon2d make_base_footprint(const PlannerParam & p, const bool
   return base_footprint;
 }
 
-lanelet::BasicPolygon2d project_to_pose(
-  const autoware_utils::Polygon2d & base_footprint, const geometry_msgs::msg::Pose & pose)
+lanelet::BasicPolygon2d project_to_trajectory_point(
+  const autoware_utils::Polygon2d & footprint,
+  const autoware_planning_msgs::msg::TrajectoryPoint & trajectory_point)
 {
-  const auto angle = tf2::getYaw(pose.orientation);
-  const auto rotated_footprint = autoware_utils::rotate_polygon(base_footprint, angle);
-  lanelet::BasicPolygon2d footprint;
-  for (const auto & p : rotated_footprint.outer())
-    footprint.emplace_back(p.x() + pose.position.x, p.y() + pose.position.y);
-  return footprint;
+  lanelet::BasicPolygon2d projected_footprint;
+  const auto angle = tf2::getYaw(trajectory_point.pose.orientation);
+  const auto rotated_footprint = autoware_utils::rotate_polygon(footprint, angle);
+  for (const auto & p : rotated_footprint.outer()) {
+    projected_footprint.emplace_back(
+      p.x() + trajectory_point.pose.position.x, p.y() + trajectory_point.pose.position.y);
+  }
+  return projected_footprint;
 }
 
 std::vector<lanelet::BasicPolygon2d> calculate_trajectory_footprints(
   const EgoData & ego_data, const PlannerParam & params)
 {
   const auto base_footprint = make_base_footprint(params);
+  const auto current_ego_position =
+    autoware_utils::Point2d(ego_data.pose.position.x, ego_data.pose.position.y);
+  const auto current_ego_yaw = tf2::getYaw(ego_data.pose.orientation);
   std::vector<lanelet::BasicPolygon2d> trajectory_footprints;
   trajectory_footprints.reserve(ego_data.trajectory_points.size());
-  for (auto i = 0UL; i < ego_data.trajectory_points.size(); ++i) {
-    const auto & trajectory_pose = ego_data.trajectory_points[i].pose;
-    const auto angle = tf2::getYaw(trajectory_pose.orientation);
-    const auto rotated_footprint = autoware_utils::rotate_polygon(base_footprint, angle);
-    lanelet::BasicPolygon2d footprint;
-    for (const auto & p : rotated_footprint.outer())
-      footprint.emplace_back(
-        p.x() + trajectory_pose.position.x, p.y() + trajectory_pose.position.y);
-    trajectory_footprints.push_back(footprint);
+  // cut the first footprints to (roughly) start after the current ego front
+  const auto last_cut_index = [&]() {
+    auto s = 0.0;
+    for (auto i = 0UL; i + 1 < ego_data.trajectory_points.size(); ++i) {
+      s += autoware_utils::calc_distance2d(
+        ego_data.trajectory_points[i], ego_data.trajectory_points[i + 1]);
+      if (s >= params.front_offset) {
+        return i + 1;
+      }
+    }
+    return ego_data.trajectory_points.size() - 1UL;
+  }();
+  for (auto i = 0UL; i <= last_cut_index; ++i) {
+    const auto & trajectory_point = ego_data.trajectory_points[i];
+    // cut the footprint beyond the current ego front
+    const autoware_utils::Point2d ego_pos_in_fp_frame(
+      trajectory_point.pose.position.x - current_ego_position.x(),
+      trajectory_point.pose.position.y - current_ego_position.y());
+    const auto angle_diff = autoware_utils_math::normalize_radian(
+      tf2::getYaw(trajectory_point.pose.orientation) - current_ego_yaw);
+    const auto ego_front_x_in_trajectory_point_frame =
+      ego_pos_in_fp_frame.x() + std::cos(angle_diff) * params.front_offset;
+    // empty footprint if the current ego front is ahead
+    if (ego_front_x_in_trajectory_point_frame >= base_footprint.outer()[0].x()) {
+      trajectory_footprints.emplace_back();
+    } else {
+      auto base_footprint_beyond_current_ego_front = base_footprint;
+      for (auto & p : base_footprint_beyond_current_ego_front.outer()) {
+        p.x() = std::max(ego_front_x_in_trajectory_point_frame, p.x());
+      }
+      trajectory_footprints.push_back(
+        project_to_trajectory_point(base_footprint_beyond_current_ego_front, trajectory_point));
+    }
+  }
+  for (auto i = last_cut_index + 1; i < ego_data.trajectory_points.size(); ++i) {
+    const auto & trajectory_point = ego_data.trajectory_points[i];
+    trajectory_footprints.push_back(project_to_trajectory_point(base_footprint, trajectory_point));
   }
   return trajectory_footprints;
 }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/footprint.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/footprint.hpp
@@ -30,13 +30,7 @@ namespace autoware::motion_velocity_planner::out_of_lane
 /// @return base ego footprint
 autoware_utils::Polygon2d make_base_footprint(
   const PlannerParam & p, const bool ignore_offset = false);
-/// @brief project a footprint to the given pose
-/// @param [in] base_footprint footprint to project
-/// @param [in] pose projection pose
-/// @return footprint projected to the given pose
-lanelet::BasicPolygon2d project_to_pose(
-  const autoware_utils::Polygon2d & base_footprint, const geometry_msgs::msg::Pose & pose);
-/// @brief calculate the trajectory footprints
+/// @brief calculate the trajectory footprints beyond the current ego front
 /// @details the resulting polygon follows the format used by the lanelet library: clockwise order
 /// and implicit closing edge
 /// @param [in] ego_data data related to the ego vehicle (includes its trajectory)


### PR DESCRIPTION
## Description

In order to avoid detecting out of lane collisions that are unavoidable, this PR cuts the trajectory footprints that are behind the current ego front.

| Before | After |
| --- | --- |
|<video src="https://github.com/user-attachments/assets/4d160355-9e48-4bd3-bf4c-d682dd148377"/> | <video src="https://github.com/user-attachments/assets/3c60bfda-efca-4021-a85c-72bcbf251784"/> |






## Related links

**Private Links:**

- [TIER IV JIRA](https://tier4.atlassian.net/browse/RT1-10493)

## How was this PR tested?

Psim, rosbag, and evaluator
- [TIER IV Evaluator](https://evaluation.tier4.jp/evaluation/reports/d17a5846-24dc-57ef-a8ee-8fc197924ca3?project_id=prd_jt) : no degradation.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Remove some possible false positives with the `out_of_lane` module.
