### PR TITLE
fix: use autowarefoundation for CHANGELOG instead of youtalk fork

### DIFF
--- a/system/autoware_system_monitor/CHANGELOG.rst
+++ b/system/autoware_system_monitor/CHANGELOG.rst
@@ -30,7 +30,7 @@ Changelog for package autoware_system_monitor
 
 0.44.1 (2025-05-01)
 -------------------
-* fix(autoware_system_monitor): quick fix for autoware_system_monitor (`#10506 <https://github.com/youtalk/autoware_universe/issues/10506>`_)
+* fix(autoware_system_monitor): quick fix for autoware_system_monitor (`#10506 <https://github.com/autowarefoundation/autoware_universe/issues/10506>`_)
   * feat(autoware_system_monitor): quick fix, autoware_system_monitor, fix sompile issue : v0.0
   * feat(autoware_system_monitor): quick fix, autoware_system_monitor, add comment by sasaki san: v0.1
   ---------


### PR DESCRIPTION
## Description

This PR fixes the URL in the CHANGELOG file to point to the autowarefoundation upstream repo instead of a fork.

## Related links

**Parent Issue:**

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
