### PR TITLE
feat(autoware_command_mode_switcher_plugins): publish hazard lights c…

### DIFF
--- a/system/autoware_command_mode_switcher/config/default.param.yaml
+++ b/system/autoware_command_mode_switcher/config/default.param.yaml
@@ -14,6 +14,7 @@
       # <plugin name>:  e.g. autoware::command_mode_switcher::StopSwitcher:
       #   <parameter name>: <value>
       autoware::command_mode_switcher::ComfortableStopSwitcher:
+        hazard_lights_hz: 20 
         min_acceleration: -1.0
         max_jerk: 0.6
         min_jerk: -0.6

--- a/system/autoware_command_mode_switcher/config/default.param.yaml
+++ b/system/autoware_command_mode_switcher/config/default.param.yaml
@@ -14,7 +14,7 @@
       # <plugin name>:  e.g. autoware::command_mode_switcher::StopSwitcher:
       #   <parameter name>: <value>
       autoware::command_mode_switcher::ComfortableStopSwitcher:
-        hazard_lights_hz: 20 
+        hazard_lights_hz: 20
         min_acceleration: -1.0
         max_jerk: 0.6
         min_jerk: -0.6

--- a/system/autoware_command_mode_switcher_plugins/package.xml
+++ b/system/autoware_command_mode_switcher_plugins/package.xml
@@ -13,6 +13,7 @@
   <depend>autoware_command_mode_switcher</depend>
   <depend>autoware_command_mode_types</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.cpp
@@ -21,7 +21,7 @@ namespace autoware::command_mode_switcher
 
 void ComfortableStopSwitcher::initialize()
 {
-  params_.hazard_lights_hz = node_->declare_parameter<int>(expand_param("hazard_lights_hz"));
+  int hazard_lights_hz = node_->declare_parameter<int>(expand_param("hazard_lights_hz"));
   params_.min_acceleration = node_->declare_parameter<float>(expand_param("min_acceleration"));
   params_.max_jerk = node_->declare_parameter<float>(expand_param("max_jerk"));
   params_.min_jerk = node_->declare_parameter<float>(expand_param("min_jerk"));
@@ -37,7 +37,7 @@ void ComfortableStopSwitcher::initialize()
   sub_odom_ =
     std::make_unique<autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
       node_, "/localization/kinematic_state");
-  rclcpp::Rate rate(params_.hazard_lights_hz);
+  rclcpp::Rate rate(hazard_lights_hz);
   pub_hazard_lights_timer_ = rclcpp::create_timer(
     node_, node_->get_clock(), rate.period(),
     std::bind(&ComfortableStopSwitcher::publish_hazard_lights_command, this));

--- a/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.cpp
@@ -21,19 +21,29 @@ namespace autoware::command_mode_switcher
 
 void ComfortableStopSwitcher::initialize()
 {
+  params_.hazard_lights_hz = node_->declare_parameter<int>(expand_param("hazard_lights_hz"));
+  params_.min_acceleration = node_->declare_parameter<float>(expand_param("min_acceleration"));
+  params_.max_jerk = node_->declare_parameter<float>(expand_param("max_jerk"));
+  params_.min_jerk = node_->declare_parameter<float>(expand_param("min_jerk"));
+
   pub_velocity_limit_ = node_->create_publisher<tier4_planning_msgs::msg::VelocityLimit>(
     "/planning/scenario_planning/max_velocity_candidates", rclcpp::QoS{1}.transient_local());
   pub_velocity_limit_clear_command_ =
     node_->create_publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>(
       "/planning/scenario_planning/clear_velocity_limit", rclcpp::QoS{1}.transient_local());
+  pub_hazard_lights_command_ =
+    node_->create_publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>(
+      "/system/hazard_lights_cmd", rclcpp::QoS{1});
   sub_odom_ =
     std::make_unique<autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
       node_, "/localization/kinematic_state");
+  rclcpp::Rate rate(params_.hazard_lights_hz);
+  pub_hazard_lights_timer_ = rclcpp::create_timer(
+    node_, node_->get_clock(), rate.period(),
+    std::bind(&ComfortableStopSwitcher::publish_hazard_lights_command, this));
 
-  params_.min_acceleration = node_->declare_parameter<float>(expand_param("min_acceleration"));
-  params_.max_jerk = node_->declare_parameter<float>(expand_param("max_jerk"));
-  params_.min_jerk = node_->declare_parameter<float>(expand_param("min_jerk"));
   mrm_state_ = MrmState::Normal;
+  enable_hazard_lights_ = false;
 }
 
 SourceState ComfortableStopSwitcher::update_source_state(bool request)
@@ -44,10 +54,12 @@ SourceState ComfortableStopSwitcher::update_source_state(bool request)
 
   if (request) {
     publish_velocity_limit();
+    enable_hazard_lights_ = true;
     mrm_state_ = MrmState::Operating;
     return SourceState{true, false};
   } else {
     publish_velocity_limit_clear_command();
+    enable_hazard_lights_ = false;
     mrm_state_ = MrmState::Normal;
     return SourceState{false, true};
   }
@@ -87,6 +99,16 @@ void ComfortableStopSwitcher::publish_velocity_limit_clear_command()
 
   pub_velocity_limit_clear_command_->publish(velocity_limit_clear_command);
   RCLCPP_INFO_STREAM(node_->get_logger(), "Comfortable stop is canceled.");
+}
+
+void ComfortableStopSwitcher::publish_hazard_lights_command()
+{
+  using autoware_vehicle_msgs::msg::HazardLightsCommand;
+  auto hazard_lights_command = HazardLightsCommand();
+  hazard_lights_command.stamp = node_->now();
+  hazard_lights_command.command =
+    enable_hazard_lights_ ? HazardLightsCommand::ENABLE : HazardLightsCommand::DISABLE;
+  pub_hazard_lights_command_->publish(hazard_lights_command);
 }
 
 bool ComfortableStopSwitcher::is_stopped()

--- a/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.hpp
@@ -21,6 +21,7 @@
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
@@ -32,6 +33,7 @@ namespace autoware::command_mode_switcher
 
 struct Params
 {
+  int hazard_lights_hz;
   float min_acceleration;
   float max_jerk;
   float min_jerk;
@@ -53,14 +55,19 @@ public:
 private:
   void publish_velocity_limit();
   void publish_velocity_limit_clear_command();
+  void publish_hazard_lights_command();
   bool is_stopped();
 
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
     pub_velocity_limit_clear_command_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
+    pub_hazard_lights_command_;
+  rclcpp::TimerBase::SharedPtr pub_hazard_lights_timer_;
   std::unique_ptr<autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>> sub_odom_;
 
   MrmState mrm_state_;
+  bool enable_hazard_lights_;
   struct Params params_;
 };
 

--- a/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.hpp
@@ -33,7 +33,6 @@ namespace autoware::command_mode_switcher
 
 struct Params
 {
-  int hazard_lights_hz;
   float min_acceleration;
   float max_jerk;
   float min_jerk;


### PR DESCRIPTION
## Description
Adds hazard lights publisher to comfortable stop switcher.
hazard_lighs_selector node selects Autonomous mode's hazard light or comfortable stop's one.

## Related links

**Private Links:**

- [ITER IV internal link](https://star4.slack.com/archives/C07DMS06H6U/p1750744524686969?thread_ts=1750725169.461089&cid=C07DMS06H6U)

## How was this PR tested?

- Confirmed build succeeded
- Real vehicle testing

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `/system/hazard_lights_cmd` | `autoware_vehicle_msgs/msg/HazardLightsCommand`   | comfortable stop's hazard lights command |

## Effects on system behavior

None.
