### PR TITLE
feat(tier4_system_launch): add arg for diag reset remapping

### DIFF
--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -26,6 +26,7 @@
   <arg name="diagnostic_graph_aggregator_graph_path"/>
   <arg name="diag_struct_topic" default="/diagnostics_graph/struct"/>
   <arg name="diag_status_topic" default="/diagnostics_graph/status"/>
+  <arg name="diag_reset_srv" default="/diagnostics_graph/reset"/>
   <arg name="availability_converter_param_path" default="$(find-pkg-share autoware_diagnostic_graph_aggregator)/config/converter.param.yaml"/>
   <arg name="command_mode_switcher_param_path" default="$(find-pkg-share autoware_command_mode_switcher)/config/default.param.yaml"/>
   <arg name="command_mode_decider_param_path" default="$(find-pkg-share autoware_command_mode_decider)/config/default.param.yaml"/>
@@ -122,6 +123,7 @@
         <arg name="graph_file" value="$(var diagnostic_graph_aggregator_graph_path)"/>
         <arg name="~/struct" value="$(var diag_struct_topic)"/>
         <arg name="~/status" value="$(var diag_status_topic)"/>
+        <arg name="~/reset" value="$(var diag_reset_srv)"/>
         <arg name="converter_param_file" value="$(var availability_converter_param_path)"/>
       </include>
     </group>


### PR DESCRIPTION
## Description
Enable to remap diag reset service from autoware_launch files.
This PR is necessary for redundant configuration.

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C0657FNJ5EG/p1750246110031379?thread_ts=1750126461.095959&cid=C0657FNJ5EG)

## How was this PR tested?

- Confirmed build succeeded
- Real minibus testing

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
