### PR TITLE
feat(tier4_autoware_api_launch): add arg for replacing default adapi …

### DIFF
--- a/launch/tier4_autoware_api_launch/launch/autoware_api.launch.xml
+++ b/launch/tier4_autoware_api_launch/launch/autoware_api.launch.xml
@@ -9,6 +9,9 @@
   <arg name="rosbridge_respawn" default="true"/>
   <arg name="rosbridge_max_message_size" default="10000000"/>
 
+  <!-- Parameter files -->
+  <arg name="default_adapi_param_path" default="$(find-pkg-share autoware_default_adapi)/config/default_adapi.param.yaml"/>
+
   <!-- Deprecated API -->
   <group if="$(var launch_deprecated_api)">
     <include file="$(find-pkg-share tier4_autoware_api_launch)/launch/deprecated_api.launch.xml"/>
@@ -16,7 +19,9 @@
 
   <!-- AD API -->
   <group>
-    <include file="$(find-pkg-share autoware_default_adapi_universe)/launch/default_adapi.launch.py" if="$(var launch_default_adapi)"/>
+    <include file="$(find-pkg-share autoware_default_adapi_universe)/launch/default_adapi.launch.py" if="$(var launch_default_adapi)">
+      <arg name="config" value="$(var default_adapi_param_path)"/>
+    </include>
     <include file="$(find-pkg-share autoware_adapi_adaptors)/launch/rviz_adaptors.launch.xml" if="$(var launch_rviz_adaptors)"/>
   </group>
 


### PR DESCRIPTION
## Description
Enable to change adapi param path form autoware_launch.
This PR is necessary for redundant configuration.

## Related links

Mrm description is needed to change for every production.
https://github.com/autowarefoundation/autoware_universe/pull/10838

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Confirmed build succeeded
- Real minibus testing

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
