### PR TITLE
fix(command_mode_switcher_plugins): fix velocity limit message

### DIFF
--- a/system/autoware_command_mode_switcher_plugins/package.xml
+++ b/system/autoware_command_mode_switcher_plugins/package.xml
@@ -12,11 +12,11 @@
 
   <depend>autoware_command_mode_switcher</depend>
   <depend>autoware_command_mode_types</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
-  <depend>tier4_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.cpp
@@ -21,11 +21,10 @@ namespace autoware::command_mode_switcher
 
 void ComfortableStopSwitcher::initialize()
 {
-  pub_velocity_limit_ = node_->create_publisher<tier4_planning_msgs::msg::VelocityLimit>(
+  pub_velocity_limit_ = node_->create_publisher<VelocityLimit>(
     "/planning/scenario_planning/max_velocity_candidates", rclcpp::QoS{1}.transient_local());
-  pub_velocity_limit_clear_command_ =
-    node_->create_publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>(
-      "/planning/scenario_planning/clear_velocity_limit", rclcpp::QoS{1}.transient_local());
+  pub_velocity_limit_clear_command_ = node_->create_publisher<VelocityLimitClearCommand>(
+    "/planning/scenario_planning/clear_velocity_limit", rclcpp::QoS{1}.transient_local());
   sub_odom_ =
     std::make_unique<autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
       node_, "/localization/kinematic_state");
@@ -65,7 +64,7 @@ MrmState ComfortableStopSwitcher::update_mrm_state()
 
 void ComfortableStopSwitcher::publish_velocity_limit()
 {
-  auto velocity_limit = tier4_planning_msgs::msg::VelocityLimit();
+  auto velocity_limit = VelocityLimit();
   velocity_limit.stamp = node_->now();
   velocity_limit.max_velocity = 0;
   velocity_limit.use_constraints = true;
@@ -80,7 +79,7 @@ void ComfortableStopSwitcher::publish_velocity_limit()
 
 void ComfortableStopSwitcher::publish_velocity_limit_clear_command()
 {
-  auto velocity_limit_clear_command = tier4_planning_msgs::msg::VelocityLimitClearCommand();
+  auto velocity_limit_clear_command = VelocityLimitClearCommand();
   velocity_limit_clear_command.stamp = node_->now();
   velocity_limit_clear_command.command = true;
   velocity_limit_clear_command.sender = "comfortable_stop_switcher";

--- a/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/comfortable_stop.hpp
@@ -21,9 +21,9 @@
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 
 #include <memory>
 
@@ -51,13 +51,15 @@ public:
   MrmState update_mrm_state() override;
 
 private:
+  using VelocityLimit = autoware_internal_planning_msgs::msg::VelocityLimit;
+  using VelocityLimitClearCommand = autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
+
   void publish_velocity_limit();
   void publish_velocity_limit_clear_command();
   bool is_stopped();
 
-  rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
-  rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
-    pub_velocity_limit_clear_command_;
+  rclcpp::Publisher<VelocityLimit>::SharedPtr pub_velocity_limit_;
+  rclcpp::Publisher<VelocityLimitClearCommand>::SharedPtr pub_velocity_limit_clear_command_;
   std::unique_ptr<autoware_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>> sub_odom_;
 
   MrmState mrm_state_;


### PR DESCRIPTION
## Description

Fix velocity limit message type of comfortable stop plugin.

## Related links

None

## How was this PR tested?

Check that the message type is unique using the following command.
```
ros2 topic info /planning/scenario_planning/clear_velocity_limit
ros2 topic info /planning/scenario_planning/max_velocity_candidates 
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
