### PR TITLE
feat(start_planner_module): replace getArcCoordinates with getArcCoordinatesOnEgoCenterline

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
@@ -96,7 +96,8 @@ std::optional<PullOutPath> FreespacePullOut::plan(
   // push back generate road lane path between end pose and goal pose to last path
   const Pose goal_pose = route_handler->getGoalPose();
   constexpr double offset_from_end_pose = 1.0;
-  const auto arc_position_end = lanelet::utils::getArcCoordinates(road_lanes, end_pose);
+  const auto arc_position_end = lanelet::utils::getArcCoordinatesOnEgoCenterline(
+    road_lanes, end_pose, route_handler->getLaneletMapPtr());
   const double s_start = std::max(arc_position_end.length + offset_from_end_pose, 0.0);
   const auto path_end_info =
     autoware::behavior_path_planner::utils::parking_departure::calcEndArcLength(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -29,7 +29,7 @@
 using autoware::motion_utils::findNearestIndex;
 using autoware_utils::calc_distance2d;
 using autoware_utils::calc_offset_pose;
-using lanelet::utils::getArcCoordinates;
+using lanelet::utils::getArcCoordinatesOnEgoCenterline;
 namespace autoware::behavior_path_planner
 {
 using start_planner_utils::getPullOutLanes;
@@ -64,7 +64,10 @@ std::optional<PullOutPath> GeometricPullOut::plan(
   const auto pull_out_lanes = getPullOutLanes(planner_data, backward_path_length);
 
   // check if the ego is at left or right side of road lane center
-  const bool left_side_start = 0 < getArcCoordinates(road_lanes, start_pose).distance;
+  const bool left_side_start =
+    0 < getArcCoordinatesOnEgoCenterline(
+          road_lanes, start_pose, planner_data->route_handler->getLaneletMapPtr())
+          .distance;
   const double max_steer_angle =
     vehicle_info_.max_steer_angle_rad *
     parallel_parking_parameters_.geometric_pull_out_max_steer_angle_margin_scale;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -34,7 +34,7 @@
 using autoware::motion_utils::findNearestIndex;
 using autoware_utils::calc_distance2d;
 using autoware_utils::calc_offset_pose;
-using lanelet::utils::getArcCoordinates;
+using lanelet::utils::getArcCoordinatesOnEgoCenterline;
 namespace autoware::behavior_path_planner
 {
 using start_planner_utils::getPullOutLanes;
@@ -263,7 +263,8 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
     std::numeric_limits<double>::epsilon());
 
   // generate road lane reference path
-  const auto arc_position_start = getArcCoordinates(road_lanes, start_pose);
+  const auto arc_position_start =
+    getArcCoordinatesOnEgoCenterline(road_lanes, start_pose, route_handler.getLaneletMapPtr());
   const double s_start = std::max(arc_position_start.length - backward_path_length, 0.0);
   const auto path_end_info =
     autoware::behavior_path_planner::utils::parking_departure::calcEndArcLength(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
@@ -41,10 +41,10 @@ PathWithLaneId getBackwardPath(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & shoulder_lanes,
   const Pose & current_pose, const Pose & backed_pose, const double velocity)
 {
-  const auto current_pose_arc_coords =
-    lanelet::utils::getArcCoordinates(shoulder_lanes, current_pose);
-  const auto backed_pose_arc_coords =
-    lanelet::utils::getArcCoordinates(shoulder_lanes, backed_pose);
+  const auto current_pose_arc_coords = lanelet::utils::getArcCoordinatesOnEgoCenterline(
+    shoulder_lanes, current_pose, route_handler.getLaneletMapPtr());
+  const auto backed_pose_arc_coords = lanelet::utils::getArcCoordinatesOnEgoCenterline(
+    shoulder_lanes, backed_pose, route_handler.getLaneletMapPtr());
 
   const double s_start = backed_pose_arc_coords.length;
   const double s_end = current_pose_arc_coords.length;


### PR DESCRIPTION
## Description

This PR replaces `getArcCoordinates()` with `getArcCoordinatesOnEgoCenterline()` to support lanelets which has custom centerlines

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10963


- https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/49 is used

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [[PR check][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/18b5a58b-4241-55e4-a8f4-540b35c5884c?project_id=prd_jt)
- [[PR check][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/b4d75763-b44f-5737-92aa-96c03e0ea4a3?project_id=prd_jt)
- [[PR check][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/3556abf3-47c4-57dd-b485-68cb26e006ab?project_id=prd_jt)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
