### PR TITLE
feat(mission_planner_universe): prioritize bus stop lanelet as start lanelet

### DIFF
--- a/planning/autoware_mission_planner_universe/README.md
+++ b/planning/autoware_mission_planner_universe/README.md
@@ -19,18 +19,19 @@ It distributes route requests and planning results according to current MRM oper
 
 ### Parameters
 
-| Name                               | Type   | Description                                                                                                                |
-| ---------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `map_frame`                        | string | The frame name for map                                                                                                     |
-| `arrival_check_angle_deg`          | double | Angle threshold for goal check                                                                                             |
-| `arrival_check_distance`           | double | Distance threshold for goal check                                                                                          |
-| `arrival_check_duration`           | double | Duration threshold for goal check                                                                                          |
-| `goal_angle_threshold`             | double | Max goal pose angle for goal approve                                                                                       |
-| `enable_correct_goal_pose`         | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                              |
-| `reroute_time_threshold`           | double | If the time to the rerouting point at the current velocity is greater than this threshold, rerouting is possible           |
-| `minimum_reroute_length`           | double | Minimum Length for publishing a new route                                                                                  |
-| `consider_no_drivable_lanes`       | bool   | This flag is for considering no_drivable_lanes in planning or not.                                                         |
-| `allow_reroute_in_autonomous_mode` | bool   | This is a flag to allow reroute in autonomous driving mode. If false, reroute fails. If true, only safe reroute is allowed |
+| Name                                | Type   | Description                                                                                                                |
+| ----------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `map_frame`                         | string | The frame name for map                                                                                                     |
+| `arrival_check_angle_deg`           | double | Angle threshold for goal check                                                                                             |
+| `arrival_check_distance`            | double | Distance threshold for goal check                                                                                          |
+| `arrival_check_duration`            | double | Duration threshold for goal check                                                                                          |
+| `goal_angle_threshold`              | double | Max goal pose angle for goal approve                                                                                       |
+| `enable_correct_goal_pose`          | bool   | Enabling correction of goal pose according to the closest lanelet orientation                                              |
+| `reroute_time_threshold`            | double | If the time to the rerouting point at the current velocity is greater than this threshold, rerouting is possible           |
+| `minimum_reroute_length`            | double | Minimum Length for publishing a new route                                                                                  |
+| `consider_no_drivable_lanes`        | bool   | This flag is for considering no_drivable_lanes in planning or not.                                                         |
+| `allow_reroute_in_autonomous_mode`  | bool   | This is a flag to allow reroute in autonomous driving mode. If false, reroute fails. If true, only safe reroute is allowed |
+| `prioritize_bus_stop_as_start_lane` | bool   | If the start pose overlaps multiple lanelets, prioritize the one tagged as "bus_stop"                                      |
 
 ### Services
 

--- a/planning/autoware_mission_planner_universe/config/mission_planner.param.yaml
+++ b/planning/autoware_mission_planner_universe/config/mission_planner.param.yaml
@@ -11,3 +11,4 @@
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
     check_footprint_inside_lanes: true
     allow_reroute_in_autonomous_mode: true
+    prioritize_bus_stop_as_start_lane: false # If the start pose overlaps with multiple lanelets, prioritize the one tagged as "bus_stop"

--- a/planning/autoware_mission_planner_universe/schema/mission_planner.schema.json
+++ b/planning/autoware_mission_planner_universe/schema/mission_planner.schema.json
@@ -53,6 +53,11 @@
           "type": "boolean",
           "description": "This flag is for considering no_drivable_lanes in planning or not",
           "default": "false"
+        },
+        "prioritize_bus_stop_as_start_lane": {
+          "type": "boolean",
+          "description": "If the start pose overlaps multiple lanelets, prioritize the one tagged as 'bus_stop'",
+          "default": "false"
         }
       },
       "required": [
@@ -64,7 +69,8 @@
         "enable_correct_goal_pose",
         "reroute_time_threshold",
         "minimum_reroute_length",
-        "consider_no_drivable_lanes"
+        "consider_no_drivable_lanes",
+        "prioritize_bus_stop_as_start_lane"
       ]
     }
   },

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -87,6 +87,8 @@ void DefaultPlanner::initialize_common(rclcpp::Node * node)
   param_.consider_no_drivable_lanes = node_->declare_parameter<bool>("consider_no_drivable_lanes");
   param_.check_footprint_inside_lanes =
     node_->declare_parameter<bool>("check_footprint_inside_lanes");
+  param_.prioritize_bus_stop_as_start_lane =
+    node_->declare_parameter<bool>("prioritize_bus_stop_as_start_lane");
 }
 
 void DefaultPlanner::initialize(rclcpp::Node * node)
@@ -341,7 +343,8 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
     const auto goal_check_point = points.at(i);
     lanelet::ConstLanelets path_lanelets;
     if (!route_handler_.planPathLaneletsBetweenCheckpoints(
-          start_check_point, goal_check_point, &path_lanelets, param_.consider_no_drivable_lanes)) {
+          start_check_point, goal_check_point, &path_lanelets, param_.consider_no_drivable_lanes,
+          param_.prioritize_bus_stop_as_start_lane)) {
       RCLCPP_WARN(logger, "Failed to plan route.");
       return route_msg;
     }

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.hpp
@@ -39,6 +39,7 @@ struct DefaultPlannerParameters
   bool enable_correct_goal_pose;
   bool consider_no_drivable_lanes;
   bool check_footprint_inside_lanes;
+  bool prioritize_bus_stop_as_start_lane;
 };
 
 class DefaultPlanner : public mission_planner_universe::PlannerPlugin


### PR DESCRIPTION
## Description

This PR adds an option to able to prioritize bus stop lanelet as the start lanelet in `mission_planner_universe` package

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10963

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `prioritize_bus_stop_as_start_lane`   | `bool` | `false`         | If the start pose overlaps multiple lanelets, prioritize the one tagged as "bus_stop" |

## Effects on system behavior

None.
