### PR TITLE
fix(autoware_system_monitor): fix a ticket link in CHANGELOG.rst (about v0.44.0)

### DIFF
--- a/system/autoware_system_monitor/CHANGELOG.rst
+++ b/system/autoware_system_monitor/CHANGELOG.rst
@@ -38,6 +38,9 @@ Changelog for package autoware_system_monitor
 
 0.44.0 (2025-04-18)
 -------------------
+* fix(process_monitor): get process statistics directly from /proc files to avoid process spawning of Linux commands (`#10379 <https://github.com/autowarefoundation/autoware_universe/issues/10379>`_)
+  ---------
+* Contributors: nishikawa-masaki
 
 0.43.0 (2025-03-21)
 -------------------


### PR DESCRIPTION
## Description
The change log for "autoware_system_monitor" about v0.44.0 was missing though performance improvement for process_monitor had been introduced in the version.
The cause of the missing log is unknown. Maybe it was because the merging was made just before the versioning operation.

This PR adds the missing ticket link to the v0.44.0 log line in autoware_system_monitor/CHANGELOG.rst.

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

- Just an addition of text comment. No need to test it

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
