### PR TITLE
chore(boundary_departure): add logging for monitoring

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -57,9 +57,11 @@ void BoundaryDeparturePreventionModule::init(
       if (output_.diagnostic_output[DepartureType::CRITICAL_DEPARTURE]) {
         lvl = node_param_.diagnostic_level[DepartureType::CRITICAL_DEPARTURE];
         msg = "vehicle is leaving boundary";
+        RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 500, "%s", msg.c_str());
       } else if (output_.diagnostic_output[DepartureType::APPROACHING_DEPARTURE]) {
         lvl = node_param_.diagnostic_level[DepartureType::APPROACHING_DEPARTURE];
         msg = "vehicle is moving towards the boundary";
+        RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 1000, "%s", msg.c_str());
       } else if (output_.diagnostic_output[DepartureType::NEAR_BOUNDARY]) {
         lvl = node_param_.diagnostic_level[DepartureType::NEAR_BOUNDARY];
         msg = "vehicle is near boundary";


### PR DESCRIPTION
## Description

Add logging to so that the output can be monitored with TIER IV tools.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
