### PR TITLE
feat(start_planner_module): register start_planner module in bus stop

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
@@ -231,6 +231,7 @@ private:
 
   bool isModuleRunning() const;
   bool isCurrentPoseOnEgoCenterline() const;
+  bool isCurrentPoseOnBusStop() const;
 
   /**
    * @brief Check if the ego vehicle is preventing the rear vehicle from passing through.
@@ -256,7 +257,7 @@ ego pose.
     */
   bool isPreventingRearVehicleFromPassingThrough(const Pose & ego_pose) const;
 
-  bool isCloseToOriginalStartPose() const;
+  bool isFarFromOriginalStartPose() const;
   bool hasArrivedAtGoal() const;
   bool isMoving() const;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -289,10 +289,10 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
 
   bool has_non_shifted_path = false;
 
-  // if shift length is too short, add non sifted path
-  constexpr double MINIMUM_SHIFT_LENGTH = 0.01;
+  // if shift length is too short, add non shifted path
   const double shift_length = arc_position_start.distance;
-  const bool is_smaller_than_minimum = std::abs(shift_length) < MINIMUM_SHIFT_LENGTH;
+  const bool is_smaller_than_minimum =
+    std::abs(shift_length) < parameters_.th_distance_to_middle_of_the_road;
 
   if (is_smaller_than_minimum) {
     candidate_paths.push_back(non_shifted_path);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -394,13 +394,14 @@ bool StartPlannerModule::isExecutionRequested() const
   }
 
   // Return false and do not request execution if any of the following conditions are true:
-  // - The start pose is on the centerline or on "waypoints" (custom centerline)
-  // - The vehicle has already arrived at the start position planner.
+  // - The vehicle is on the centerline or on "waypoints" (custom centerline)
+  //    [ignore this check if the vehicle is on a bus stop]
+  // - The vehicle is far enough from the original start position.
   // - The vehicle has reached the goal position.
   // - The vehicle is still moving.
   if (
-    isCurrentPoseOnEgoCenterline() || isCloseToOriginalStartPose() || hasArrivedAtGoal() ||
-    isMoving()) {
+    (!isCurrentPoseOnBusStop() && isCurrentPoseOnEgoCenterline()) || isFarFromOriginalStartPose() ||
+    hasArrivedAtGoal() || isMoving()) {
     return false;
   }
 
@@ -429,6 +430,14 @@ bool StartPlannerModule::isCurrentPoseOnEgoCenterline() const
       .distance;
 
   return std::abs(lateral_distance_to_center_lane) < parameters_->th_distance_to_middle_of_the_road;
+}
+
+bool StartPlannerModule::isCurrentPoseOnBusStop() const
+{
+  lanelet::ConstLanelet current_lanelet;
+  planner_data_->route_handler->getClosestLaneletWithinRoute(getEgoPose(), &current_lanelet);
+
+  return current_lanelet.hasAttribute("bus_stop");
 }
 
 bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
@@ -619,7 +628,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough(const Pose & 
          gap_between_ego_and_lane_border;
 }
 
-bool StartPlannerModule::isCloseToOriginalStartPose() const
+bool StartPlannerModule::isFarFromOriginalStartPose() const
 {
   const Pose start_pose = planner_data_->route_handler->getOriginalStartPose();
   return autoware_utils::calc_distance2d(
@@ -728,12 +737,14 @@ bool StartPlannerModule::canTransitSuccessState()
   //   - Insufficient margin against static objects.
   //   - No path found that stays within the lane.
   //   In such cases, a stop point needs to be embedded and keep running start_planner.
-  // - Can transit to success if the end point of the pullout path is reached.
+  // - Can transit to success if both of the conditions below is satisfied:
+  //   - The end point of the pullout path is reached
+  //   - The vehicle has left the bus stop if that is the case
   if (!status_.driving_forward || !status_.found_pull_out_path) {
     return false;
   }
 
-  if (hasReachedPullOutEnd()) {
+  if (hasReachedPullOutEnd() && !isCurrentPoseOnBusStop()) {
     RCLCPP_DEBUG(getLogger(), "Transit to success: Reached the end point of the pullout path.");
     return true;
   }
@@ -1126,9 +1137,17 @@ bool StartPlannerModule::findPullOutPath(
   PlannerDebugData debug_data{
     planner->getPlannerType(), backwards_distance, collision_check_margin, {}};
 
-  const auto pull_out_path =
-    planner->plan(start_pose_candidate, goal_pose, planner_data_, debug_data);
-  debug_data_vector.push_back(debug_data);
+  const auto pull_out_path = std::invoke([&]() -> std::optional<PullOutPath> {
+    if (isCurrentPoseOnEgoCenterline()) {
+      PullOutPath path;
+      path.partial_paths.push_back(getPreviousModuleOutput().path);
+      return path;
+    }
+    auto path_opt = planner->plan(start_pose_candidate, goal_pose, planner_data_, debug_data);
+    debug_data_vector.push_back(debug_data);
+    return path_opt;
+  });
+
   // If no path is found, return false
   if (!pull_out_path) {
     return false;


### PR DESCRIPTION
## Description

This PR is created to run `start_planner` in case ego is in a bus stop

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10963

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
