### PR TITLE
fix(start_planner,boundary_departure_checker): remove micro inner rings after bg::union_

### DIFF
--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker.cpp
@@ -226,6 +226,20 @@ bool BoundaryDepartureChecker::updateFusedLaneletPolygonForPath(
   }
 
   fused_lanelets_polygon = lanelet_unions.front();
+
+  // Remove micro holes (micro inner rings) caused by boost::geometry::union_
+  {
+    constexpr double area_threshold = 1e-5;  // [m^2]
+    auto & inners = fused_lanelets_polygon->inners();
+    inners.erase(
+      std::remove_if(
+        inners.begin(), inners.end(),
+        [&](const auto & inner_ring) {
+          return std::abs(boost::geometry::area(inner_ring)) < area_threshold;
+        }),
+      inners.end());
+  }
+
   return true;
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -383,6 +383,21 @@ bool StartPlannerModule::isInsideLanelets() const
     }
   }
 
+  // Remove micro holes (micro inner rings) caused by boost::geometry::union_
+  {
+    constexpr double area_threshold = 1e-5;  // [m^2]
+    for (auto & combined_lanelet : combined_lanelets) {
+      auto & inners = combined_lanelet.inners();
+      inners.erase(
+        std::remove_if(
+          inners.begin(), inners.end(),
+          [&](const auto & inner_ring) {
+            return std::abs(boost::geometry::area(inner_ring)) < area_threshold;
+          }),
+        inners.end());
+    }
+  }
+
   // Check if the vehicle footprint is completely within the combined lanelets
   return boost::geometry::within(footprint_polygon, combined_lanelets);
 }


### PR DESCRIPTION
## Description

This PR removes micro inner rings after bg::union_ function when there are lanelets overlapping (e.g. when bus stop lanelets and regular lanelets)

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10963

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

| before  |  after  |
|---|---|
| <img width="1192" height="1286" alt="outside" src="https://github.com/user-attachments/assets/ea6b6ccd-8ddc-4398-98e2-238cd780b114" />  | <img width="1203" height="1300" alt="inside" src="https://github.com/user-attachments/assets/76820d48-5adc-4343-883f-01ae22488c23" />  | 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
