### PR TITLE
feat(start_planner_module,bpp_common): safety check for bus stop pull out

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -1159,7 +1159,14 @@ lanelet::ConstLanelets extendPrevLane(
       target_prev_lane = prev_lane;
       break;
     }
-    if (!only_in_route && !target_prev_lane) target_prev_lane = prev_lane;
+
+    if (!only_in_route) {
+      // prioritize straight lanelets over the other types of turn direction tags
+      const auto & turn_direction = prev_lane.attributeOr("turn_direction", std::string("none"));
+      if (turn_direction == "straight" || !target_prev_lane) {
+        target_prev_lane = prev_lane;
+      }
+    }
   }
   if (target_prev_lane) {
     extended_lanes.insert(extended_lanes.begin(), *target_prev_lane);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -305,9 +305,10 @@ bool StartPlannerModule::requiresDynamicObjectsCollisionDetection() const
     return false;
   }
 
-  // Return true and always perform collision detection if the following condition is true:
+  // Return true and always perform collision detection if any of the following conditions are true:
   // - Rear vehicle check is set to be skipped.
-  if (skip_rear_vehicle_check) {
+  // - The vehicle is on a bus stop
+  if (skip_rear_vehicle_check || isCurrentPoseOnBusStop()) {
     return true;
   }
 
@@ -1636,13 +1637,20 @@ bool StartPlannerModule::isSafePath() const
   }
   std::vector<ExtendedPredictedObject> merged_target_object;
   merged_target_object.reserve(
-    target_objects_on_lane.on_current_lane.size() + target_objects_on_lane.on_shoulder_lane.size());
+    target_objects_on_lane.on_current_lane.size() + target_objects_on_lane.on_shoulder_lane.size() +
+    target_objects_on_lane.on_right_lane.size() + target_objects_on_lane.on_left_lane.size());
   merged_target_object.insert(
     merged_target_object.end(), target_objects_on_lane.on_current_lane.begin(),
     target_objects_on_lane.on_current_lane.end());
   merged_target_object.insert(
     merged_target_object.end(), target_objects_on_lane.on_shoulder_lane.begin(),
     target_objects_on_lane.on_shoulder_lane.end());
+  merged_target_object.insert(
+    merged_target_object.end(), target_objects_on_lane.on_right_lane.begin(),
+    target_objects_on_lane.on_right_lane.end());
+  merged_target_object.insert(
+    merged_target_object.end(), target_objects_on_lane.on_left_lane.begin(),
+    target_objects_on_lane.on_left_lane.end());
 
   return autoware::behavior_path_planner::utils::path_safety_checker::checkSafetyWithRSS(
     pull_out_path, ego_predicted_path, merged_target_object, debug_data_.collision_check,


### PR DESCRIPTION
## Description

:exclamation: This PR needs to be tested with https://github.com/autowarefoundation/autoware_universe/pull/10970 if not merged yet.

This PR enables safety check during pull out from bus stop. 

Also fixes 2 issues:

---

- Attention lanelets for safety check:

| Before  | After  |
|---|---|
| <img width="642" height="1293" alt="attention_before" src="https://github.com/user-attachments/assets/b1a46b45-141c-4742-8528-47089e3751ef" />|  <img width="515" height="1278" alt="attention_after" src="https://github.com/user-attachments/assets/d07d12b0-87da-4852-ae30-ec8b4d2ab057" />|

---

- Consider cars approaching in opposite lanes if [include_opposite_lane](https://github.com/autowarefoundation/autoware_launch/blob/4a6ed4286e516297a0c74473666253a9626f9045/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml#L137C11-L137C39): `true`


| Before (click on the picture to watch the video)  | After (click on the picture to watch the video)  |
|---|---|
| [![Watch the video](https://github.com/user-attachments/assets/42d5046a-04ff-441f-984b-f4ec101b5049)](https://github.com/user-attachments/assets/ab94ea79-2da9-4c44-8f94-4ee5fbe4ae7b) | [![Watch the video](https://github.com/user-attachments/assets/0b90ca19-b1e9-438b-ac90-3a3ee520e107)](https://github.com/user-attachments/assets/8aa11dce-ca8f-45b8-9d98-c96062ffab00)  |




## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10963#issuecomment-3060698308

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
