### PR TITLE
perf(planning_validator): switch planning_validator back to event driven

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
@@ -62,9 +62,9 @@ public:
   explicit PlanningValidatorNode(const rclcpp::NodeOptions & options);
 
 private:
-  void onTimer();
+  void onTrajectory(const Trajectory::ConstSharedPtr & traj_msg);
   void setupParameters();
-  void setData();
+  void setData(const Trajectory::ConstSharedPtr & traj_msg);
   bool isDataReady();
 
   void validate(const std::shared_ptr<const PlanningValidatorData> & data);
@@ -75,6 +75,7 @@ private:
   void displayStatus();
 
   // subscriber
+  rclcpp::Subscription<Trajectory>::SharedPtr sub_trajectory_;
   autoware_utils::InterProcessPollingSubscriber<
     LaneletRoute, autoware_utils::polling_policy::Newest>
     sub_route_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
@@ -87,8 +88,6 @@ private:
     this, "~/input/kinematics"};
   autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> sub_acceleration_{
     this, "~/input/acceleration"};
-  autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_trajectory_{
-    this, "~/input/trajectory"};
 
   // publisher
   rclcpp::Publisher<Trajectory>::SharedPtr pub_traj_;
@@ -111,7 +110,6 @@ private:
   std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
 
   StopWatch<std::chrono::milliseconds> stop_watch_;
-  rclcpp::TimerBase::SharedPtr timer_;
 };
 }  // namespace autoware::planning_validator
 


### PR DESCRIPTION
## Description

Recently planning_validator node was changed to timer based operating on a 10Hz timer, which resulted in a significant increase in planning response time.

This PR switches planning_validator node back to event driven, triggering immediately upon receiving trajectory topic.

## Related links

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
