### PR TITLE
fix(multi_object_tracker): correct index usage of association matrix

### DIFF
--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -288,7 +288,7 @@ void TrackerProcessor::mergeOverlappedTracker(const rclcpp::Time & time)
   for (size_t i = 0; i < label_size; ++i) {
     for (size_t j = 0; j < label_size; ++j) {
       search_distance_sq_per_label[i] =
-        std::max(search_distance_sq_per_label[i], config_.max_dist_matrix(j, i));
+        std::max(search_distance_sq_per_label[i], config_.max_dist_matrix(i, j));
     }
   }
 


### PR DESCRIPTION
## Description

Bug fix of data association matrix > max_dist_matrix usage for tracker pruning.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
