### PR TITLE
fix(behavior_path_planner): resample the path before generating the drivable area

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/behavior_path_goal_planner_module/default_fixed_goal_planner.hpp"
 
-#include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 
 #include <autoware_lanelet2_extension/utility/query.hpp>
@@ -101,8 +100,6 @@ PathWithLaneId DefaultFixedGoalPlanner::modifyPathForSmoothGoalConnection(
     }
     goal_search_radius -= range_reduce_by;
   }
-  refined_path =
-    utils::resamplePathWithSpline(refined_path, planner_data->parameters.input_path_interval, true);
   return refined_path;
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/behavior_path_goal_planner_module/default_fixed_goal_planner.hpp"
 
+#include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 
 #include <autoware_lanelet2_extension/utility/query.hpp>
@@ -100,6 +101,8 @@ PathWithLaneId DefaultFixedGoalPlanner::modifyPathForSmoothGoalConnection(
     }
     goal_search_radius -= range_reduce_by;
   }
+  refined_path =
+    utils::resamplePathWithSpline(refined_path, planner_data->parameters.input_path_interval, true);
   return refined_path;
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -17,7 +17,6 @@
 
 #include "autoware/behavior_path_planner_common/data_manager.hpp"
 #include "autoware/behavior_path_planner_common/interface/scene_module_interface.hpp"
-#include "autoware_utils/ros/debug_publisher.hpp"
 #include "autoware_utils/ros/logger_level_configure.hpp"
 #include "planner_manager.hpp"
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -170,7 +170,7 @@ private:
   /**
    * @brief extract path from behavior tree output
    */
-  PathWithLaneId::SharedPtr getPath(
+  static PathWithLaneId::SharedPtr getPath(
     const BehaviorModuleOutput & output, const std::shared_ptr<PlannerData> & planner_data);
 
   /**

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -172,10 +172,7 @@ private:
    * @brief extract path from behavior tree output
    */
   PathWithLaneId::SharedPtr getPath(
-    const BehaviorModuleOutput & output, const std::shared_ptr<PlannerData> & planner_data,
-    const std::shared_ptr<PlannerManager> & planner_manager);
-
-  bool keepInputPoints(const std::vector<std::shared_ptr<SceneModuleStatus>> & statuses) const;
+    const BehaviorModuleOutput & output, const std::shared_ptr<PlannerData> & planner_data);
 
   /**
    * @brief skip smooth goal connection

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -715,7 +715,7 @@ PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(
   auto path = !output.path.points.empty() ? std::make_shared<PathWithLaneId>(output.path)
                                           : planner_data->prev_output_path;
   path->header = planner_data->route_handler->getRouteHeader();
-  return std::make_shared<PathWithLaneId>(*path);
+  return path;
 }
 
 void BehaviorPathPlannerNode::onTrafficSignals(const TrafficLightGroupArray::ConstSharedPtr msg)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/behavior_path_planner/behavior_path_planner_node.hpp"
 
-#include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 
 #include <autoware_utils/ros/update_param.hpp>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -373,7 +373,7 @@ void BehaviorPathPlannerNode::run()
   const auto output = planner_manager_->run(planner_data_);
 
   // path handling
-  const auto path = getPath(output, planner_data_, planner_manager_);
+  const auto path = getPath(output, planner_data_);
   path->header.stamp = stamp;
   // update planner data
   planner_data_->prev_output_path = path;
@@ -709,41 +709,14 @@ Path BehaviorPathPlannerNode::convertToPath(
 }
 
 PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(
-  const BehaviorModuleOutput & output, const std::shared_ptr<PlannerData> & planner_data,
-  const std::shared_ptr<PlannerManager> & planner_manager)
+  const BehaviorModuleOutput & output, const std::shared_ptr<PlannerData> & planner_data)
 {
   // TODO(Horibe) do some error handling when path is not available.
 
   auto path = !output.path.points.empty() ? std::make_shared<PathWithLaneId>(output.path)
                                           : planner_data->prev_output_path;
   path->header = planner_data->route_handler->getRouteHeader();
-
-  PathWithLaneId connected_path;
-  const auto module_status_ptr_vec = planner_manager->getSceneModuleStatus();
-
-  const auto resampled_path = utils::resamplePathWithSpline(
-    *path, planner_data->parameters.output_path_interval, keepInputPoints(module_status_ptr_vec));
-  return std::make_shared<PathWithLaneId>(resampled_path);
-}
-
-// This is a temporary process until motion planning can take the terminal pose into account
-bool BehaviorPathPlannerNode::keepInputPoints(
-  const std::vector<std::shared_ptr<SceneModuleStatus>> & statuses) const
-{
-  const std::vector<std::string> target_modules = {"goal_planner", "avoidance"};
-
-  const auto target_status = ModuleStatus::RUNNING;
-
-  for (auto & status : statuses) {
-    if (status->is_waiting_approval || status->status == target_status) {
-      if (
-        std::find(target_modules.begin(), target_modules.end(), status->module_name) !=
-        target_modules.end()) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return std::make_shared<PathWithLaneId>(*path);
 }
 
 void BehaviorPathPlannerNode::onTrafficSignals(const TrafficLightGroupArray::ConstSharedPtr msg)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -17,11 +17,8 @@
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp"
 #include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
-#include "autoware_utils/ros/debug_publisher.hpp"
-#include "autoware_utils/system/stop_watch.hpp"
 
 #include <autoware_lanelet2_extension/utility/query.hpp>
-#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <magic_enum.hpp>
 
 #include <boost/scope_exit.hpp>


### PR DESCRIPTION
## Description

When smoothly connecting the goal to the rest of the path, the `goal_planner` removes some path points prior to the goal. When the path is turning just before the goal, this leads to the curve of the path being lost and can cause issues in the drivable area expansion feature (see https://github.com/autowarefoundation/autoware_universe/issues/9844).

This PR fixes the issue by resampling the path before generating the drivable area, instead of after.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/9844

## How was this PR tested?

Psim
Evaluator [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/39c542db-2ecf-5ded-9d84-7508f3d20d20?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
