### PR TITLE
feat(rear_collision_checker): improve collision detection logic

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
@@ -56,6 +56,7 @@
         nominal_negative_jerk: -0.6                 # [m/s^3]
 
       blind_spot:
+        lookahead_time: 4.0                         # [s]
         check:
           left: true
           right: false
@@ -64,6 +65,7 @@
           outer: 0.3                                # [m]
 
       adjacent_lane:
+        lookahead_time: 4.0                         # [s]
         offset:
           left: -0.5                                # [m]
           right: -0.5                               # [m]

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/config/rear_collision_checker.param.yaml
@@ -7,10 +7,10 @@
       pointcloud:
         range:
           dead_zone: 0.3                            # [m]
-          buffer: 3.0                               # [m]
+          buffer: 1.0                               # [m]
         crop_box_filter:
           x:
-            max: 10.0                               # [m]
+            max: 30.0                               # [m]
             min: -100.0                             # [m]
           z:
             max: -1.0                               # [m]
@@ -58,6 +58,7 @@
       blind_spot:
         lookahead_time: 4.0                         # [s]
         check:
+          front: false
           left: true
           right: false
         offset:
@@ -66,6 +67,8 @@
 
       adjacent_lane:
         lookahead_time: 4.0                         # [s]
+        check:
+          front: true
         offset:
           left: -0.5                                # [m]
           right: -0.5                               # [m]

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
@@ -139,6 +139,10 @@ rear_collision_checker_node:
         type: double
 
     blind_spot:
+      lookahead_time:
+        type: double
+        validation:
+          gt<>: [0.0]
       check:
         left:
           type: bool
@@ -151,6 +155,10 @@ rear_collision_checker_node:
           type: double
 
     adjacent_lane:
+      lookahead_time:
+        type: double
+        validation:
+          gt<>: [0.0]
       offset:
         left:
           type: double

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
@@ -144,6 +144,8 @@ rear_collision_checker_node:
         validation:
           gt<>: [0.0]
       check:
+        front:
+          type: bool
         left:
           type: bool
         right:
@@ -159,6 +161,9 @@ rear_collision_checker_node:
         type: double
         validation:
           gt<>: [0.0]
+      check:
+        front:
+          type: bool
       offset:
         left:
           type: double

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -470,7 +470,10 @@ auto RearCollisionChecker::get_pointcloud_objects(
     const auto stop_distance_ego =
       0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
 
-    const auto forward_distance = context_->vehicle_info.max_longitudinal_offset_m;
+    const auto forward_distance = p.common.pointcloud.range.buffer +
+                                  std::max(
+                                    context_->vehicle_info.max_longitudinal_offset_m,
+                                    (p.common.blind_spot.check.front ? stop_distance_ego : 0.0));
     const auto backward_distance = p.common.pointcloud.range.buffer -
                                    context_->vehicle_info.min_longitudinal_offset_m +
                                    std::max(0.0, stop_distance_object - stop_distance_ego);
@@ -491,7 +494,10 @@ auto RearCollisionChecker::get_pointcloud_objects(
     const auto stop_distance_ego =
       0.5 * std::pow(current_velocity, 2.0) / std::abs(max_deceleration_ego);
 
-    const auto forward_distance = context_->vehicle_info.max_longitudinal_offset_m;
+    const auto forward_distance = p.common.pointcloud.range.buffer +
+                                  std::max(
+                                    context_->vehicle_info.max_longitudinal_offset_m,
+                                    (p.common.adjacent_lane.check.front ? stop_distance_ego : 0.0));
     const auto backward_distance = p.common.pointcloud.range.buffer -
                                    context_->vehicle_info.min_longitudinal_offset_m +
                                    std::max(0.0, stop_distance_object - stop_distance_ego);
@@ -575,7 +581,7 @@ auto RearCollisionChecker::get_pointcloud_objects_on_adjacent_lane(
 
       if (
         opt_pointcloud_object.value().relative_distance <
-        p.common.pointcloud.range.dead_zone - context_->vehicle_info.max_longitudinal_offset_m) {
+        p.common.pointcloud.range.dead_zone - forward_distance) {
         return objects;
       }
 
@@ -620,7 +626,7 @@ auto RearCollisionChecker::get_pointcloud_objects_on_adjacent_lane(
 
       if (
         opt_pointcloud_object.value().relative_distance <
-        p.common.pointcloud.range.dead_zone - context_->vehicle_info.max_longitudinal_offset_m) {
+        p.common.pointcloud.range.dead_zone - forward_distance) {
         return objects;
       }
 
@@ -693,7 +699,7 @@ auto RearCollisionChecker::get_pointcloud_objects_at_blind_spot(
 
   if (
     opt_pointcloud_object.value().relative_distance <
-    p.common.pointcloud.range.dead_zone - context_->vehicle_info.max_longitudinal_offset_m) {
+    p.common.pointcloud.range.dead_zone - forward_distance) {
     return objects;
   }
 


### PR DESCRIPTION
## Description

This PR includes two functional improvements.

First, a new parameter named `lookahead_time` was introduced to allow more intuitive configuration of the collision detection start timing. Previously, it was difficult to adjust how far ahead collisions should be predicted, which sometimes resulted in delayed transitions to MRM just before a potential collision, as shown in the video below.

```yaml
      adjacent_lane:
        lookahead_time: 4.0                         # [s]
```

| BEFORE | AFTER |
| --- | --- |
|  <video src="https://github.com/user-attachments/assets/8779f5e4-ad20-4266-932a-460b055e8673"/> |  <video src="https://github.com/user-attachments/assets/171a5b6e-b88c-439d-a9d8-e950af121cd9"/> |

Second, the collision detection logic was extended to include objects located in front of the ego vehicle. Previously, such objects were excluded from collision checks, which led to situations like the one shown in the video below, where AEB did not activate. To address this, RCC was enhanced to predict collisions with forward objects as well. Whether or not to predict collisions with forward objects can be configured using the following parameter.

```yaml
      adjacent_lane:
        ...
        check:
          front: true
```

| BEFORE | AFTER |
| --- | --- |
|  <video src="https://github.com/user-attachments/assets/a40bb0c8-83e1-4815-96e3-b6c40f3f8fef"/> |  <video src="https://github.com/user-attachments/assets/fdbe81b8-5f7f-4a9f-b114-ece420265f58"/> |

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
