### PR TITLE
feat(autoware_cuda_utils): add thrust utils

### DIFF
--- a/sensing/autoware_cuda_utils/CMakeLists.txt
+++ b/sensing/autoware_cuda_utils/CMakeLists.txt
@@ -23,6 +23,7 @@ if(BUILD_TESTING)
     test/test_cuda_unique_ptr.cu
     test/test_cuda_utils.cu
     test/test_stream_unique_ptr.cu
+    test/test_thrust_utils.cu
     test/test_main.cpp
   )
 

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/thrust_utils.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/thrust_utils.hpp
@@ -1,0 +1,82 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_UTILS__THRUST_UTILS_HPP_
+#define AUTOWARE__CUDA_UTILS__THRUST_UTILS_HPP_
+
+#include <cuda_runtime_api.h>
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+
+namespace autoware::cuda_utils
+{
+
+[[nodiscard]] inline auto thrust_on_stream(cudaStream_t stream)
+{
+  return thrust::cuda::par.on(stream);
+}
+
+namespace thrust_stream
+{
+
+template <typename T, typename AllocT>
+void fill(
+  typename thrust::device_vector<T, AllocT>::iterator first,
+  typename thrust::device_vector<T, AllocT>::iterator last, const T & value, cudaStream_t stream)
+{
+  thrust::fill(thrust_on_stream(stream), first, last, value);
+}
+
+template <typename T, typename AllocT>
+void fill(thrust::device_vector<T, AllocT> & vec, const T & value, cudaStream_t stream)
+{
+  fill<T, AllocT>(vec.begin(), vec.end(), value, stream);
+}
+
+template <typename T, typename AllocT>
+void fill_n(
+  typename thrust::device_vector<T, AllocT>::iterator first, std::size_t n, const T & value,
+  cudaStream_t stream)
+{
+  thrust::fill_n(thrust_on_stream(stream), first, n, value);
+}
+
+template <typename T, typename AllocT>
+void fill_n(
+  thrust::device_vector<T, AllocT> & vec, std::size_t n, const T & value, cudaStream_t stream)
+{
+  fill_n<T, AllocT>(vec.begin(), n, value, stream);
+}
+
+template <typename T, typename AllocT>
+auto count(
+  typename thrust::device_vector<T, AllocT>::iterator first,
+  typename thrust::device_vector<T, AllocT>::iterator last, const T & value, cudaStream_t stream)
+{
+  return thrust::count(thrust_on_stream(stream), first, last, value);
+}
+
+template <typename T, typename AllocT>
+auto count(thrust::device_vector<T, AllocT> & vec, const T & value, cudaStream_t stream)
+{
+  return count<T, AllocT>(vec.begin(), vec.end(), value, stream);
+}
+
+}  // namespace thrust_stream
+
+}  // namespace autoware::cuda_utils
+
+#endif  // AUTOWARE__CUDA_UTILS__THRUST_UTILS_HPP_

--- a/sensing/autoware_cuda_utils/test/test_thrust_utils.cu
+++ b/sensing/autoware_cuda_utils/test/test_thrust_utils.cu
@@ -73,14 +73,15 @@ TEST_F(ThrustUtilsTest, CountFunctionality)
 {
   auto stream = autoware::cuda_utils::makeCudaStream();
 
-  thrust::device_vector<int> vec(6);
-  thrust::fill(vec.begin(), vec.end(), 1);
-  thrust::fill(vec.begin() + 2, vec.end() - 1, 0);  // Set last 3 elements to 0
+  thrust::device_vector<int> vec(20);
+  thrust::fill(vec.begin(), vec.end(), 0);
+  thrust::fill(vec.begin(), vec.begin() + 3, 1);  // Three '1's at the beginning
+  thrust::fill(vec.end() - 3, vec.end(), 1);      // Three '1's at the end
 
   long count = autoware::cuda_utils::thrust_stream::count(vec, 1, *stream);
 
   // Synchronize to ensure the operation completed
   cudaStreamSynchronize(*stream);
 
-  EXPECT_EQ(count, 3);  // There are three '1's in the vector
+  EXPECT_EQ(count, 6);  // There are six '1's in the vector
 }

--- a/sensing/autoware_cuda_utils/test/test_thrust_utils.cu
+++ b/sensing/autoware_cuda_utils/test/test_thrust_utils.cu
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/cuda_utils/cuda_gtest_utils.hpp"
 #include "autoware/cuda_utils/stream_unique_ptr.hpp"
 
 #include <autoware/cuda_utils/thrust_utils.hpp>
@@ -19,7 +20,11 @@
 #include <gtest/gtest.h>
 #include <thrust/logical.h>
 
-TEST(ThrustUtilsTest, ThrustOnStreamFunction)
+class ThrustUtilsTest : public autoware::cuda_utils::CudaTest
+{
+};
+
+TEST_F(ThrustUtilsTest, ThrustOnStreamFunction)
 {
   // Test that thrust_on_stream returns a valid execution policy
   cudaStream_t stream{};
@@ -33,7 +38,7 @@ TEST(ThrustUtilsTest, ThrustOnStreamFunction)
   cudaStreamDestroy(stream);
 }
 
-TEST(ThrustUtilsTest, FillFunctionality)
+TEST_F(ThrustUtilsTest, FillFunctionality)
 {
   auto stream = autoware::cuda_utils::makeCudaStream();
 
@@ -46,7 +51,7 @@ TEST(ThrustUtilsTest, FillFunctionality)
   // Check if all elements are filled with 42
   EXPECT_EQ(thrust::count(vec.begin(), vec.end(), 42), 100);
 }
-TEST(ThrustUtilsTest, FillNFunctionality)
+TEST_F(ThrustUtilsTest, FillNFunctionality)
 {
   auto stream = autoware::cuda_utils::makeCudaStream();
 
@@ -64,7 +69,7 @@ TEST(ThrustUtilsTest, FillNFunctionality)
   EXPECT_EQ(thrust::count(vec.begin() + 50, vec.end(), 0), 50);
 }
 
-TEST(ThrustUtilsTest, CountFunctionality)
+TEST_F(ThrustUtilsTest, CountFunctionality)
 {
   auto stream = autoware::cuda_utils::makeCudaStream();
 

--- a/sensing/autoware_cuda_utils/test/test_thrust_utils.cu
+++ b/sensing/autoware_cuda_utils/test/test_thrust_utils.cu
@@ -1,0 +1,81 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_utils/stream_unique_ptr.hpp"
+
+#include <autoware/cuda_utils/thrust_utils.hpp>
+
+#include <gtest/gtest.h>
+#include <thrust/logical.h>
+
+TEST(ThrustUtilsTest, ThrustOnStreamFunction)
+{
+  // Test that thrust_on_stream returns a valid execution policy
+  cudaStream_t stream{};
+  cudaStreamCreate(&stream);
+
+  auto policy = autoware::cuda_utils::thrust_on_stream(stream);
+  // If this compiles and runs without error, the function works
+  (void)policy;  // Suppress unused variable warning
+  SUCCEED();
+
+  cudaStreamDestroy(stream);
+}
+
+TEST(ThrustUtilsTest, FillFunctionality)
+{
+  auto stream = autoware::cuda_utils::makeCudaStream();
+
+  thrust::device_vector<int> vec(100, 0);
+  autoware::cuda_utils::thrust_stream::fill(vec, 42, *stream);
+
+  // Synchronize to ensure the operation completed
+  cudaStreamSynchronize(*stream);
+
+  // Check if all elements are filled with 42
+  EXPECT_EQ(thrust::count(vec.begin(), vec.end(), 42), 100);
+}
+TEST(ThrustUtilsTest, FillNFunctionality)
+{
+  auto stream = autoware::cuda_utils::makeCudaStream();
+
+  thrust::device_vector<int> vec(100);
+  thrust::fill(vec.begin(), vec.end(), 0);  // Initialize with zeros
+
+  autoware::cuda_utils::thrust_stream::fill_n(vec, 50, 99, *stream);
+
+  // Synchronize to ensure the operation completed
+  cudaStreamSynchronize(*stream);
+
+  // Check if the first 50 elements are filled with 99
+  EXPECT_EQ(thrust::count(vec.begin(), vec.begin() + 50, 99), 50);
+  // Check if the rest are still zero
+  EXPECT_EQ(thrust::count(vec.begin() + 50, vec.end(), 0), 50);
+}
+
+TEST(ThrustUtilsTest, CountFunctionality)
+{
+  auto stream = autoware::cuda_utils::makeCudaStream();
+
+  thrust::device_vector<int> vec(6);
+  thrust::fill(vec.begin(), vec.end(), 1);
+  thrust::fill(vec.begin() + 2, vec.end() - 1, 0);  // Set last 3 elements to 0
+
+  long count = autoware::cuda_utils::thrust_stream::count(vec, 1, *stream);
+
+  // Synchronize to ensure the operation completed
+  cudaStreamSynchronize(*stream);
+
+  EXPECT_EQ(count, 3);  // There are three '1's in the vector
+}


### PR DESCRIPTION
## Description

Add functions that facilitate the use of Thrust on specific CUDA streams.
This PR is a prerequisite for the thrust-on-stream performance optimization for `autoware_cuda_pointcloud_preprocessor`.

This PR adds the following:
* a `autoware/cuda_utils/thrust_utils.hpp` header
  * a `thrust_on_stream(stream)` function to get a Thrust execution policy that executes on the stream
  * a `thrust_stream` namespace containing convenient wrappers around `thrust::fill`, `thrust::count` etc. that take a `stream` argument
* unit tests for the above functionality

### Usage

```c++
thrust::fill(thrust_on_stream(my_stream), decive_vec.begin(), device_vec.end(), 42.0);
thrust_stream::fill(decive_vec.begin(), device_vec.end(), 42.0, my_stream);
thrust_stream::fill(device_vec, 42.0, my_stream);

// The same APIs exist for these functions as well:
thrust_stream::fill_n(device_vec, 10, 42.0, my_stream);
size_t result = thrust_stream::count(device_vec, 42.0, my_stream);
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Unit tests pass.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
