### PR TITLE
perf(autoware_cuda_pointcloud_preprocessor): execute thrust operations on the node's own CUDA stream

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -20,6 +20,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <autoware/cuda_utils/thrust_utils.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -67,6 +67,8 @@ public:
     const std::uint32_t first_point_rel_stamp_nsec);
 
 private:
+  static cudaStream_t initialize_stream();
+
   void organizePointcloud();
 
   CropBoxParameters self_crop_box_parameters_{};
@@ -112,7 +114,6 @@ private:
   thrust::device_vector<std::uint32_t> device_indices_;
   thrust::device_vector<TwistStruct2D> device_twist_2d_structs_;
   thrust::device_vector<TwistStruct3D> device_twist_3d_structs_;
-  thrust::device_vector<CropBoxParameters> host_crop_box_structs_;
   thrust::device_vector<CropBoxParameters> device_crop_box_structs_;
 };
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/organize_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/organize_kernels.hpp
@@ -24,7 +24,7 @@ namespace autoware::cuda_pointcloud_preprocessor
 
 std::size_t querySortWorkspace(
   int num_items, int num_segments, int * offsets_device, std::uint32_t * keys_in_device,
-  std::uint32_t * keys_out_device);
+  std::uint32_t * keys_out_device, cudaStream_t & stream);
 
 void organizeLaunch(
   const InputPointType * input_points, std::uint32_t * index_tensor, std::int32_t * ring_indexes,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/types.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/types.hpp
@@ -15,10 +15,7 @@
 #ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__TYPES_HPP_
 #define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__TYPES_HPP_
 
-#include <cuda_runtime.h>
-
 #include <cmath>
-#include <cstddef>
 #include <cstdint>
 
 namespace autoware::cuda_pointcloud_preprocessor
@@ -76,26 +73,6 @@ struct RingOutlierFilterParameters
 {
   float distance_ratio{std::nanf("")};
   float object_length_threshold{std::nanf("")};
-};
-
-template <typename T>
-class MemoryPoolAllocator
-{
-public:
-  using value_type = T;
-  explicit MemoryPoolAllocator(cudaMemPool_t pool) : m_pool(pool) {}
-
-  T * allocate(std::size_t n)
-  {
-    void * ptr = nullptr;
-    cudaMallocFromPoolAsync(&ptr, n * sizeof(T), m_pool, cudaStreamDefault);
-    return static_cast<T *>(ptr);
-  }
-
-  void deallocate(T * ptr, std::size_t) { cudaFreeAsync(ptr, cudaStreamDefault); }
-
-protected:
-  cudaMemPool_t m_pool;
 };
 }  // namespace autoware::cuda_pointcloud_preprocessor
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -24,6 +24,7 @@
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 #include <autoware/cuda_utils/cuda_check_error.hpp>
+#include <autoware/cuda_utils/thrust_utils.hpp>
 #include <cub/cub.cuh>
 
 #include <sensor_msgs/msg/point_field.hpp>
@@ -35,8 +36,12 @@
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 
+#include <cstdint>
+
 namespace autoware::cuda_pointcloud_preprocessor
 {
+
+namespace thrust_stream = cuda_utils::thrust_stream;
 
 CudaPointcloudPreprocessor::CudaPointcloudPreprocessor()
 {
@@ -125,20 +130,15 @@ CudaPointcloudPreprocessor::CudaPointcloudPreprocessor()
     thrust::device_vector<InputPointType, MemoryPoolAllocator<InputPointType>>(allocator_points);
   device_organized_points_.resize(num_organized_points_);
 
-  CHECK_CUDA_ERROR(cudaMemsetAsync(
-    thrust::raw_pointer_cast(device_max_ring_.data()), 0, sizeof(std::int32_t), stream_));
-  CHECK_CUDA_ERROR(cudaMemsetAsync(
-    thrust::raw_pointer_cast(device_max_points_per_ring_.data()), 0, sizeof(std::int32_t),
-    stream_));
-  CHECK_CUDA_ERROR(cudaMemsetAsync(
-    thrust::raw_pointer_cast(device_indexes_tensor_.data()), 0x255, sizeof(std::uint32_t),
-    stream_));
+  thrust_stream::fill(device_max_ring_, 0, stream_);
+  thrust_stream::fill(device_max_points_per_ring_, 0, stream_);
+  thrust_stream::fill(device_indexes_tensor_, UINT32_MAX, stream_);
 
   sort_workspace_bytes_ = querySortWorkspace(
     num_rings_ * max_points_per_ring_, num_rings_,
     thrust::raw_pointer_cast(device_segment_offsets_.data()),
     thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-    thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()));
+    thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
 
   device_sort_workspace_ =
     thrust::device_vector<std::uint8_t, MemoryPoolAllocator<std::uint8_t>>(allocator_uint8);
@@ -182,12 +182,10 @@ void CudaPointcloudPreprocessor::preallocateOutput()
 
 void CudaPointcloudPreprocessor::organizePointcloud()
 {
-  CHECK_CUDA_ERROR(cudaMemsetAsync(
-    thrust::raw_pointer_cast(device_ring_index_.data()), 0, num_rings_ * sizeof(std::int32_t),
-    stream_));
-  CHECK_CUDA_ERROR(cudaMemsetAsync(
-    thrust::raw_pointer_cast(device_indexes_tensor_.data()), num_raw_points_,
-    num_organized_points_ * sizeof(std::uint32_t), stream_));
+  thrust_stream::fill_n(device_ring_index_, num_rings_, 0, stream_);
+  thrust_stream::fill_n(
+    device_indexes_tensor_, num_organized_points_, static_cast<std::uint32_t>(num_raw_points_),
+    stream_);
 
   if (num_raw_points_ == 0) {
     output_pointcloud_ptr_->data.reset();
@@ -222,30 +220,27 @@ void CudaPointcloudPreprocessor::organizePointcloud()
     num_organized_points_ = num_rings_ * max_points_per_ring_;
 
     device_ring_index_.resize(num_rings_);
-    thrust::fill(device_ring_index_.begin(), device_ring_index_.end(), 0);
+    thrust_stream::fill(device_ring_index_, 0, stream_);
     device_indexes_tensor_.resize(num_organized_points_);
-    thrust::fill(device_indexes_tensor_.begin(), device_indexes_tensor_.end(), num_raw_points_);
+    thrust_stream::fill<uint32_t>(device_indexes_tensor_, num_raw_points_, stream_);
     device_sorted_indexes_tensor_.resize(num_organized_points_);
-    thrust::fill(
-      device_sorted_indexes_tensor_.begin(), device_sorted_indexes_tensor_.end(), num_raw_points_);
+    thrust_stream::fill<uint32_t>(device_sorted_indexes_tensor_, num_raw_points_, stream_);
     device_segment_offsets_.resize(num_rings_ + 1);
     device_organized_points_.resize(num_organized_points_);
-    thrust::fill(
-      device_organized_points_.begin(), device_organized_points_.end(), InputPointType{});
+    thrust_stream::fill(device_organized_points_, InputPointType{}, stream_);
 
     device_transformed_points_.resize(num_organized_points_);
-    thrust::fill(
-      device_transformed_points_.begin(), device_transformed_points_.end(), InputPointType{});
+    thrust_stream::fill(device_transformed_points_, InputPointType{}, stream_);
     device_crop_mask_.resize(num_organized_points_);
-    thrust::fill(device_crop_mask_.begin(), device_crop_mask_.end(), 0);
+    thrust_stream::fill(device_crop_mask_, 0U, stream_);
     device_nan_mask_.resize(num_organized_points_);
-    thrust::fill(device_nan_mask_.begin(), device_nan_mask_.end(), 0);
+    thrust_stream::fill<uint8_t>(device_nan_mask_, 0, stream_);
     device_mismatch_mask_.resize(num_organized_points_);
-    thrust::fill(device_mismatch_mask_.begin(), device_mismatch_mask_.end(), 0);
+    thrust_stream::fill<uint8_t>(device_mismatch_mask_, 0, stream_);
     device_ring_outlier_mask_.resize(num_organized_points_);
-    thrust::fill(device_ring_outlier_mask_.begin(), device_ring_outlier_mask_.end(), 0);
+    thrust_stream::fill(device_ring_outlier_mask_, 0U, stream_);
     device_indices_.resize(num_organized_points_);
-    thrust::fill(device_indices_.begin(), device_indices_.end(), 0);
+    thrust_stream::fill(device_indices_, 0U, stream_);
 
     preallocateOutput();
 
@@ -268,7 +263,7 @@ void CudaPointcloudPreprocessor::organizePointcloud()
     sort_workspace_bytes_ = querySortWorkspace(
       num_organized_points_, num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
       thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()));
+      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
     device_sort_workspace_.resize(sort_workspace_bytes_);
 
     organizeLaunch(
@@ -287,7 +282,7 @@ void CudaPointcloudPreprocessor::organizePointcloud()
       num_organized_points_ * sizeof(std::uint32_t), cudaMemcpyDeviceToDevice, stream_));
   } else {
     cub::DeviceSegmentedRadixSort::SortKeys(
-      reinterpret_cast<void *>(thrust::raw_pointer_cast(device_sort_workspace_.data())),
+      reinterpret_cast<void *>(thrust::raw_pointer_cast(device_sort_workspace_.data())),  // NOLINT
       sort_workspace_bytes_, thrust::raw_pointer_cast(device_indexes_tensor_.data()),
       thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), num_organized_points_,
       num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
@@ -296,7 +291,7 @@ void CudaPointcloudPreprocessor::organizePointcloud()
   }
 
   // reuse device_indexes_tensor_ to store valid point location
-  thrust::fill(device_indexes_tensor_.begin(), device_indexes_tensor_.end(), 0);
+  thrust_stream::fill(device_indexes_tensor_, 0U, stream_);
 
   const int organized_points_blocks_per_grid =
     (num_organized_points_ + threads_per_block_ - 1) / threads_per_block_;
@@ -340,8 +335,8 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   }
 
   // Reset all contents in the device vector
-  thrust::fill(device_input_points_.begin(), device_input_points_.end(), InputPointType{});
-  thrust::fill(device_organized_points_.begin(), device_organized_points_.end(), InputPointType{});
+  thrust_stream::fill(device_input_points_, InputPointType{}, stream_);
+  thrust_stream::fill(device_organized_points_, InputPointType{}, stream_);
 
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     thrust::raw_pointer_cast(device_input_points_.data()), input_pointcloud_msg.data.data(),
@@ -352,12 +347,11 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   organizePointcloud();
 
   // Reset all contents in the device vector
-  thrust::fill(
-    device_transformed_points_.begin(), device_transformed_points_.end(), InputPointType{});
-  thrust::fill(device_ring_outlier_mask_.begin(), device_ring_outlier_mask_.end(), 0);
-  thrust::fill(device_mismatch_mask_.begin(), device_mismatch_mask_.end(), 0);
-  thrust::fill(device_nan_mask_.begin(), device_nan_mask_.end(), 0);
-  thrust::fill(device_crop_mask_.begin(), device_crop_mask_.end(), 0);
+  thrust_stream::fill(device_transformed_points_, InputPointType{}, stream_);
+  thrust_stream::fill<uint32_t>(device_ring_outlier_mask_, 0, stream_);
+  thrust_stream::fill<uint8_t>(device_mismatch_mask_, 0, stream_);
+  thrust_stream::fill<uint8_t>(device_nan_mask_, 0, stream_);
+  thrust_stream::fill<uint32_t>(device_crop_mask_, 0, stream_);
 
   tf2::Quaternion rotation_quaternion(
     transform_msg.transform.rotation.x, transform_msg.transform.rotation.y,
@@ -425,7 +419,7 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
       static_cast<int>(host_crop_box_structs_.size()), crop_box_blocks_per_grid, threads_per_block_,
       stream_);
   } else {
-    thrust::fill_n(thrust::device, device_crop_mask, num_organized_points_, 1);
+    thrust_stream::fill_n(device_crop_mask_, num_organized_points_, 1U, stream_);
   }
 
   // Undistortion
@@ -461,8 +455,8 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     device_ring_outlier_mask, threads_per_block_, blocks_per_grid, stream_);
 
   thrust::inclusive_scan(
-    thrust::device, device_ring_outlier_mask, device_ring_outlier_mask + num_organized_points_,
-    device_indices);
+    cuda_utils::thrust_on_stream(stream_), device_ring_outlier_mask,
+    device_ring_outlier_mask + num_organized_points_, device_indices);
 
   int num_output_points{};
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
@@ -472,14 +466,9 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 
   // Get information and extract points after filters
-  size_t num_crop_box_passed_points =
-    thrust::count(thrust::device, device_crop_mask_.begin(), device_crop_mask_.end(), 1);
-
-  size_t num_nan_points =
-    thrust::count(thrust::device, device_nan_mask_.begin(), device_nan_mask_.end(), 1);
-
-  size_t mismatch_count =
-    thrust::count(thrust::device, device_mismatch_mask_.begin(), device_mismatch_mask_.end(), 1);
+  size_t num_crop_box_passed_points = thrust_stream::count(device_crop_mask_, 1U, stream_);
+  size_t num_nan_points = thrust_stream::count<uint8_t>(device_nan_mask_, 1, stream_);
+  size_t mismatch_count = thrust_stream::count<uint8_t>(device_mismatch_mask_, 1, stream_);
 
   stats_.num_nan_points = static_cast<int>(num_nan_points);
   stats_.num_crop_box_passed_points = static_cast<int>(num_crop_box_passed_points);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/organize_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/organize_kernels.cu
@@ -75,14 +75,20 @@ __global__ void gatherKernel(
 
 std::size_t querySortWorkspace(
   int num_items, int num_segments, int * offsets_device, std::uint32_t * keys_in_device,
-  std::uint32_t * keys_out_device)
+  std::uint32_t * keys_out_device, cudaStream_t & stream)
 {
   // Determine temporary device storage requirements
   void * temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
+
+  // Same as the default SortKeys arguments. Needed because the `stream` argument comes after them,
+  // so they have to be handed to the function as well.
+  int begin_bit = 0;
+  int end_bit = sizeof(std::uint32_t) * 8;
+
   CHECK_CUDA_ERROR(cub::DeviceSegmentedRadixSort::SortKeys(
     temp_storage, temp_storage_bytes, keys_in_device, keys_out_device, num_items, num_segments,
-    offsets_device, offsets_device + 1));
+    offsets_device, offsets_device + 1, begin_bit, end_bit, stream));
 
   return temp_storage_bytes;
 }


### PR DESCRIPTION
## Description

This PR replaces all `thrust::` algorithm calls with their `thrust_stream::` equivalents that were introduced in #10997.
Thrust executes algorithms operating on device vectors on the process's default stream by default, and `thrust_stream` ensures execution on the stream the user provided.

Since Autoware CUDA Pointcloud Preprocessor is using CUDA Blackboard which requires all GPU data pub/sub to be done in one process, multiple CUDA-based nodes are commonly launched into the same node container (= process).
Thus, nodes triggering a sync on the default stream might cause delays and inefficiencies for other nodes in the container.

This PR reduces the `39.2%` default stream utilization to just `0.3%` -- a 130x improvement :innocent: 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Ran on software version [TIER IV INTERNAL](https://github.com/tier4/pilot-auto.x2/tree/sensing/beta/v4.3), on data [TIER IV INTERNAL](https://console.mob.tier4.jp/projects/x2_dev/rosbag?viz=stream&agg=count&from_ts=1737521882&to_ts=1753160282&live=true&query=log_file_name%3A%28b364d6c9-a553-42b1-842b-6afd55d3b268_2025-04-23-15-37-43%29&file_id=4e333ff5-4cae-4916-82d2-63ea9714dbbe).

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Expected performance increase in LiDAR pipeline, including Centerpoint. Less contention on default stream.
