### PR TITLE
test(cuda_utils): add unit tests, CUDA test helpers that skip if no CUDA device is available

### DIFF
--- a/sensing/autoware_cuda_utils/CMakeLists.txt
+++ b/sensing/autoware_cuda_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22)
 project(autoware_cuda_utils)
 
 find_package(autoware_cmake REQUIRED)
@@ -14,8 +14,32 @@ endif()
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-endif()
 
-ament_export_dependencies(CUDA)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_find_gtest()
+
+  cuda_add_executable(test_autoware_cuda_utils
+    test/test_cuda_check_error.cu
+    test/test_cuda_unique_ptr.cu
+    test/test_cuda_utils.cu
+    test/test_stream_unique_ptr.cu
+    test/test_main.cpp
+  )
+
+  target_link_libraries(test_autoware_cuda_utils
+    ${GTEST_LIBRARIES}
+    ${GTEST_MAIN_LIBRARIES}
+  )
+
+  target_include_directories(test_autoware_cuda_utils
+    PRIVATE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+    SYSTEM
+    ${GTEST_INCLUDE_DIRS}
+  )
+
+  ament_add_gtest_test(test_autoware_cuda_utils)
+endif()
 
 ament_auto_package()

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_gtest_utils.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_gtest_utils.hpp
@@ -1,0 +1,67 @@
+// Copyright 2022 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code is licensed under CC0 1.0 Universal (Public Domain).
+// You can use this without any limitation.
+// https://creativecommons.org/publicdomain/zero/1.0/deed.en
+// borrowed from https://proc-cpuinfo.fixstars.com/2019/02/cuda_smart_pointer/
+
+#ifndef AUTOWARE__CUDA_UTILS__CUDA_GTEST_UTILS_HPP_
+#define AUTOWARE__CUDA_UTILS__CUDA_GTEST_UTILS_HPP_
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#define SKIP_TEST_IF_CUDA_UNAVAILABLE()                              \
+  if (!autoware::cuda_utils::is_cuda_runtime_available()) {          \
+    GTEST_SKIP() << "CUDA runtime is not available. Skipping test."; \
+  }
+
+namespace autoware::cuda_utils
+{
+
+/**
+ * @brief Check if CUDA is available at runtime.
+ * @return true if CUDA is available, false otherwise.
+ */
+inline bool is_cuda_runtime_available()
+{
+  int device_count = 0;
+  cudaError_t error = cudaGetDeviceCount(&device_count);
+  return (error == cudaSuccess && device_count > 0);
+}
+
+/**
+ * @brief Base class for CUDA-related tests that runs only if CUDA is available.
+ *
+ * Usage: Inherit from this class and use the child class as a test fixture.
+ * Example:
+ *
+ * ```c++
+ * class MyTestSuite : public autoware::cuda_utils::CudaTest {};
+ *
+ * TEST_F(MyTestSuite, MyTest) {
+ *   // Your test code here
+ * }
+ * ```
+ */
+class CudaTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { SKIP_TEST_IF_CUDA_UNAVAILABLE(); }
+};
+
+}  // namespace autoware::cuda_utils
+
+#endif  // AUTOWARE__CUDA_UTILS__CUDA_GTEST_UTILS_HPP_

--- a/sensing/autoware_cuda_utils/package.xml
+++ b/sensing/autoware_cuda_utils/package.xml
@@ -16,6 +16,7 @@
 
   <depend>autoware_cuda_dependency_meta</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/sensing/autoware_cuda_utils/test/test_cuda_check_error.cu
+++ b/sensing/autoware_cuda_utils/test/test_cuda_check_error.cu
@@ -1,0 +1,32 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+TEST(CudaCheckErrorTest, MacroUsageWithSuccess)
+{
+  // Test the CHECK_CUDA_ERROR macro with success - should not throw
+  EXPECT_NO_THROW(CHECK_CUDA_ERROR(cudaSuccess));
+}
+
+TEST(CudaCheckErrorTest, MacroUsageWithError)
+{
+  // Test the CHECK_CUDA_ERROR macro with error - should throw
+  EXPECT_THROW(CHECK_CUDA_ERROR(cudaErrorInvalidValue), std::runtime_error);
+}

--- a/sensing/autoware_cuda_utils/test/test_cuda_unique_ptr.cu
+++ b/sensing/autoware_cuda_utils/test/test_cuda_unique_ptr.cu
@@ -13,19 +13,24 @@
 // limitations under the License.
 
 #include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_gtest_utils.hpp"
 #include "autoware/cuda_utils/cuda_unique_ptr.hpp"
 
 #include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 
-TEST(CudaUniquePtrTest, MakeUniqueDeviceMemory)
+class CudaUniquePtrTest : public autoware::cuda_utils::CudaTest
+{
+};
+
+TEST_F(CudaUniquePtrTest, MakeUniqueDeviceMemory)
 {
   // Test creating a single object on device
   auto ptr = autoware::cuda_utils::make_unique<float>();
   EXPECT_NE(ptr.get(), nullptr);
 }
 
-TEST(CudaUniquePtrTest, MakeUniqueDeviceArray)
+TEST_F(CudaUniquePtrTest, MakeUniqueDeviceArray)
 {
   // Test creating an array on device
   auto ptr = autoware::cuda_utils::make_unique<float[]>(100);
@@ -37,7 +42,7 @@ TEST(CudaUniquePtrTest, MakeUniqueDeviceArray)
   EXPECT_EQ(attributes.devicePointer, ptr.get());
 }
 
-TEST(CudaUniquePtrTest, MakeUniqueHostMemory)
+TEST_F(CudaUniquePtrTest, MakeUniqueHostMemory)
 {
   // Test creating a single object on host
   auto ptr = autoware::cuda_utils::make_unique_host<float>();
@@ -49,14 +54,14 @@ TEST(CudaUniquePtrTest, MakeUniqueHostMemory)
   EXPECT_EQ(attributes.hostPointer, ptr.get());
 }
 
-TEST(CudaUniquePtrTest, MakeUniqueHostArray)
+TEST_F(CudaUniquePtrTest, MakeUniqueHostArray)
 {
   // Test creating an array on host
   auto ptr = autoware::cuda_utils::make_unique_host<float[]>(100, cudaHostAllocDefault);
   EXPECT_NE(ptr.get(), nullptr);
 }
 
-TEST(CudaUniquePtrTest, DeleterFunctionality)
+TEST_F(CudaUniquePtrTest, DeleterFunctionality)
 {
   // Test that CudaDeleter and CudaDeleterHost types exist and are usable
   {

--- a/sensing/autoware_cuda_utils/test/test_cuda_unique_ptr.cu
+++ b/sensing/autoware_cuda_utils/test/test_cuda_unique_ptr.cu
@@ -75,5 +75,8 @@ TEST_F(CudaUniquePtrTest, DeleterFunctionality)
   }
 
   // If we reach here without crashes, deleters worked correctly
+  // TODO: Ideally, we would confirm that the memory was freed, but CUDA provides no API for that.
+  // Instead, calling any CUDA API on a freed pointer is undefined behavior and usually results in a
+  // SEGFAULT.
   SUCCEED();
 }

--- a/sensing/autoware_cuda_utils/test/test_cuda_unique_ptr.cu
+++ b/sensing/autoware_cuda_utils/test/test_cuda_unique_ptr.cu
@@ -1,0 +1,74 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_unique_ptr.hpp"
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+TEST(CudaUniquePtrTest, MakeUniqueDeviceMemory)
+{
+  // Test creating a single object on device
+  auto ptr = autoware::cuda_utils::make_unique<float>();
+  EXPECT_NE(ptr.get(), nullptr);
+}
+
+TEST(CudaUniquePtrTest, MakeUniqueDeviceArray)
+{
+  // Test creating an array on device
+  auto ptr = autoware::cuda_utils::make_unique<float[]>(100);
+  EXPECT_NE(ptr.get(), nullptr);
+
+  cudaPointerAttributes attributes{};
+  CHECK_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr.get()));
+  EXPECT_EQ(attributes.type, cudaMemoryTypeDevice);
+  EXPECT_EQ(attributes.devicePointer, ptr.get());
+}
+
+TEST(CudaUniquePtrTest, MakeUniqueHostMemory)
+{
+  // Test creating a single object on host
+  auto ptr = autoware::cuda_utils::make_unique_host<float>();
+  EXPECT_NE(ptr.get(), nullptr);
+
+  cudaPointerAttributes attributes{};
+  CHECK_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr.get()));
+  EXPECT_EQ(attributes.type, cudaMemoryTypeHost);
+  EXPECT_EQ(attributes.hostPointer, ptr.get());
+}
+
+TEST(CudaUniquePtrTest, MakeUniqueHostArray)
+{
+  // Test creating an array on host
+  auto ptr = autoware::cuda_utils::make_unique_host<float[]>(100, cudaHostAllocDefault);
+  EXPECT_NE(ptr.get(), nullptr);
+}
+
+TEST(CudaUniquePtrTest, DeleterFunctionality)
+{
+  // Test that CudaDeleter and CudaDeleterHost types exist and are usable
+  {
+    auto ptr = autoware::cuda_utils::make_unique<int>();
+    // Deleter will be called automatically on scope exit
+  }
+
+  {
+    auto ptr = autoware::cuda_utils::make_unique_host<int>();
+    // Deleter will be called automatically on scope exit
+  }
+
+  // If we reach here without crashes, deleters worked correctly
+  SUCCEED();
+}

--- a/sensing/autoware_cuda_utils/test/test_cuda_utils.cu
+++ b/sensing/autoware_cuda_utils/test/test_cuda_utils.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_gtest_utils.hpp"
 #include "autoware/cuda_utils/cuda_utils.hpp"
 
 #include <cuda_runtime_api.h>
@@ -20,6 +21,8 @@
 
 TEST(CudaUtilsTest, ClearAsyncFunction)
 {
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
   // Create a CUDA stream for testing
   cudaStream_t stream{};
   CHECK_CUDA_ERROR(cudaStreamCreate(&stream));

--- a/sensing/autoware_cuda_utils/test/test_cuda_utils.cu
+++ b/sensing/autoware_cuda_utils/test/test_cuda_utils.cu
@@ -1,0 +1,41 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_utils.hpp"
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+TEST(CudaUtilsTest, ClearAsyncFunction)
+{
+  // Create a CUDA stream for testing
+  cudaStream_t stream{};
+  CHECK_CUDA_ERROR(cudaStreamCreate(&stream));
+
+  // Allocate some device memory
+  float * device_ptr{};
+  CHECK_CUDA_ERROR(
+    cudaMalloc(reinterpret_cast<void **>(&device_ptr), 100 * sizeof(float)));  // NOLINT
+
+  // Test the clear_async function
+  EXPECT_NO_THROW(autoware::cuda_utils::clear_async(device_ptr, 100, stream));
+
+  // Synchronize to ensure the operation completed
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream));
+
+  // Clean up
+  CHECK_CUDA_ERROR(cudaFree(device_ptr));
+  CHECK_CUDA_ERROR(cudaStreamDestroy(stream));
+}

--- a/sensing/autoware_cuda_utils/test/test_main.cpp
+++ b/sensing/autoware_cuda_utils/test/test_main.cpp
@@ -1,0 +1,21 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/sensing/autoware_cuda_utils/test/test_stream_unique_ptr.cu
+++ b/sensing/autoware_cuda_utils/test/test_stream_unique_ptr.cu
@@ -1,0 +1,78 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <autoware/cuda_utils/stream_unique_ptr.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(StreamUniquePtrTest, MakeCudaStreamDefault)
+{
+  // Test creating a CUDA stream with default flags
+  auto stream = autoware::cuda_utils::makeCudaStream();
+  EXPECT_NE(stream.get(), nullptr);
+
+  // Check that the stream is valid
+  cudaStream_t raw_stream = *stream.get();
+  EXPECT_EQ(cudaStreamQuery(raw_stream), cudaSuccess);
+}
+
+TEST(StreamUniquePtrTest, MakeCudaStreamWithFlags)
+{
+  // Test creating a CUDA stream with custom flags
+  auto stream = autoware::cuda_utils::makeCudaStream(cudaStreamNonBlocking);
+  EXPECT_NE(stream.get(), nullptr);
+
+  // Check that the stream is valid
+  cudaStream_t raw_stream = *stream.get();
+  EXPECT_EQ(cudaStreamQuery(raw_stream), cudaSuccess);
+
+  // Check that the stream is non-blocking
+  unsigned int flags{};
+  CHECK_CUDA_ERROR(cudaStreamGetFlags(raw_stream, &flags));
+  EXPECT_EQ(flags, cudaStreamNonBlocking);
+}
+
+TEST(StreamUniquePtrTest, StreamDeleterFunctionality)
+{
+  // Test that StreamDeleter properly handles cleanup
+  {
+    auto stream = autoware::cuda_utils::makeCudaStream();
+    // Deleter will be called automatically on scope exit
+  }
+}
+
+TEST(StreamUniquePtrTest, StreamReset)
+{
+  // Test that we can reset a stream
+  auto stream = autoware::cuda_utils::makeCudaStream();
+  EXPECT_NE(stream.get(), nullptr);
+  stream.reset();
+  EXPECT_EQ(stream.get(), nullptr);
+}
+
+TEST(StreamUniquePtrTest, StreamMove)
+{
+  // Test moving a stream unique pointer
+  auto stream1 = autoware::cuda_utils::makeCudaStream();
+  EXPECT_NE(stream1.get(), nullptr);
+
+  auto stream2 = std::move(stream1);
+  EXPECT_EQ(stream1.get(), nullptr);
+  EXPECT_NE(stream2.get(), nullptr);
+
+  // Check that the moved stream is still valid
+  EXPECT_EQ(cudaStreamQuery(*stream2), cudaSuccess);
+}

--- a/sensing/autoware_cuda_utils/test/test_stream_unique_ptr.cu
+++ b/sensing/autoware_cuda_utils/test/test_stream_unique_ptr.cu
@@ -13,12 +13,17 @@
 // limitations under the License.
 
 #include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_gtest_utils.hpp"
 
 #include <autoware/cuda_utils/stream_unique_ptr.hpp>
 
 #include <gtest/gtest.h>
 
-TEST(StreamUniquePtrTest, MakeCudaStreamDefault)
+class StreamUniquePtrTest : public autoware::cuda_utils::CudaTest
+{
+};
+
+TEST_F(StreamUniquePtrTest, MakeCudaStreamDefault)
 {
   // Test creating a CUDA stream with default flags
   auto stream = autoware::cuda_utils::makeCudaStream();
@@ -29,7 +34,7 @@ TEST(StreamUniquePtrTest, MakeCudaStreamDefault)
   EXPECT_EQ(cudaStreamQuery(raw_stream), cudaSuccess);
 }
 
-TEST(StreamUniquePtrTest, MakeCudaStreamWithFlags)
+TEST_F(StreamUniquePtrTest, MakeCudaStreamWithFlags)
 {
   // Test creating a CUDA stream with custom flags
   auto stream = autoware::cuda_utils::makeCudaStream(cudaStreamNonBlocking);
@@ -45,7 +50,7 @@ TEST(StreamUniquePtrTest, MakeCudaStreamWithFlags)
   EXPECT_EQ(flags, cudaStreamNonBlocking);
 }
 
-TEST(StreamUniquePtrTest, StreamDeleterFunctionality)
+TEST_F(StreamUniquePtrTest, StreamDeleterFunctionality)
 {
   // Test that StreamDeleter properly handles cleanup
   {
@@ -54,7 +59,7 @@ TEST(StreamUniquePtrTest, StreamDeleterFunctionality)
   }
 }
 
-TEST(StreamUniquePtrTest, StreamReset)
+TEST_F(StreamUniquePtrTest, StreamReset)
 {
   // Test that we can reset a stream
   auto stream = autoware::cuda_utils::makeCudaStream();
@@ -63,7 +68,7 @@ TEST(StreamUniquePtrTest, StreamReset)
   EXPECT_EQ(stream.get(), nullptr);
 }
 
-TEST(StreamUniquePtrTest, StreamMove)
+TEST_F(StreamUniquePtrTest, StreamMove)
 {
   // Test moving a stream unique pointer
   auto stream1 = autoware::cuda_utils::makeCudaStream();

--- a/sensing/autoware_cuda_utils/test/test_stream_unique_ptr.cu
+++ b/sensing/autoware_cuda_utils/test/test_stream_unique_ptr.cu
@@ -57,6 +57,12 @@ TEST_F(StreamUniquePtrTest, StreamDeleterFunctionality)
     auto stream = autoware::cuda_utils::makeCudaStream();
     // Deleter will be called automatically on scope exit
   }
+
+  // If we reach here without crashes, deleters worked correctly
+  // TODO: Ideally, we would confirm that the stream handle is now invalid, but CUDA provides no API
+  // for that. Instead, calling any CUDA API on a destroyed stream is undefined behavior and usually
+  // results in a SEGFAULT.
+  SUCCEED();
 }
 
 TEST_F(StreamUniquePtrTest, StreamReset)


### PR DESCRIPTION
## Description

After coming to the sad realization in #10997 that our CI currently has no GPUs and thus cannot execute CUDA unit tests, I implemented a minimal set of helpers to run CUDA tests if a GPU is available, while skipping if there is not.

The helpers are in `autoware/cuda_utils/cuda_gtest_utils.hpp` and consist of:
* the `bool is_cuda_runtime_available()` function
* the `SKIP_TEST_IF_CUDA_UNAVAILABLE()` for use with individual test cases
* the `class CudaTest : public ::testing::Test` class to use as the base class for a suite of CUDA-related tests

I also moved the non-thrust unit tests from #10997 to here since they are unrelated to that PR, and serve as validation for the gtest utils implemented here.

Unit tests do not use `ament_add_gtest` directly, as CUDA code would be compiled with a C++ compiler and thus fail compilation.
Instead, the executable is build by hand using `cuda_add_executable`, and the tests are registered by `ament_add_gtest_test`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Unit tests pass on my local machine, and are correctly skipped in [CI](https://github.com/autowarefoundation/autoware_universe/actions/runs/16317329159/job/46086319301?pr=10999#logs):

```
 [==========] 13 tests from 4 test suites ran. (0 ms total)
1: [  PASSED  ] 2 tests.
1: [  SKIPPED ] 11 tests, listed below:
1: [  SKIPPED ] CudaUniquePtrTest.MakeUniqueDeviceMemory
1: [  SKIPPED ] CudaUniquePtrTest.MakeUniqueDeviceArray
1: [  SKIPPED ] CudaUniquePtrTest.MakeUniqueHostMemory
1: [  SKIPPED ] CudaUniquePtrTest.MakeUniqueHostArray
1: [  SKIPPED ] CudaUniquePtrTest.DeleterFunctionality
1: [  SKIPPED ] CudaUtilsTest.ClearAsyncFunction
1: [  SKIPPED ] StreamUniquePtrTest.MakeCudaStreamDefault
1: [  SKIPPED ] StreamUniquePtrTest.MakeCudaStreamWithFlags
1: [  SKIPPED ] StreamUniquePtrTest.StreamDeleterFunctionality
1: [  SKIPPED ] StreamUniquePtrTest.StreamReset
1: [  SKIPPED ] StreamUniquePtrTest.StreamMove
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
