### PR TITLE
fix(radar_tracks_objects_converter): publish topic even if objects array is empty

### DIFF
--- a/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
+++ b/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
@@ -163,10 +163,8 @@ void RadarTracksMsgsConverterNode::onTimer()
 
   TrackedObjects tracked_objects = convertRadarTrackToTrackedObjects();
   DetectedObjects detected_objects = convertTrackedObjectsToDetectedObjects(tracked_objects);
-  if (!tracked_objects.objects.empty()) {
-    pub_tracked_objects_->publish(tracked_objects);
-    pub_detected_objects_->publish(detected_objects);
-  }
+  pub_tracked_objects_->publish(tracked_objects);
+  pub_detected_objects_->publish(detected_objects);
 }
 
 DetectedObjects RadarTracksMsgsConverterNode::convertTrackedObjectsToDetectedObjects(


### PR DESCRIPTION
## Description

Related https://tier4.atlassian.net/browse/RT0-37772 and https://star4.slack.com/archives/C076ZGRC15X/p1752711671288259.
(TIER IV internal link)

It enforce to this node to publish topic even if objects number is 0 so that the latter process can properly work.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
