### PR TITLE
fix(intersection): add guard to optional of lane_id_interval

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/interpolated_path_info.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/interpolated_path_info.hpp
@@ -40,7 +40,7 @@ struct InterpolatedPathInfo
   /** the associative lane ids of lane_id */
   std::set<lanelet::Id> associative_lane_ids{};
   /** the range of indices for the path points with associative lane id */
-  std::optional<std::pair<size_t, size_t>> lane_id_interval{std::nullopt};
+  std::pair<size_t, size_t> lane_id_interval;
 };
 
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp
@@ -117,7 +117,7 @@ IntersectionModule::OcclusionType IntersectionModule::detectOcclusion(
   const double occlusion_dist_thr = planner_param_.occlusion.occlusion_required_clearance_distance;
 
   const auto & path_ip = interpolated_path_info.path;
-  const auto & lane_interval_ip = interpolated_path_info.lane_id_interval.value();
+  const auto & lane_interval_ip = interpolated_path_info.lane_id_interval;
 
   const auto first_attention_area_idx =
     util::getFirstPointInsidePolygon(path_ip, lane_interval_ip, first_attention_area);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_stuck.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_stuck.cpp
@@ -369,7 +369,7 @@ bool IntersectionModule::checkYieldStuckVehicleInIntersection(
   const double yield_stuck_distance_thr = planner_param_.yield_stuck.distance_threshold;
 
   LineString2d sparse_intersection_path;
-  const auto [start, end] = interpolated_path_info.lane_id_interval.value();
+  const auto [start, end] = interpolated_path_info.lane_id_interval;
   for (unsigned i = start; i < end; ++i) {
     const auto & point = interpolated_path_info.path.points.at(i).point.pose.position;
     const auto yaw = tf2::getYaw(interpolated_path_info.path.points.at(i).point.pose.orientation);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -60,7 +60,7 @@ static std::optional<lanelet::ConstLanelet> getFirstConflictingLanelet(
   const autoware_utils::LinearRing2d & footprint, const double vehicle_length)
 {
   const auto & path_ip = interpolated_path_info.path;
-  const auto [lane_start, end] = interpolated_path_info.lane_id_interval.value();
+  const auto [lane_start, end] = interpolated_path_info.lane_id_interval;
   const size_t vehicle_length_idx = static_cast<size_t>(vehicle_length / interpolated_path_info.ds);
   const size_t start =
     static_cast<size_t>(std::max<int>(0, static_cast<int>(lane_start) - vehicle_length_idx));
@@ -101,16 +101,13 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path)
   const auto interpolated_path_info_opt = util::generateInterpolatedPath(
     lane_id_, associative_ids_, *path, planner_param_.path_interpolation_ds, logger_);
   if (!interpolated_path_info_opt) {
-    RCLCPP_DEBUG_SKIPFIRST_THROTTLE(logger_, *clock_, 1000 /* ms */, "splineInterpolate failed");
+    RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
+      logger_, *clock_, 1000 /* ms */,
+      "splineInterpolate failed or Path has no interval on intersection lane");
     RCLCPP_DEBUG(logger_, "===== plan end =====");
     return false;
   }
   const auto & interpolated_path_info = interpolated_path_info_opt.value();
-  if (!interpolated_path_info.lane_id_interval) {
-    RCLCPP_WARN(logger_, "Path has no interval on intersection lane %ld", lane_id_);
-    RCLCPP_DEBUG(logger_, "===== plan end =====");
-    return false;
-  }
 
   const double baselink2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
   const auto local_footprint = planner_data_->vehicle_info_.createFootprint(0.0, 0.0);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
@@ -141,7 +141,7 @@ std::optional<size_t> getFirstPointInsidePolygonByFootprint(
   const autoware_utils::LinearRing2d & footprint, const double vehicle_length)
 {
   const auto & path_ip = interpolated_path_info.path;
-  const auto [lane_start, lane_end] = interpolated_path_info.lane_id_interval.value();
+  const auto [lane_start, lane_end] = interpolated_path_info.lane_id_interval;
   const size_t vehicle_length_idx = static_cast<size_t>(vehicle_length / interpolated_path_info.ds);
   // NOTE(soblin): subtract vehicle_length_idx for the case where ego's footprint overlaps with
   // attention lane at lane_start already. In such case, the intersection stopline needs to be
@@ -172,7 +172,7 @@ getFirstPointInsidePolygonsByFootprint(
   const autoware_utils::LinearRing2d & footprint, const double vehicle_length)
 {
   const auto & path_ip = interpolated_path_info.path;
-  const auto [lane_start, lane_end] = interpolated_path_info.lane_id_interval.value();
+  const auto [lane_start, lane_end] = interpolated_path_info.lane_id_interval;
   const size_t vehicle_length_idx = static_cast<size_t>(vehicle_length / interpolated_path_info.ds);
   const size_t start =
     static_cast<size_t>(std::max<int>(0, static_cast<int>(lane_start) - vehicle_length_idx));
@@ -380,8 +380,12 @@ std::optional<InterpolatedPathInfo> generateInterpolatedPath(
   interpolated_path_info.ds = ds;
   interpolated_path_info.lane_id = lane_id;
   interpolated_path_info.associative_lane_ids = associative_lane_ids;
-  interpolated_path_info.lane_id_interval =
+  const auto lane_id_interval =
     findLaneIdsInterval(interpolated_path_info.path, associative_lane_ids);
+  if (!lane_id_interval) {
+    return std::nullopt;
+  }
+  interpolated_path_info.lane_id_interval = lane_id_interval.value();
   return interpolated_path_info;
 }
 
@@ -483,9 +487,8 @@ std::optional<size_t> find_maximum_footprint_overshoot_position(
   if (turn_direction != "left" && turn_direction != "right") {
     return std::nullopt;
   }
-
   const auto & path = interpolated_path_info.path;
-  const auto & [_, intersection_end] = interpolated_path_info.lane_id_interval.value();
+  const auto & [_, intersection_end] = interpolated_path_info.lane_id_interval;
   return find_maximum_footprint_overshoot_position_impl(
     path, local_footprint, merging_lanelet, min_distance_threshold, search_start_idx,
     intersection_end);


### PR DESCRIPTION
## Description

Guard against `interpolated_path_info.lane_id_interval` was insufficiently handled in order to make intersection module operate in abnormal cases as much as possible. This PR fixed the module not to operate anyway if `interpolated_path_info.lane_id_interval` was null.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
