### PR TITLE
fix(planning_validator): suppress unnecessary error messages

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
@@ -229,6 +229,31 @@ struct PlanningValidatorContext
       diag_updater->force_update();
     }
   }
+
+  void init_validation_status()
+  {
+    auto & s = validation_status;
+    s->is_valid_size = true;
+    s->is_valid_finite_value = true;
+    s->is_valid_interval = true;
+    s->is_valid_relative_angle = true;
+    s->is_valid_curvature = true;
+    s->is_valid_lateral_acc = true;
+    s->is_valid_lateral_jerk = true;
+    s->is_valid_longitudinal_max_acc = true;
+    s->is_valid_longitudinal_min_acc = true;
+    s->is_valid_steering = true;
+    s->is_valid_steering_rate = true;
+    s->is_valid_velocity_deviation = true;
+    s->is_valid_distance_deviation = true;
+    s->is_valid_longitudinal_distance_deviation = true;
+    s->is_valid_forward_trajectory_length = true;
+    s->is_valid_latency = true;
+    s->is_valid_yaw_deviation = true;
+    s->is_valid_trajectory_shift = true;
+    s->is_valid_intersection_collision_check = true;
+    s->is_valid_rear_collision_check = true;
+  }
 };
 
 }  // namespace autoware::planning_validator

--- a/planning/planning_validator/autoware_planning_validator/src/node.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/node.cpp
@@ -121,6 +121,8 @@ void PlanningValidatorNode::onTrajectory(const Trajectory::ConstSharedPtr & traj
 
   if (!isDataReady()) return;
 
+  context_->init_validation_status();
+
   context_->data->set_nearest_trajectory_indices();
 
   context_->debug_pose_publisher->clearMarkers();


### PR DESCRIPTION
## Description

This PR adds initialization of all validation status flags to true to prevent unnecessary error messages.
Previously, when certain plugins were not launched via the preset file, uninitialized status flags could lead to misleading error outputs.
With this change, it has been confirmed that no such errors appear even when arbitrary plugins are disabled in the preset configuration.

## Related links

**Parent Issue:**

- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03QU7K50D8/p1752714228502499)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
