### PR TITLE
feat: enable to remap control cmd from autoware launch

### DIFF
--- a/control/autoware_control_command_gate/launch/control_command_gate.launch.xml
+++ b/control/autoware_control_command_gate/launch/control_command_gate.launch.xml
@@ -1,14 +1,23 @@
 <launch>
   <arg name="config" default="$(find-pkg-share autoware_control_command_gate)/config/default.param.yaml"/>
+  <arg name="~/output/control" default="/control/command/control_cmd"/>
+  <arg name="~/output/gear" default="/control/command/gear_cmd"/>
+  <arg name="~/output/turn_indicators" default="/control/command/turn_indicators_cmd"/>
+  <arg name="~/output/hazard_lights" default="/control/command/hazard_lights_cmd"/>
+  <arg name="~/inputs/main/control" default="/control/trajectory_follower/control_cmd"/>
+  <arg name="~/inputs/main/gear" default="/control/shift_decider/gear_cmd"/>
+  <arg name="~/inputs/main/hazard_lights" default="/planning/hazard_lights_cmd"/>
+  <arg name="~/inputs/main/turn_indicators" default="/planning/turn_indicators_cmd"/>
+
   <node pkg="autoware_control_command_gate" exec="control_command_gate_node">
     <param from="$(var config)"/>
-    <remap from="~/output/control" to="/control/command/control_cmd"/>
-    <remap from="~/output/gear" to="/control/command/gear_cmd"/>
-    <remap from="~/output/turn_indicators" to="/control/command/turn_indicators_cmd"/>
-    <remap from="~/output/hazard_lights" to="/control/command/hazard_lights_cmd"/>
-    <remap from="~/inputs/main/control" to="/control/trajectory_follower/control_cmd"/>
-    <remap from="~/inputs/main/gear" to="/control/shift_decider/gear_cmd"/>
-    <remap from="~/inputs/main/hazard_lights" to="/planning/hazard_lights_cmd"/>
-    <remap from="~/inputs/main/turn_indicators" to="/planning/turn_indicators_cmd"/>
+    <remap from="~/output/control" to="$(var ~/output/control)"/>
+    <remap from="~/output/gear" to="$(var ~/output/gear)"/>
+    <remap from="~/output/turn_indicators" to="$(var ~/output/turn_indicators)"/>
+    <remap from="~/output/hazard_lights" to="$(var ~/output/hazard_lights)"/>
+    <remap from="~/inputs/main/control" to="$(var ~/inputs/main/control)"/>
+    <remap from="~/inputs/main/gear" to="$(var ~/inputs/main/gear)"/>
+    <remap from="~/inputs/main/hazard_lights" to="$(var ~/inputs/main/hazard_lights)"/>
+    <remap from="~/inputs/main/turn_indicators" to="$(var ~/inputs/main/turn_indicators)"/>
   </node>
 </launch>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -51,12 +51,16 @@
   <let name="operation_mode_transition_manager_plugin" value="AutonomousModeTransitionFlagNode" if="$(var use_control_command_gate)"/>
   <let name="operation_mode_transition_manager_plugin" value="OperationModeTransitionManager" unless="$(var use_control_command_gate)"/>
 
+  <!-- topic remap -->
+  <arg name="output_control_cmd" default="/control/command/control_cmd"/>
+
   <group>
     <push-ros-namespace namespace="control"/>
 
     <group if="$(var use_control_command_gate)">
       <include file="$(find-pkg-share autoware_control_command_gate)/launch/control_command_gate.launch.xml">
         <arg name="config" value="$(var control_command_gate_param_path)"/>
+        <arg name="~/output/control" value="$(var output_control_cmd)"/>
       </include>
     </group>
     <group if="$(var use_control_command_gate)">


### PR DESCRIPTION
## Description
Enable to remap control cmd from autoware launch.

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C0657FNJ5EG/p1752641874013789?thread_ts=1752049436.269489&cid=C0657FNJ5EG)

## How was this PR tested?
Comfirmed that remap control cmd
write tier4_control_components.launch following:
```
  <let name="output_control_cmd" value="/main/control/command/control_cmd"/>
  <include file="$(find-pkg-share tier4_control_launch)/launch/control.launch.xml">
    ~
    <!-- topic remap-->
    <arg name="output_control_cmd" value="$(var output_control_cmd)"/>
  </include>
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
