### PR TITLE
feat(autoware_system_monitor): publish cpu_temperature

### DIFF
--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp
@@ -28,6 +28,7 @@
 
 #include <tier4_external_api_msgs/msg/cpu_status.hpp>
 #include <tier4_external_api_msgs/msg/cpu_usage.hpp>
+#include <tier4_external_api_msgs/msg/cpu_temperature.hpp>
 
 #include <atomic>
 #include <climits>
@@ -148,6 +149,13 @@ protected:
     diagnostic_updater::DiagnosticStatusWrapper & stat);  // NOLINT(runtime/references)
 
   /**
+   * @brief Get CPU thermal throttling status
+   * @return DiagStatus::OK or WARN or ERROR
+   * @note ERROR indicates that thermal throttling is active or status retrieval failed
+   */
+  virtual int getThermalThrottlingStatus();
+
+  /**
    * @brief timer callback to collect cpu statistics
    */
   void onTimer();
@@ -157,6 +165,11 @@ protected:
    * @param [in] usage CPU usage
    */
   virtual void publishCpuUsage(tier4_external_api_msgs::msg::CpuUsage usage);
+
+  /**
+   * @brief publish CPU temperature as an independent topic
+   */
+  void publishCpuTemperature();
 
   // Updater won't be changed after initialization. No need to protect it with mutex.
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
@@ -213,6 +226,7 @@ protected:
 
   // Publisher
   rclcpp::Publisher<tier4_external_api_msgs::msg::CpuUsage>::SharedPtr pub_cpu_usage_;
+  rclcpp::Publisher<tier4_external_api_msgs::msg::CpuTemperature>::SharedPtr pub_cpu_temperature_;
 
   rclcpp::TimerBase::SharedPtr timer_;  //!< @brief timer to collect cpu statistics
   rclcpp::CallbackGroup::SharedPtr timer_callback_group_;  //!< @brief Callback Group

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp
@@ -153,7 +153,7 @@ protected:
    * @return DiagStatus::OK or WARN or ERROR
    * @note ERROR indicates that thermal throttling is active or status retrieval failed
    */
-  virtual int getThermalThrottlingStatus();
+  virtual int getThermalThrottlingStatus() const;
 
   /**
    * @brief timer callback to collect cpu statistics
@@ -231,11 +231,11 @@ protected:
   rclcpp::TimerBase::SharedPtr timer_;  //!< @brief timer to collect cpu statistics
   rclcpp::CallbackGroup::SharedPtr timer_callback_group_;  //!< @brief Callback Group
 
-  std::mutex mutex_snapshot_;         //!< @brief mutex for protecting snapshot
-  TemperatureData temperature_data_;  //!< @brief snapshot of CPU temperature
-  UsageData usage_data_;              //!< @brief snapshot of CPU usage
-  LoadData load_data_;                //!< @brief snapshot of CPU load average
-  FrequencyData frequency_data_;      //!< @brief snapshot of CPU frequency
+  mutable std::mutex mutex_snapshot_;  //!< @brief mutex for protecting snapshot
+  TemperatureData temperature_data_;   //!< @brief snapshot of CPU temperature
+  UsageData usage_data_;               //!< @brief snapshot of CPU usage
+  LoadData load_data_;                 //!< @brief snapshot of CPU load average
+  FrequencyData frequency_data_;       //!< @brief snapshot of CPU frequency
 
 private:
   /**

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/cpu_monitor_base.hpp
@@ -27,8 +27,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_external_api_msgs/msg/cpu_status.hpp>
-#include <tier4_external_api_msgs/msg/cpu_usage.hpp>
 #include <tier4_external_api_msgs/msg/cpu_temperature.hpp>
+#include <tier4_external_api_msgs/msg/cpu_usage.hpp>
 
 #include <atomic>
 #include <climits>

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/intel_cpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/intel_cpu_monitor.hpp
@@ -57,6 +57,11 @@ protected:
     diagnostic_updater::DiagnosticStatusWrapper & stat) override;  // NOLINT(runtime/references)
 
   /**
+   * @brief Get CPU thermal throttling status
+   */
+  int getThermalThrottlingStatus() override;
+
+  /**
    * @brief get names for core temperature files
    */
   void getTemperatureFileNames() override;

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/intel_cpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/intel_cpu_monitor.hpp
@@ -59,7 +59,7 @@ protected:
   /**
    * @brief Get CPU thermal throttling status
    */
-  int getThermalThrottlingStatus() override;
+  int getThermalThrottlingStatus() const override;
 
   /**
    * @brief get names for core temperature files

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/raspi_cpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/raspi_cpu_monitor.hpp
@@ -82,6 +82,11 @@ protected:
   void updateThermalThrottlingImpl(
     diagnostic_updater::DiagnosticStatusWrapper & stat) override;  // NOLINT(runtime/references)
 
+  /**
+   * @brief Get CPU thermal throttling status
+   */
+  int getThermalThrottlingStatus() override;
+
   // The format of Thermal Throttling report depends on CPU model.
   // So, Thermal Throttling report is implemented in derived class.
 

--- a/system/autoware_system_monitor/include/system_monitor/cpu_monitor/raspi_cpu_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/cpu_monitor/raspi_cpu_monitor.hpp
@@ -85,7 +85,7 @@ protected:
   /**
    * @brief Get CPU thermal throttling status
    */
-  int getThermalThrottlingStatus() override;
+  int getThermalThrottlingStatus() const override;
 
   // The format of Thermal Throttling report depends on CPU model.
   // So, Thermal Throttling report is implemented in derived class.

--- a/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -110,6 +110,9 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
   pub_cpu_usage_ =
     this->create_publisher<tier4_external_api_msgs::msg::CpuUsage>("~/cpu_usage", durable_qos);
 
+  pub_cpu_temperature_ =
+    this->create_publisher<tier4_external_api_msgs::msg::CpuTemperature>("~/cpu_temperature", durable_qos);
+
   using namespace std::literals::chrono_literals;
   // Start timer for collecting cpu statistics
   timer_callback_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
@@ -472,6 +475,12 @@ void CPUMonitorBase::updateThermalThrottlingImpl(
     this->get_logger(), "CPUMonitorBase::checkThermalThrottlingImpl not implemented.");
 }
 
+int CPUMonitorBase::getThermalThrottlingStatus()
+{
+  RCLCPP_INFO_ONCE(this->get_logger(), "CPUMonitorBase::getThermalThrottlingStatus not implemented.");
+  return DiagStatus::OK;
+}
+
 void CPUMonitorBase::checkFrequency()
 {
   // Remember start time to measure elapsed time
@@ -595,6 +604,23 @@ void CPUMonitorBase::publishCpuUsage(tier4_external_api_msgs::msg::CpuUsage usag
   pub_cpu_usage_->publish(usage);
 }
 
+void CPUMonitorBase::publishCpuTemperature()
+{
+  using tier4_external_api_msgs::msg::CpuTemperature;
+  CpuTemperature cpu_temperature;
+  cpu_temperature.stamp = this->now();
+  cpu_temperature.hostname = hostname_;
+  {
+    std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
+    if (!temperature_data_.core_data.empty()) {
+      cpu_temperature.temperature = temperature_data_.core_data[0].temperature;
+    }
+  }
+  int thermal_throttling = getThermalThrottlingStatus();
+  cpu_temperature.thermal_throttling = thermal_throttling == DiagStatus::OK ? CpuTemperature::THERMAL_THROTTLING_OFF : CpuTemperature::THERMAL_THROTTLING_ON;
+  pub_cpu_temperature_->publish(cpu_temperature);
+}
+
 void CPUMonitorBase::onTimer()
 {
   checkTemperature();
@@ -602,4 +628,6 @@ void CPUMonitorBase::onTimer()
   checkLoad();
   checkFrequency();
   checkThermalThrottling();
+
+  publishCpuTemperature();
 }

--- a/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -110,8 +110,8 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
   pub_cpu_usage_ =
     this->create_publisher<tier4_external_api_msgs::msg::CpuUsage>("~/cpu_usage", durable_qos);
 
-  pub_cpu_temperature_ =
-    this->create_publisher<tier4_external_api_msgs::msg::CpuTemperature>("~/cpu_temperature", durable_qos);
+  pub_cpu_temperature_ = this->create_publisher<tier4_external_api_msgs::msg::CpuTemperature>(
+    "~/cpu_temperature", durable_qos);
 
   using namespace std::literals::chrono_literals;
   // Start timer for collecting cpu statistics
@@ -477,7 +477,8 @@ void CPUMonitorBase::updateThermalThrottlingImpl(
 
 int CPUMonitorBase::getThermalThrottlingStatus()
 {
-  RCLCPP_INFO_ONCE(this->get_logger(), "CPUMonitorBase::getThermalThrottlingStatus not implemented.");
+  RCLCPP_INFO_ONCE(
+    this->get_logger(), "CPUMonitorBase::getThermalThrottlingStatus not implemented.");
   return DiagStatus::OK;
 }
 
@@ -617,7 +618,9 @@ void CPUMonitorBase::publishCpuTemperature()
     }
   }
   int thermal_throttling = getThermalThrottlingStatus();
-  cpu_temperature.thermal_throttling = thermal_throttling == DiagStatus::OK ? CpuTemperature::THERMAL_THROTTLING_OFF : CpuTemperature::THERMAL_THROTTLING_ON;
+  cpu_temperature.thermal_throttling = thermal_throttling == DiagStatus::OK
+                                         ? CpuTemperature::THERMAL_THROTTLING_OFF
+                                         : CpuTemperature::THERMAL_THROTTLING_ON;
   pub_cpu_temperature_->publish(cpu_temperature);
 }
 

--- a/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -475,7 +475,7 @@ void CPUMonitorBase::updateThermalThrottlingImpl(
     this->get_logger(), "CPUMonitorBase::checkThermalThrottlingImpl not implemented.");
 }
 
-int CPUMonitorBase::getThermalThrottlingStatus()
+int CPUMonitorBase::getThermalThrottlingStatus() const
 {
   RCLCPP_INFO_ONCE(
     this->get_logger(), "CPUMonitorBase::getThermalThrottlingStatus not implemented.");
@@ -618,7 +618,7 @@ void CPUMonitorBase::publishCpuTemperature()
     }
   }
   int thermal_throttling = getThermalThrottlingStatus();
-  cpu_temperature.thermal_throttling = thermal_throttling == DiagStatus::OK
+  cpu_temperature.thermal_throttling = (thermal_throttling == DiagStatus::OK)
                                          ? CpuTemperature::THERMAL_THROTTLING_OFF
                                          : CpuTemperature::THERMAL_THROTTLING_ON;
   pub_cpu_temperature_->publish(cpu_temperature);

--- a/system/autoware_system_monitor/src/cpu_monitor/intel_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/intel_cpu_monitor.cpp
@@ -210,6 +210,12 @@ void CPUMonitor::updateThermalThrottlingImpl(diagnostic_updater::DiagnosticStatu
   stat.addf("execution time", "%f ms", thermal_throttling_data_.elapsed_ms);
 }
 
+int CPUMonitor::getThermalThrottlingStatus()
+{
+  std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
+  return thermal_throttling_data_.summary_status;
+}
+
 // This function is called from a locked context in the timer callback.
 void CPUMonitor::getTemperatureFileNames()
 {

--- a/system/autoware_system_monitor/src/cpu_monitor/intel_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/intel_cpu_monitor.cpp
@@ -210,7 +210,7 @@ void CPUMonitor::updateThermalThrottlingImpl(diagnostic_updater::DiagnosticStatu
   stat.addf("execution time", "%f ms", thermal_throttling_data_.elapsed_ms);
 }
 
-int CPUMonitor::getThermalThrottlingStatus()
+int CPUMonitor::getThermalThrottlingStatus() const
 {
   std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
   return thermal_throttling_data_.summary_status;

--- a/system/autoware_system_monitor/src/cpu_monitor/raspi_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/raspi_cpu_monitor.cpp
@@ -105,6 +105,12 @@ void CPUMonitor::updateThermalThrottlingImpl(diagnostic_updater::DiagnosticStatu
   stat.addf("execution time", "%f ms", thermal_throttling_data_.elapsed_ms);
 }
 
+int CPUMonitor::getThermalThrottlingStatus()
+{
+  std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
+  return thermal_throttling_data_.summary_status;
+}
+
 // This function is called from a locked context in the timer callback.
 void CPUMonitor::getTemperatureFileNames()
 {

--- a/system/autoware_system_monitor/src/cpu_monitor/raspi_cpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/raspi_cpu_monitor.cpp
@@ -105,7 +105,7 @@ void CPUMonitor::updateThermalThrottlingImpl(diagnostic_updater::DiagnosticStatu
   stat.addf("execution time", "%f ms", thermal_throttling_data_.elapsed_ms);
 }
 
-int CPUMonitor::getThermalThrottlingStatus()
+int CPUMonitor::getThermalThrottlingStatus() const
 {
   std::lock_guard<std::mutex> lock_snapshot(mutex_snapshot_);
   return thermal_throttling_data_.summary_status;


### PR DESCRIPTION
## Description

- The System Monitor currently measures system resource statuses and publishes the results mainly to the /diagnostics topic. However, due to the complex structure of the /diagnostics message, extracting specific information (e.g., memory usage) can be expensive for external tools or monitoring systems.
- To make system resource status more easily accessible, the measured data should be published to a dedicated topic.  This enables external resource monitoring tools to access system resource statuses without parsing diagnostic arrays
- This PR introduces a feature to publish CPU temperature data 

## Related links

**This PR needs the following PR**
- https://github.com/tier4/tier4_autoware_msgs/pull/187

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-38268)
- This PR is one of the PRs needed for metrics collection

## How was this PR tested?

I confirmed `/system/system_monitor/cpu_monitor/cpu_temperature` topic shows the measured data

<img width="741" height="369" alt="Screenshot from 2025-07-18 19-33-16" src="https://github.com/user-attachments/assets/ed5b8718-a781-4d67-afc8-c51488938fda" />

## Notes for reviewers

- ~This feature currently supports only Intel CPUs and Raspberry Pi.~ On platforms other than Intel CPUs and Raspberry Pi, thermal throttling detection is not implemented, and THERMAL_THROTTLING_OFF will be reported.
- ~I tried adding const to `getThermalThrottlingStatus()`, but it caused a compilation error due to the use of std::mutex, so I left it non-const.~

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `/system/system_monitor/cpu_monitor/cpu_temperature` | `tier4_external_api_msgs/msg/CpuTemperature`   | [CPU temperature](https://github.com/iwatake2222/tier4_autoware_msgs/blob/feat_external_api_system_monitor/tier4_external_api_msgs/msg/CpuTemperature.msg) |

## Effects on system behavior

None.
