### PR TITLE
feat(autoware_system_monitor): publish hdd_status

### DIFF
--- a/system/autoware_system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
@@ -29,6 +29,7 @@
 #include <tier4_external_api_msgs/msg/hdd_status.hpp>
 
 #include <climits>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/system/autoware_system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
@@ -122,9 +122,7 @@ struct HddUsage
   std::string filesystem;  //!< @brief Name of the filesystem device (e.g., "/dev/nvme0n1p2")
   std::string mounted_on;  //!< @brief Mount point of the filesystem (e.g., "/")
 
-  HddUsage() : size(0), used(0), avail(0), capacity(0)
-  {
-  }
+  HddUsage() : size(0), used(0), avail(0), capacity(0) {}
 };
 
 /**
@@ -366,7 +364,8 @@ protected:
 
   std::vector<HddUsage> hdd_usages_;  //!< @brief list of HDD usage
 
-  rclcpp::Publisher<tier4_external_api_msgs::msg::HddStatus>::SharedPtr pub_hdd_status_;  //!< @brief publisher
+  rclcpp::Publisher<tier4_external_api_msgs::msg::HddStatus>::SharedPtr
+    pub_hdd_status_;  //!< @brief publisher
 
   /**
    * @brief HDD SMART status messages

--- a/system/autoware_system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/hdd_monitor/hdd_monitor.hpp
@@ -113,16 +113,16 @@ struct HddStat
 /**
  * @brief usage of HDD for each partition
  */
-struct HddUsage
+struct HddPartitionStatus
 {
-  int size;                //!< @brief Total size of the filesystem in megabytes (MB)
-  int used;                //!< @brief Used space in the filesystem in megabytes (MB)
-  int avail;               //!< @brief Available (free) space in the filesystem in megabytes (MB)
-  int capacity;            //!< @brief Percentage of used space in the filesystem (0–100)
+  int32_t size;            //!< @brief Total size of the filesystem in megabytes (MB)
+  int32_t used;            //!< @brief Used space in the filesystem in megabytes (MB)
+  int32_t avail;           //!< @brief Available (free) space in the filesystem in megabytes (MB)
+  int32_t capacity;        //!< @brief Percentage of used space in the filesystem (0–100)
   std::string filesystem;  //!< @brief Name of the filesystem device (e.g., "/dev/nvme0n1p2")
   std::string mounted_on;  //!< @brief Mount point of the filesystem (e.g., "/")
 
-  HddUsage() : size(0), used(0), avail(0), capacity(0) {}
+  HddPartitionStatus() : size(0), used(0), avail(0), capacity(0) {}
 };
 
 /**
@@ -362,7 +362,7 @@ protected:
   HddInfoList hdd_info_list_;               //!< @brief list of HDD information
   rclcpp::Time last_hdd_stat_update_time_;  //!< @brief last HDD statistics update time
 
-  std::vector<HddUsage> hdd_usages_;  //!< @brief list of HDD usage
+  std::vector<HddPartitionStatus> hdd_partition_statuses_;  //!< @brief list of partition status
 
   rclcpp::Publisher<tier4_external_api_msgs::msg::HddStatus>::SharedPtr
     pub_hdd_status_;  //!< @brief publisher

--- a/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -76,7 +76,8 @@ HddMonitor::HddMonitor(const rclcpp::NodeOptions & options)
   // Publisher
   rclcpp::QoS durable_qos{1};
   durable_qos.transient_local();
-  pub_hdd_status_ = this->create_publisher<tier4_external_api_msgs::msg::HddStatus>("~/hdd_status", durable_qos);
+  pub_hdd_status_ =
+    this->create_publisher<tier4_external_api_msgs::msg::HddStatus>("~/hdd_status", durable_qos);
 
   timer_ = rclcpp::create_timer(this, get_clock(), 1s, std::bind(&HddMonitor::onTimer, this));
 }

--- a/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -356,17 +356,13 @@ void HddMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
         level = DiagStatus::OK;
       }
 
-      try {
-        stat.add(fmt::format("HDD {}: status", hdd_index), usage_dict_.at(level));
-        stat.add(fmt::format("HDD {}: filesystem", hdd_index), filesystem.c_str());
-        stat.add(fmt::format("HDD {}: size", hdd_index), (list.at(1) + " MiB").c_str());
-        stat.add(fmt::format("HDD {}: used", hdd_index), (list.at(2) + " MiB").c_str());
-        stat.add(fmt::format("HDD {}: avail", hdd_index), (list.at(3) + " MiB").c_str());
-        stat.add(fmt::format("HDD {}: use", hdd_index), list.at(4).c_str());
-        stat.add(fmt::format("HDD {}: mounted on", hdd_index), mounted.c_str());
-      } catch (std::exception & e) {
-        stat.add(fmt::format("HDD {}: status", hdd_index), "index error");
-      }
+      stat.add(fmt::format("HDD {}: status", hdd_index), usage_dict_.at(level));
+      stat.add(fmt::format("HDD {}: filesystem", hdd_index), filesystem.c_str());
+      stat.add(fmt::format("HDD {}: size", hdd_index), fmt::format("{} MiB", size));
+      stat.add(fmt::format("HDD {}: used", hdd_index), fmt::format("{} MiB", used));
+      stat.add(fmt::format("HDD {}: avail", hdd_index), fmt::format("{} MiB", avail));
+      stat.add(fmt::format("HDD {}: use", hdd_index), fmt::format("{}", capacity));
+      stat.add(fmt::format("HDD {}: mounted on", hdd_index), mounted.c_str());
 
       auto & hdd_partition_status = hdd_partition_statuses_.emplace_back();
       hdd_partition_status.size = size;

--- a/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -368,7 +368,7 @@ void HddMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
         stat.add(fmt::format("HDD {}: status", hdd_index), "index error");
       }
 
-      auto& hdd_partition_status = hdd_partition_statuses_.emplace_back();
+      auto & hdd_partition_status = hdd_partition_statuses_.emplace_back();
       hdd_partition_status.size = size;
       hdd_partition_status.used = used;
       hdd_partition_status.avail = avail;
@@ -970,7 +970,7 @@ void HddMonitor::publishHddStatus()
   hdd_status.hostname = hostname_;
 
   for (const auto & hdd_partition_status : hdd_partition_statuses_) {
-    auto& partition = hdd_status.partitions.emplace_back();
+    auto & partition = hdd_status.partitions.emplace_back();
     partition.size = hdd_partition_status.size;
     partition.used = hdd_partition_status.used;
     partition.avail = hdd_partition_status.avail;
@@ -990,7 +990,7 @@ void HddMonitor::publishHddStatus()
     float read_iops = hdd_stats_[itr->first].read_iops_;
     float write_iops = hdd_stats_[itr->first].write_iops_;
 
-    auto& device = hdd_status.devices.emplace_back();
+    auto & device = hdd_status.devices.emplace_back();
     device.name = itr->second.disk_device_;
     device.read_data_rate = read_data_rate;
     device.write_data_rate = write_data_rate;


### PR DESCRIPTION
## Description

- The System Monitor currently measures system resource statuses and publishes the results mainly to the /diagnostics topic. However, due to the complex structure of the /diagnostics message, extracting specific information (e.g., memory usage) can be expensive for external tools or monitoring systems.
- To make system resource status more easily accessible, the measured data should be published to a dedicated topic.  This enables external resource monitoring tools to access system resource statuses without parsing diagnostic arrays
- This PR introduces a feature to publish HDD status

## Related links

**This PR needs the following PR**
- https://github.com/tier4/tier4_autoware_msgs/pull/187

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-38268)
- This PR is one of the PRs needed for metrics collection

## How was this PR tested?

I confirmed `/system/system_monitor/hdd_monitor/hdd_status` topic shows the measured data

<img width="749" height="640" alt="Screenshot from 2025-07-18 19-35-00" src="https://github.com/user-attachments/assets/534643b4-94db-4af4-9d53-8ea8de919b08" />


## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `/system/system_monitor/hdd_monitor/hdd_status` | `tier4_external_api_msgs/msg/HddStatus`   | [HDD status](https://github.com/iwatake2222/tier4_autoware_msgs/blob/feat_external_api_system_monitor/tier4_external_api_msgs/msg/HddStatus.msg) |

## Effects on system behavior

None.
