### PR TITLE
feat(autoware_system_monitor): publish network_status

### DIFF
--- a/system/autoware_system_monitor/include/system_monitor/net_monitor/net_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/net_monitor/net_monitor.hpp
@@ -25,6 +25,9 @@
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 
+#include <tier4_external_api_msgs/msg/network_interface_status.hpp>
+#include <tier4_external_api_msgs/msg/network_status.hpp>
+
 #include <boost/asio.hpp>
 
 #include <climits>
@@ -366,8 +369,15 @@ protected:
    */
   void close_connection();
 
+  /**
+   * @brief publish Network status
+   */
+  void publishNetworkStatus();
+
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
   rclcpp::TimerBase::SharedPtr timer_;   //!< @brief timer to get Network information
+
+  rclcpp::Publisher<tier4_external_api_msgs::msg::NetworkStatus>::SharedPtr pub_network_status_;  //!< @brief publisher
 
   char hostname_[HOST_NAME_MAX + 1];             //!< @brief host name
   std::map<std::string, Bytes> bytes_;           //!< @brief list of bytes

--- a/system/autoware_system_monitor/include/system_monitor/net_monitor/net_monitor.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/net_monitor/net_monitor.hpp
@@ -377,7 +377,8 @@ protected:
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
   rclcpp::TimerBase::SharedPtr timer_;   //!< @brief timer to get Network information
 
-  rclcpp::Publisher<tier4_external_api_msgs::msg::NetworkStatus>::SharedPtr pub_network_status_;  //!< @brief publisher
+  rclcpp::Publisher<tier4_external_api_msgs::msg::NetworkStatus>::SharedPtr
+    pub_network_status_;  //!< @brief publisher
 
   char hostname_[HOST_NAME_MAX + 1];             //!< @brief host name
   std::map<std::string, Bytes> bytes_;           //!< @brief list of bytes

--- a/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
@@ -69,6 +69,11 @@ NetMonitor::NetMonitor(const rclcpp::NodeOptions & options)
   updater_.add("IP Packet Reassembles Failed", this, &NetMonitor::check_reassembles_failed);
   updater_.add("UDP Buf Errors", this, &NetMonitor::check_udp_buf_errors);
 
+  // Publisher
+  rclcpp::QoS durable_qos{1};
+  durable_qos.transient_local();
+  pub_network_status_ = this->create_publisher<tier4_external_api_msgs::msg::NetworkStatus>("~/network_status", durable_qos);
+
   nl80211_.init();
 
   // Run I/O service processing loop
@@ -374,6 +379,7 @@ void NetMonitor::on_timer()
 {
   // Update list of network information
   update_network_list();
+  publishNetworkStatus();
 }
 
 void NetMonitor::shutdown_nl80211()
@@ -734,6 +740,46 @@ void NetMonitor::close_connection()
 {
   // Close socket
   socket_->close();
+}
+
+void NetMonitor::publishNetworkStatus()
+{
+  tier4_external_api_msgs::msg::NetworkStatus network_status;
+  network_status.stamp = this->now();
+  network_status.hostname = hostname_;
+
+  for (const auto & network : network_list_) {
+    // Skip if network is not supported
+    if (network.is_invalid) continue;
+
+    tier4_external_api_msgs::msg::NetworkInterfaceStatus interface_status;
+    interface_status.name = network.interface_name;
+    interface_status.rx_traffic = network.rx_traffic;
+    interface_status.tx_traffic = network.tx_traffic;
+    interface_status.capacity = network.speed;
+    interface_status.rx_errors = network.rx_errors;
+    interface_status.tx_errors = network.tx_errors;
+    interface_status.collisions = network.collisions;
+    network_status.interfaces.push_back(interface_status);
+  }
+
+  uint64_t total_errors = 0;
+  uint64_t unit_errors = 0;
+  NetSnmp::Result ret = NetSnmp::Result::OK;
+  ret = reassembles_failed_info_.check_metrics(total_errors, unit_errors);
+  if (ret != NetSnmp::Result::READ_ERROR) {
+    network_status.error_ip_packet_reassembles_failed = unit_errors;
+  }
+  ret = udp_rcvbuf_errors_info_.check_metrics(total_errors, unit_errors);
+  if (ret != NetSnmp::Result::READ_ERROR) {
+    network_status.error_udp_buf_rx = unit_errors;
+  }
+  ret = udp_sndbuf_errors_info_.check_metrics(total_errors, unit_errors);
+  if (ret != NetSnmp::Result::READ_ERROR) {
+    network_status.error_udp_buf_tx = unit_errors;
+  }
+
+  pub_network_status_->publish(network_status);
 }
 
 NetSnmp::NetSnmp(rclcpp::Node * node)

--- a/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
@@ -72,7 +72,8 @@ NetMonitor::NetMonitor(const rclcpp::NodeOptions & options)
   // Publisher
   rclcpp::QoS durable_qos{1};
   durable_qos.transient_local();
-  pub_network_status_ = this->create_publisher<tier4_external_api_msgs::msg::NetworkStatus>("~/network_status", durable_qos);
+  pub_network_status_ = this->create_publisher<tier4_external_api_msgs::msg::NetworkStatus>(
+    "~/network_status", durable_qos);
 
   nl80211_.init();
 

--- a/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
@@ -753,7 +753,7 @@ void NetMonitor::publishNetworkStatus()
     // Skip if network is not supported
     if (network.is_invalid) continue;
 
-    tier4_external_api_msgs::msg::NetworkInterfaceStatus interface_status;
+    auto & interface_status = network_status.interfaces.emplace_back();
     interface_status.name = network.interface_name;
     interface_status.rx_traffic = network.rx_traffic;
     interface_status.tx_traffic = network.tx_traffic;
@@ -761,7 +761,6 @@ void NetMonitor::publishNetworkStatus()
     interface_status.rx_errors = network.rx_errors;
     interface_status.tx_errors = network.tx_errors;
     interface_status.collisions = network.collisions;
-    network_status.interfaces.push_back(interface_status);
   }
 
   uint64_t total_errors = 0;

--- a/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
@@ -766,8 +766,7 @@ void NetMonitor::publishNetworkStatus()
 
   uint64_t total_errors = 0;
   uint64_t unit_errors = 0;
-  NetSnmp::Result ret = NetSnmp::Result::OK;
-  ret = reassembles_failed_info_.check_metrics(total_errors, unit_errors);
+  NetSnmp::Result ret = reassembles_failed_info_.check_metrics(total_errors, unit_errors);
   if (ret != NetSnmp::Result::READ_ERROR) {
     network_status.error_ip_packet_reassembles_failed = unit_errors;
   }


### PR DESCRIPTION
## Description

- The System Monitor currently measures system resource statuses and publishes the results mainly to the /diagnostics topic. However, due to the complex structure of the /diagnostics message, extracting specific information (e.g., memory usage) can be expensive for external tools or monitoring systems.
- To make system resource status more easily accessible, the measured data should be published to a dedicated topic.  This enables external resource monitoring tools to access system resource statuses without parsing diagnostic arrays
- This PR introduces a feature to publish network status

## Related links

**This PR needs the following PR**
- https://github.com/tier4/tier4_autoware_msgs/pull/187

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-38268)
- This PR is one of the PRs needed for metrics collection

## How was this PR tested?

I confirmed `/system/system_monitor/net_monitor/network_status` topic shows the measured data

<img width="737" height="1516" alt="Screenshot from 2025-07-18 19-35-44" src="https://github.com/user-attachments/assets/638bb15b-752b-4386-93b2-722c0f1fe06e" />

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `/system/system_monitor/net_monitor/network_status` | `tier4_external_api_msgs/msg/NetworkStatus`   | [Network status](https://github.com/iwatake2222/tier4_autoware_msgs/blob/feat_external_api_system_monitor/tier4_external_api_msgs/msg/NetworkStatus.msg) |

## Effects on system behavior

None.
