### PR TITLE
fix(diffusion_planner): modify unread parameters

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -1,9 +1,8 @@
 /**:
   ros__parameters:
     plugins_path: $(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so
-    artifact_dir: $(env HOME)/autoware_data/diffusion_planner
-    onnx_model_path: $(var artifact_dir)/diffusion_planner.onnx
-    args_path: $(var artifact_dir)/diffusion_planner.param.json
+    onnx_model_path: $(env HOME)/autoware_data/diffusion_planner/diffusion_planner.onnx
+    args_path: $(env HOME)/autoware_data/diffusion_planner/diffusion_planner.param.json
     planning_frequency_hz: 10.0
     ignore_neighbors: false
     ignore_unknown_neighbors: true

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
+  <arg name="artifact_dir" default="$(env HOME)/autoware_data/diffusion_planner" description="Path to diffusion planner artifacts directory"/>
   <arg name="diffusion_planner_param_path" default="$(find-pkg-share autoware_diffusion_planner)/config/diffusion_planner.param.yaml"/>
 
   <node pkg="autoware_diffusion_planner" exec="autoware_diffusion_planner_node" name="diffusion_planner_node" output="screen">
@@ -13,8 +14,5 @@
     <remap from="~/input/traffic_signals" to="/perception/traffic_light_recognition/traffic_signals"/>
     <remap from="~/input/tracked_objects" to="/perception/object_recognition/tracking/objects"/>
     <remap from="~/input/vector_map" to="/map/vector_map"/>
-    <param name="onnx_model_path" value="$(var onnx_model_path)"/>
-    <param name="args_path" value="$(var args_path)"/>
-    <param name="build_only" value="$(var build_only)"/>
   </node>
 </launch>

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="artifact_dir" default="$(env HOME)/autoware_data/diffusion_planner" description="Path to diffusion planner artifacts directory"/>
   <arg name="diffusion_planner_param_path" default="$(find-pkg-share autoware_diffusion_planner)/config/diffusion_planner.param.yaml"/>
 
   <node pkg="autoware_diffusion_planner" exec="autoware_diffusion_planner_node" name="diffusion_planner_node" output="screen">


### PR DESCRIPTION
## Description

The launch sequence is currently disabled, so no runtime issues were expected. However, it was failing due to incorrect parameters. This PR fixes those parameter errors.
```
 [ERROR] [launch]: Caught exception in launch (see debug for traceback): launch configuration 'artifact_dir' does not exist
  [WARNING] [launch_ros.actions.load_composable_nodes]: Abandoning wait for the '/system/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_container/_container/load_node'
   service, due to shutdown.
  Future exception was never retrieved
  future: <Future finished exception=InvalidHandle('cannot use Destroyable because destruction was requested')>
  Traceback (most recent call last):
    File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 197, in _load_in_sequence
      self._load_node(next_load_node_request, context)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 119, in _load_node
      while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 176, in wait_for_service
      while self.context.ok() and not self.service_is_ready() and timeout_sec > 0.0:
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 159, in service_is_ready
      with self.handle:
  rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
  Future exception was never retrieved
  future: <Future finished exception=InvalidHandle('cannot use Destroyable because destruction was requested')>
  Traceback (most recent call last):
    File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 197, in _load_in_sequence
      self._load_node(next_load_node_request, context)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 119, in _load_node
      while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 176, in wait_for_service
      while self.context.ok() and not self.service_is_ready() and timeout_sec > 0.0:
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 159, in service_is_ready
      with self.handle:
  rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
  Future exception was never retrieved
  future: <Future finished exception=InvalidHandle('cannot use Destroyable because destruction was requested')>
  Traceback (most recent call last):
    File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 197, in _load_in_sequence
      self._load_node(next_load_node_request, context)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 119, in _load_node
      while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 176, in wait_for_service
      while self.context.ok() and not self.service_is_ready() and timeout_sec > 0.0:
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 159, in service_is_ready
      with self.handle:
  rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
  Future exception was never retrieved
  future: <Future finished exception=InvalidHandle('cannot use Destroyable because destruction was requested')>
  Traceback (most recent call last):
    File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 197, in _load_in_sequence
      self._load_node(next_load_node_request, context)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 119, in _load_node
      while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 176, in wait_for_service
      while self.context.ok() and not self.service_is_ready() and timeout_sec > 0.0:
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 159, in service_is_ready
      with self.handle:
  rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
  Future exception was never retrieved
  future: <Future finished exception=InvalidHandle('cannot use Destroyable because destruction was requested')>
  Traceback (most recent call last):
    File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 197, in _load_in_sequence
      self._load_node(next_load_node_request, context)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 119, in _load_node
      while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 176, in wait_for_service
      while self.context.ok() and not self.service_is_ready() and timeout_sec > 0.0:
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 159, in service_is_ready
      with self.handle:
  rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
  Future exception was never retrieved
  future: <Future finished exception=InvalidHandle('cannot use Destroyable because destruction was requested')>
  Traceback (most recent call last):
    File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 197, in _load_in_sequence
      self._load_node(next_load_node_request, context)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 119, in _load_node
      while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 176, in wait_for_service
      while self.context.ok() and not self.service_is_ready() and timeout_sec > 0.0:
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 159, in service_is_ready
      with self.handle:
  rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
  Future exception was never retrieved
  future: <Future finished exception=InvalidHandle('cannot use Destroyable because destruction was requested')>
  Traceback (most recent call last):
    File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
      result = self.fn(*self.args, **self.kwargs)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 197, in _load_in_sequence
      self._load_node(next_load_node_request, context)
    File "/opt/ros/humble/lib/python3.10/site-packages/launch_ros/actions/load_composable_nodes.py", line 119, in _load_node
      while not self.__rclpy_load_node_client.wait_for_service(timeout_sec=1.0):
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 176, in wait_for_service
      while self.context.ok() and not self.service_is_ready() and timeout_sec > 0.0:
    File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/client.py", line 159, in service_is_ready
      with self.handle:
  rclpy._rclpy_pybind11.InvalidHandle: cannot use Destroyable because destruction was requested
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I tested with planning simulator

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
