### PR TITLE
feat(map_based_prediction): prevent predicted path from chattering under noisy pose and velocity estimation

### DIFF
--- a/perception/autoware_map_based_prediction/README.md
+++ b/perception/autoware_map_based_prediction/README.md
@@ -191,6 +191,13 @@ This module treats **Pedestrians** and **Bicycles** as objects using the crosswa
 
 If there are a reachable crosswalk entry points within the `prediction_time_horizon` and the objects satisfies above condition, this module outputs additional predicted path to cross the opposite side via the crosswalk entry point.
 
+To prevent the predicted crossing path from chattering due to noise in the estimated pose or velocity of a pedestrian who is judged to have crossing intention, the module holds the crossing intention state for a certain duration based on the following parameters:
+
+| Parameter                        | Unit | Type   | Description                                                                                      |
+| -------------------------------- | ---- | ------ | ------------------------------------------------------------------------------------------------ |
+| `crossing_intention_duration`    | [s]  | double | Minimum duration that crossing intention must continuously persist to be judged as true          |
+| `no_crossing_intention_duration` | [s]  | double | Minimum duration that lack of crossing intention must continuously persist to be judged as false |
+
 This module takes into account the corresponding traffic light information.
 When RED signal is indicated, we assume the target object will not walk across.
 In addition, if the target object is stopping (not moving) against GREEN signal, we assume the target object will not walk across either.
@@ -243,8 +250,6 @@ If the target object is inside the road or crosswalk, this module outputs one or
 | `object_buffer_time_length`                                      | [s]   | double | Time span of object history to store the information                                                                                  |
 | `history_time_length`                                            | [s]   | double | Time span of object information used for prediction                                                                                   |
 | `prediction_time_horizon_rate_for_validate_shoulder_lane_length` | [-]   | double | prediction path will disabled when the estimated path length exceeds lanelet length. This parameter control the estimated path length |
-| `crossing_intention_duration`                                    | [s]   | double | Minimum duration that crossing intention must continuously persist to be judged as true                                               |
-| `no_crossing_intention_duration`                                 | [s]   | double | Minimum duration that lack of crossing intention must continuously persist to be judged as false                                      |
 
 ## Assumptions / Known limits
 

--- a/perception/autoware_map_based_prediction/README.md
+++ b/perception/autoware_map_based_prediction/README.md
@@ -198,6 +198,10 @@ To prevent the predicted crossing path from chattering due to noise in the estim
 | `crossing_intention_duration`    | [s]  | double | Minimum duration that crossing intention must continuously persist to be judged as true          |
 | `no_crossing_intention_duration` | [s]  | double | Minimum duration that lack of crossing intention must continuously persist to be judged as false |
 
+!!! note
+
+    Increasing `no_crossing_intention_duration` can reduce the frequency of false positives caused by noise that mistakenly indicates crossing intention. However, it also delays the system’s response to pedestrians who actually intend to cross. Therefore, setting this parameter to a large value is **not recommended**.
+
 This module takes into account the corresponding traffic light information.
 When RED signal is indicated, we assume the target object will not walk across.
 In addition, if the target object is stopping (not moving) against GREEN signal, we assume the target object will not walk across either.

--- a/perception/autoware_map_based_prediction/README.md
+++ b/perception/autoware_map_based_prediction/README.md
@@ -243,6 +243,8 @@ If the target object is inside the road or crosswalk, this module outputs one or
 | `object_buffer_time_length`                                      | [s]   | double | Time span of object history to store the information                                                                                  |
 | `history_time_length`                                            | [s]   | double | Time span of object information used for prediction                                                                                   |
 | `prediction_time_horizon_rate_for_validate_shoulder_lane_length` | [-]   | double | prediction path will disabled when the estimated path length exceeds lanelet length. This parameter control the estimated path length |
+| `crossing_intention_duration`                                    | [s]   | double | Minimum duration that crossing intention must continuously persist to be judged as true                                               |
+| `no_crossing_intention_duration`                                 | [s]   | double | Minimum duration that lack of crossing intention must continuously persist to be judged as false                                      |
 
 ## Assumptions / Known limits
 

--- a/perception/autoware_map_based_prediction/README.md
+++ b/perception/autoware_map_based_prediction/README.md
@@ -200,7 +200,7 @@ To prevent the predicted crossing path from chattering due to noise in the estim
 
 !!! note
 
-    Increasing `no_crossing_intention_duration` can reduce the frequency of false positives caused by noise that mistakenly indicates crossing intention. However, it also delays the system’s response to pedestrians who actually intend to cross. Therefore, setting this parameter to a large value is **not recommended**.
+    Increasing `crossing_intention_duration` can reduce the frequency of false positives caused by noise that mistakenly indicates crossing intention. However, it also delays the system’s response to pedestrians who actually intend to cross. Therefore, setting this parameter to a large value is **not recommended**.
 
 This module takes into account the corresponding traffic light information.
 When RED signal is indicated, we assume the target object will not walk across.

--- a/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
+++ b/perception/autoware_map_based_prediction/config/map_based_prediction.param.yaml
@@ -32,6 +32,8 @@
     use_crosswalk_user_history:
       match_lost_and_appeared_users: false
       remember_lost_users: false
+    crossing_intention_duration: 0.3    # [s] Minimum duration that crossing intention must continuously persist to be judged as true
+    no_crossing_intention_duration: 1.0 # [s] Minimum duration that lack of crossing intention must continuously persist to be judged as false
 
     # parameters for lc prediction
     lane_change_detection:

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/data_structure.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/data_structure.hpp
@@ -91,10 +91,17 @@ struct ObjectData
   Maneuver output_maneuver{
     Maneuver::UNINITIALIZED};  // output maneuver considering previous one shot maneuvers
 };
+struct Intention
+{
+  rclcpp::Time last_crossing_intention_time;
+  rclcpp::Time last_no_crossing_intention_time;
+  Eigen::Vector2d point;
+};
 struct CrosswalkUserData
 {
   std_msgs::msg::Header header;
   autoware_perception_msgs::msg::TrackedObject tracked_object;
+  std::vector<Intention> intention_history;
 };
 
 using LaneletsData = std::vector<LaneletData>;

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/predictor_vru.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/predictor_vru.hpp
@@ -59,7 +59,8 @@ public:
     double threshold_velocity_assumed_as_stopping,
     const std::vector<double> & distance_set_for_no_intention_to_walk,
     const std::vector<double> & timeout_set_for_no_intention_to_walk,
-    double prediction_sampling_time_interval, double prediction_time_horizon)
+    double prediction_sampling_time_interval, double prediction_time_horizon,
+    double crossing_intention_duration, double no_crossing_intention_duration)
   {
     match_lost_and_appeared_crosswalk_users_ = match_lost_and_appeared_crosswalk_users;
     min_crosswalk_user_velocity_ = min_crosswalk_user_velocity;
@@ -70,6 +71,8 @@ public:
     distance_set_for_no_intention_to_walk_ = distance_set_for_no_intention_to_walk;
     timeout_set_for_no_intention_to_walk_ = timeout_set_for_no_intention_to_walk;
     prediction_time_horizon_ = prediction_time_horizon;
+    crossing_intention_duration_ = crossing_intention_duration;
+    no_crossing_intention_duration_ = no_crossing_intention_duration;
 
     path_generator_ = std::make_shared<PathGenerator>(
       prediction_sampling_time_interval, min_crosswalk_user_velocity);
@@ -117,11 +120,18 @@ private:
   double max_crosswalk_user_delta_yaw_threshold_for_lanelet_;
   bool use_crosswalk_signal_;
   double threshold_velocity_assumed_as_stopping_;
+  double crossing_intention_duration_{0.0};
+  double no_crossing_intention_duration_{0.0};
   std::vector<double> distance_set_for_no_intention_to_walk_;
   std::vector<double> timeout_set_for_no_intention_to_walk_;
 
   //// process
   std::optional<lanelet::Id> getTrafficSignalId(const lanelet::ConstLanelet & way_lanelet);
+  bool hasPotentialToReachWithHistory(
+    const TrackedObject & object, const Eigen::Vector2d & center_point,
+    const Eigen::Vector2d & right_point, const Eigen::Vector2d & left_point,
+    const double time_horizon, const double min_object_vel,
+    const double max_crosswalk_user_delta_yaw_threshold_for_lanelet);
   PredictedObject getPredictedObjectAsCrosswalkUser(const TrackedObject & object);
   void updateCrosswalkUserHistory(
     const std_msgs::msg::Header & header, const TrackedObject & object,

--- a/perception/autoware_map_based_prediction/schema/map_based_prediction.schema.json
+++ b/perception/autoware_map_based_prediction/schema/map_based_prediction.schema.json
@@ -85,6 +85,16 @@
           "default": 0.8,
           "description": "prediction path will disabled when the estimated path length exceeds lanelet length. This parameter control the estimated path length"
         },
+        "crossing_intention_duration": {
+          "type": "number",
+          "default": 0.3,
+          "description": "Minimum duration that crossing intention must continuously persist to be judged as true"
+        },
+        "no_crossing_intention_duration": {
+          "type": "number",
+          "default": 1.0,
+          "description": "Minimum duration that lack of crossing intention must continuously persist to be judged as false"
+        },
         "lane_change_detection": {
           "type": "object",
           "properties": {
@@ -158,7 +168,9 @@
         "sigma_yaw_angle_deg",
         "object_buffer_time_length",
         "history_time_length",
-        "prediction_time_horizon_rate_for_validate_shoulder_lane_length"
+        "prediction_time_horizon_rate_for_validate_shoulder_lane_length",
+        "crossing_intention_duration",
+        "no_crossing_intention_duration"
       ]
     }
   },

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -447,6 +447,9 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
       declare_parameter<bool>("crosswalk_with_signal.use_crosswalk_signal");
     double threshold_velocity_assumed_as_stopping =
       declare_parameter<double>("crosswalk_with_signal.threshold_velocity_assumed_as_stopping");
+    double crossing_intention_duration = declare_parameter<double>("crossing_intention_duration");
+    double no_crossing_intention_duration =
+      declare_parameter<double>("no_crossing_intention_duration");
     std::vector<double> distance_set_for_no_intention_to_walk =
       declare_parameter<std::vector<double>>(
         "crosswalk_with_signal.distance_set_for_no_intention_to_walk");
@@ -458,7 +461,8 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
       max_crosswalk_user_delta_yaw_threshold_for_lanelet, use_crosswalk_signal,
       threshold_velocity_assumed_as_stopping, distance_set_for_no_intention_to_walk,
       timeout_set_for_no_intention_to_walk, prediction_sampling_time_interval_,
-      prediction_time_horizon_.pedestrian);
+      prediction_time_horizon_.pedestrian, crossing_intention_duration,
+      no_crossing_intention_duration);
   }
 
   // debug parameter


### PR DESCRIPTION
## Description

This PR improves the robustness of crossing intention estimation against noise in velocity and pose estimation.
Previously, small fluctuations in perceived object velocity or orientation could cause the estimated intention to switch frequently, leading to unstable behavior near crosswalks.

To address this, a time-based filtering mechanism was introduced. The intention is now only judged as true or false if the corresponding condition has persisted for a specified duration.

`crossing_intention_duration` defines how long the system must continuously detect a crossing intention before accepting it.

`no_crossing_intention_duration` defines how long the system must continuously detect the absence of intention before clearing it.

As a result, the intention estimation becomes more stable and less sensitive to temporary perception noise, improving overall system reliability.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

| BEFORE | AFTER |
| --- | --- |
|  <video src="https://github.com/user-attachments/assets/c8d3f868-2ee3-462c-a36c-e7911bd36404"/> |  <video src="https://github.com/user-attachments/assets/7dcb7950-d2e5-42fa-bf45-db80e343c721"/> |

```
webauto ci scenario run --project-id prd_jt --scenario-id 8f516365-80ed-40e0-9d64-7e90d456002f --scenario-version-id 38 --scenario-parameters '__tier4_modifier_deceleration_parameter=-3,__tier4_modifier_ego_speed=11.1111,__tier4_modifier_front_overhang=1,__tier4_modifier_max_blinker_change_count=5,__tier4_modifier_max_deceleration=10,__tier4_modifier_max_goal_lateral_deviation_abs=1000,__tier4_modifier_max_goal_yaw_deviation_abs=5,__tier4_modifier_max_lateral_deviation_abs=15,__tier4_modifier_max_lateral_trajectory_displacement_local=15,__tier4_modifier_max_processing_time=1000,__tier4_modifier_max_resampled_relative_angle=5,__tier4_modifier_max_stand_still=100,__tier4_modifier_max_steer_change_count=20,__tier4_modifier_max_steer_rate_fast=15,__tier4_modifier_max_steer_rate_slow=13,__tier4_modifier_max_stop_deviation_abs=50,__tier4_modifier_min_npc_distance_euclidian=0,__tier4_modifier_min_npc_longitudinal_distance_euclidian=0,__tier4_modifier_min_npc_longitudinal_distance_lateral=0,__tier4_modifier_pedestrian_speed=2.0833,__tier4_modifier_start_pedestrian_distance=-6,__tier4_modifier_wheel_base=2.79' --simulation-name planning_sim_v2
```

- [x] [[PR check (OTA)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/94bdce39-48ce-56e2-be03-38acaeca98af?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/382cb653-4acc-59d6-83dc-cdf0e9bd772b?project_id=prd_jt)
- [x] [PR check (OTA)][Lexus][FuncVerificationScenario_Basic] planning test

## Notes for reviewers

None.

## Interface changes

| Version | Parameter Name               | Type   | Default Value | Description                                                                                     |
|:--------|:-----------------------------|:-------|:---------------|:------------------------------------------------------------------------------------------------|
| New     | `crossing_intention_duration`    | double | `1.0`          | Minimum duration for which the crossing intention must continuously persist to be considered true  |
| New     | `no_crossing_intention_duration` | double | `1.0`          | Minimum duration for which the absence of crossing intention must continuously persist to be considered false |


<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
