### PR TITLE
fix(static_obstacle_avoidance): correct lane departure check during obstacle avoidance

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -872,10 +872,21 @@ bool StaticObstacleAvoidanceModule::isSafePath(
   };
 
   if (parameters_->policy_detection_reliability == "not_enough") {
+    lanelet::ConstLanelets check_lanes{};
+    for (const auto & lane : avoid_data_.current_lanelets) {
+      if (avoid_data_.target_objects.empty()) {
+        break;
+      }
+
+      check_lanes.push_back(lane);
+
+      if (lane.id() == avoid_data_.target_objects.back().overhang_lanelet.id()) {
+        break;
+      }
+    }
     if (has_left_shift) {
-      const auto exist_adjacent_lane = std::all_of(
-        avoid_data_.current_lanelets.begin(), avoid_data_.current_lanelets.end(),
-        [this](const auto & lane) {
+      const auto exist_adjacent_lane =
+        std::all_of(check_lanes.begin(), check_lanes.end(), [this](const auto & lane) {
           return planner_data_->route_handler->getLeftLanelet(lane, true, false);
         });
       if (!exist_adjacent_lane && !is_within_current_lane(false)) {
@@ -883,9 +894,8 @@ bool StaticObstacleAvoidanceModule::isSafePath(
       }
     }
     if (has_right_shift) {
-      const auto exist_adjacent_lane = std::all_of(
-        avoid_data_.current_lanelets.begin(), avoid_data_.current_lanelets.end(),
-        [this](const auto & lane) {
+      const auto exist_adjacent_lane =
+        std::all_of(check_lanes.begin(), check_lanes.end(), [this](const auto & lane) {
           return planner_data_->route_handler->getRightLanelet(lane, true, false);
         });
       if (!exist_adjacent_lane && !is_within_current_lane(true)) {


### PR DESCRIPTION
## Description

This PR updates the logic that checks for the existence of adjacent lanes during obstacle avoidance.

Previously, the system checked whether adjacent lanes (left or right) existed for all current lanelets. However, this is unnecessary and may lead to incorrect results, especially when the route includes branches or merges beyond the avoidance target.

With this update, the adjacent lane existence check is limited to the range of lanelets between the ego vehicle and the last avoidance target object. This refinement ensures that lane departure detection during avoidance is based only on the relevant portion of the route.

:information_source: **This change does not affect the intended behavior of the system**, as the adjacent lane check is only adjusted to reflect the necessary scope for accurate detection.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [[PR check (OTA)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/c3187b27-8780-552a-88d1-9c472ac6b613?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/66184129-ee15-5389-a81f-dcdc7c1f8f3d?project_id=prd_jt)
- [x] [[PR#11030 check][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/38361026-e35f-5781-896b-e433d782facf?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
