### PR TITLE
fix(intersection_collision_checker): use parameter instead of static constexpr

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/types.hpp
@@ -135,15 +135,13 @@ public:
 
   void update_history(const double dist, const double dt)
   {
-    static constexpr size_t max_size = 10;
-
     const auto last_timestamp = timestamp_history.empty() ? 0.0 : timestamp_history.back();
 
     distance_history.push_back(dist);
     timestamp_history.push_back(last_timestamp + dt);
 
-    if (distance_history.size() > max_size) distance_history.pop_front();
-    if (timestamp_history.size() > max_size) timestamp_history.pop_front();
+    if (distance_history.size() > buffer_size) distance_history.pop_front();
+    if (timestamp_history.size() > buffer_size) timestamp_history.pop_front();
   }
 
   bool update_velocity()


### PR DESCRIPTION
## Description

minor fix to use parameterized value instead of a static constexpr

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
