### PR TITLE
fix(static_obstacle_avoidance): load missing unstable classification parameter

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
@@ -122,6 +122,8 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
       get_or_declare_parameter<double>(*node, ns + "intersection.yaw_deviation");
     p.object_last_seen_threshold =
       get_or_declare_parameter<double>(*node, ns + "max_compensation_time");
+    p.unstable_classification_time =
+      get_or_declare_parameter<double>(*node, ns + "unstable_classification_time");
   }
 
   {


### PR DESCRIPTION
## Description

This PR fixes a bug where the `unstable_classification_time` parameter was not being loaded in the static obstacle avoidance module, despite being defined in the parameter structure. This oversight prevented the module from properly utilizing the unstable classification handling functionality.

### Changes

- Added parameter loading for the existing `unstable_classification_time` parameter in the `getParameter` function

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/78ecf951-b0bd-5646-82e2-5ecd76e163d8?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/3a7dc916-0685-5567-8aa2-0f91ae5e3515?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/e99537cb-3692-547d-a9f7-0eb555ed89b6?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
