### PR TITLE
feat(tier4_perception_launch): add missing remappings to launch file

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -153,6 +153,7 @@ class GroundSegmentationPipeline:
                 remappings=[
                     ("~/input/odom", "/localization/kinematic_state"),
                     ("output", "concatenated/pointcloud"),
+                    ("output_info", "concatenated/pointcloud_info"),
                 ],
                 parameters=[
                     {
@@ -296,7 +297,7 @@ class GroundSegmentationPipeline:
         )
         return components
 
-    def create_single_frame_obstacle_segmentation_components(self, input_topic, output_topic):
+    def create_single_frame_obstacle_segmentation_components(self, input_topic, output_topic, output_info_topic):
         additional_lidars = self.ground_segmentation_param["additional_lidars"]
         use_ransac = bool(self.ground_segmentation_param["ransac_input_topics"])
         use_additional = bool(additional_lidars)
@@ -318,6 +319,7 @@ class GroundSegmentationPipeline:
                     input_topics=[common_pipeline_output]
                     + [f"{x}/pointcloud" for x in additional_lidars],
                     output_topic=relay_topic if use_ransac else output_topic,
+                    output_info_topic=relay_topic + "_info" if use_ransac else output_info_topic,
                 )
             )
 
@@ -330,6 +332,7 @@ class GroundSegmentationPipeline:
                         relay_topic if use_additional else common_pipeline_output,
                     ],
                     output_topic=output_topic,
+                    output_info_topic=output_info_topic,
                 )
             )
 
@@ -482,7 +485,7 @@ class GroundSegmentationPipeline:
         return components
 
     @staticmethod
-    def get_additional_lidars_concatenated_component(input_topics, output_topic):
+    def get_additional_lidars_concatenated_component(input_topics, output_topic, output_info_topic):
         return ComposableNode(
             package="autoware_pointcloud_preprocessor",
             plugin="autoware::pointcloud_preprocessor::PointCloudConcatenateDataSynchronizerComponent",
@@ -490,6 +493,7 @@ class GroundSegmentationPipeline:
             remappings=[
                 ("~/input/odom", "/localization/kinematic_state"),
                 ("output", output_topic),
+                ("output_info", output_info_topic),
             ],
             parameters=[
                 {
@@ -502,7 +506,7 @@ class GroundSegmentationPipeline:
         )
 
     @staticmethod
-    def get_single_frame_obstacle_segmentation_concatenated_component(input_topics, output_topic):
+    def get_single_frame_obstacle_segmentation_concatenated_component(input_topics, output_topic, output_info_topic):
         return ComposableNode(
             package="autoware_pointcloud_preprocessor",
             plugin="autoware::pointcloud_preprocessor::PointCloudConcatenateDataSynchronizerComponent",
@@ -510,6 +514,7 @@ class GroundSegmentationPipeline:
             remappings=[
                 ("~/input/odom", "/localization/kinematic_state"),
                 ("output", output_topic),
+                ("output_info", output_info_topic),
             ],
             parameters=[
                 {
@@ -533,6 +538,11 @@ def launch_setup(context, *args, **kwargs):
                 pipeline.single_frame_obstacle_seg_output
                 if pipeline.use_single_frame_filter or pipeline.use_time_series_filter
                 else pipeline.output_topic
+            ),
+            output_info_topic=(
+                pipeline.single_frame_obstacle_seg_output + "_info"
+                if pipeline.use_single_frame_filter or pipeline.use_time_series_filter
+                else pipeline.output_topic + "_info"
             ),
         )
     )


### PR DESCRIPTION
## Description

Simple update of new output topic for pointcloud preprocessor.
Introduced in https://github.com/autowarefoundation/autoware_universe/pull/10851.
Even though this topic from ground segmentation pipeline might be not used, I believe we prefer to keep properly organized topic names.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
