### PR TITLE
fix(lane_change): properly handle force activation when there is no valid LC path

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -238,7 +238,7 @@ bool LaneChangeInterface::canTransitSuccessState()
 
 bool LaneChangeInterface::canTransitFailureState()
 {
-  const auto force_activated = [&]() {
+  const auto force_activated = std::invoke([&]() {
     const bool is_force_activated = std::any_of(
       rtc_interface_ptr_map_.begin(), rtc_interface_ptr_map_.end(),
       [&](const auto & rtc) { return rtc.second->isForceActivated(uuid_map_.at(rtc.first)); });
@@ -249,9 +249,9 @@ bool LaneChangeInterface::canTransitFailureState()
       return false;
     }
     return is_force_activated;
-  };
+  });
 
-  if (force_activated()) {
+  if (force_activated) {
     RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 5000, "unsafe but force executed");
     return false;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -238,11 +238,20 @@ bool LaneChangeInterface::canTransitSuccessState()
 
 bool LaneChangeInterface::canTransitFailureState()
 {
-  const auto force_activated = std::any_of(
-    rtc_interface_ptr_map_.begin(), rtc_interface_ptr_map_.end(),
-    [&](const auto & rtc) { return rtc.second->isForceActivated(uuid_map_.at(rtc.first)); });
+  const auto force_activated = [&]() {
+    const bool is_force_activated = std::any_of(
+      rtc_interface_ptr_map_.begin(), rtc_interface_ptr_map_.end(),
+      [&](const auto & rtc) { return rtc.second->isForceActivated(uuid_map_.at(rtc.first)); });
 
-  if (force_activated) {
+    if (is_force_activated && !module_type_->isValidPath()) {
+      RCLCPP_WARN_THROTTLE(
+        getLogger(), *clock_, 1000, "Force activated, but no valid path. Ignore force activation.");
+      return false;
+    }
+    return is_force_activated;
+  };
+
+  if (force_activated()) {
     RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 5000, "unsafe but force executed");
     return false;
   }


### PR DESCRIPTION
## Description

If force activation request is received when there is no valid lc path, LC module state will be left hanging in RUNNING state and cannot properly transition to FAILURE.

This PR fixes this issue by confirming there is a valid path when force activation request is received. If there is no valid path, the request is ignored and a warning msg is displayed.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
