### PR TITLE
docs(autoware_diffusion_planner): remove obsolete information

### DIFF
--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -62,13 +62,13 @@ Parameters can be set via YAML (see `config/diffusion_planner.param.yaml`).
 
 ## Outputs
 
-| Topic                        | Message Type                                  | Description                                |
-| ---------------------------- | --------------------------------------------- | ------------------------------------------ |
-| `~/output/trajectory`        | autoware_planning_msgs/msg/Trajectory         | Planned trajectory for the ego vehicle     |
-| `~/output/trajectories`      | autoware_internal_planning_msgs/msg/CandidateTrajectories   | Multiple candidate trajectories            |
-| `~/output/predicted_objects` | autoware_perception_msgs/msg/PredictedObjects | Predicted future states of dynamic objects |
-| `~/debug/lane_marker`        | visualization_msgs/msg/MarkerArray            | Lane debug markers                         |
-| `~/debug/route_marker`       | visualization_msgs/msg/MarkerArray            | Route debug markers                        |
+| Topic                        | Message Type                                              | Description                                |
+| ---------------------------- | --------------------------------------------------------- | ------------------------------------------ |
+| `~/output/trajectory`        | autoware_planning_msgs/msg/Trajectory                     | Planned trajectory for the ego vehicle     |
+| `~/output/trajectories`      | autoware_internal_planning_msgs/msg/CandidateTrajectories | Multiple candidate trajectories            |
+| `~/output/predicted_objects` | autoware_perception_msgs/msg/PredictedObjects             | Predicted future states of dynamic objects |
+| `~/debug/lane_marker`        | visualization_msgs/msg/MarkerArray                        | Lane debug markers                         |
+| `~/debug/route_marker`       | visualization_msgs/msg/MarkerArray                        | Route debug markers                        |
 
 ---
 

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -65,7 +65,7 @@ Parameters can be set via YAML (see `config/diffusion_planner.param.yaml`).
 | Topic                        | Message Type                                  | Description                                |
 | ---------------------------- | --------------------------------------------- | ------------------------------------------ |
 | `~/output/trajectory`        | autoware_planning_msgs/msg/Trajectory         | Planned trajectory for the ego vehicle     |
-| `~/output/trajectories`      | autoware_new_planning_msgs/msg/Trajectories   | Multiple candidate trajectories            |
+| `~/output/trajectories`      | autoware_internal_planning_msgs/msg/CandidateTrajectories   | Multiple candidate trajectories            |
 | `~/output/predicted_objects` | autoware_perception_msgs/msg/PredictedObjects | Predicted future states of dynamic objects |
 | `~/debug/lane_marker`        | visualization_msgs/msg/MarkerArray            | Lane debug markers                         |
 | `~/debug/route_marker`       | visualization_msgs/msg/MarkerArray            | Route debug markers                        |


### PR DESCRIPTION
## Description

- README in `autoware_diffusion_planner` package has the obsolete information, so remove it and update with correct information.

## Related links

None.

## How was this PR tested?

This PR includes the changes only with docs. So I did not run any tests.

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
