### PR TITLE
feat(out_of_lane): add safety factors to the published planning factor

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/calculate_slowdown_points.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/calculate_slowdown_points.cpp
@@ -136,16 +136,9 @@ std::optional<geometry_msgs::msg::Pose> calculate_last_in_lane_pose(
 }
 
 std::optional<geometry_msgs::msg::Pose> calculate_slowdown_pose(
-  const EgoData & ego_data, const OutOfLaneData & out_of_lane_data, const PlannerParam & params)
+  const EgoData & ego_data, const OutOfLanePoint & out_of_lane_point, const PlannerParam & params)
 {
-  // points are ordered by trajectory index so the first one has the smallest index and arc length
-  const auto point_to_avoid_it = std::find_if(
-    out_of_lane_data.outside_points.cbegin(), out_of_lane_data.outside_points.cend(),
-    [&](const auto & p) { return p.to_avoid; });
-  if (point_to_avoid_it == out_of_lane_data.outside_points.cend()) {
-    return std::nullopt;
-  }
-  auto slowdown_pose = calculate_last_in_lane_pose(ego_data, *point_to_avoid_it, params);
+  auto slowdown_pose = calculate_last_in_lane_pose(ego_data, out_of_lane_point, params);
   if (slowdown_pose && params.use_map_stop_lines) {
     // try to use a map stop line ahead of the stop pose
     auto stop_arc_length =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/calculate_slowdown_points.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/calculate_slowdown_points.hpp
@@ -47,11 +47,11 @@ std::optional<geometry_msgs::msg::Pose> calculate_last_in_lane_pose(
 
 /// @brief calculate the slowdown point to insert in the trajectory
 /// @param ego_data ego data (trajectory, velocity, etc)
-/// @param out_of_lane_data data about out of lane areas
+/// @param out_of_lane_point out of lane point to avoid
 /// @param params parameters
 /// @return optional slowdown pose to insert in the trajectory
 std::optional<geometry_msgs::msg::Pose> calculate_slowdown_pose(
-  const EgoData & ego_data, const OutOfLaneData & out_of_lane_data, const PlannerParam & params);
+  const EgoData & ego_data, const OutOfLanePoint & out_of_lane_point, const PlannerParam & params);
 
 /// @brief calculate the minimum stop and slowdown distances of ego
 /// @param [inout] ego_data ego data where minimum stop and slowdown distances are set

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
@@ -47,7 +47,7 @@ namespace autoware::motion_velocity_planner::out_of_lane
 
 void update_collision_times(
   OutOfLaneData & out_of_lane_data, const std::unordered_set<size_t> & potential_collision_indexes,
-  const autoware_utils::Polygon2d & object_footprint, const double time)
+  const autoware_utils::Polygon2d & object_footprint, const CollisionTime & time)
 {
   for (const auto index : potential_collision_indexes) {
     auto & out_of_lane_point = out_of_lane_data.outside_points[index];
@@ -185,18 +185,21 @@ bool at_least_one_lanelet_in_common(
 }
 
 void calculate_object_path_time_collisions(
-  OutOfLaneData & out_of_lane_data,
-  const autoware_perception_msgs::msg::PredictedPath & object_path,
-  const autoware_perception_msgs::msg::Shape & object_shape,
+  OutOfLaneData & out_of_lane_data, const size_t & object_path_id,
+  const autoware_perception_msgs::msg::PredictedObject & object,
   const route_handler::RouteHandler & route_handler,
   const bool validate_predicted_paths_on_lanelets)
 {
+  const auto & object_path = object.kinematics.predicted_paths[object_path_id];
   const auto time_step = rclcpp::Duration(object_path.time_step).seconds();
-  auto time = 0.0;
+  CollisionTime collision_time;
+  collision_time.object_uuid = object.object_id;
+  collision_time.object_path_id = object_path_id;
+  collision_time.collision_time = 0.0;
   std::optional<lanelet::Ids>
     object_path_lanelet_ids;  // calculated only once for the 1st collision found
   for (const auto & object_pose : object_path.path) {
-    const auto object_footprint = autoware_utils::to_polygon2d(object_pose, object_shape);
+    const auto object_footprint = autoware_utils::to_polygon2d(object_pose, object.shape);
     std::vector<OutAreaNode> query_results;
     out_of_lane_data.outside_areas_rtree.query(
       boost::geometry::index::intersects(object_footprint.outer()),
@@ -211,8 +214,9 @@ void calculate_object_path_time_collisions(
         potential_collision_indexes.insert(index);
       }
     }
-    update_collision_times(out_of_lane_data, potential_collision_indexes, object_footprint, time);
-    time += time_step;
+    update_collision_times(
+      out_of_lane_data, potential_collision_indexes, object_footprint, collision_time);
+    collision_time.collision_time += time_step;
   }
 }
 
@@ -224,9 +228,9 @@ void calculate_objects_time_collisions(
   for (const auto & object : objects) {
     auto shape = object.shape;
     shape.dimensions.y += params.objects_extra_width * 0.5;
-    for (const auto & path : object.kinematics.predicted_paths) {
+    for (auto path_id = 0UL; path_id < object.kinematics.predicted_paths.size(); ++path_id) {
       calculate_object_path_time_collisions(
-        out_of_lane_data, path, object.shape, route_handler,
+        out_of_lane_data, path_id, object, route_handler,
         params.validate_predicted_paths_on_lanelets);
     }
   }
@@ -239,8 +243,8 @@ void calculate_min_max_arrival_times(
   auto min_time = std::numeric_limits<double>::infinity();
   auto max_time = -std::numeric_limits<double>::infinity();
   for (const auto & t : out_of_lane_point.collision_times) {
-    min_time = std::min(t, min_time);
-    max_time = std::max(t, max_time);
+    min_time = std::min(t.collision_time, min_time);
+    max_time = std::max(t.collision_time, max_time);
   }
   if (min_time <= max_time) {
     out_of_lane_point.min_object_arrival_time = min_time;
@@ -254,7 +258,7 @@ void calculate_min_max_arrival_times(
         std::min(std::abs(ego_time - min_time), std::abs(ego_time - max_time));
     }
   }
-};
+}
 
 void calculate_collisions_to_avoid(
   OutOfLaneData & out_of_lane_data,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.hpp
@@ -31,9 +31,9 @@ namespace autoware::motion_velocity_planner::out_of_lane
 /// @brief calculate the times and points where ego collides with an object's path outside of its
 /// lane
 void calculate_object_path_time_collisions(
-  OutOfLaneData & out_of_lane_data,
-  const autoware_perception_msgs::msg::PredictedPath & object_path,
-  const autoware_perception_msgs::msg::Shape & object_shape,
+  OutOfLaneData & out_of_lane_data, const size_t & object_path_id,
+  const autoware_perception_msgs::msg::PredictedObject & object,
+  const route_handler::RouteHandler & route_handler,
   const bool validate_predicted_paths_on_lanelets);
 
 /// @brief calculate the times and points where ego collides with an object outside of its lane

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -359,7 +359,6 @@ void OutOfLaneModule::update_result(
   if (!slowdown_pose) {
     return;
   }
-  auto planning_factor = PlanningFactor::SLOW_DOWN;
   const auto arc_length =
     motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0UL, slowdown_pose->position) -
     ego_data.longitudinal_offset_to_first_trajectory_index;
@@ -367,7 +366,6 @@ void OutOfLaneModule::update_result(
     arc_length <= params_.stop_dist_threshold ? 0.0 : params_.slow_velocity;
   previous_slowdown_pose_ = slowdown_pose;
   if (slowdown_velocity == 0.0) {
-    planning_factor = PlanningFactor::STOP;
     result.stop_points.push_back(slowdown_pose->position);
   } else {
     result.slowdown_intervals.emplace_back(
@@ -412,6 +410,9 @@ void OutOfLaneModule::update_result(
   for (const auto & [_, safety_factor] : factor_per_object) {
     safety_factors.factors.push_back(safety_factor);
   }
+
+  const auto planning_factor =
+    slowdown_velocity == 0.0 ? PlanningFactor::STOP : PlanningFactor::SLOW_DOWN;
   planning_factor_interface_->add(
     ego_data.trajectory_points, ego_data.pose, *slowdown_pose, planning_factor, safety_factors);
 }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -32,11 +32,17 @@
 #include <autoware_utils/ros/published_time_publisher.hpp>
 #include <autoware_utils/ros/update_param.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
 #include <rclcpp/logging.hpp>
+
+#include <autoware_internal_planning_msgs/msg/safety_factor.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <unique_identifier_msgs/msg/detail/uuid__struct.hpp>
 
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/geometries/multi_polygon.hpp>
+#include <boost/uuid/uuid.hpp>
 
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Polygon.h>
@@ -47,6 +53,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::motion_velocity_planner
@@ -58,7 +65,7 @@ using visualization_msgs::msg::MarkerArray;
 void OutOfLaneModule::init(rclcpp::Node & node, const std::string & module_name)
 {
   module_name_ = module_name;
-  logger_ = node.get_logger();
+  logger_ = node.get_logger().get_child(module_name_);
   clock_ = node.get_clock();
   init_parameters(node);
 
@@ -235,11 +242,28 @@ out_of_lane::OutOfLaneData prepare_out_of_lane_data(const out_of_lane::EgoData &
 std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose(
   const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data)
 {
-  auto slowdown_pose = out_of_lane::calculate_slowdown_pose(ego_data, out_of_lane_data, params_);
+  // points are ordered by trajectory index so the first one has the smallest index and arc length
+  const auto point_to_avoid_it = std::find_if(
+    out_of_lane_data.outside_points.cbegin(), out_of_lane_data.outside_points.cend(),
+    [&](const auto & p) { return p.to_avoid; });
+  const auto has_point_to_avoid = (point_to_avoid_it != out_of_lane_data.outside_points.cend());
+  const auto slowdown_pose =
+    has_point_to_avoid ? out_of_lane::calculate_slowdown_pose(ego_data, *point_to_avoid_it, params_)
+                       : std::nullopt;
+
+  const auto log_cannot_stop = [&]() {
+    if (has_point_to_avoid && !slowdown_pose) {
+      RCLCPP_WARN_THROTTLE(
+        logger_, *clock_, 1000, "Could not insert slowdown point because of deceleration limits");
+    }
+  };
 
   update_slowdown_pose_buffer(ego_data, slowdown_pose);
 
-  if (slowdown_pose_buffer_.empty()) return {};
+  if (slowdown_pose_buffer_.empty()) {
+    log_cannot_stop();
+    return {};
+  }
 
   // get nearest active slowdown pose
   auto min_arc_length = std::numeric_limits<double>::max();
@@ -250,12 +274,13 @@ std::optional<geometry_msgs::msg::Pose> OutOfLaneModule::calculate_slowdown_pose
     min_arc_length = sp.arc_length;
   }
 
-  if (!nearest_slowdown_pose) return {};
+  if (!nearest_slowdown_pose) {
+    log_cannot_stop();
+    return {};
+  }
 
-  slowdown_pose = motion_utils::calcInterpolatedPose(
+  return motion_utils::calcInterpolatedPose(
     ego_data.trajectory_points, nearest_slowdown_pose->arc_length);
-
-  return slowdown_pose;
 }
 
 void OutOfLaneModule::update_slowdown_pose_buffer(
@@ -331,33 +356,64 @@ void OutOfLaneModule::update_result(
   VelocityPlanningResult & result, const std::optional<geometry_msgs::msg::Pose> & slowdown_pose,
   const out_of_lane::EgoData & ego_data, const out_of_lane::OutOfLaneData & out_of_lane_data)
 {
-  if (slowdown_pose) {
-    const auto arc_length =
-      motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0UL, slowdown_pose->position) -
-      ego_data.longitudinal_offset_to_first_trajectory_index;
-    const auto slowdown_velocity =
-      arc_length <= params_.stop_dist_threshold ? 0.0 : params_.slow_velocity;
-    previous_slowdown_pose_ = slowdown_pose;
-    if (slowdown_velocity == 0.0) {
-      result.stop_points.push_back(slowdown_pose->position);
-    } else {
-      result.slowdown_intervals.emplace_back(
-        slowdown_pose->position, slowdown_pose->position, slowdown_velocity);
-    }
-
-    planning_factor_interface_->add(
-      ego_data.trajectory_points, ego_data.pose, *slowdown_pose, PlanningFactor::SLOW_DOWN,
-      SafetyFactorArray{});
-    virtual_wall_marker_creator.add_virtual_walls(
-      out_of_lane::debug::create_virtual_walls(*slowdown_pose, slowdown_velocity == 0.0, params_));
-    virtual_wall_publisher_->publish(virtual_wall_marker_creator.create_markers(clock_->now()));
-  } else if (std::any_of(
-               out_of_lane_data.outside_points.begin(), out_of_lane_data.outside_points.end(),
-               [](const auto & p) { return p.to_avoid; })) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_, 1000,
-      "[out_of_lane] Could not insert slowdown point because of deceleration limits");
+  if (!slowdown_pose) {
+    return;
   }
+  auto planning_factor = PlanningFactor::SLOW_DOWN;
+  const auto arc_length =
+    motion_utils::calcSignedArcLength(ego_data.trajectory_points, 0UL, slowdown_pose->position) -
+    ego_data.longitudinal_offset_to_first_trajectory_index;
+  const auto slowdown_velocity =
+    arc_length <= params_.stop_dist_threshold ? 0.0 : params_.slow_velocity;
+  previous_slowdown_pose_ = slowdown_pose;
+  if (slowdown_velocity == 0.0) {
+    planning_factor = PlanningFactor::STOP;
+    result.stop_points.push_back(slowdown_pose->position);
+  } else {
+    result.slowdown_intervals.emplace_back(
+      slowdown_pose->position, slowdown_pose->position, slowdown_velocity);
+  }
+  virtual_wall_marker_creator.add_virtual_walls(
+    out_of_lane::debug::create_virtual_walls(*slowdown_pose, slowdown_velocity == 0.0, params_));
+  virtual_wall_publisher_->publish(virtual_wall_marker_creator.create_markers(clock_->now()));
+
+  SafetyFactorArray safety_factors;
+  safety_factors.header.stamp = clock_->now();
+  safety_factors.header.frame_id = "map";
+
+  const auto avoided_point_it = std::find_if(
+    out_of_lane_data.outside_points.cbegin(), out_of_lane_data.outside_points.cend(),
+    [&](const auto & p) { return p.to_avoid; });
+  std::unordered_map<std::string, autoware_internal_planning_msgs::msg::SafetyFactor>
+    factor_per_object;
+  if (avoided_point_it != out_of_lane_data.outside_points.cend()) {
+    for (const auto & collision : avoided_point_it->collision_times) {
+      const auto is_possible_collision =
+        collision.collision_time >= avoided_point_it->min_object_arrival_time &&
+        collision.collision_time <= avoided_point_it->max_object_arrival_time;
+      if (is_possible_collision) {
+        const auto uuid = autoware_utils_uuid::to_hex_string(collision.object_uuid);
+        if (factor_per_object.count(uuid) == 0) {
+          autoware_internal_planning_msgs::msg::SafetyFactor sf;
+          sf.is_safe = false;
+          sf.object_id = collision.object_uuid;
+          sf.type = autoware_internal_planning_msgs::msg::SafetyFactor::OBJECT;
+          sf.ttc_begin = static_cast<float>(*avoided_point_it->ttc);
+          sf.ttc_end = static_cast<float>(*avoided_point_it->ttc);
+          factor_per_object[uuid] = sf;
+        } else {
+          auto & sf = factor_per_object[uuid];
+          sf.ttc_begin = std::min(sf.ttc_begin, static_cast<float>(*avoided_point_it->ttc));
+          sf.ttc_end = std::max(sf.ttc_end, static_cast<float>(*avoided_point_it->ttc));
+        }
+      }
+    }
+  }
+  for (const auto & [_, safety_factor] : factor_per_object) {
+    safety_factors.factors.push_back(safety_factor);
+  }
+  planning_factor_interface_->add(
+    ego_data.trajectory_points, ego_data.pose, *slowdown_pose, planning_factor, safety_factors);
 }
 
 VelocityPlanningResult OutOfLaneModule::plan(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -77,7 +77,7 @@ private:
   std::string module_name_{"uninitialized"};
   rclcpp::Clock::SharedPtr clock_{nullptr};
   std::optional<geometry_msgs::msg::Pose> previous_slowdown_pose_{std::nullopt};
-  std::vector<out_of_lane::SlowdownPose> slowdown_pose_buffer_{};
+  std::vector<out_of_lane::SlowdownPose> slowdown_pose_buffer_;
 
 protected:
   // Debug

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -23,6 +23,7 @@
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
 
 #include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/index/rtree.hpp>
@@ -127,12 +128,26 @@ struct EgoData
     map_stop_points;  // ego stop points (and their corresponding stop lines) taken from the map
 };
 
+/// @brief a collision time along with the object and path id that cause the collision
+struct CollisionTime
+{
+  double collision_time{};
+  unique_identifier_msgs::msg::UUID object_uuid;
+  size_t object_path_id{};
+
+  // Overload needed to store the struct in std::set
+  bool operator<(const CollisionTime & other) const
+  {
+    return collision_time < other.collision_time;
+  }
+};
+
 /// @brief data related to an out of lane trajectory point
 struct OutOfLanePoint
 {
   size_t trajectory_index;
   autoware_utils::MultiPolygon2d out_overlaps;
-  std::set<double> collision_times;
+  std::set<CollisionTime> collision_times;
   std::optional<double> min_object_arrival_time;
   std::optional<double> max_object_arrival_time;
   std::optional<double> ttc;


### PR DESCRIPTION
## Description

Refactor the code of the `out_of_lane` module to record the objects that cause a collision. This information is then used to populate the `SafetyFactorArray` of the planning factor published by the module.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
