### PR TITLE
Rt1 10807 configurable diagnostic level

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -32,6 +32,19 @@
 #include <unordered_map>
 #include <vector>
 
+namespace
+{
+using autoware::motion_velocity_planner::experimental::DepartureType;
+std::string to_string(DepartureType type)
+{
+  auto str = std::string(magic_enum::enum_name(type));
+  std::transform(
+    str.begin(), str.end(), str.begin(), [](unsigned char c) { return std::tolower(c); });
+  std::replace(str.begin(), str.end(), '_', ' ');
+  return str;
+}
+}  // namespace
+
 namespace autoware::motion_velocity_planner::experimental
 {
 
@@ -51,20 +64,24 @@ void BoundaryDeparturePreventionModule::init(
   updater_ptr_->setHardwareID("motion_velocity_boundary_departure_prevention");
   updater_ptr_->add(
     "boundary_departure", [this](diagnostic_updater::DiagnosticStatusWrapper & stat) {
-      int8_t lvl{DiagStatus::OK};
-      std::string msg{"OK"};
+      const auto type = std::invoke([&]() {
+        if (output_.diagnostic_output[DepartureType::CRITICAL_DEPARTURE]) {
+          return DepartureType::CRITICAL_DEPARTURE;
+        }
+        if (output_.diagnostic_output[DepartureType::APPROACHING_DEPARTURE]) {
+          return DepartureType::APPROACHING_DEPARTURE;
+        }
+        if (output_.diagnostic_output[DepartureType::NEAR_BOUNDARY]) {
+          return DepartureType::NEAR_BOUNDARY;
+        }
+        return DepartureType::NONE;
+      });
 
-      if (output_.diagnostic_output[DepartureType::CRITICAL_DEPARTURE]) {
-        lvl = node_param_.diagnostic_level[DepartureType::CRITICAL_DEPARTURE];
-        msg = "vehicle is leaving boundary";
-        RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 500, "%s", msg.c_str());
-      } else if (output_.diagnostic_output[DepartureType::APPROACHING_DEPARTURE]) {
-        lvl = node_param_.diagnostic_level[DepartureType::APPROACHING_DEPARTURE];
-        msg = "vehicle is moving towards the boundary";
+      auto lvl = node_param_.diagnostic_level[type];
+      auto msg = to_string(type);
+
+      if (lvl != DiagStatus::OK && type != DepartureType::NONE) {
         RCLCPP_ERROR_THROTTLE(logger_, *clock_ptr_, 1000, "%s", msg.c_str());
-      } else if (output_.diagnostic_output[DepartureType::NEAR_BOUNDARY]) {
-        lvl = node_param_.diagnostic_level[DepartureType::NEAR_BOUNDARY];
-        msg = "vehicle is near boundary";
       }
 
       stat.summary(lvl, msg);
@@ -277,12 +294,12 @@ VelocityPlanningResult BoundaryDeparturePreventionModule::plan(
       return msg;
     }));
 
+    updater_ptr_->force_update();
     if (!result_opt) {
       RCLCPP_DEBUG(logger_, "Planning skipped: %s", result_opt.error().c_str());
       return {};
     }
 
-    updater_ptr_->force_update();
     return *result_opt;
   } catch (const std::exception & e) {
     RCLCPP_WARN(logger_, "Exception is caught: %s", e.what());

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
@@ -143,7 +143,7 @@ struct NodeParam
     });
 
     const auto select_diag_lvl = [](const int level) {
-      if (DiagStatus::OK) {
+      if (level == 0) {
         return DiagStatus::OK;
       }
 
@@ -169,6 +169,7 @@ struct NodeParam
       const auto critical_departure_diag_lvl =
         select_diag_lvl(get_or_declare_parameter<int>(node, ns_diag + "critical_departure"));
 
+      diag.insert({DepartureType::NONE, DiagStatus::OK});
       diag.insert({DepartureType::NEAR_BOUNDARY, near_boundary_diag_lvl});
       diag.insert({DepartureType::APPROACHING_DEPARTURE, approaching_departure_diag_lvl});
       diag.insert({DepartureType::CRITICAL_DEPARTURE, critical_departure_diag_lvl});


### PR DESCRIPTION
## Description

fix diagnostic cannot be properly configured.
It is expected that if the diagnostic status is set to 0, there shouldn't be any error being published by RCLCPP. 

```
      diagnostic:
        # Diagnostic status
        #  0: OK (Default)
        #  1: WARN
        #  2: ERROR
        near_boundary: 0
        approaching_departure: 0
        critical_departure: 2
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

set diagnostic status to 1 or 2 in boundary departure prevention param file.
If tier4 diagnostic is available, then apply the following patch 

```
diff --git a/autoware_launch/config/system/tier4_diagnostics/planning.yaml b/autoware_launch/config/system/tier4_diagnostics/planning.yaml
index e5ff65e4..7a88c08a 100644
--- a/autoware_launch/config/system/tier4_diagnostics/planning.yaml
+++ b/autoware_launch/config/system/tier4_diagnostics/planning.yaml
@@ -40,6 +40,7 @@ units:
       # - { type: link, link: /planning/015-collision_checker-error }
       - { type: link, link: /planning/016-path_optimizer_emergency_stop-error }
       # - { type: link, link: /planning/017-rear_collision_checker-error }
+      - { type: link, link: /planning/018-boundary_departure-error }
 
   - path: /planning/comfortable_stop
     type: and
@@ -152,6 +153,12 @@ units:
       type: link
       link: /planning/017-rear_collision_checker
 
+  - path: /planning/018-boundary_departure-error
+    type: warn-to-ok
+    item:
+      type: link
+      link: /planning/018-boundary_departure
+
   - path: /planning/001-topic_status/route
     type: diag
     node: topic_state_monitor_mission_planning_route
@@ -253,3 +260,9 @@ units:
     node: planning_validator
     name: rear_collision_check
     timeout: 1.0
+
+  - path: /planning/018-boundary_departure
+    type: diag
+    node: motion_velocity_planner
+    name: boundary_departure
+    timeout: 1.0

```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
