### PR TITLE
fix(autoware_multi_object_tracker): set default existence probability for untrusted channels

### DIFF
--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -109,7 +109,7 @@ void InputStream::onMessage(
   uncertainty::normalizeUncertainty(dynamic_objects);
 
   // If the channel does not trust existence probability, set it to default
-  if (!channel_.trust_existence_probability){
+  if (!channel_.trust_existence_probability) {
     for (auto & object : dynamic_objects.objects) {
       object.existence_probability = types::default_existence_probability;
     }

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -108,6 +108,13 @@ void InputStream::onMessage(
   // Normalize the object uncertainty
   uncertainty::normalizeUncertainty(dynamic_objects);
 
+  // If the channel does not trust existence probability, set it to default
+  if (!channel_.trust_existence_probability){
+    for (auto & object : dynamic_objects.objects) {
+      object.existence_probability = types::default_existence_probability;
+    }
+  }
+
   // Move the objects_with_uncertainty to the objects queue
   objects_que_.push_back(std::move(dynamic_objects));
   while (objects_que_.size() > que_size_) {


### PR DESCRIPTION
## Description

the channel configuration `trust_existence_probability` was only implemented on the tracker initialization, but not in the update.
This PR implements default existence probability when the option is false.

## Related links

**Parent Issue:**

[TIER IV INTERNAL](https://star4.slack.com/archives/C076ZGRC15X/p1753424015987739)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
