### PR TITLE
feat(surround_obstacle_checker): add safety factors to the published planning factor

### DIFF
--- a/planning/autoware_surround_obstacle_checker/CMakeLists.txt
+++ b/planning/autoware_surround_obstacle_checker/CMakeLists.txt
@@ -43,6 +43,7 @@ rclcpp_components_register_node(${PROJECT_NAME}
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
   test/test_surround_obstacle_checker.cpp
+  test/test_planning_factor.cpp
   )
   target_link_libraries(test_${PROJECT_NAME}
     ${PROJECT_NAME}

--- a/planning/autoware_surround_obstacle_checker/package.xml
+++ b/planning/autoware_surround_obstacle_checker/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
+  <depend>autoware_universe_utils</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>diagnostic_msgs</depend>

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
@@ -99,16 +99,10 @@ bool SurroundObstacleCheckerDebugNode::pushPose(
   }
 }
 
-bool SurroundObstacleCheckerDebugNode::pushObstaclePoint(
-  const geometry_msgs::msg::Point & obstacle_point, const PointType & type)
+void SurroundObstacleCheckerDebugNode::pushStopObstacle(
+  const std::optional<StopObstacle> & stop_obstacle)
 {
-  switch (type) {
-    case PointType::NoStart:
-      stop_obstacle_point_ptr_ = std::make_shared<geometry_msgs::msg::Point>(obstacle_point);
-      return true;
-    default:
-      return false;
-  }
+  stop_obstacle_ = stop_obstacle;
 }
 
 void SurroundObstacleCheckerDebugNode::publishFootprints()
@@ -147,11 +141,20 @@ void SurroundObstacleCheckerDebugNode::publish()
   safety_factors.header.stamp = clock_->now();
   safety_factors.header.frame_id = "map";
 
-  if (stop_obstacle_point_ptr_ != nullptr) {
+  if (stop_obstacle_.has_value()) {
+    const auto type = [&]() {
+      if (stop_obstacle_.value().is_point_cloud) {
+        return autoware_internal_planning_msgs::msg::SafetyFactor::POINTCLOUD;
+      } else {
+        return autoware_internal_planning_msgs::msg::SafetyFactor::OBJECT;
+      }
+    }();
+
     autoware_internal_planning_msgs::msg::SafetyFactor safety_factor;
     safety_factor.is_safe = false;
-    safety_factor.type = autoware_internal_planning_msgs::msg::SafetyFactor::POINTCLOUD;
-    safety_factor.points.push_back(*stop_obstacle_point_ptr_);
+    safety_factor.type = type;
+    safety_factor.object_id = stop_obstacle_.value().uuid;
+    safety_factor.points = {stop_obstacle_.value().nearest_point};
     safety_factors.factors.push_back(safety_factor);
   }
 
@@ -165,7 +168,7 @@ void SurroundObstacleCheckerDebugNode::publish()
 
   /* reset variables */
   stop_pose_ptr_ = nullptr;
-  stop_obstacle_point_ptr_ = nullptr;
+  stop_obstacle_.reset();
 }
 
 MarkerArray SurroundObstacleCheckerDebugNode::makeVisualizationMarker()
@@ -174,11 +177,11 @@ MarkerArray SurroundObstacleCheckerDebugNode::makeVisualizationMarker()
   rclcpp::Time current_time = this->clock_->now();
 
   // visualize surround object
-  if (stop_obstacle_point_ptr_ != nullptr) {
+  if (stop_obstacle_.has_value()) {
     auto marker = create_default_marker(
       "map", current_time, "no_start_obstacle_text", 0, Marker::TEXT_VIEW_FACING,
       create_marker_scale(0.0, 0.0, 1.0), create_marker_color(1.0, 1.0, 1.0, 0.999));
-    marker.pose.position = *stop_obstacle_point_ptr_;
+    marker.pose.position = stop_obstacle_.value().nearest_point;
     marker.pose.position.z += 2.0;  // add half of the heights of obj roughly
     marker.text = "!";
     msg.markers.push_back(marker);

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
@@ -143,11 +143,23 @@ void SurroundObstacleCheckerDebugNode::publish()
   const auto visualization_msg = makeVisualizationMarker();
   debug_viz_pub_->publish(visualization_msg);
 
+  autoware_internal_planning_msgs::msg::SafetyFactorArray safety_factors;
+  safety_factors.header.stamp = clock_->now();
+  safety_factors.header.frame_id = "map";
+
+  if (stop_obstacle_point_ptr_ != nullptr) {
+    autoware_internal_planning_msgs::msg::SafetyFactor safety_factor;
+    safety_factor.is_safe = false;
+    safety_factor.type = autoware_internal_planning_msgs::msg::SafetyFactor::POINTCLOUD;
+    safety_factor.points.push_back(*stop_obstacle_point_ptr_);
+    safety_factors.factors.push_back(safety_factor);
+  }
+
   /* publish stop reason for autoware api */
   if (stop_pose_ptr_ != nullptr) {
     planning_factor_interface_->add(
       0.0, *stop_pose_ptr_, autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
-      autoware_internal_planning_msgs::msg::SafetyFactorArray{});
+      safety_factors);
   }
   planning_factor_interface_->publish();
 

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp
@@ -15,6 +15,9 @@
 #ifndef DEBUG_MARKER_HPP_
 #define DEBUG_MARKER_HPP_
 
+#include "type_alias.hpp"
+#include "types.hpp"
+
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -32,14 +35,6 @@
 
 namespace autoware::surround_obstacle_checker
 {
-
-using autoware::vehicle_info_utils::VehicleInfo;
-using autoware_internal_planning_msgs::msg::ControlPoint;
-using autoware_internal_planning_msgs::msg::PlanningFactor;
-using autoware_internal_planning_msgs::msg::PlanningFactorArray;
-using geometry_msgs::msg::PolygonStamped;
-using visualization_msgs::msg::Marker;
-using visualization_msgs::msg::MarkerArray;
 
 namespace bg = boost::geometry;
 using Point2d = bg::model::d2::point_xy<double>;
@@ -59,7 +54,7 @@ public:
     const rclcpp::Clock::SharedPtr clock, rclcpp::Node & node);
 
   bool pushPose(const geometry_msgs::msg::Pose & pose, const PoseType & type);
-  bool pushObstaclePoint(const geometry_msgs::msg::Point & obstacle_point, const PointType & type);
+  void pushStopObstacle(const std::optional<StopObstacle> & stop_obstacle);
   void publish();
   void publishFootprints();
 
@@ -85,7 +80,7 @@ private:
 
   PolygonStamped boostPolygonToPolygonStamped(const Polygon2d & boost_polygon, const double & z);
 
-  std::shared_ptr<geometry_msgs::msg::Point> stop_obstacle_point_ptr_;
+  std::optional<StopObstacle> stop_obstacle_;
   std::shared_ptr<geometry_msgs::msg::Pose> stop_pose_ptr_;
   rclcpp::Clock::SharedPtr clock_;
 };

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -38,6 +38,7 @@
 #else
 #include <tf2_eigen/tf2_eigen.hpp>
 #endif
+#include <tf2/utils.h>
 
 #include <algorithm>
 #include <functional>
@@ -167,8 +168,10 @@ void SurroundObstacleCheckerNode::onTimer()
   constexpr double epsilon = 1e-3;
   switch (state_) {
     case State::PASS: {
-      const auto is_obstacle_found =
-        !nearest_obstacle ? false : nearest_obstacle.value().first < epsilon;
+      const auto is_obstacle_found = [&]() {
+        if (!nearest_obstacle.has_value()) return false;
+        return nearest_obstacle.value().neareset_distance < epsilon;
+      }();
 
       bool is_stop_required = false;
       std::tie(is_stop_required, last_obstacle_found_time_) = isStopRequired(
@@ -195,9 +198,11 @@ void SurroundObstacleCheckerNode::onTimer()
     }
 
     case State::STOP: {
-      const auto is_obstacle_found = !nearest_obstacle ? false
-                                                       : nearest_obstacle.value().first <
-                                                           param.surround_check_hysteresis_distance;
+      const auto is_obstacle_found = [&]() {
+        if (!nearest_obstacle.has_value()) return false;
+        return nearest_obstacle.value().neareset_distance <
+               param.surround_check_hysteresis_distance;
+      }();
 
       bool is_stop_required = false;
       std::tie(is_stop_required, last_obstacle_found_time_) = isStopRequired(
@@ -223,8 +228,8 @@ void SurroundObstacleCheckerNode::onTimer()
       break;
   }
 
-  if (nearest_obstacle) {
-    debug_ptr_->pushObstaclePoint(nearest_obstacle.value().second, PointType::NoStart);
+  if (nearest_obstacle.has_value()) {
+    debug_ptr_->pushStopObstacle(nearest_obstacle);
   }
 
   if (state_ == State::STOP) {
@@ -239,27 +244,28 @@ void SurroundObstacleCheckerNode::onTimer()
   debug_ptr_->publish();
 }
 
-std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacle() const
+std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacle() const
 {
   const auto nearest_pointcloud = getNearestObstacleByPointCloud();
   const auto nearest_object = getNearestObstacleByDynamicObject();
-  if (!nearest_pointcloud && !nearest_object) {
+  if (!nearest_pointcloud.has_value() && !nearest_object.has_value()) {
     return {};
   }
 
-  if (!nearest_pointcloud) {
+  if (!nearest_pointcloud.has_value()) {
     return nearest_object;
   }
 
-  if (!nearest_object) {
+  if (!nearest_object.has_value()) {
     return nearest_pointcloud;
   }
 
-  return nearest_pointcloud.value().first < nearest_object.value().first ? nearest_pointcloud
-                                                                         : nearest_object;
+  return nearest_pointcloud.value().neareset_distance < nearest_object.value().neareset_distance
+           ? nearest_pointcloud
+           : nearest_object;
 }
 
-std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCloud() const
+std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCloud() const
 {
   const auto param = param_listener_->get_params();
 
@@ -274,7 +280,7 @@ std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCl
   const auto transform_stamped =
     getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
 
-  if (!transform_stamped) {
+  if (!transform_stamped.has_value()) {
     return std::nullopt;
   }
 
@@ -291,10 +297,19 @@ std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCl
   const double base_to_front = vehicle_info_.max_longitudinal_offset_m + front_margin;
   const double base_to_rear = vehicle_info_.rear_overhang_m + back_margin;
   const double width = vehicle_info_.vehicle_width_m + side_margin * 2;
+  const auto base_link_origin = []() {
+    geometry_msgs::msg::Pose p;
+    p.position.x = 0.0;
+    p.position.y = 0.0;
+    p.position.z = 0.0;
+    p.orientation = autoware_utils_geometry::create_quaternion_from_yaw(0.0);
+    return p;
+  }();
   const auto ego_polygon =
-    autoware_utils::to_footprint(odometry_ptr_->pose.pose, base_to_front, base_to_rear, width);
+    autoware_utils::to_footprint(base_link_origin, base_to_front, base_to_rear, width);
 
-  geometry_msgs::msg::Point nearest_point;
+  // distance comparison on base_link frame
+  geometry_msgs::msg::Point nearest_point_base_link;
   double minimum_distance = std::numeric_limits<double>::max();
   bool was_minimum_distance_updated = false;
   for (const auto & p : transformed_pointcloud) {
@@ -303,30 +318,52 @@ std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCl
     const auto distance_to_object = bg::distance(ego_polygon, boost_point);
 
     if (distance_to_object < minimum_distance) {
-      nearest_point = create_point(p.x, p.y, p.z);
+      nearest_point_base_link = create_point(p.x, p.y, p.z);
       minimum_distance = distance_to_object;
       was_minimum_distance_updated = true;
     }
   }
 
   if (was_minimum_distance_updated) {
-    return std::make_pair(minimum_distance, nearest_point);
+    // transform the nearest point from base_link to map frame
+    const auto nearest_point_map = [&]() {
+      geometry_msgs::msg::Point nearest_point_map;
+      const auto & pose = odometry_ptr_->pose.pose;
+      const double cos_yaw = std::cos(tf2::getYaw(pose.orientation));
+      const double sin_yaw = std::sin(tf2::getYaw(pose.orientation));
+      const double x_rot =
+        cos_yaw * nearest_point_base_link.x - sin_yaw * nearest_point_base_link.y;
+      const double y_rot =
+        sin_yaw * nearest_point_base_link.x + cos_yaw * nearest_point_base_link.y;
+      nearest_point_map.x = x_rot + pose.position.x;
+      nearest_point_map.y = y_rot + pose.position.y;
+      nearest_point_map.z = nearest_point_base_link.z + pose.position.z;
+      return nearest_point_map;
+    }();
+
+    StopObstacle obstacle;
+    obstacle.is_point_cloud = true;
+    obstacle.neareset_distance = minimum_distance;
+    obstacle.nearest_point = nearest_point_map;
+    obstacle.uuid = UUID();  // Default UUID
+    return obstacle;
   }
   return std::nullopt;
 }
 
-std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynamicObject() const
+std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynamicObject() const
 {
-  if (!object_ptr_ || !getUseDynamicObject()) return std::nullopt;
+  if (!object_ptr_ || !getUseDynamicObject()) {
+    return std::nullopt;
+  }
 
   const auto param = param_listener_->get_params();
 
   // TODO(murooka) check computation cost
-  geometry_msgs::msg::Point nearest_point;
+  PredictedObject nearest_object;
   double minimum_distance = std::numeric_limits<double>::max();
   bool was_minimum_distance_updated = false;
   for (const auto & object : object_ptr_->objects) {
-    const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const int label = object.classification.front().label;
     const auto & str_label = label_map_.at(label);
 
@@ -348,14 +385,21 @@ std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynamic
     const auto distance_to_object = bg::distance(ego_polygon, object_polygon);
 
     if (distance_to_object < minimum_distance) {
-      nearest_point = object_pose.position;
+      nearest_object = object;
       minimum_distance = distance_to_object;
       was_minimum_distance_updated = true;
     }
   }
 
   if (was_minimum_distance_updated) {
-    return std::make_pair(minimum_distance, nearest_point);
+    const auto & object_position =
+      nearest_object.kinematics.initial_pose_with_covariance.pose.position;
+    StopObstacle obstacle;
+    obstacle.is_point_cloud = false;
+    obstacle.neareset_distance = minimum_distance;
+    obstacle.nearest_point = object_position;
+    obstacle.uuid = nearest_object.object_id;
+    return obstacle;
   }
   return std::nullopt;
 }

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -170,7 +170,7 @@ void SurroundObstacleCheckerNode::onTimer()
     case State::PASS: {
       const auto is_obstacle_found = [&]() {
         if (!nearest_obstacle.has_value()) return false;
-        return nearest_obstacle.value().neareset_distance < epsilon;
+        return nearest_obstacle.value().nearest_distance < epsilon;
       }();
 
       bool is_stop_required = false;
@@ -200,8 +200,7 @@ void SurroundObstacleCheckerNode::onTimer()
     case State::STOP: {
       const auto is_obstacle_found = [&]() {
         if (!nearest_obstacle.has_value()) return false;
-        return nearest_obstacle.value().neareset_distance <
-               param.surround_check_hysteresis_distance;
+        return nearest_obstacle.value().nearest_distance < param.surround_check_hysteresis_distance;
       }();
 
       bool is_stop_required = false;
@@ -260,7 +259,7 @@ std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacle() co
     return nearest_pointcloud;
   }
 
-  return nearest_pointcloud.value().neareset_distance < nearest_object.value().neareset_distance
+  return nearest_pointcloud.value().nearest_distance < nearest_object.value().nearest_distance
            ? nearest_pointcloud
            : nearest_object;
 }
@@ -343,7 +342,7 @@ std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacleByPoi
 
     StopObstacle obstacle;
     obstacle.is_point_cloud = true;
-    obstacle.neareset_distance = minimum_distance;
+    obstacle.nearest_distance = minimum_distance;
     obstacle.nearest_point = nearest_point_map;
     obstacle.uuid = UUID();  // Default UUID
     return obstacle;
@@ -396,7 +395,7 @@ std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacleByDyn
       nearest_object.kinematics.initial_pose_with_covariance.pose.position;
     StopObstacle obstacle;
     obstacle.is_point_cloud = false;
-    obstacle.neareset_distance = minimum_distance;
+    obstacle.nearest_distance = minimum_distance;
     obstacle.nearest_point = object_position;
     obstacle.uuid = nearest_object.object_id;
     return obstacle;

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -14,6 +14,7 @@
 
 #include "node.hpp"
 
+#include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/update_param.hpp>
@@ -38,7 +39,6 @@
 #else
 #include <tf2_eigen/tf2_eigen.hpp>
 #endif
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <functional>
@@ -325,20 +325,9 @@ std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacleByPoi
 
   if (was_minimum_distance_updated) {
     // transform the nearest point from base_link to map frame
-    const auto nearest_point_map = [&]() {
-      geometry_msgs::msg::Point nearest_point_map;
-      const auto & pose = odometry_ptr_->pose.pose;
-      const double cos_yaw = std::cos(tf2::getYaw(pose.orientation));
-      const double sin_yaw = std::sin(tf2::getYaw(pose.orientation));
-      const double x_rot =
-        cos_yaw * nearest_point_base_link.x - sin_yaw * nearest_point_base_link.y;
-      const double y_rot =
-        sin_yaw * nearest_point_base_link.x + cos_yaw * nearest_point_base_link.y;
-      nearest_point_map.x = x_rot + pose.position.x;
-      nearest_point_map.y = y_rot + pose.position.y;
-      nearest_point_map.z = nearest_point_base_link.z + pose.position.z;
-      return nearest_point_map;
-    }();
+    const auto & pose = odometry_ptr_->pose.pose;
+    const auto nearest_point_map =
+      autoware::universe_utils::transformPoint(nearest_point_base_link, pose);
 
     StopObstacle obstacle;
     obstacle.is_point_cloud = true;

--- a/planning/autoware_surround_obstacle_checker/src/node.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.hpp
@@ -18,9 +18,11 @@
 #include "autoware_utils/ros/logger_level_configure.hpp"
 #include "autoware_utils/ros/polling_subscriber.hpp"
 #include "debug_marker.hpp"
-#include "surround_obstacle_checker_node_parameters.hpp"
+#include "type_alias.hpp"
+#include "types.hpp"
 
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
+#include <autoware_surround_obstacle_checker/surround_obstacle_checker_node_parameters.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -48,15 +50,6 @@
 namespace autoware::surround_obstacle_checker
 {
 
-using autoware::motion_utils::VehicleStopChecker;
-using autoware::vehicle_info_utils::VehicleInfo;
-using autoware_internal_planning_msgs::msg::VelocityLimit;
-using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
-using autoware_perception_msgs::msg::PredictedObjects;
-using autoware_perception_msgs::msg::Shape;
-
-using Obstacle = std::pair<double /* distance */, geometry_msgs::msg::Point>;
-
 enum class State { PASS, STOP };
 
 class SurroundObstacleCheckerNode : public rclcpp::Node
@@ -71,17 +64,11 @@ private:
 
   void onTimer();
 
-  void onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
+  std::optional<StopObstacle> getNearestObstacle() const;
 
-  void onDynamicObjects(const PredictedObjects::ConstSharedPtr msg);
+  std::optional<StopObstacle> getNearestObstacleByPointCloud() const;
 
-  void onOdometry(const nav_msgs::msg::Odometry::ConstSharedPtr msg);
-
-  std::optional<Obstacle> getNearestObstacle() const;
-
-  std::optional<Obstacle> getNearestObstacleByPointCloud() const;
-
-  std::optional<Obstacle> getNearestObstacleByDynamicObject() const;
+  std::optional<StopObstacle> getNearestObstacleByDynamicObject() const;
 
   std::optional<geometry_msgs::msg::TransformStamped> getTransform(
     const std::string & source, const std::string & target, const rclcpp::Time & stamp,
@@ -108,9 +95,6 @@ private:
   rclcpp::Publisher<VelocityLimit>::SharedPtr pub_velocity_limit_;
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     pub_processing_time_;
-
-  // parameter callback result
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
   // stop checker
   std::unique_ptr<VehicleStopChecker> vehicle_stop_checker_;

--- a/planning/autoware_surround_obstacle_checker/src/type_alias.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/type_alias.hpp
@@ -1,0 +1,54 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TYPE_ALIAS_HPP_
+#define TYPE_ALIAS_HPP_
+
+#include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <geometry_msgs/msg/polygon_stamped.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+namespace autoware::surround_obstacle_checker
+{
+
+using autoware::motion_utils::VehicleStopChecker;
+using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_internal_planning_msgs::msg::ControlPoint;
+using autoware_internal_planning_msgs::msg::PlanningFactor;
+using autoware_internal_planning_msgs::msg::PlanningFactorArray;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
+using geometry_msgs::msg::PolygonStamped;
+using unique_identifier_msgs::msg::UUID;
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
+
+using geometry_msgs::msg::Point;
+using geometry_msgs::msg::Pose;
+
+}  // namespace autoware::surround_obstacle_checker
+
+#endif  // TYPE_ALIAS_HPP_

--- a/planning/autoware_surround_obstacle_checker/src/types.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/types.hpp
@@ -23,7 +23,7 @@ namespace autoware::surround_obstacle_checker
 struct StopObstacle
 {
   bool is_point_cloud;
-  double neareset_distance;
+  double nearest_distance;
   Point nearest_point;
   UUID uuid;
 };

--- a/planning/autoware_surround_obstacle_checker/src/types.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/types.hpp
@@ -1,0 +1,33 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TYPES_HPP_
+#define TYPES_HPP_
+
+#include "type_alias.hpp"
+
+namespace autoware::surround_obstacle_checker
+{
+
+struct StopObstacle
+{
+  bool is_point_cloud;
+  double neareset_distance;
+  Point nearest_point;
+  UUID uuid;
+};
+
+}  // namespace autoware::surround_obstacle_checker
+
+#endif  // TYPES_HPP_

--- a/planning/autoware_surround_obstacle_checker/test/test_planning_factor.cpp
+++ b/planning/autoware_surround_obstacle_checker/test/test_planning_factor.cpp
@@ -172,13 +172,13 @@ public:
     pointcloud.data.resize(pointcloud.row_step * pointcloud.height);
 
     const auto odometry = autoware::test_utils::makeInitialPose();
-    const float expexted_base_link_x =
+    const float expected_base_link_x =
       0.5f * std::cos(-tf2::getYaw(odometry.pose.pose.orientation));
     const float expected_base_link_y =
       0.5f * std::sin(-tf2::getYaw(odometry.pose.pose.orientation));
 
     std::array<float, 4> point = {
-      expexted_base_link_x, expected_base_link_y, 0.0f,
+      expected_base_link_x, expected_base_link_y, 0.0f,
       1.0f};  // x, y, z, intensity in base_link frame
     std::memcpy(pointcloud.data.data(), point.data(), point.size() * sizeof(float));
     pub_pointcloud_->publish(pointcloud);

--- a/planning/autoware_surround_obstacle_checker/test/test_planning_factor.cpp
+++ b/planning/autoware_surround_obstacle_checker/test/test_planning_factor.cpp
@@ -1,0 +1,273 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/node.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware/planning_test_manager/autoware_planning_test_manager.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
+
+#include <gtest/gtest.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::surround_obstacle_checker
+{
+
+using autoware::planning_test_manager::PlanningInterfaceTestManager;
+using autoware_internal_planning_msgs::msg::SafetyFactor;
+
+class SurroundObstacleCheckerPlanningFactorTest : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    test_node_ = std::make_shared<rclcpp::Node>("planning_interface_test_node");
+    test_target_node_ = generateTestTargetNode();
+
+    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(test_node_);
+
+    const std::string output_planning_factors_topic =
+      "planning/planning_factors/surround_obstacle_checker";
+    sub_planning_factor_ =
+      test_node_->create_subscription<autoware_internal_planning_msgs::msg::PlanningFactorArray>(
+        output_planning_factors_topic, rclcpp::QoS{1},
+        [this](autoware_internal_planning_msgs::msg::PlanningFactorArray::SharedPtr msg) {
+          planning_factor_msg_ = msg;
+        });
+
+    pub_odometry_ = test_node_->create_publisher<nav_msgs::msg::Odometry>(
+      "/surround_obstacle_checker_node/input/odometry", 1);
+    pub_kinematic_state_ =
+      test_node_->create_publisher<nav_msgs::msg::Odometry>("/localization/kinematic_state", 1);
+    pub_dynamic_objects_ = test_node_->create_publisher<PredictedObjects>(
+      "/surround_obstacle_checker_node/input/objects", 1);
+    pub_pointcloud_ = test_node_->create_publisher<sensor_msgs::msg::PointCloud2>(
+      "/surround_obstacle_checker_node/input/pointcloud", 1);
+  }
+
+  void setEnableCheck(const std::string & type, const bool enable)
+  {
+    auto param_client = std::make_shared<rclcpp::SyncParametersClient>(test_target_node_);
+    while (!param_client->wait_for_service(std::chrono::seconds(1))) {
+      if (!rclcpp::ok()) {
+        RCLCPP_ERROR(
+          test_target_node_->get_logger(), "Interrupted while waiting for the service. Exiting.");
+        return;
+      }
+      RCLCPP_INFO(test_target_node_->get_logger(), "service not available, waiting again...");
+    }
+
+    std::vector<rclcpp::Parameter> new_parameters;
+    new_parameters.push_back(rclcpp::Parameter(type + ".enable_check", enable));
+    param_client->set_parameters(new_parameters);
+  }
+
+  std::shared_ptr<SurroundObstacleCheckerNode> generateTestTargetNode()
+  {
+    auto node_options = rclcpp::NodeOptions{};
+    const auto autoware_test_utils_dir =
+      ament_index_cpp::get_package_share_directory("autoware_test_utils");
+
+    autoware::test_utils::updateNodeOptions(
+      node_options,
+      {autoware_test_utils_dir + "/config/test_common.param.yaml",
+       autoware_test_utils_dir + "/config/test_nearest_search.param.yaml",
+       autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml",
+       ament_index_cpp::get_package_share_directory("autoware_surround_obstacle_checker") +
+         "/config/surround_obstacle_checker.param.yaml"});
+
+    return std::make_shared<SurroundObstacleCheckerNode>(node_options);
+  }
+
+  void publishStaticTransforms()
+  {
+    const auto odometry = autoware::test_utils::makeInitialPose();
+    geometry_msgs::msg::TransformStamped transform;
+    transform.header.stamp = test_node_->now();
+    transform.header.frame_id = "map";
+    transform.child_frame_id = "base_link";
+    transform.transform.translation.x = odometry.pose.pose.position.x;
+    transform.transform.translation.y = odometry.pose.pose.position.y;
+    transform.transform.translation.z = odometry.pose.pose.position.z;
+    transform.transform.rotation = odometry.pose.pose.orientation;
+    tf_broadcaster_->sendTransform(transform);
+  }
+
+  void publishMandatoryTopics()
+  {
+    auto odometry = autoware::test_utils::makeInitialPose();
+    odometry.header.stamp = test_target_node_->now();
+    odometry.header.frame_id = "map";
+    odometry.child_frame_id = "base_link";
+
+    pub_odometry_->publish(odometry);
+    pub_kinematic_state_->publish(odometry);
+  }
+
+  void publishDynamicObject(const unique_identifier_msgs::msg::UUID & object_id)
+  {
+    autoware_perception_msgs::msg::PredictedObject object;
+    object.object_id = object_id;
+    object.existence_probability = 1.0f;
+    object.classification.resize(1);
+    object.classification[0].label =
+      autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN;
+    object.kinematics.initial_pose_with_covariance.pose.position.x = 3722.16015625 + 0.5,
+    object.kinematics.initial_pose_with_covariance.pose.position.y = 73723.515625;
+    object.kinematics.initial_pose_with_covariance.pose.position.z = 0.0;
+    object.kinematics.initial_pose_with_covariance.pose.orientation =
+      autoware_utils_geometry::create_quaternion_from_yaw(0.0);
+
+    autoware_perception_msgs::msg::PredictedObjects dynamic_objects;
+    dynamic_objects.header.stamp = test_target_node_->now();
+    dynamic_objects.header.frame_id = "map";
+    dynamic_objects.objects.push_back(object);
+
+    pub_dynamic_objects_->publish(dynamic_objects);
+  }
+
+  void publishPointCloud()
+  {
+    sensor_msgs::msg::PointCloud2 pointcloud;
+    pointcloud.header.stamp = test_target_node_->now();
+    pointcloud.header.frame_id = "base_link";
+    pointcloud.height = 1;
+    pointcloud.width = 1;
+    pointcloud.is_dense = true;
+    pointcloud.is_bigendian = false;
+    pointcloud.fields.resize(3);
+    pointcloud.fields[0].name = "x";
+    pointcloud.fields[0].offset = 0;
+    pointcloud.fields[0].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    pointcloud.fields[0].count = 1;
+    pointcloud.fields[1].name = "y";
+    pointcloud.fields[1].offset = 4;
+    pointcloud.fields[1].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    pointcloud.fields[1].count = 1;
+    pointcloud.fields[2].name = "z";
+    pointcloud.fields[2].offset = 8;
+    pointcloud.fields[2].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    pointcloud.fields[2].count = 1;
+    pointcloud.point_step = 16;  // 4 bytes for each field
+    pointcloud.row_step = pointcloud.point_step * pointcloud.width;
+    pointcloud.data.resize(pointcloud.row_step * pointcloud.height);
+
+    const auto odometry = autoware::test_utils::makeInitialPose();
+    const float expexted_base_link_x =
+      0.5f * std::cos(-tf2::getYaw(odometry.pose.pose.orientation));
+    const float expected_base_link_y =
+      0.5f * std::sin(-tf2::getYaw(odometry.pose.pose.orientation));
+
+    std::array<float, 4> point = {
+      expexted_base_link_x, expected_base_link_y, 0.0f,
+      1.0f};  // x, y, z, intensity in base_link frame
+    std::memcpy(pointcloud.data.data(), point.data(), point.size() * sizeof(float));
+    pub_pointcloud_->publish(pointcloud);
+  }
+
+  void validatePlanningFactor(
+    const unique_identifier_msgs::msg::UUID & validate_object_id,
+    const uint16_t expected_object_type)
+  {
+    // make sure planning_factor_msg_ is received
+    EXPECT_NE(planning_factor_msg_, nullptr);
+
+    // make sure planning_factor_msg_ is not empty
+    EXPECT_EQ(planning_factor_msg_->factors.size(), 1);
+
+    for (const auto & factor : planning_factor_msg_->factors) {
+      EXPECT_FALSE(factor.safety_factors.is_safe);
+
+      // make sure control_points is not empty
+      EXPECT_GE(factor.control_points.size(), 1);
+      for (auto & control_point : factor.control_points) {
+        EXPECT_LT(control_point.distance, 200.0);
+      }
+
+      // make sure safety_factors is not empty
+      EXPECT_EQ(factor.safety_factors.factors.size(), 1);
+
+      const auto & safety_factor = factor.safety_factors.factors.at(0);
+
+      EXPECT_EQ(safety_factor.type, expected_object_type);
+      EXPECT_FALSE(safety_factor.is_safe);
+      EXPECT_EQ(safety_factor.points.size(), 1);
+
+      const double expected_x = 3722.16015625 + 0.5;
+      const double expected_y = 73723.515625;
+
+      Point2d validate_point_2d(expected_x, expected_y);
+      Point2d safety_factor_point_2d(safety_factor.points.at(0).x, safety_factor.points.at(0).y);
+      EXPECT_NEAR(bg::distance(validate_point_2d, safety_factor_point_2d), 0.0, 1e-6);
+
+      EXPECT_EQ(safety_factor.object_id, validate_object_id);
+    }
+  }
+  void TearDown() override { rclcpp::shutdown(); }
+
+  void spinSome()
+  {
+    rclcpp::spin_some(test_target_node_);
+    rclcpp::spin_some(test_node_);
+  }
+
+private:
+  rclcpp::Node::SharedPtr test_node_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odometry_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_kinematic_state_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::PredictedObjects>::SharedPtr
+    pub_dynamic_objects_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_pointcloud_;
+  std::shared_ptr<SurroundObstacleCheckerNode> test_target_node_;
+  rclcpp::Subscription<autoware_internal_planning_msgs::msg::PlanningFactorArray>::SharedPtr
+    sub_planning_factor_;
+  autoware_internal_planning_msgs::msg::PlanningFactorArray::SharedPtr planning_factor_msg_;
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
+};
+
+TEST_F(SurroundObstacleCheckerPlanningFactorTest, TestByDynamicObject)
+{
+  const auto object_id = autoware_utils_uuid::generate_uuid();
+  for (size_t i = 0; i < 5; i++) {
+    publishMandatoryTopics();
+    publishDynamicObject(object_id);
+    spinSome();
+    rclcpp::sleep_for(std::chrono::milliseconds(100));
+  }
+  validatePlanningFactor(object_id, SafetyFactor::OBJECT);
+}
+
+TEST_F(SurroundObstacleCheckerPlanningFactorTest, TestByPointCloud)
+{
+  setEnableCheck("pointcloud", true);
+  const auto default_id = unique_identifier_msgs::msg::UUID{};
+  for (size_t i = 0; i < 5; i++) {
+    publishStaticTransforms();
+    publishMandatoryTopics();
+    publishPointCloud();
+    spinSome();
+    rclcpp::sleep_for(std::chrono::milliseconds(100));
+  }
+  validatePlanningFactor(default_id, SafetyFactor::POINTCLOUD);
+}
+
+}  // namespace autoware::surround_obstacle_checker


### PR DESCRIPTION
## Description

Modified the node to output the position of the surrounding obstacle as a safety factor when the vehicle continues to stop due to the presence of an obstacle.

for dynamic object
```
header:
  stamp:
    sec: 1754471033
    nanosec: 672960685
  frame_id: map
factors:
- module: surround_obstacle_checker
  is_driving_forward: true
  control_points:
  - pose:
      position:
        x: 65807.20236144973
        y: 722.58775493961
        z: 755.2288120813373
      orientation:
        x: -0.007346690804710143
        y: -0.010259139380741078
        z: -0.5821745060128938
        w: 0.8129659407023333
    velocity: 0.0
    shift_length: 0.0
    distance: 0.0
  behavior: 3
  detail: ''
  safety_factors:
    header:
      stamp:
        sec: 1754471033
        nanosec: 672953167
      frame_id: map
    factors:
    - type: 2
      object_id:
        uuid:
        - 141
        - 249
        - 27
        - 225
        - 52
        - 227
        - 106
        - 128
        - 195
        - 117
        - 67
        - 45
        - 42
        - 26
        - 249
        - 168
      predicted_path:
        path: []
        time_step:
          sec: 0
          nanosec: 0
        confidence: 0.0
      ttc_begin: 0.0
      ttc_end: 0.0
      points:
      - x: 65808.9996974628
        y: 718.240854914087
        z: 755.9431253896905
      is_safe: false
    is_safe: false
    detail: ''
```

for point cloud(need enable parameter)
```
header:
  stamp:
    sec: 1754471227
    nanosec: 966537242
  frame_id: map
factors:
- module: surround_obstacle_checker
  is_driving_forward: true
  control_points:
  - pose:
      position:
        x: 65807.20236300194
        y: 722.5877503764781
        z: 755.22877192005
      orientation:
        x: -0.007346690804710143
        y: -0.010259139380741078
        z: -0.5821745060128938
        w: 0.8129659407023333
    velocity: 0.0
    shift_length: 0.0
    distance: 0.0
  behavior: 3
  detail: ''
  safety_factors:
    header:
      stamp:
        sec: 1754471227
        nanosec: 966528893
      frame_id: map
    factors:
    - type: 1
      object_id:
        uuid:
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
        - 0
      predicted_path:
        path: []
        time_step:
          sec: 0
          nanosec: 0
        confidence: 0.0
      ttc_begin: 0.0
      ttc_end: 0.0
      points:
      - x: 65808.59783397564
        y: 718.5732892622763
        z: 756.0488434384712
      is_safe: false
    is_safe: false
    detail: ''

```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [[PR check (OTA)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/23b49c20-06aa-5815-a9ba-f8c5165ee315?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/cd28d541-eb3f-5421-ab01-8ab6f0f62000?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/ca3ed5c3-a3c2-557b-b628-692d0ddd62ab?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
