### PR TITLE
feat(run_out): add parameters to select which debug markers to publish

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/CMakeLists.txt
@@ -8,5 +8,3 @@ pluginlib_export_plugin_description_file(autoware_motion_velocity_planner plugin
 ament_auto_add_library(${PROJECT_NAME} SHARED
   DIRECTORY src
 )
-
-ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/config/run_out.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/config/run_out.param.yaml
@@ -1,3 +1,0 @@
-/**:
-  ros__parameters:
-    none: true

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/schema/run_out.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/schema/run_out.schema.json
@@ -319,6 +319,32 @@
               "type": "string",
               "description": "debug markers specific to each object classification labels will only be published for this one",
               "default": "PEDESTRIAN"
+            },
+            "enabled_markers": {
+              "type": "object",
+              "description": "if true, the corresponding debug markers are published",
+              "properties": {
+                "ego_footprint": {
+                  "type": "boolean",
+                  "default": "true"
+                },
+                "objects": {
+                  "type": "boolean",
+                  "default": "true"
+                },
+                "collisions": {
+                  "type": "boolean",
+                  "default": "true"
+                },
+                "decisions": {
+                  "type": "boolean",
+                  "default": "true"
+                },
+                "filtering_data": {
+                  "type": "boolean",
+                  "default": "false"
+                }
+              }
             }
           }
         }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
@@ -15,6 +15,7 @@
 #ifndef DEBUG_HPP_
 #define DEBUG_HPP_
 
+#include "parameters.hpp"
 #include "types.hpp"
 
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
@@ -358,7 +359,7 @@ inline MarkerArray make_debug_markers(
   const TrajectoryCornerFootprint & ego_footprint, const std::vector<Object> & filtered_objects,
   const ObjectDecisionsTracker & decisions_tracker,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & smoothed_trajectory_points,
-  const double comfortable_time_to_stop, const FilteringData & filtering_data)
+  const FilteringData & filtering_data, const Parameters & params)
 {
   MarkerArray markers;
   const auto concat = [&](MarkerArray && a) {
@@ -366,11 +367,22 @@ inline MarkerArray make_debug_markers(
       markers.markers.end(), std::make_move_iterator(a.markers.begin()),
       std::make_move_iterator(a.markers.end()));
   };
-  concat(run_out::make_debug_footprint_markers(ego_footprint, filtered_objects));
-  concat(run_out::make_debug_object_markers(filtered_objects));
-  concat(run_out::make_debug_decisions_markers(decisions_tracker));
-  concat(run_out::make_debug_min_stop_marker(smoothed_trajectory_points, comfortable_time_to_stop));
-  concat(run_out::make_debug_filtering_data_marker(filtering_data));
+  if (params.debug.enabled_markers.ego_footprint) {
+    concat(run_out::make_debug_footprint_markers(ego_footprint, filtered_objects));
+  }
+  if (params.debug.enabled_markers.objects) {
+    concat(run_out::make_debug_object_markers(filtered_objects));
+  }
+  if (params.debug.enabled_markers.decisions) {
+    concat(run_out::make_debug_decisions_markers(decisions_tracker));
+  }
+  if (params.debug.enabled_markers.filtering_data) {
+    concat(run_out::make_debug_filtering_data_marker(filtering_data));
+  }
+  concat(run_out::make_debug_min_stop_marker(
+    smoothed_trajectory_points,
+    params.ignore_collision_conditions.if_ego_arrives_first_and_cannot_stop
+      .calculated_stop_time_limit));
   return markers;
 }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
@@ -41,8 +41,7 @@ namespace autoware::motion_velocity_planner::run_out
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 
-inline MarkerArray make_debug_footprint_markers(
-  const run_out::TrajectoryCornerFootprint & ego, const std::vector<run_out::Object> & objects)
+inline MarkerArray make_debug_ego_footprint_markers(const run_out::TrajectoryCornerFootprint & ego)
 {
   MarkerArray markers;
   Marker m;
@@ -73,9 +72,19 @@ inline MarkerArray make_debug_footprint_markers(
     m.points.push_back(universe_utils::createPoint(p.x(), p.y(), 0.0));
   }
   markers.markers.push_back(m);
+  return markers;
+}
 
+inline MarkerArray make_debug_objects_footprint_markers(
+  const std::vector<run_out::Object> & objects)
+{
+  MarkerArray markers;
+  Marker m;
+  m.header.frame_id = "map";
+  m.type = Marker::LINE_STRIP;
+  m.color = universe_utils::createMarkerColor(0.0, 1.0, 0.0, 1.0);
+  m.scale.x = 0.2;
   m.type = Marker::LINE_LIST;
-  m.points.clear();
   m.ns = "objects_footprints";
   m.color.r = 1.0;
   for (const auto & object : objects) {
@@ -109,7 +118,7 @@ inline MarkerArray make_debug_footprint_markers(
   return markers;
 }
 
-inline MarkerArray make_debug_object_markers(const std::vector<Object> & objects)
+inline MarkerArray make_debug_collisions_markers(const std::vector<Object> & objects)
 {
   MarkerArray markers;
   Marker m;
@@ -368,10 +377,13 @@ inline MarkerArray make_debug_markers(
       std::make_move_iterator(a.markers.end()));
   };
   if (params.debug.enabled_markers.ego_footprint) {
-    concat(run_out::make_debug_footprint_markers(ego_footprint, filtered_objects));
+    concat(run_out::make_debug_ego_footprint_markers(ego_footprint));
   }
   if (params.debug.enabled_markers.objects) {
-    concat(run_out::make_debug_object_markers(filtered_objects));
+    concat(run_out::make_debug_objects_footprint_markers(filtered_objects));
+  }
+  if (params.debug.enabled_markers.collisions) {
+    concat(run_out::make_debug_collisions_markers(filtered_objects));
   }
   if (params.debug.enabled_markers.decisions) {
     concat(run_out::make_debug_decisions_markers(decisions_tracker));

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
@@ -84,18 +84,33 @@ inline MarkerArray make_debug_objects_footprint_markers(
   m.type = Marker::LINE_STRIP;
   m.color = universe_utils::createMarkerColor(0.0, 1.0, 0.0, 1.0);
   m.scale.x = 0.2;
+  m.type = Marker::LINE_LIST;
   m.ns = "objects_footprints";
   m.color.r = 1.0;
   for (const auto & object : objects) {
     for (const auto & footprint : object.predicted_path_footprints) {
       const auto & f = footprint.predicted_path_footprint;
-      for (const auto corner : {front_left, front_right, rear_left, rear_right}) {
-        m.points.clear();
-        for (const auto & p : f.corner_linestrings[corner]) {
-          m.points.push_back(autoware_utils::create_point(p.x(), p.y(), 0.0));
-        }
-        markers.markers.push_back(m);
-        m.id++;
+      for (auto i = 0UL; i + 1 < f.corner_linestrings[front_left].size(); ++i) {
+        m.points.push_back(universe_utils::createPoint(
+          f.corner_linestrings[front_left][i].x(), f.corner_linestrings[front_left][i].y(), 0.0));
+        m.points.push_back(universe_utils::createPoint(
+          f.corner_linestrings[front_left][i + 1].x(), f.corner_linestrings[front_left][i + 1].y(),
+          0.0));
+        m.points.push_back(universe_utils::createPoint(
+          f.corner_linestrings[front_right][i].x(), f.corner_linestrings[front_right][i].y(), 0.0));
+        m.points.push_back(universe_utils::createPoint(
+          f.corner_linestrings[front_right][i + 1].x(),
+          f.corner_linestrings[front_right][i + 1].y(), 0.0));
+        m.points.push_back(universe_utils::createPoint(
+          f.corner_linestrings[rear_left][i].x(), f.corner_linestrings[rear_left][i].y(), 0.0));
+        m.points.push_back(universe_utils::createPoint(
+          f.corner_linestrings[rear_left][i + 1].x(), f.corner_linestrings[rear_left][i + 1].y(),
+          0.0));
+        m.points.push_back(universe_utils::createPoint(
+          f.corner_linestrings[rear_right][i].x(), f.corner_linestrings[rear_right][i].y(), 0.0));
+        m.points.push_back(universe_utils::createPoint(
+          f.corner_linestrings[rear_right][i + 1].x(), f.corner_linestrings[rear_right][i + 1].y(),
+          0.0));
       }
     }
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
@@ -84,33 +84,18 @@ inline MarkerArray make_debug_objects_footprint_markers(
   m.type = Marker::LINE_STRIP;
   m.color = universe_utils::createMarkerColor(0.0, 1.0, 0.0, 1.0);
   m.scale.x = 0.2;
-  m.type = Marker::LINE_LIST;
   m.ns = "objects_footprints";
   m.color.r = 1.0;
   for (const auto & object : objects) {
     for (const auto & footprint : object.predicted_path_footprints) {
       const auto & f = footprint.predicted_path_footprint;
-      for (auto i = 0UL; i + 1 < f.corner_linestrings[front_left].size(); ++i) {
-        m.points.push_back(universe_utils::createPoint(
-          f.corner_linestrings[front_left][i].x(), f.corner_linestrings[front_left][i].y(), 0.0));
-        m.points.push_back(universe_utils::createPoint(
-          f.corner_linestrings[front_left][i + 1].x(), f.corner_linestrings[front_left][i + 1].y(),
-          0.0));
-        m.points.push_back(universe_utils::createPoint(
-          f.corner_linestrings[front_right][i].x(), f.corner_linestrings[front_right][i].y(), 0.0));
-        m.points.push_back(universe_utils::createPoint(
-          f.corner_linestrings[front_right][i + 1].x(),
-          f.corner_linestrings[front_right][i + 1].y(), 0.0));
-        m.points.push_back(universe_utils::createPoint(
-          f.corner_linestrings[rear_left][i].x(), f.corner_linestrings[rear_left][i].y(), 0.0));
-        m.points.push_back(universe_utils::createPoint(
-          f.corner_linestrings[rear_left][i + 1].x(), f.corner_linestrings[rear_left][i + 1].y(),
-          0.0));
-        m.points.push_back(universe_utils::createPoint(
-          f.corner_linestrings[rear_right][i].x(), f.corner_linestrings[rear_right][i].y(), 0.0));
-        m.points.push_back(universe_utils::createPoint(
-          f.corner_linestrings[rear_right][i + 1].x(), f.corner_linestrings[rear_right][i + 1].y(),
-          0.0));
+      for (const auto corner : {front_left, front_right, rear_left, rear_right}) {
+        m.points.clear();
+        for (const auto & p : f.corner_linestrings[corner]) {
+          m.points.push_back(autoware_utils::create_point(p.x(), p.y(), 0.0));
+        }
+        markers.markers.push_back(m);
+        m.id++;
       }
     }
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/parameters.hpp
@@ -134,6 +134,13 @@ struct Parameters
   struct
   {
     std::string object_label;
+    struct
+    {
+      bool ego_footprint = false;
+      bool objects = false;
+      bool decisions = false;
+      bool filtering_data = false;
+    } enabled_markers;
   } debug;
 
   /// @brief Get the parameter defined for a specific object label, or the default value if it was
@@ -259,6 +266,14 @@ struct Parameters
         get_object_parameter<double>(node, ns, label, ".standstill_duration_after_cut");
     }
     debug.object_label = getOrDeclareParameter<std::string>(node, ns + ".debug.object_label");
+    debug.enabled_markers.ego_footprint =
+      getOrDeclareParameter<bool>(node, ns + ".debug.enabled_markers.ego_footprint");
+    debug.enabled_markers.objects =
+      getOrDeclareParameter<bool>(node, ns + ".debug.enabled_markers.objects");
+    debug.enabled_markers.decisions =
+      getOrDeclareParameter<bool>(node, ns + ".debug.enabled_markers.decisions");
+    debug.enabled_markers.filtering_data =
+      getOrDeclareParameter<bool>(node, ns + ".debug.enabled_markers.filtering_data");
 
     max_history_duration = std::max(stop_off_time_buffer, stop_on_time_buffer);
   }
@@ -367,6 +382,12 @@ struct Parameters
         object_parameters_per_label[label].preserved_distance);
     }
     updateParam(params, ns + ".debug.object_label", debug.object_label);
+    updateParam(
+      params, ns + ".debug.enabled_markers.ego_footprint", debug.enabled_markers.ego_footprint);
+    updateParam(params, ns + ".debug.enabled_markers.objects", debug.enabled_markers.objects);
+    updateParam(params, ns + ".debug.enabled_markers.decisions", debug.enabled_markers.decisions);
+    updateParam(
+      params, ns + ".debug.enabled_markers.filtering_data", debug.enabled_markers.filtering_data);
 
     max_history_duration = std::max(stop_off_time_buffer, stop_on_time_buffer);
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/parameters.hpp
@@ -138,6 +138,7 @@ struct Parameters
     {
       bool ego_footprint = false;
       bool objects = false;
+      bool collisions = false;
       bool decisions = false;
       bool filtering_data = false;
     } enabled_markers;
@@ -270,6 +271,8 @@ struct Parameters
       getOrDeclareParameter<bool>(node, ns + ".debug.enabled_markers.ego_footprint");
     debug.enabled_markers.objects =
       getOrDeclareParameter<bool>(node, ns + ".debug.enabled_markers.objects");
+    debug.enabled_markers.collisions =
+      getOrDeclareParameter<bool>(node, ns + ".debug.enabled_markers.collisions");
     debug.enabled_markers.decisions =
       getOrDeclareParameter<bool>(node, ns + ".debug.enabled_markers.decisions");
     debug.enabled_markers.filtering_data =
@@ -385,6 +388,7 @@ struct Parameters
     updateParam(
       params, ns + ".debug.enabled_markers.ego_footprint", debug.enabled_markers.ego_footprint);
     updateParam(params, ns + ".debug.enabled_markers.objects", debug.enabled_markers.objects);
+    updateParam(params, ns + ".debug.enabled_markers.collisions", debug.enabled_markers.collisions);
     updateParam(params, ns + ".debug.enabled_markers.decisions", debug.enabled_markers.decisions);
     updateParam(
       params, ns + ".debug.enabled_markers.filtering_data", debug.enabled_markers.filtering_data);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/run_out_module.cpp
@@ -258,9 +258,7 @@ VelocityPlanningResult RunOutModule::plan(
       filtering_data[run_out::Parameters::string_to_label(params_.debug.object_label)];
     debug_publisher_->publish(run_out::make_debug_markers(
       ego_footprint, filtered_objects, decisions_tracker_, smoothed_trajectory_points,
-      params_.ignore_collision_conditions.if_ego_arrives_first_and_cannot_stop
-        .calculated_stop_time_limit,
-      filtering_data_to_publish));
+      filtering_data_to_publish, params_));
   }
   publish_debug_trajectory(smoothed_trajectory_points, result.velocity_planning_result);
   objects_of_interest_marker_interface_->publishMarkerArray();


### PR DESCRIPTION
## Description

The `run_out` module debug markers can be too heavy and cause performance issues.
This PR adds parameters to enable or disable the publishing of some debug markers.

## Related links

Launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1580

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Using the following scene with many objects/collisions:
<img width="1500" height="1095" alt="image" src="https://github.com/user-attachments/assets/16a09da3-f663-4495-afa7-87b5e2c7cec4" />

Using `ros2 topic bw /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out/debug_markers` to evaluate the size of the debug markers message.

| Enabled debug markers | Message size |
| --- | --- |
| None | 0.24 KB |
| All | 460 KB |
| `ego_footprint` |53.74 KB |
| `objects` | 190 KB |
| `collisions` | 6.38 KB |
| `decisions` | 1.28 KB |
| `filtering_data` |210 KB |

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `debug.enabled_markers.ego_footprint`   | `bool` | `true`         | Enable publishing of the "ego_footprint" debug markers |
| Added | `debug.enabled_markers.objects`   | `bool` | `true`         | Enable publishing of the "objects" debug markers |
| Added | `debug.enabled_markers.collisions`   | `bool` | `true`         | Enable publishing of the "collisions" debug markers |
| Added | `debug.enabled_markers.decisions`   | `bool` | `true`         | Enable publishing of the "decisions" debug markers |
| Added | `debug.enabled_markers.filtering_data`   | `bool` | `false`         | Enable publishing of the "filtering_data" debug markers |

## Effects on system behavior

None.
