### PR TITLE
fix(boundary_departure): merging multiple close by departure points

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
@@ -188,7 +188,7 @@ struct DeparturePoint
   DepartureType departure_type{DepartureType::NONE};
   AbnormalityType abnormality_type{AbnormalityType::NORMAL};
   Point2d point;
-  double th_dist_hysteresis{2.0};
+  double th_point_merge_distance_m{2.0};
   double lat_dist_to_bound{1000.0};
   double dist_on_traj{1000.0};
   double velocity{0.0};
@@ -202,7 +202,7 @@ struct DeparturePoint
   [[nodiscard]] bool is_nearby(const Point2d & candidate_point) const
   {
     const auto diff = boost::geometry::distance(point, candidate_point);
-    return diff < th_dist_hysteresis;
+    return diff < th_point_merge_distance_m;
   }
 
   [[nodiscard]] Point to_geom_pt(const double z = 0.0) const
@@ -224,7 +224,7 @@ struct CriticalDeparturePoint : DeparturePoint
     departure_type = base.departure_type;
     abnormality_type = base.abnormality_type;
     point = base.point;
-    th_dist_hysteresis = base.th_dist_hysteresis;
+    th_point_merge_distance_m = base.th_point_merge_distance_m;
     lat_dist_to_bound = base.lat_dist_to_bound;
     dist_on_traj = base.dist_on_traj;
     velocity = base.velocity;

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
@@ -134,7 +134,7 @@ struct Param
   // New params
   TriggerThreshold th_trigger;
   int th_max_lateral_query_num{5};
-  double th_dist_hysteresis_m{1.0};
+  double th_point_merge_distance_m{1.0};
   double footprint_extra_margin{0.0};
   AbnormalitiesConfigs abnormality_configs;
   std::vector<std::string> boundary_types_to_detect;

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
@@ -401,7 +401,7 @@ double compute_braking_distance(
  * - Retains only points up to and including the first CRITICAL_DEPARTURE point (if any).
  *
  * @param projections_to_bound  List of lateral projections to road boundaries.
- * @param th_dist_hysteresis_m  Threshold distance used for hysteresis logic in departure
+ * @param th_point_merge_distance_m  Threshold distance used for hysteresis logic in departure
  * classification.
  * @param lon_offset_m          Longitudinal offset from ego base link to the reference
  * trajectory.
@@ -409,7 +409,7 @@ double compute_braking_distance(
  */
 DeparturePoints get_departure_points(
   const std::vector<ClosestProjectionToBound> & projections_to_bound,
-  const double th_dist_hysteresis_m, const double lon_offset_m);
+  const double th_point_merge_distance_m, const double lon_offset_m);
 
 /**
  * @brief Find nearby uncrossable linestrings around the given pose.

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -256,6 +256,7 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
       break;
     }
   }
+
   return min_to_bound;
 }
 
@@ -307,12 +308,12 @@ Side<DeparturePoints> BoundaryDepartureChecker::get_departure_points(
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  const auto th_dist_hysteresis_m = param_ptr_->th_dist_hysteresis_m;
+  const auto th_point_merge_distance_m = param_ptr_->th_point_merge_distance_m;
 
   Side<DeparturePoints> departure_points;
   for (const auto side_key : g_side_keys) {
     departure_points[side_key] = utils::get_departure_points(
-      projections_to_bound[side_key], th_dist_hysteresis_m, lon_offset_m);
+      projections_to_bound[side_key], th_point_merge_distance_m, lon_offset_m);
   }
   return departure_points;
 }

--- a/common/autoware_boundary_departure_checker/src/utils.cpp
+++ b/common/autoware_boundary_departure_checker/src/utils.cpp
@@ -50,7 +50,7 @@ using autoware::boundary_departure_checker::utils::to_segment_2d;
 namespace bg = boost::geometry;
 
 DeparturePoint create_departure_point(
-  const ClosestProjectionToBound & projection_to_bound, const double th_dist_hysteresis_m,
+  const ClosestProjectionToBound & projection_to_bound, const double th_point_merge_distance_m,
   const double lon_offset_m)
 {
   DeparturePoint point;
@@ -58,7 +58,7 @@ DeparturePoint create_departure_point(
   point.lat_dist_to_bound = projection_to_bound.lat_dist;
   point.departure_type = projection_to_bound.departure_type;
   point.point = projection_to_bound.pt_on_bound;
-  point.th_dist_hysteresis = th_dist_hysteresis_m;
+  point.th_point_merge_distance_m = th_point_merge_distance_m;
   point.dist_on_traj = projection_to_bound.lon_dist_on_ref_traj - lon_offset_m;
   point.idx_from_ego_traj = projection_to_bound.ego_sides_idx;
   point.can_be_removed = (point.departure_type == DepartureType::NONE) || point.dist_on_traj <= 0.0;
@@ -635,13 +635,13 @@ double compute_braking_distance(
 
 DeparturePoints get_departure_points(
   const std::vector<ClosestProjectionToBound> & projections_to_bound,
-  const double th_dist_hysteresis_m, const double lon_offset_m)
+  const double th_point_merge_distance_m, const double lon_offset_m)
 {
   DeparturePoints departure_points;
   departure_points.reserve(projections_to_bound.size());
   for (const auto & projection_to_bound : projections_to_bound) {
     const auto point =
-      create_departure_point(projection_to_bound, th_dist_hysteresis_m, lon_offset_m);
+      create_departure_point(projection_to_bound, th_point_merge_distance_m, lon_offset_m);
 
     if (point.can_be_removed) {
       continue;
@@ -652,7 +652,29 @@ DeparturePoints get_departure_points(
 
   std::sort(departure_points.begin(), departure_points.end());
   erase_after_first_match(departure_points);
-  return departure_points;
+
+  DeparturePoints filtered_points;
+  size_t i = 0;
+  while (i < departure_points.size()) {
+    const auto & current = departure_points[i];
+    filtered_points.push_back(current);
+
+    size_t j = i + 1;
+    while (j < departure_points.size() &&
+           departure_points[j].departure_type != DepartureType::CRITICAL_DEPARTURE &&
+           std::abs(departure_points[j].dist_on_traj - current.dist_on_traj) <=
+             current.th_point_merge_distance_m) {
+      if (
+        current.departure_type == DepartureType::APPROACHING_DEPARTURE ||
+        departure_points[j].departure_type == DepartureType::APPROACHING_DEPARTURE) {
+        filtered_points.back().departure_type = DepartureType::APPROACHING_DEPARTURE;
+      }
+      ++j;
+    }
+    i = j;
+  }
+
+  return filtered_points;
 }
 
 tl::expected<std::vector<lanelet::LineString3d>, std::string> get_uncrossable_linestrings_near_pose(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/config/boundary_departure_prevention.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/config/boundary_departure_prevention.param.yaml
@@ -3,7 +3,7 @@
     boundary_departure_prevention:
       boundary_types_to_detect: [road_border]
       th_max_lateral_query_num: 5
-      th_dist_hysteresis_m: 1.0
+      th_point_merge_distance_m: 1.0
       th_pt_shift:
         dist_m: 0.2
         angle_deg: 5.0

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/schema/boundary_departure_prevention.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/schema/boundary_departure_prevention.schema.json
@@ -19,9 +19,9 @@
           "default": 5
         },
 
-        "th_dist_hysteresis_m": {
+        "th_point_merge_distance_m": {
           "type": "number",
-          "description": "Minimum distance between critical points to avoid duplicates [m].",
+          "description": "Distance threshold to merge nearby points [m].",
           "default": 1.0
         },
 
@@ -350,7 +350,7 @@
       "required": [
         "boundary_types_to_detect",
         "th_max_lateral_query_num",
-        "th_dist_hysteresis_m",
+        "th_point_merge_distance_m",
         "th_pt_shift",
         "abnormality",
         "diagnostic",

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -487,7 +487,7 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
 
   utils::update_critical_departure_points(
     output_.departure_points, output_.critical_departure_points, *ref_traj_pts_opt,
-    node_param_.bdc_param.th_dist_hysteresis_m,
+    node_param_.bdc_param.th_point_merge_distance_m,
     ego_dist_on_traj_with_offset_m(!planner_data->is_driving_forward),
     node_param_.th_pt_shift_dist_m, node_param_.th_pt_shift_angle_rad);
   toc_curr_watch("update_critical_departure_points");

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
@@ -67,8 +67,8 @@ struct NodeParam
     const std::string module_name{"boundary_departure_prevention."};
     bdc_param.boundary_types_to_detect = get_or_declare_parameter<std::vector<std::string>>(
       node, module_name + "boundary_types_to_detect");
-    bdc_param.th_dist_hysteresis_m =
-      get_or_declare_parameter<double>(node, module_name + "th_dist_hysteresis_m");
+    bdc_param.th_point_merge_distance_m =
+      get_or_declare_parameter<double>(node, module_name + "th_point_merge_distance_m");
     th_pt_shift_angle_rad =
       get_or_declare_parameter<double>(node, module_name + "th_pt_shift.dist_m");
     th_pt_shift_angle_rad = autoware_utils_math::deg2rad(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -93,11 +93,7 @@ DepartureIntervals init_departure_intervals(
       continue;
     }
 
-    std::sort(
-      interval.candidates.begin(), interval.candidates.end(),
-      [](const DeparturePoint & a, const DeparturePoint & b) {
-        return a.dist_on_traj < b.dist_on_traj;
-      });
+    std::sort(interval.candidates.begin(), interval.candidates.end());
 
     interval.start_dist_on_traj = interval.candidates.front().dist_on_traj - vehicle_length_m;
     interval.start = aw_ref_traj.compute(interval.start_dist_on_traj);
@@ -218,6 +214,12 @@ void update_departure_intervals(
       departure_intervals, departure_points[side_key], aw_ref_traj, vehicle_length_m, side_key,
       enable_type);
   }
+
+  auto new_departure_intervals = init_departure_intervals(
+    aw_ref_traj, departure_points, vehicle_length_m, enable_type, is_departure_persist);
+  std::move(
+    new_departure_intervals.begin(), new_departure_intervals.end(),
+    std::back_inserter(departure_intervals));
 
   if (!departure_intervals.empty()) {
     DepartureIntervals merged;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
@@ -156,7 +156,7 @@ void update_departure_intervals(
  * @param[in] new_departure_points New departure points from the current cycle.
  * @param[in,out] critical_departure_points Persistent list of critical points to update.
  * @param[in] aw_ref_traj Reference trajectory.
- * @param[in] th_dist_hysteresis_m Min distance to avoid adding duplicates.
+ * @param[in] th_point_merge_distance_m Min distance to avoid adding duplicates.
  * @param[in] offset_from_ego Ignore points before this arc-length.
  * @param[in] th_pt_shift_dist_m Threshold distance to detect point drift.
  * @param[in] th_pt_shift_angle_rad Threshold angle to detect pose change.
@@ -164,9 +164,9 @@ void update_departure_intervals(
 void update_critical_departure_points(
   const Side<DeparturePoints> & new_departure_points,
   CriticalDeparturePoints & critical_departure_points,
-  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double th_dist_hysteresis_m,
-  const double offset_from_ego, const double th_pt_shift_dist_m,
-  const double th_pt_shift_angle_rad);
+  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
+  const double th_point_merge_distance_m, const double offset_from_ego,
+  const double th_pt_shift_dist_m, const double th_pt_shift_angle_rad);
 
 /**
  * @brief Build slow-down segments ahead of the ego vehicle.


### PR DESCRIPTION
## Description

The PR aims to fix issues with merging closeby departure points and departure intervals.

### Merging closeby departure points

#### Before

Close-by points scatter

<img width="909" height="183" alt="unmerged" src="https://github.com/user-attachments/assets/133a3826-05c8-43cb-912b-97e38112bb8c" />

https://github.com/user-attachments/assets/eb5fce33-ac1d-4a65-bf82-fbfc03310b0d

#### After

Merging nearby points

<img width="1044" height="279" alt="merge_distance drawio" src="https://github.com/user-attachments/assets/fd76b8c1-2afa-4b63-a3ad-2dd2bc2a9503" />

Result

<img width="909" height="93" alt="merged" src="https://github.com/user-attachments/assets/9d54a761-9ae5-48fb-ac19-27bd7bcb49c0" />

https://github.com/user-attachments/assets/e6b4d752-497a-4cf5-b138-a7377c50362d

### Merging closeby departure interval

Departure points is grouped together

<img width="1392" height="342" alt="lane_departure_prevention_use_cases-Page-8" src="https://github.com/user-attachments/assets/81b86a11-4533-47a7-8790-12419618616d" />

Example

<img width="2340" height="300" alt="merging1" src="https://github.com/user-attachments/assets/79df54af-7634-42be-9f47-1d7d8a1b3689" />

<img width="2220" height="303" alt="merging2" src="https://github.com/user-attachments/assets/e8ec3e0c-c8c5-4166-92bb-e05086634160" />

<img width="2250" height="303" alt="merging3" src="https://github.com/user-attachments/assets/dc1d45eb-997a-4234-ad9c-9b6a1941ddd3" />

But if the point is inline, it is not merged. So this PR aims to fix this as well

<img width="675" height="375" alt="not merged to fix" src="https://github.com/user-attachments/assets/b1c1a6d3-1c71-4969-907d-89e312064a8d" />

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

[CommonBasic](https://evaluation.tier4.jp/evaluation/reports/2b2e8dbf-69d2-5499-aed0-72b44ac3ab3f?project_id=prd_jt)
[FuncVerification](https://evaluation.tier4.jp/evaluation/reports/f513573d-a156-5342-9631-f769edd6ea42?project_id=prd_jt)
[CommonDLR](https://evaluation.tier4.jp/evaluation/reports/c1437ce6-a2a0-5c12-9c56-b9acf19fe882?project_id=prd_jt)

⚠️ note that this feature is tested with several other PR

- https://github.com/autowarefoundation/autoware_universe/pull/11073


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |
🔴⬆️ -->
#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `th_dist_hysteresis_m` | `double` | `1.0`         | Minimum distance between critical points to avoid duplicates [m] |
| New     | `th_point_merge_distance_m` | `double` | `1.0`         | Distance threshold to merge nearby points [m]. |



## Effects on system behavior

None.
