### PR TITLE
feat(pose instability detector): change diag level

### DIFF
--- a/localization/autoware_pose_instability_detector/README.md
+++ b/localization/autoware_pose_instability_detector/README.md
@@ -13,8 +13,8 @@ The results of this comparison are then output to the `/diagnostics` topic.
 
 ![rqt_runtime_monitor](./media/rqt_runtime_monitor.png)
 
-If this node outputs WARN messages to `/diagnostics`, it means that the EKF output is significantly different from the integrated twist values.
-In other words, WARN outputs indicate that the vehicle has moved to a place outside the expected range based on the twist values.
+If this node outputs ERROR messages to `/diagnostics`, it means that the EKF output is significantly different from the integrated twist values.
+In other words, ERROR outputs indicate that the vehicle has moved to a place outside the expected range based on the twist values.
 This discrepancy suggests that there may be an issue with either the estimated pose or the input twist.
 
 The following diagram provides an overview of how the procedure looks like:

--- a/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
+++ b/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
@@ -166,11 +166,11 @@ void PoseInstabilityDetector::callback_timer()
     kv.value = std::to_string(values[i]);
     status.values.push_back(kv);
     kv.key = labels[i] + ":status";
-    kv.value = (ok ? "OK" : "WARN");
+    kv.value = (ok ? "OK" : "ERROR");
     status.values.push_back(kv);
   }
-  status.level = (all_ok ? DiagnosticStatus::OK : DiagnosticStatus::WARN);
-  status.message = (all_ok ? "OK" : "WARN");
+  status.level = (all_ok ? DiagnosticStatus::OK : DiagnosticStatus::ERROR);
+  status.message = (all_ok ? "OK" : "ERROR");
 
   DiagnosticArray diagnostics;
   diagnostics.header.stamp = latest_odometry_time;


### PR DESCRIPTION
## Description

To link with MRM, change diag level from `WARN` to `ERROR`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Just checking if it can be built

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
