### PR TITLE
fix(operation_mode_transition_manager): modify the engage condition

### DIFF
--- a/control/autoware_operation_mode_transition_manager/src/state.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.cpp
@@ -224,15 +224,6 @@ bool AutonomousMode::isModeChangeAvailable(const InputData & input_data)
   const auto & trajectory_follower_control_cmd = input_data.trajectory_follower_control_cmd.value();
   const auto & control_cmd = input_data.control_cmd.value();
 
-  if (!check_engage_condition_) {
-    setAllOk(debug_info_);
-    return true;
-  }
-
-  const auto current_speed = kinematics.twist.twist.linear.x;
-  const auto target_control_speed = control_cmd.longitudinal.velocity;
-  const auto & param = engage_acceptable_param_;
-
   if (!enable_engage_on_driving_ && std::fabs(current_speed) > 1.0e-2) {
     RCLCPP_INFO_THROTTLE(
       logger_, *clock_, 3000,
@@ -241,6 +232,15 @@ bool AutonomousMode::isModeChangeAvailable(const InputData & input_data)
     debug_info_ = DebugInfo{};  // all false
     return false;
   }
+
+  if (!check_engage_condition_) {
+    setAllOk(debug_info_);
+    return true;
+  }
+
+  const auto current_speed = kinematics.twist.twist.linear.x;
+  const auto target_control_speed = control_cmd.longitudinal.velocity;
+  const auto & param = engage_acceptable_param_;
 
   if (trajectory.points.size() < 2) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(

--- a/control/autoware_operation_mode_transition_manager/src/state.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.cpp
@@ -223,6 +223,9 @@ bool AutonomousMode::isModeChangeAvailable(const InputData & input_data)
   const auto & trajectory = input_data.trajectory.value();
   const auto & trajectory_follower_control_cmd = input_data.trajectory_follower_control_cmd.value();
   const auto & control_cmd = input_data.control_cmd.value();
+  const auto current_speed = kinematics.twist.twist.linear.x;
+  const auto target_control_speed = control_cmd.longitudinal.velocity;
+  const auto & param = engage_acceptable_param_;
 
   if (!enable_engage_on_driving_ && std::fabs(current_speed) > 1.0e-2) {
     RCLCPP_INFO_THROTTLE(
@@ -237,10 +240,6 @@ bool AutonomousMode::isModeChangeAvailable(const InputData & input_data)
     setAllOk(debug_info_);
     return true;
   }
-
-  const auto current_speed = kinematics.twist.twist.linear.x;
-  const auto target_control_speed = control_cmd.longitudinal.velocity;
-  const auto & param = engage_acceptable_param_;
 
   if (trajectory.points.size() < 2) {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(


### PR DESCRIPTION
## Description

This PR will fix a problem: for bool isModeChangeAvailable(), when `check_engage_condition_` is set as `false`, it will return `true` before `enable_engage_on_driving_`  is checked.
So, even if `enable_engage_on_driving_` is set as `false`, the vehicle can be engaged when the vehicle is driving. It is dangerous.

I made a change in this PR.
The condition of `enable_engage_on_driving_` will be checked before `check_engage_condition_`. 

## Related links

https://tier4.atlassian.net/browse/RT0-38624

## How was this PR tested?

None.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
