### PR TITLE
fix(planning_validator): init validation status

### DIFF
--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -264,6 +264,8 @@ ControlValidator::ControlValidator(const rclcpp::NodeOptions & options)
 
   setup_parameters();
 
+  validation_filtering(validation_status_);
+
   setup_diag();
 }
 

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
@@ -174,6 +174,7 @@ struct PlanningValidatorContext
     data = std::make_shared<PlanningValidatorData>();
     validation_status = std::make_shared<PlanningValidatorStatus>();
     diag_updater = std::make_shared<Updater>(node);
+    init_validation_status();
   }
 
   autoware::vehicle_info_utils::VehicleInfo vehicle_info;


### PR DESCRIPTION
## Description

The trajectory validation was previously outputting an ERROR status even when no trajectory had been published from upstream modules.
However, it is inappropriate to judge the trajectory as invalid before any trajectory has been received.
This update changes the behavior so that the validation result remains OK until a trajectory is actually subscribed.

Note: The absence of a published trajectory is expected to be detected and reported by a separate diagnostic.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [[PR check][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/a00054e6-e0d7-5405-969b-f874dded9efc?project_id=prd_jt)
- [x] [[PR check][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/a7f03bf3-89dd-5450-b82b-316bc234c0c3?project_id=prd_jt)
- [x] [[PR check][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/bdd55008-ae99-589c-ae27-867e075ffa75?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
