### PR TITLE
feat(system_monitor): add host name for system monitor

### DIFF
--- a/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -96,13 +96,16 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
 
   updater_.setHardwareID(hostname_);
   // Update diagnostic data collected by the timer callback.
-  updater_.add("CPU Temperature", this, &CPUMonitorBase::updateTemperature);
-  updater_.add("CPU Usage", this, &CPUMonitorBase::updateUsage);
-  updater_.add("CPU Load Average", this, &CPUMonitorBase::updateLoad);
-  updater_.add("CPU Frequency", this, &CPUMonitorBase::updateFrequency);
+  updater_.add(
+    std::string(hostname_) + ": CPU Temperature", this, &CPUMonitorBase::updateTemperature);
+  updater_.add(std::string(hostname_) + ": CPU Usage", this, &CPUMonitorBase::updateUsage);
+  updater_.add(std::string(hostname_) + ": CPU Load Average", this, &CPUMonitorBase::updateLoad);
+  updater_.add(std::string(hostname_) + ": CPU Frequency", this, &CPUMonitorBase::updateFrequency);
   // Data format of ThermalThrottling differs among platforms.
   // So checking of status and updating of diagnostic are executed simultaneously.
-  updater_.add("CPU Thermal Throttling", this, &CPUMonitorBase::updateThermalThrottling);
+  updater_.add(
+    std::string(hostname_) + ": CPU Thermal Throttling", this,
+    &CPUMonitorBase::updateThermalThrottling);
 
   // Publisher
   rclcpp::QoS durable_qos{1};

--- a/system/autoware_system_monitor/src/gpu_monitor/gpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/gpu_monitor_base.cpp
@@ -37,11 +37,13 @@ GPUMonitorBase::GPUMonitorBase(const std::string & node_name, const rclcpp::Node
   gethostname(hostname_, sizeof(hostname_));
 
   updater_.setHardwareID(hostname_);
-  updater_.add("GPU Temperature", this, &GPUMonitorBase::checkTemp);
-  updater_.add("GPU Usage", this, &GPUMonitorBase::checkUsage);
-  updater_.add("GPU Memory Usage", this, &GPUMonitorBase::checkMemoryUsage);
-  updater_.add("GPU Thermal Throttling", this, &GPUMonitorBase::checkThrottling);
-  updater_.add("GPU Frequency", this, &GPUMonitorBase::checkFrequency);
+  updater_.add(std::string(hostname_) + ": GPU Temperature", this, &GPUMonitorBase::checkTemp);
+  updater_.add(std::string(hostname_) + ": GPU Usage", this, &GPUMonitorBase::checkUsage);
+  updater_.add(
+    std::string(hostname_) + ": GPU Memory Usage", this, &GPUMonitorBase::checkMemoryUsage);
+  updater_.add(
+    std::string(hostname_) + ": GPU Thermal Throttling", this, &GPUMonitorBase::checkThrottling);
+  updater_.add(std::string(hostname_) + ": GPU Frequency", this, &GPUMonitorBase::checkFrequency);
 }
 
 void GPUMonitorBase::update()

--- a/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -53,16 +53,22 @@ HddMonitor::HddMonitor(const rclcpp::NodeOptions & options)
   getHddParams();
 
   updater_.setHardwareID(hostname_);
-  updater_.add("HDD Temperature", this, &HddMonitor::checkSmartTemperature);
-  updater_.add("HDD PowerOnHours", this, &HddMonitor::checkSmartPowerOnHours);
-  updater_.add("HDD TotalDataWritten", this, &HddMonitor::checkSmartTotalDataWritten);
-  updater_.add("HDD RecoveredError", this, &HddMonitor::checkSmartRecoveredError);
-  updater_.add("HDD Usage", this, &HddMonitor::checkUsage);
-  updater_.add("HDD ReadDataRate", this, &HddMonitor::checkReadDataRate);
-  updater_.add("HDD WriteDataRate", this, &HddMonitor::checkWriteDataRate);
-  updater_.add("HDD ReadIOPS", this, &HddMonitor::checkReadIops);
-  updater_.add("HDD WriteIOPS", this, &HddMonitor::checkWriteIops);
-  updater_.add("HDD Connection", this, &HddMonitor::checkConnection);
+  updater_.add(
+    std::string(hostname_) + ": HDD Temperature", this, &HddMonitor::checkSmartTemperature);
+  updater_.add(
+    std::string(hostname_) + ": HDD PowerOnHours", this, &HddMonitor::checkSmartPowerOnHours);
+  updater_.add(
+    std::string(hostname_) + ": HDD TotalDataWritten", this,
+    &HddMonitor::checkSmartTotalDataWritten);
+  updater_.add(
+    std::string(hostname_) + ": HDD RecoveredError", this, &HddMonitor::checkSmartRecoveredError);
+  updater_.add(std::string(hostname_) + ": HDD Usage", this, &HddMonitor::checkUsage);
+  updater_.add(std::string(hostname_) + ": HDD ReadDataRate", this, &HddMonitor::checkReadDataRate);
+  updater_.add(
+    std::string(hostname_) + ": HDD WriteDataRate", this, &HddMonitor::checkWriteDataRate);
+  updater_.add(std::string(hostname_) + ": HDD ReadIOPS", this, &HddMonitor::checkReadIops);
+  updater_.add(std::string(hostname_) + ": HDD WriteIOPS", this, &HddMonitor::checkWriteIops);
+  updater_.add(std::string(hostname_) + ": HDD Connection", this, &HddMonitor::checkConnection);
 
   // get HDD connection status
   updateHddConnections();

--- a/system/autoware_system_monitor/src/mem_monitor/mem_monitor.cpp
+++ b/system/autoware_system_monitor/src/mem_monitor/mem_monitor.cpp
@@ -38,11 +38,11 @@ MemMonitor::MemMonitor(const rclcpp::NodeOptions & options)
 {
   gethostname(hostname_, sizeof(hostname_));
   updater_.setHardwareID(hostname_);
-  updater_.add("Memory Usage", this, &MemMonitor::checkUsage);
+  updater_.add(std::string(hostname_) + ": Memory Usage", this, &MemMonitor::checkUsage);
 
   // Enable ECC error detection if edac-utils package is installed
   if (!bp::search_path("edac-util").empty()) {
-    updater_.add("Memory ECC", this, &MemMonitor::checkEcc);
+    updater_.add(std::string(hostname_) + ": Memory ECC", this, &MemMonitor::checkEcc);
   }
 
   // Publisher

--- a/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
+++ b/system/autoware_system_monitor/src/net_monitor/net_monitor.cpp
@@ -62,12 +62,16 @@ NetMonitor::NetMonitor(const rclcpp::NodeOptions & options)
 
   gethostname(hostname_, sizeof(hostname_));
   updater_.setHardwareID(hostname_);
-  updater_.add("Network Connection", this, &NetMonitor::check_connection);
-  updater_.add("Network Usage", this, &NetMonitor::check_usage);
-  updater_.add("Network Traffic", this, &NetMonitor::monitor_traffic);
-  updater_.add("Network CRC Error", this, &NetMonitor::check_crc_error);
-  updater_.add("IP Packet Reassembles Failed", this, &NetMonitor::check_reassembles_failed);
-  updater_.add("UDP Buf Errors", this, &NetMonitor::check_udp_buf_errors);
+  updater_.add(
+    std::string(hostname_) + ": Network Connection", this, &NetMonitor::check_connection);
+  updater_.add(std::string(hostname_) + ": Network Usage", this, &NetMonitor::check_usage);
+  updater_.add(std::string(hostname_) + ": Network Traffic", this, &NetMonitor::monitor_traffic);
+  updater_.add(std::string(hostname_) + ": Network CRC Error", this, &NetMonitor::check_crc_error);
+  updater_.add(
+    std::string(hostname_) + ": IP Packet Reassembles Failed", this,
+    &NetMonitor::check_reassembles_failed);
+  updater_.add(
+    std::string(hostname_) + ": UDP Buf Errors", this, &NetMonitor::check_udp_buf_errors);
 
   // Publisher
   rclcpp::QoS durable_qos{1};

--- a/system/autoware_system_monitor/src/ntp_monitor/ntp_monitor.cpp
+++ b/system/autoware_system_monitor/src/ntp_monitor/ntp_monitor.cpp
@@ -51,7 +51,7 @@ NTPMonitor::NTPMonitor(const rclcpp::NodeOptions & options)
   chronyc_exists_ = (p.empty()) ? false : true;
 
   updater_.setHardwareID(hostname_);
-  updater_.add("NTP Offset", this, &NTPMonitor::checkOffset);
+  updater_.add(std::string(hostname_) + ": NTP Offset", this, &NTPMonitor::checkOffset);
 
   // Start timer to execute top command
   timer_callback_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);

--- a/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
@@ -456,7 +456,7 @@ void ProcessMonitor::initialize()
   gethostname(hostname_, sizeof(hostname_));
 
   updater_.setHardwareID(hostname_);
-  updater_.add("Tasks Summary", this, &ProcessMonitor::monitorProcesses);
+  updater_.add(std::string(hostname_) + ": Tasks Summary", this, &ProcessMonitor::monitorProcesses);
 
   // As long as the number of processes is less than EXPECTED_NUM_PROCESSES,
   // the size of the maps can be a compile-time constant.
@@ -471,12 +471,14 @@ void ProcessMonitor::initialize()
   snapshot_ = std::make_unique<ProcessStatistics>();
 
   for (int32_t index = 0; index < getNumOfProcs(); ++index) {
-    auto task = std::make_shared<DiagTask>(fmt::format("High-load Proc[{}]", index));
+    auto task = std::make_shared<DiagTask>(
+      fmt::format(std::string(hostname_) + ": High-load Proc[{}]", index));
     load_tasks_.emplace_back(task);
     updater_.add(*task);  // The life of task is managed by load_tasks_.
   }
   for (int32_t index = 0; index < getNumOfProcs(); ++index) {
-    auto task = std::make_shared<DiagTask>(fmt::format("High-mem Proc[{}]", index));
+    auto task = std::make_shared<DiagTask>(
+      fmt::format(std::string(hostname_) + ": High-mem Proc[{}]", index));
     memory_tasks_.emplace_back(task);
     updater_.add(*task);  // The life of task is managed by memory_tasks_.
   }

--- a/system/autoware_system_monitor/src/voltage_monitor/voltage_monitor.cpp
+++ b/system/autoware_system_monitor/src/voltage_monitor/voltage_monitor.cpp
@@ -73,7 +73,7 @@ VoltageMonitor::VoltageMonitor(const rclcpp::NodeOptions & options)
     }
     callback = &VoltageMonitor::checkVoltage;
   }
-  updater_.add("CMOS Battery Status", this, callback);
+  updater_.add(std::string(hostname_) + ": CMOS Battery Status", this, callback);
 }
 
 void VoltageMonitor::checkVoltage(diagnostic_updater::DiagnosticStatusWrapper & stat)


### PR DESCRIPTION
## Description

This PR will add a hostname for the system monitor. The reason for these changes is that the system monitor will be run on the other ECUs (such as Sub ECU, Perception ECU, etc).

We have implemented this feature in the old version of Autoware, and it works fine, so I want to resubmit the PR this time.

## Related links

- https://github.com/tier4/autoware_universe/pull/1636

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
