### PR TITLE
feat(control_evaluator): add option to output_metrics only when ego is moving

### DIFF
--- a/evaluator/autoware_control_evaluator/config/control_evaluator.param.yaml
+++ b/evaluator/autoware_control_evaluator/config/control_evaluator.param.yaml
@@ -1,10 +1,9 @@
 /**:
   ros__parameters:
     output_metrics_only_moving:
-      is_active: true # if true, aggregate metrics for output_metrics statistics only when the ego is moving
+      enabled: true # if true, aggregate metrics for output_metrics statistics only when the ego is moving
       metric_list:
         - closest_object_distance
-
     planning_factor_metrics:
       topic_prefix: /planning/planning_factors/
       stop_deviation:

--- a/evaluator/autoware_control_evaluator/config/control_evaluator.param.yaml
+++ b/evaluator/autoware_control_evaluator/config/control_evaluator.param.yaml
@@ -1,5 +1,10 @@
 /**:
   ros__parameters:
+    output_metrics_only_moving:
+      is_active: true # if true, aggregate metrics for output_metrics statistics only when the ego is moving
+      metric_list:
+        - closest_object_distance
+
     planning_factor_metrics:
       topic_prefix: /planning/planning_factors/
       stop_deviation:

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -164,6 +164,10 @@ private:
   std::optional<double> prev_steering_angle_{std::nullopt};
   std::optional<double> prev_steering_rate_{std::nullopt};
   std::optional<double> prev_steering_angle_timestamp_{std::nullopt};
+
+  // for output_metrics_only_moving
+  float ego_speed_{0.0};
+  std::array<bool, static_cast<size_t>(Metric::SIZE)> is_output_metrics_only_moving{};
 };
 }  // namespace control_diagnostics
 

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -89,7 +89,7 @@ public:
   void AddKinematicStateMetricMsg(
     const Odometry & odom, const AccelWithCovarianceStamped & accel_stamped);
   void AddSteeringMetricMsg(const SteeringReport & steering_report);
-  void AddStopDeviationMetricMsg(const Odometry & odom);
+  void AddStopDeviationMetricMsg();
   void onTimer();
 
 private:

--- a/evaluator/autoware_control_evaluator/schema/autoware_control_evaluator.schema.json
+++ b/evaluator/autoware_control_evaluator/schema/autoware_control_evaluator.schema.json
@@ -6,6 +6,27 @@
     "autoware_control_evaluator": {
       "type": "object",
       "properties": {
+        "output_metrics_only_moving": {
+          "description": "aggregate some metrics for output_metrics statistics only when the ego is moving",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "enable output_metrics_only_moving",
+              "type": "boolean",
+              "default": true
+            },
+            "metric_list": {
+              "description": "list of metrics to enable for output_metrics_only_moving",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "closest_object_distance"
+              ]
+            }
+          }
+        },
         "planning_factor_metrics": {
           "description": "metrics' parameters for planning_factor evaluation",
           "type": "object",
@@ -55,7 +76,10 @@
           }
         }
       },
-      "required": ["planning_factor_metrics", "object_metrics"]
+      "required": [
+        "planning_factor_metrics",
+        "object_metrics"
+      ]
     }
   },
   "properties": {
@@ -66,8 +90,12 @@
           "$ref": "#/definitions/autoware_control_evaluator"
         }
       },
-      "required": ["ros__parameters"]
+      "required": [
+        "ros__parameters"
+      ]
     }
   },
-  "required": ["/**"]
+  "required": [
+    "/**"
+  ]
 }

--- a/evaluator/autoware_control_evaluator/schema/autoware_control_evaluator.schema.json
+++ b/evaluator/autoware_control_evaluator/schema/autoware_control_evaluator.schema.json
@@ -21,9 +21,7 @@
               "items": {
                 "type": "string"
               },
-              "default": [
-                "closest_object_distance"
-              ]
+              "default": ["closest_object_distance"]
             }
           }
         },
@@ -76,10 +74,7 @@
           }
         }
       },
-      "required": [
-        "planning_factor_metrics",
-        "object_metrics"
-      ]
+      "required": ["planning_factor_metrics", "object_metrics"]
     }
   },
   "properties": {
@@ -90,12 +85,8 @@
           "$ref": "#/definitions/autoware_control_evaluator"
         }
       },
-      "required": [
-        "ros__parameters"
-      ]
+      "required": ["ros__parameters"]
     }
   },
-  "required": [
-    "/**"
-  ]
+  "required": ["/**"]
 }

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -74,13 +74,13 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
   // Parameters
   output_metrics_ = declare_parameter<bool>("output_metrics");
   distance_filter_thr_m_ = declare_parameter<double>("object_metrics.distance_filter_thr_m");
-  
+
   // Setting about Output metrics only when the vehicle is moving
   const bool output_metrics_only_moving_enabled =
     declare_parameter<bool>("output_metrics_only_moving.enabled");
   const std::vector<std::string> output_metrics_only_moving_metric_list =
     declare_parameter<std::vector<std::string>>("output_metrics_only_moving.metric_list");
-  
+
   is_output_metrics_only_moving.fill(false);
   if (output_metrics_only_moving_enabled) {
     for (const auto & metric_str : output_metrics_only_moving_metric_list) {
@@ -213,7 +213,9 @@ void ControlEvaluatorNode::AddMetricMsg(
   metric_msg.name = metric_to_str.at(metric);
   metric_msg.value = std::to_string(metric_value);
   metrics_msg_.metric_array.push_back(metric_msg);
-  if (output_metrics_ && accumulate_metric && (ego_speed_ > 0.001 || !is_output_metrics_only_moving[metric_id])) {
+  if (
+    output_metrics_ && accumulate_metric &&
+    (ego_speed_ > 0.001 || !is_output_metrics_only_moving[metric_id])) {
     metric_accumulators_[metric_id].add(metric_value);
   }
 }

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -261,7 +261,7 @@ void ControlEvaluatorNode::AddBoundaryDistanceMetricMsg(
 
   if (behavior_path.left_bound.size() >= 1) {
     LineString2d left_boundary;
-    for (const auto & p : behavior_path.left_bound) left_boundary.push_back(Point2d(p.x, p.y));
+    for (const auto & p : behavior_path.left_bound) left_boundary.emplace_back(p.x, p.y);
     double distance_to_left_boundary =
       metrics::utils::calc_distance_to_line(current_vehicle_footprint, left_boundary);
 
@@ -274,7 +274,7 @@ void ControlEvaluatorNode::AddBoundaryDistanceMetricMsg(
 
   if (behavior_path.right_bound.size() >= 1) {
     LineString2d right_boundary;
-    for (const auto & p : behavior_path.right_bound) right_boundary.push_back(Point2d(p.x, p.y));
+    for (const auto & p : behavior_path.right_bound) right_boundary.emplace_back(p.x, p.y);
     double distance_to_right_boundary =
       metrics::utils::calc_distance_to_line(current_vehicle_footprint, right_boundary);
 

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -462,7 +462,7 @@ void ControlEvaluatorNode::AddGoalDeviationMetricMsg(const Odometry & odom)
   AddMetricMsg(Metric::goal_yaw_deviation_abs, yaw_deviation_value_abs, is_ego_stopped_near_goal);
 }
 
-void ControlEvaluatorNode::AddStopDeviationMetricMsg(const Odometry & odom)
+void ControlEvaluatorNode::AddStopDeviationMetricMsg()
 {
   const auto get_min_distance_signed =
     [](const PlanningFactorArray::ConstSharedPtr & planning_factors) -> std::optional<double> {
@@ -575,7 +575,7 @@ void ControlEvaluatorNode::onTimer()
     ego_speed_ = std::abs(odom->twist.twist.linear.x);
 
     // add planning_factor related metrics
-    AddStopDeviationMetricMsg(*odom);
+    AddStopDeviationMetricMsg();
 
     // add object related metrics
     const auto objects = objects_sub_.take_data();


### PR DESCRIPTION
## Description
Add an option to accumulate `output_metrics` only when the ego is moving

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim

Evaluators: https://github.com/tier4/auto-evaluator/actions/runs/16794062288
- https://evaluation.tier4.jp/evaluation/reports/bec20f55-2328-5427-a0ec-74911a2d2568/?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/22adae36-ede4-57b4-9c00-31e5333fdac6/?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/06532098-91f7-5837-99ac-842e7e36b5f1/?project_id=prd_jt
 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
