### PR TITLE
refactor the merge_departure_intervals function to avoid crashes

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -198,45 +198,44 @@ void check_departure_points_between_intervals(
   }
 }
 
-DepartureIntervals merge_departure_intervals(DepartureIntervals & departure_intervals)
+void merge_departure_intervals(DepartureIntervals & departure_intervals)
 {
   if (departure_intervals.size() <= 1) {
-    return departure_intervals;
+    return;
   }
+  // Sort intervals by start distance to make merging straightforward
+  std::sort(
+    departure_intervals.begin(), departure_intervals.end(),
+    [](const auto & a, const auto & b) { return a.start_dist_on_traj < b.start_dist_on_traj; });
+
   DepartureIntervals merged;
+  merged.reserve(departure_intervals.size());
   merged.push_back(departure_intervals.front());
 
   for (size_t i = 1; i < departure_intervals.size(); ++i) {
-    auto & next_interval_mut = departure_intervals[i];
-    auto & curr_interval_mut = merged.back();
-    const auto is_same_direction = curr_interval_mut.side_key == next_interval_mut.side_key;
-    if (!is_same_direction) {
-      merged.push_back(next_interval_mut);
-    }
+    auto & last_merged = merged.back();
+    const auto & current = departure_intervals[i];
 
-    const auto is_end_in_between =
-      curr_interval_mut.start_dist_on_traj <= next_interval_mut.end_dist_on_traj &&
-      next_interval_mut.end_dist_on_traj <= curr_interval_mut.end_dist_on_traj;
-    const auto is_start_in_between =
-      curr_interval_mut.start_dist_on_traj <= next_interval_mut.start_dist_on_traj &&
-      next_interval_mut.start_dist_on_traj <= curr_interval_mut.end_dist_on_traj;
+    // Check for overlap on the same side
+    bool is_overlapping = (last_merged.end_dist_on_traj >= current.start_dist_on_traj) &&
+                          (last_merged.side_key == current.side_key);
 
-    if (is_start_in_between && !is_end_in_between) {
-      curr_interval_mut.end = next_interval_mut.end;
-      curr_interval_mut.end_dist_on_traj = next_interval_mut.end_dist_on_traj;
-      next_interval_mut.has_merged = true;
-    } else if (!is_start_in_between && is_end_in_between) {
-      curr_interval_mut.start = next_interval_mut.start;
-      curr_interval_mut.start_dist_on_traj = next_interval_mut.start_dist_on_traj;
-      next_interval_mut.has_merged = true;
-    } else if (is_start_in_between && is_end_in_between) {
-      next_interval_mut.has_merged = true;
+    if (is_overlapping) {
+      // Extend the previous interval if the current one goes further
+      if (current.end_dist_on_traj > last_merged.end_dist_on_traj) {
+        last_merged.end = current.end;
+        last_merged.end_dist_on_traj = current.end_dist_on_traj;
+      }
+      // You can also merge the 'candidates' vectors here if needed
+      last_merged.candidates.insert(
+        last_merged.candidates.end(), current.candidates.begin(), current.candidates.end());
     } else {
-      merged.push_back(next_interval_mut);
+      // No overlap, start a new merged interval
+      merged.push_back(current);
     }
   }
 
-  return merged;
+  departure_intervals = std::move(merged);
 }
 
 void update_departure_intervals(
@@ -272,7 +271,7 @@ void update_departure_intervals(
     new_departure_intervals.begin(), new_departure_intervals.end(),
     std::back_inserter(departure_intervals));
 
-  departure_intervals = merge_departure_intervals(departure_intervals);
+  merge_departure_intervals(departure_intervals);
 }
 
 void update_critical_departure_points(


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
