### PR TITLE
fix(boundary_departure): gradual slow down with feasible profile

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.cpp
@@ -132,16 +132,17 @@ tl::expected<double, std::string> SlowDownInterpolator::find_reach_time(
 }
 
 std::optional<double> SlowDownInterpolator::find_feasible_accel(
-  double gap, double v0, double vt, double a0, double a_comf, double a_max, double j_comf)
+  double gap, double v0, double vt, double a0, double a_comfortable, double a_max,
+  double j_comfortable)
 {
-  if (d_slow(v0, vt, a0, a_max, j_comf) > gap)
-    return std::nullopt;  // even a_max + j_comf won't fit
+  if (d_slow(v0, vt, a0, a_max, j_comfortable) > gap)
+    return std::nullopt;  // even a_max + j_comfortable won't fit
 
-  double lo = a_comf;             // weaker (less negative)
+  double lo = a_comfortable;      // weaker (less negative)
   double hi = a_max;              // stronger
   for (int i = 0; i < 40; ++i) {  // 40 iters → <1 mm precision
     double mid = 0.5 * (lo + hi);
-    (d_slow(v0, vt, a0, mid, j_comf) > gap ? lo : hi) = mid;
+    (d_slow(v0, vt, a0, mid, j_comfortable) > gap ? lo : hi) = mid;
 
     if (std::abs(hi) - std::abs(mid) < std::numeric_limits<double>::epsilon()) {
       break;
@@ -206,8 +207,9 @@ tl::expected<double, std::string> SlowDownInterpolator::calc_velocity_with_profi
   const auto v_brake = v_t(t_brake, j_brake, a_lim, v_0);
 
   if (lon_dist_to_dpt_pt < 1e-3) {
-    const double v_feas = std::sqrt(std::max(v_0 * v_0 + 2.0 * a_brake * lon_dist_to_dpt_pt, 0.0));
-    return std::max(v_target, std::min(v_0, v_feas));
+    const double v_feasible =
+      std::sqrt(std::max(v_0 * v_0 + 2.0 * a_brake * lon_dist_to_dpt_pt, 0.0));
+    return std::max(v_target, std::min(v_0, v_feasible));
   }
 
   /* ---------- Case 1: Target lies inside jerk ramp ---------- */

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.cpp
@@ -29,7 +29,7 @@ SlowDownInterpolator::get_interp_to_point(
 {
   const auto target_vel = interp_velocity(curr_vel, lat_dist_to_bound_m, side_key);
 
-  if (lon_dist_to_bound_m <= 0.0) return tl::make_unexpected("Point behind ego.");  // already past
+  if (lon_dist_to_bound_m < 0.0) return tl::make_unexpected("Point behind ego.");  // already past
 
   const auto a_comfort = th_trigger_.th_acc_mps2.min;
   const auto j_comfort = th_trigger_.th_jerk_mps3.min;
@@ -40,22 +40,37 @@ SlowDownInterpolator::get_interp_to_point(
     get_comfort_distance(lon_dist_to_bound_m, curr_vel, target_vel, curr_acc);
 
   if (comfort_dist_opt) {
-    const auto v_brake_opt = calc_velocity_with_profile(
-      curr_acc, curr_vel, target_vel, j_comfort, a_comfort, lon_dist_to_bound_m);
-    return v_brake_opt
-             ? tl::expected<SlowDownPlan, std::string>(
-                 SlowDownPlan{*comfort_dist_opt, *v_brake_opt, a_comfort})
-             : tl::make_unexpected(
-                 "Failed to calculate velocity with comfort profile." + v_brake_opt.error());
+    const auto d_comfort = std::clamp(*comfort_dist_opt, 0.0, lon_dist_to_bound_m);
+    const auto v_brake_opt =
+      calc_velocity_with_profile(curr_acc, curr_vel, target_vel, j_comfort, a_comfort, d_comfort);
+    if (v_brake_opt) {
+      return tl::expected<SlowDownPlan, std::string>(
+        SlowDownPlan{d_comfort, *v_brake_opt, a_comfort});
+    }
   }
 
-  const auto v_brake_opt =
-    calc_velocity_with_profile(curr_acc, curr_vel, target_vel, j_max, a_max, lon_dist_to_bound_m);
+  const auto a_feasible_opt = find_feasible_accel(
+    lon_dist_to_bound_m, curr_vel, target_vel, curr_acc, a_comfort, a_max, j_comfort);
+  if (a_feasible_opt) {
+    const auto d_feasible = std::clamp(
+      d_slow(curr_vel, target_vel, curr_acc, *a_feasible_opt, j_comfort), 0.0, lon_dist_to_bound_m);
+    const auto v_brake_opt = calc_velocity_with_profile(
+      curr_acc, curr_vel, target_vel, j_comfort, *a_feasible_opt,
+      std::clamp(d_feasible, 0.0, lon_dist_to_bound_m));
+    if (v_brake_opt) {
+      return tl::expected<SlowDownPlan, std::string>(
+        SlowDownPlan{d_feasible, *v_brake_opt, a_feasible_opt.value()});
+    }
+  }
 
-  return v_brake_opt ? tl::expected<SlowDownPlan, std::string>(
-                         SlowDownPlan{*comfort_dist_opt, *v_brake_opt, a_comfort})
-                     : tl::make_unexpected(
-                         "Failed to calculate velocity with max profile: " + v_brake_opt.error());
+  const auto d_hard =
+    std::clamp(d_slow(curr_vel, target_vel, curr_acc, a_max, j_max), 0.0, lon_dist_to_bound_m);
+  const auto v_brake_opt =
+    calc_velocity_with_profile(curr_acc, curr_vel, target_vel, j_max, a_max, 0.0);
+
+  return v_brake_opt
+           ? tl::expected<SlowDownPlan, std::string>(SlowDownPlan{d_hard, *v_brake_opt, a_max})
+           : tl::make_unexpected("Failed to calculate velocity profile: " + v_brake_opt.error());
 }
 
 double SlowDownInterpolator::interp_velocity(
@@ -118,6 +133,25 @@ tl::expected<double, std::string> SlowDownInterpolator::find_reach_time(
   }
 
   return 0.5 * (t_min + t_max);
+}
+
+std::optional<double> SlowDownInterpolator::find_feasible_accel(
+  double gap, double v0, double vt, double a0, double a_comf, double a_max, double j_comf)
+{
+  if (d_slow(v0, vt, a0, a_max, j_comf) > gap)
+    return std::nullopt;  // even a_max + j_comf won't fit
+
+  double lo = a_comf;             // weaker (less negative)
+  double hi = a_max;              // stronger
+  for (int i = 0; i < 40; ++i) {  // 40 iters → <1 mm precision
+    double mid = 0.5 * (lo + hi);
+    (d_slow(v0, vt, a0, mid, j_comf) > gap ? lo : hi) = mid;
+
+    if (std::abs(hi) - std::abs(mid) < std::numeric_limits<double>::epsilon()) {
+      break;
+    }
+  }
+  return hi;  // smallest accel that works
 }
 
 double SlowDownInterpolator::t_j(const double a_0, const double a, const double j)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.hpp
@@ -80,6 +80,9 @@ private:
   static tl::expected<double, std::string> find_reach_time(
     double j, double a, double v0, double dist, double t_min, double t_max);
 
+  static std::optional<double> find_feasible_accel(
+    double gap, double v0, double vt, double a0, double a_comf, double a_max, double j_comf);
+
   [[nodiscard]] std::optional<double> get_comfort_distance(
     const double lon_dist_to_dpt_pt, const double v_0, const double v_target,
     const double a_0) const;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.hpp
@@ -81,7 +81,8 @@ private:
     double j, double a, double v0, double dist, double t_min, double t_max);
 
   static std::optional<double> find_feasible_accel(
-    double gap, double v0, double vt, double a0, double a_comf, double a_max, double j_comf);
+    double gap, double v0, double vt, double a0, double a_comfortable, double a_max,
+    double j_comfortable);
 
   [[nodiscard]] std::optional<double> get_comfort_distance(
     const double lon_dist_to_dpt_pt, const double v_0, const double v_target,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -333,8 +333,8 @@ std::vector<std::tuple<Pose, Pose, double>> get_slow_down_intervals(
   std::vector<std::tuple<Pose, Pose, double>> slowdown_intervals;
 
   for (const auto & departure_interval : departure_intervals) {
-    const auto slow_down_dist_on_traj_m = departure_interval.end_dist_on_traj;
-    const auto lon_dist_to_bound_m = slow_down_dist_on_traj_m - ego_dist_on_traj_m;
+    const auto slow_down_dist_on_traj_m = departure_interval.start_dist_on_traj;
+    const auto lon_dist_to_bound_m = (slow_down_dist_on_traj_m - ego_dist_on_traj_m);
 
     const auto & candidates = departure_interval.candidates;
     const auto lat_dist_to_bound_itr = std::min_element(
@@ -358,7 +358,7 @@ std::vector<std::tuple<Pose, Pose, double>> get_slow_down_intervals(
 
     const auto rel_dist_m = vel_opt->rel_dist_m;
     const auto start_pose = std::invoke([&]() {
-      if (ego_dist_on_traj_m + rel_dist_m < lon_dist_to_bound_m) {
+      if (ego_dist_on_traj_m + rel_dist_m < slow_down_dist_on_traj_m) {
         return ref_traj_pts.compute(ego_dist_on_traj_m + rel_dist_m).pose;
       }
       return departure_interval.start.pose;


### PR DESCRIPTION
## Description

Previously only comfortable-based and  sudden-based deceleration profiles are accepted. However, due to to this, it has caused several sudden deceleration problem.

To fix this, this PR calculated feasible acceleration if comfortable decel is not possible.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

TBA

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
