### PR TITLE
perf(boundary_departure): more efficient arc length calculations for ego footprint points

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
@@ -199,12 +199,10 @@ public:
    * filtering based on hysteresis and distance, and grouping results using side keys.
    *
    * @param projections_to_bound Closest projections to road boundaries for each side.
-   * @param lon_offset_m         Longitudinal offset from ego to front of trajectory (including
-   * vehicle length).
    * @return Side-keyed container of filtered departure points.
    */
   Side<DeparturePoints> get_departure_points(
-    const ClosestProjectionsToBound & projections_to_bound, const double lon_offset_m);
+    const ClosestProjectionsToBound & projections_to_bound);
   // === Abnormalities
 
 private:

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
@@ -162,7 +162,6 @@ public:
    * trajectory index, and selects the best candidate based on lateral distance and classification
    * logic (CRITICAL/NEAR).
    *
-   * @param aw_ref_traj          Reference trajectory used to compute longitudinal distances.
    * @param projections_to_bound Abnormality-aware projections to boundaries.
    * @param side_key             Side to process (left or right).
    * @return Vector of closest projections with departure classification, or an error message on
@@ -170,7 +169,6 @@ public:
    */
   tl::expected<std::vector<ClosestProjectionToBound>, std::string>
   get_closest_projections_to_boundaries_side(
-    const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
     const Abnormalities<ProjectionsToBound> & projections_to_bound, const double min_braking_dist,
     const double max_braking_dist, const SideKey side_key);
 
@@ -182,13 +180,11 @@ public:
    * type based on braking feasibility (APPROACHING_DEPARTURE) using trajectory spacing and braking
    * model.
    *
-   * @param aw_ref_traj          Reference trajectory.
    * @param projections_to_bound Abnormality-wise projections to boundaries.
    * @return ClosestProjectionsToBound structure containing selected points for both sides, or error
    * string.
    */
   tl::expected<ClosestProjectionsToBound, std::string> get_closest_projections_to_boundaries(
-    const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
     const Abnormalities<ProjectionsToBound> & projections_to_bound, const double curr_vel,
     const double curr_acc);
 

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/boundary_departure_checker.hpp
@@ -195,10 +195,13 @@ public:
    * filtering based on hysteresis and distance, and grouping results using side keys.
    *
    * @param projections_to_bound Closest projections to road boundaries for each side.
+   * @param pred_traj_idx_to_ref_traj_lon_dist mapping from an index of the predicted trajectory to
+   * the corresponding arc length on the reference trajectory
    * @return Side-keyed container of filtered departure points.
    */
   Side<DeparturePoints> get_departure_points(
-    const ClosestProjectionsToBound & projections_to_bound);
+    const ClosestProjectionsToBound & projections_to_bound,
+    const std::vector<double> & pred_traj_idx_to_ref_traj_lon_dist);
   // === Abnormalities
 
 private:

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
@@ -120,16 +120,19 @@ struct ProjectionToBound
   double lon_dist_on_ref_traj{std::numeric_limits<double>::max()};
   Segment2d nearest_bound_seg;
   double lat_dist{std::numeric_limits<double>::max()};
+  double lon_offset{};  // offset between the pt_on_ego and the front of the ego segment
   size_t ego_sides_idx{0};
   double time_from_start{std::numeric_limits<double>::max()};
   ProjectionToBound() = default;
   explicit ProjectionToBound(size_t idx) : ego_sides_idx(idx) {}
   ProjectionToBound(
-    Point2d pt_on_ego, Point2d pt_on_bound, Segment2d seg, double lat_dist, size_t idx)
+    Point2d pt_on_ego, Point2d pt_on_bound, Segment2d seg, double lat_dist, double lon_offset,
+    size_t idx)
   : pt_on_ego(std::move(pt_on_ego)),
     pt_on_bound(std::move(pt_on_bound)),
     nearest_bound_seg(std::move(seg)),
     lat_dist(lat_dist),
+    lon_offset(lon_offset),
     ego_sides_idx(idx)
   {
   }

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
@@ -117,7 +117,7 @@ struct ProjectionToBound
 {
   Point2d pt_on_ego;    // orig
   Point2d pt_on_bound;  // proj
-  double lon_dist_on_ref_traj{std::numeric_limits<double>::max()};
+  double lon_dist_on_pred_traj{std::numeric_limits<double>::max()};
   Segment2d nearest_bound_seg;
   double lat_dist{std::numeric_limits<double>::max()};
   double lon_offset{};  // offset between the pt_on_ego and the front of the ego segment
@@ -150,7 +150,7 @@ struct ClosestProjectionToBound : ProjectionToBound
     nearest_bound_seg = base.nearest_bound_seg;
     lat_dist = base.lat_dist;
     ego_sides_idx = base.ego_sides_idx;
-    lon_dist_on_ref_traj = base.lon_dist_on_ref_traj;
+    lon_dist_on_pred_traj = base.lon_dist_on_pred_traj;
   }
 
   ClosestProjectionToBound(

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
@@ -117,6 +117,7 @@ struct ProjectionToBound
 {
   Point2d pt_on_ego;    // orig
   Point2d pt_on_bound;  // proj
+  double lon_dist_on_ref_traj{std::numeric_limits<double>::max()};
   Segment2d nearest_bound_seg;
   double lat_dist{std::numeric_limits<double>::max()};
   size_t ego_sides_idx{0};
@@ -136,7 +137,6 @@ struct ProjectionToBound
 
 struct ClosestProjectionToBound : ProjectionToBound
 {
-  double lon_dist_on_ref_traj{std::numeric_limits<double>::max()};
   DepartureType departure_type = DepartureType::NONE;
   AbnormalityType abnormality_type = AbnormalityType::NORMAL;
   ClosestProjectionToBound() = default;
@@ -147,14 +147,13 @@ struct ClosestProjectionToBound : ProjectionToBound
     nearest_bound_seg = base.nearest_bound_seg;
     lat_dist = base.lat_dist;
     ego_sides_idx = base.ego_sides_idx;
+    lon_dist_on_ref_traj = base.lon_dist_on_ref_traj;
   }
 
   ClosestProjectionToBound(
-    const ProjectionToBound & base, const double lon_dist, const AbnormalityType abnormality_type,
+    const ProjectionToBound & base, const AbnormalityType abnormality_type,
     const DepartureType departure_type)
-  : lon_dist_on_ref_traj(lon_dist),
-    departure_type(departure_type),
-    abnormality_type(abnormality_type)
+  : departure_type(departure_type), abnormality_type(abnormality_type)
   {
     pt_on_ego = base.pt_on_ego;
     pt_on_bound = base.pt_on_bound;

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
@@ -210,7 +210,8 @@ struct DeparturePoint
   Point2d point;
   double th_point_merge_distance_m{2.0};
   double lat_dist_to_bound{1000.0};
-  double dist_on_traj{1000.0};
+  double ego_dist_on_ref_traj{1000.0};  // [m] distance along the reference trajectory of the
+                                        // corresponding predicted trajectory point
   double velocity{0.0};
   size_t idx_from_ego_traj{};
   bool can_be_removed{false};
@@ -230,7 +231,10 @@ struct DeparturePoint
     return autoware_utils::to_msg(point.to_3d(z));
   }
 
-  bool operator<(const DeparturePoint & other) const { return dist_on_traj < other.dist_on_traj; }
+  bool operator<(const DeparturePoint & other) const
+  {
+    return ego_dist_on_ref_traj < other.ego_dist_on_ref_traj;
+  }
 };
 using DeparturePoints = std::vector<DeparturePoint>;
 
@@ -246,7 +250,7 @@ struct CriticalDeparturePoint : DeparturePoint
     point = base.point;
     th_point_merge_distance_m = base.th_point_merge_distance_m;
     lat_dist_to_bound = base.lat_dist_to_bound;
-    dist_on_traj = base.dist_on_traj;
+    ego_dist_on_ref_traj = base.ego_dist_on_ref_traj;
     velocity = base.velocity;
     can_be_removed = base.can_be_removed;
   }

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp
@@ -240,7 +240,7 @@ using DeparturePoints = std::vector<DeparturePoint>;
 
 struct CriticalDeparturePoint : DeparturePoint
 {
-  TrajectoryPoint point_on_prev_traj;
+  geometry_msgs::msg::Pose pose_on_current_ref_traj;
   CriticalDeparturePoint() = default;
   explicit CriticalDeparturePoint(const DeparturePoint & base)
   {

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
@@ -386,12 +386,15 @@ double compute_braking_distance(
  * - Retains only points up to and including the first CRITICAL_DEPARTURE point (if any).
  *
  * @param projections_to_bound  List of lateral projections to road boundaries.
+ * @param pred_traj_idx_to_ref_traj_lon_dist mapping from an index of the predicted trajectory to
+ * the corresponding arc length on the reference trajectory
  * @param th_point_merge_distance_m  Threshold distance used for hysteresis logic in departure
  * classification.
  * @return Filtered, sorted `DeparturePoints` with only relevant departure markers.
  */
 DeparturePoints get_departure_points(
   const std::vector<ClosestProjectionToBound> & projections_to_bound,
+  const std::vector<double> & pred_traj_idx_to_ref_traj_lon_dist,
   const double th_point_merge_distance_m);
 
 /**

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
@@ -388,13 +388,11 @@ double compute_braking_distance(
  * @param projections_to_bound  List of lateral projections to road boundaries.
  * @param th_point_merge_distance_m  Threshold distance used for hysteresis logic in departure
  * classification.
- * @param lon_offset_m          Longitudinal offset from ego base link to the reference
- * trajectory.
  * @return Filtered, sorted `DeparturePoints` with only relevant departure markers.
  */
 DeparturePoints get_departure_points(
   const std::vector<ClosestProjectionToBound> & projections_to_bound,
-  const double th_point_merge_distance_m, const double lon_offset_m);
+  const double th_point_merge_distance_m);
 
 /**
  * @brief Find nearby uncrossable linestrings around the given pose.

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -328,7 +328,8 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries(
 }
 
 Side<DeparturePoints> BoundaryDepartureChecker::get_departure_points(
-  const ClosestProjectionsToBound & projections_to_bound)
+  const ClosestProjectionsToBound & projections_to_bound,
+  const std::vector<double> & pred_traj_idx_to_ref_traj_lon_dist)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -336,8 +337,9 @@ Side<DeparturePoints> BoundaryDepartureChecker::get_departure_points(
 
   Side<DeparturePoints> departure_points;
   for (const auto side_key : g_side_keys) {
-    departure_points[side_key] =
-      utils::get_departure_points(projections_to_bound[side_key], th_point_merge_distance_m);
+    departure_points[side_key] = utils::get_departure_points(
+      projections_to_bound[side_key], pred_traj_idx_to_ref_traj_lon_dist,
+      th_point_merge_distance_m);
   }
   return departure_points;
 }

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -252,13 +252,13 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
 
     if (
       !min_to_bound.empty() && min_pt->departure_type != DepartureType::CRITICAL_DEPARTURE &&
-      std::abs(min_to_bound.back().lon_dist_on_ref_traj - min_pt->lon_dist_on_ref_traj) < 0.5) {
+      std::abs(min_to_bound.back().lon_dist_on_pred_traj - min_pt->lon_dist_on_pred_traj) < 0.5) {
       continue;
     }
 
     const auto is_exceeding_cutoff =
       [&min_pt](const auto type, const auto braking_dist, const auto cutoff_time) {
-        return min_pt->departure_type == type && min_pt->lon_dist_on_ref_traj > braking_dist &&
+        return min_pt->departure_type == type && min_pt->lon_dist_on_pred_traj > braking_dist &&
                min_pt->time_from_start > cutoff_time;
       };
 
@@ -317,7 +317,7 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries(
     for (auto itr = std::next(min_to_bound[side_key].rbegin());
          itr != min_to_bound[side_key].rend(); ++itr) {
       if (
-        min_to_bound[side_key].back().lon_dist_on_ref_traj - itr->lon_dist_on_ref_traj <
+        min_to_bound[side_key].back().lon_dist_on_pred_traj - itr->lon_dist_on_pred_traj <
         max_braking_dist) {
         itr->departure_type = DepartureType::APPROACHING_DEPARTURE;
       }

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -330,7 +330,7 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries(
 }
 
 Side<DeparturePoints> BoundaryDepartureChecker::get_departure_points(
-  const ClosestProjectionsToBound & projections_to_bound, const double lon_offset_m)
+  const ClosestProjectionsToBound & projections_to_bound)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -338,8 +338,8 @@ Side<DeparturePoints> BoundaryDepartureChecker::get_departure_points(
 
   Side<DeparturePoints> departure_points;
   for (const auto side_key : g_side_keys) {
-    departure_points[side_key] = utils::get_departure_points(
-      projections_to_bound[side_key], th_point_merge_distance_m, lon_offset_m);
+    departure_points[side_key] =
+      utils::get_departure_points(projections_to_bound[side_key], th_point_merge_distance_m);
   }
   return departure_points;
 }

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -168,7 +168,7 @@ BoundaryDepartureChecker::get_boundary_segments_from_side(
 
 tl::expected<std::vector<ClosestProjectionToBound>, std::string>
 BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
-  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
+  [[maybe_unused]] const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
   const Abnormalities<ProjectionsToBound> & projections_to_bound, const double min_braking_dist,
   const double max_braking_dist, const SideKey side_key)
 {
@@ -256,8 +256,6 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
       std::abs(min_to_bound.back().lon_dist_on_ref_traj - min_pt->lon_dist_on_ref_traj) < 0.5) {
       continue;
     }
-    min_pt->lon_dist_on_ref_traj =
-      trajectory::closest(aw_ref_traj, utils::to_geom_pt(min_pt->pt_on_ego));
 
     const auto is_exceeding_cutoff =
       [&min_pt](const auto type, const auto braking_dist, const auto cutoff_time) {

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -168,7 +168,6 @@ BoundaryDepartureChecker::get_boundary_segments_from_side(
 
 tl::expected<std::vector<ClosestProjectionToBound>, std::string>
 BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
-  [[maybe_unused]] const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
   const Abnormalities<ProjectionsToBound> & projections_to_bound, const double min_braking_dist,
   const double max_braking_dist, const SideKey side_key)
 {
@@ -284,7 +283,6 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries_side(
 
 tl::expected<ClosestProjectionsToBound, std::string>
 BoundaryDepartureChecker::get_closest_projections_to_boundaries(
-  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
   const Abnormalities<ProjectionsToBound> & projections_to_bound, const double curr_vel,
   const double curr_acc)
 {
@@ -301,7 +299,7 @@ BoundaryDepartureChecker::get_closest_projections_to_boundaries(
 
   for (const auto side_key : g_side_keys) {
     const auto min_to_bound_opt = get_closest_projections_to_boundaries_side(
-      aw_ref_traj, projections_to_bound, min_braking_dist, max_braking_dist, side_key);
+      projections_to_bound, min_braking_dist, max_braking_dist, side_key);
 
     if (!min_to_bound_opt) {
       return tl::make_unexpected(min_to_bound_opt.error());

--- a/common/autoware_boundary_departure_checker/src/utils.cpp
+++ b/common/autoware_boundary_departure_checker/src/utils.cpp
@@ -103,12 +103,6 @@ std::vector<SegmentWithIdx> create_local_segments(const lanelet::ConstLineString
 
 namespace autoware::boundary_departure_checker::utils
 {
-double calc_dist_on_traj(
-  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const Point2d & point)
-{
-  return trajectory::closest(aw_ref_traj, to_geom_pt(point));
-}
-
 TrajectoryPoints cutTrajectory(const TrajectoryPoints & trajectory, const double length)
 {
   if (trajectory.empty()) {

--- a/common/autoware_boundary_departure_checker/src/utils.cpp
+++ b/common/autoware_boundary_departure_checker/src/utils.cpp
@@ -53,8 +53,7 @@ using autoware::boundary_departure_checker::utils::to_segment_2d;
 namespace bg = boost::geometry;
 
 DeparturePoint create_departure_point(
-  const ClosestProjectionToBound & projection_to_bound, const double th_point_merge_distance_m,
-  [[maybe_unused]] const double lon_offset_m)
+  const ClosestProjectionToBound & projection_to_bound, const double th_point_merge_distance_m)
 {
   DeparturePoint point;
   point.uuid = autoware_utils::to_hex_string(autoware_utils::generate_uuid());
@@ -648,13 +647,12 @@ DeparturePoints cluster_by_distance(const DeparturePoints & departure_points)
 
 DeparturePoints get_departure_points(
   const std::vector<ClosestProjectionToBound> & projections_to_bound,
-  const double th_point_merge_distance_m, const double lon_offset_m)
+  const double th_point_merge_distance_m)
 {
   DeparturePoints departure_points;
   departure_points.reserve(projections_to_bound.size());
   for (const auto & projection_to_bound : projections_to_bound) {
-    const auto point =
-      create_departure_point(projection_to_bound, th_point_merge_distance_m, lon_offset_m);
+    const auto point = create_departure_point(projection_to_bound, th_point_merge_distance_m);
 
     if (point.can_be_removed) {
       continue;

--- a/common/autoware_boundary_departure_checker/src/utils.cpp
+++ b/common/autoware_boundary_departure_checker/src/utils.cpp
@@ -61,7 +61,7 @@ DeparturePoint create_departure_point(
   point.departure_type = projection_to_bound.departure_type;
   point.point = projection_to_bound.pt_on_bound;
   point.th_point_merge_distance_m = th_point_merge_distance_m;
-  point.dist_on_traj = projection_to_bound.lon_dist_on_ref_traj;  // - lon_offset_m;
+  point.dist_on_traj = projection_to_bound.lon_dist_on_pred_traj;  // - lon_offset_m;
   point.idx_from_ego_traj = projection_to_bound.ego_sides_idx;
   point.can_be_removed = (point.departure_type == DepartureType::NONE) || point.dist_on_traj <= 0.0;
   return point;
@@ -599,7 +599,7 @@ ProjectionsToBound get_closest_boundary_segments_from_side(
     for (const auto & side_key : g_side_keys) {
       auto closest_bound = find_closest_segment(fp[side_key], rear_seg, i, boundaries[side_key]);
       closest_bound.time_from_start = rclcpp::Duration(ego_pred_traj[i].time_from_start).seconds();
-      closest_bound.lon_dist_on_ref_traj = s - closest_bound.lon_offset;
+      closest_bound.lon_dist_on_pred_traj = s - closest_bound.lon_offset;
       side[side_key].push_back(closest_bound);
     }
     if (i > 1) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -501,8 +501,8 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
     return ego_dist_on_traj_m + lon_offset_m(take_front_offset);
   };
 
-  output_.departure_points = boundary_departure_checker_ptr_->get_departure_points(
-    output_.closest_projections_to_bound, lon_offset_m(planner_data->is_driving_forward));
+  output_.departure_points =
+    boundary_departure_checker_ptr_->get_departure_points(output_.closest_projections_to_bound);
   toc_curr_watch("get_departure_points");
 
   // update output_.critical_departure_points

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -711,9 +711,10 @@ std::unordered_map<DepartureType, bool> BoundaryDeparturePreventionModule::get_d
     [&th_trigger, &curr_vel](const DeparturePoint & pt) {
       const auto braking_start_vel =
         std::clamp(curr_vel, th_trigger.th_vel_mps.min, th_trigger.th_vel_mps.max);
-      const auto braking_dist = boundary_departure_checker::utils::compute_braking_distance(
-        braking_start_vel, 0.0, th_trigger.th_acc_mps2.min, th_trigger.th_jerk_mps3.max,
-        th_trigger.brake_delay_s);
+      const auto braking_dist =
+        boundary_departure_checker::utils::calc_judge_line_dist_with_jerk_limit(
+          braking_start_vel, 0.0, th_trigger.th_acc_mps2.min, th_trigger.th_jerk_mps3.max,
+          th_trigger.brake_delay_s);
       return pt.ego_dist_on_ref_traj <= braking_dist;
     });
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -492,7 +492,7 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
   output_.closest_projections_to_bound = *closest_projections_to_bound_opt;
 
   const auto ego_dist_on_traj_m =
-    experimental::trajectory::closest(*ref_traj_pts_opt, curr_pose.pose);
+    motion_utils::calcSignedArcLength(raw_trajectory_points, 0UL, curr_pose.pose.position);
   toc_curr_watch("chk_ego_dist_on_traj");
 
   const auto lon_offset_m = [&vehicle_info](const bool take_front_offset) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -677,41 +677,6 @@ void BoundaryDeparturePreventionModule::update_critical_departure_points(
   std::sort(output_.critical_departure_points.begin(), output_.critical_departure_points.end());
 }
 
-CriticalDeparturePoints find_new_critical_departure_points(
-  const Side<DeparturePoints> & new_departure_points,
-  const CriticalDeparturePoints & critical_departure_points,
-  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-  const double th_point_merge_distance_m)
-{
-  CriticalDeparturePoints new_critical_departure_points;
-  for (const auto side_key : g_side_keys) {
-    for (const auto & dpt_pt : new_departure_points[side_key]) {
-      if (dpt_pt.departure_type != DepartureType::CRITICAL_DEPARTURE) {
-        continue;
-      }
-
-      if (dpt_pt.can_be_removed) {
-        continue;
-      }
-
-      const auto is_near_curr_pts = std::any_of(
-        critical_departure_points.begin(), critical_departure_points.end(),
-        [&](const CriticalDeparturePoint & crit_pt) {
-          return std::abs(dpt_pt.ego_dist_on_ref_traj - crit_pt.ego_dist_on_ref_traj) <
-                 th_point_merge_distance_m;
-        });
-
-      if (is_near_curr_pts) {
-        continue;
-      }
-
-      CriticalDeparturePoint crit_pt(dpt_pt);
-      crit_pt.point_on_prev_traj = aw_ref_traj.compute(crit_pt.ego_dist_on_ref_traj);
-      new_critical_departure_points.push_back(crit_pt);
-    }
-  }
-  return new_critical_departure_points;
-}
 std::unordered_map<DepartureType, bool> BoundaryDeparturePreventionModule::get_diagnostics(
   const double curr_vel, const double dist_with_offset_m)
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -480,7 +480,7 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
 
   const auto closest_projections_to_bound_opt =
     boundary_departure_checker_ptr_->get_closest_projections_to_boundaries(
-      *ref_traj_pts_opt, output_.abnormalities_data.projections_to_bound, curr_vel, curr_acc);
+      output_.abnormalities_data.projections_to_bound, curr_vel, curr_acc);
   toc_curr_watch("get_ref_traj");
 
   if (!closest_projections_to_bound_opt) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -74,8 +74,7 @@ private:
   void update_critical_departure_points(
     const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double offset_from_ego);
 
-  std::unordered_map<DepartureType, bool> get_diagnostics(
-    const double curr_vel, const double dist_with_offset_m);
+  std::unordered_map<DepartureType, bool> get_diagnostics(const double curr_vel);
 
   /**
    * @brief Check if critical departure has been continuously observed.

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -67,12 +67,12 @@ private:
    * Projects existing critical departure points onto the updated reference trajectory
    * and removes points that are outdated (i.e., passed by the ego or shifted significantly).
    *
-   * @param aw_ref_traj Current reference trajectory.
+   * @param raw_ref_traj Current reference trajectory.
    * @param offset_from_ego Minimum distance from ego to keep a point; points closer than this are
    * removed.
    */
   void update_critical_departure_points(
-    const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double offset_from_ego);
+    const std::vector<TrajectoryPoint> & raw_ref_traj, const double offset_from_ego);
 
   std::unordered_map<DepartureType, bool> get_diagnostics(const double curr_vel);
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -94,8 +94,7 @@ DepartureIntervals init_departure_intervals(
       continue;
     }
 
-    interval.start_dist_on_traj =
-      interval.candidates.front().ego_dist_on_ref_traj - vehicle_length_m;
+    interval.start_dist_on_traj = interval.candidates.front().ego_dist_on_ref_traj;
     interval.start = aw_ref_traj.compute(interval.start_dist_on_traj);
     interval.end_dist_on_traj = interval.candidates.back().ego_dist_on_ref_traj;
     interval.end = aw_ref_traj.compute(interval.end_dist_on_traj);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -16,6 +16,8 @@
 
 #include <autoware/boundary_departure_checker/conversion.hpp>
 #include <autoware/boundary_departure_checker/data_structs.hpp>
+#include <autoware/motion_utils/trajectory/interpolation.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/utils/closest.hpp>
 #include <magic_enum.hpp>
 #include <range/v3/algorithm/sort.hpp>
@@ -119,25 +121,26 @@ DepartureIntervals init_departure_intervals(
 }
 
 void update_departure_intervals_poses(
-  DepartureIntervals & departure_intervals,
-  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-  const TrajectoryPoint & ref_traj_fr_pt, const double ego_dist_from_traj_front,
-  const double th_pt_shift_dist_m, const double th_pt_shift_angle_rad)
+  DepartureIntervals & departure_intervals, const std::vector<TrajectoryPoint> & raw_ref_traj,
+  const double ego_dist_from_traj_front, const double th_pt_shift_dist_m,
+  const double th_pt_shift_angle_rad)
 {
   for (auto & dpt_pt : departure_intervals) {
     // update start end pose
     if (!dpt_pt.start_at_traj_front) {
-      dpt_pt.start_dist_on_traj = trajectory::closest(aw_ref_traj, dpt_pt.start);
+      dpt_pt.start_dist_on_traj =
+        motion_utils::calcSignedArcLength(raw_ref_traj, 0UL, dpt_pt.start.pose.position);
       constexpr auto th_dist_from_start{1.0};
       dpt_pt.start_at_traj_front = dpt_pt.start_dist_on_traj < th_dist_from_start;
     }
 
     if (dpt_pt.start_at_traj_front) {
       dpt_pt.start_dist_on_traj = 0.0;
-      dpt_pt.start = ref_traj_fr_pt;
+      dpt_pt.start = raw_ref_traj.front();
     }
 
-    dpt_pt.end_dist_on_traj = trajectory::closest(aw_ref_traj, dpt_pt.end);
+    dpt_pt.end_dist_on_traj =
+      motion_utils::calcSignedArcLength(raw_ref_traj, 0UL, dpt_pt.end.pose.position);
   }
 
   // remove if ego already pass the end pose.
@@ -145,15 +148,15 @@ void update_departure_intervals_poses(
     if (interval.end_dist_on_traj < ego_dist_from_traj_front) {
       return true;
     }
-    auto point_of_curr_traj = aw_ref_traj.compute(interval.end_dist_on_traj);
+    auto curr_pose =
+      autoware::motion_utils::calcInterpolatedPose(raw_ref_traj, interval.end_dist_on_traj);
     const auto & prev_pose = interval.end.pose;
-    const auto & curr_pose = point_of_curr_traj.pose;
     if (
       const auto is_shifted_opt =
         utils::is_point_shifted(prev_pose, curr_pose, th_pt_shift_dist_m, th_pt_shift_angle_rad)) {
       return true;
     }
-    interval.end = point_of_curr_traj;
+    interval.end.pose = curr_pose;
     return false;
   });
 }
@@ -239,13 +242,13 @@ void merge_departure_intervals(DepartureIntervals & departure_intervals)
 void update_departure_intervals(
   DepartureIntervals & departure_intervals, Side<DeparturePoints> & departure_points,
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double vehicle_length_m,
-  const TrajectoryPoint & ref_traj_fr_pt, const double ego_dist_from_traj_front,
+  const std::vector<TrajectoryPoint> & raw_ref_traj, const double ego_dist_from_traj_front,
   const double th_pt_shift_dist_m, const double th_pt_shift_angle_rad,
   const std::unordered_set<DepartureType> & enable_type, const bool is_reset_interval,
   const bool is_departure_persist)
 {
   update_departure_intervals_poses(
-    departure_intervals, aw_ref_traj, ref_traj_fr_pt, ego_dist_from_traj_front, th_pt_shift_dist_m,
+    departure_intervals, raw_ref_traj, ego_dist_from_traj_front, th_pt_shift_dist_m,
     th_pt_shift_angle_rad);
 
   for (const auto side_key : g_side_keys) {
@@ -275,8 +278,7 @@ void update_departure_intervals(
 CriticalDeparturePoints find_new_critical_departure_points(
   const Side<DeparturePoints> & new_departure_points,
   const CriticalDeparturePoints & critical_departure_points,
-  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-  const double th_point_merge_distance_m)
+  const std::vector<TrajectoryPoint> & raw_ref_traj, const double th_point_merge_distance_m)
 {
   CriticalDeparturePoints new_critical_departure_points;
   for (const auto side_key : g_side_keys) {
@@ -301,7 +303,8 @@ CriticalDeparturePoints find_new_critical_departure_points(
       }
 
       CriticalDeparturePoint crit_pt(dpt_pt);
-      crit_pt.point_on_prev_traj = aw_ref_traj.compute(crit_pt.ego_dist_on_ref_traj);
+      crit_pt.pose_on_current_ref_traj =
+        motion_utils::calcInterpolatedPose(raw_ref_traj, crit_pt.ego_dist_on_ref_traj);
       new_critical_departure_points.push_back(crit_pt);
     }
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
@@ -134,7 +134,7 @@ DepartureIntervals init_departure_intervals(
  * @param[in,out] departure_points Per-side departure points; may be marked removable.
  * @param[in] aw_ref_traj Reference trajectory.
  * @param[in] vehicle_length_m Used to extend intervals if points are nearby.
- * @param[in] ref_traj_fr_pt First trajectory point (used when interval starts at front).
+ * @param[in] raw_ref_traj Reference trajectory (raw points).
  * @param[in] ego_dist_from_traj_front Ego’s current distance along the trajectory.
  * @param[in] th_pt_shift_dist_m Threshold distance for detecting shifted points.
  * @param[in] th_pt_shift_angle_rad Threshold angle for detecting shifted points.
@@ -146,7 +146,7 @@ DepartureIntervals init_departure_intervals(
 void update_departure_intervals(
   DepartureIntervals & departure_intervals, Side<DeparturePoints> & departure_points,
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double vehicle_length_m,
-  const TrajectoryPoint & ref_traj_fr_pt, const double ego_dist_from_traj_front,
+  const std::vector<TrajectoryPoint> & raw_ref_traj, const double ego_dist_from_traj_front,
   const double th_pt_shift_dist_m, const double th_pt_shift_angle_rad,
   const std::unordered_set<DepartureType> & enable_type, const bool is_reset_interval,
   const bool is_departure_persist);
@@ -168,8 +168,7 @@ void update_departure_intervals(
 CriticalDeparturePoints find_new_critical_departure_points(
   const Side<DeparturePoints> & new_departure_points,
   const CriticalDeparturePoints & critical_departure_points,
-  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-  const double th_point_merge_distance_m);
+  const std::vector<TrajectoryPoint> & raw_ref_traj, const double th_point_merge_distance_m);
 
 /**
  * @brief Build slow-down segments ahead of the ego vehicle.


### PR DESCRIPTION
## Description

This PR improves performance by more efficiently calculating the arc lengths of the departing ego footprint points.
Mainly, `trajectory::closest` is replaced with `motion_utils::calcSignedArcLength()`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
