### PR TITLE
fix(planning_evaluaotr): prevent abnormal value for ttc

### DIFF
--- a/evaluator/autoware_planning_evaluator/src/metrics/obstacle_metrics.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metrics/obstacle_metrics.cpp
@@ -50,18 +50,20 @@ Accumulator<double> calcTimeToCollision(
   const PredictedObjects & obstacles, const Trajectory & traj, const double distance_threshold)
 {
   Accumulator<double> stat;
+
+  if (traj.points.empty()) {
+    return stat;
+  }
+
   /** TODO(Maxime CLEMENT):
    * this implementation assumes static obstacles and does not work for dynamic obstacles
    */
-  TrajectoryPoint p0;
-  if (!traj.points.empty()) {
-    p0 = traj.points.front();
-  }
-
+  TrajectoryPoint p0 = traj.points.front();
   double t = 0.0;  // [s] time from start of trajectory
+  constexpr double MIN_VELOCITY_THRESHOLD = 1e-3;
   for (const TrajectoryPoint & p : traj.points) {
     const double traj_dist = calc_distance2d(p0, p);
-    if (p0.longitudinal_velocity_mps != 0) {
+    if (std::abs(p0.longitudinal_velocity_mps) > MIN_VELOCITY_THRESHOLD) {
       const double dt = traj_dist / std::abs(p0.longitudinal_velocity_mps);
       t += dt;
       for (auto obstacle : obstacles.objects) {


### PR DESCRIPTION
## Description

obstacle_ttc sometimes becomes abnormally large.
The exact reason is unknown (maybe issue on application side. refer to Related Links) , but it may become large when p0 is not initialized, so a check has been added.
In addition, division by extremely small values has been prevented.

## Related links

`obstacle_ttc` osd

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- https://star4.slack.com/archives/CTEJP8L4T/p1754634222584029?thread_ts=1754633904.114969&cid=CTEJP8L4T (tier4 internal)

## How was this PR tested?



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
