### PR TITLE
refactor(boundary_departure): check output exist and matches type for diagnostic level

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -64,14 +64,19 @@ void BoundaryDeparturePreventionModule::init(
   updater_ptr_->setHardwareID("motion_velocity_boundary_departure_prevention");
   updater_ptr_->add(
     "boundary_departure", [this](diagnostic_updater::DiagnosticStatusWrapper & stat) {
+      const auto matches_type = [this](const DepartureType & type) -> bool {
+        return output_.diagnostic_output.find(type) != output_.diagnostic_output.end() &&
+               output_.diagnostic_output[type];
+      };
+
       const auto type = std::invoke([&]() {
-        if (output_.diagnostic_output[DepartureType::CRITICAL_DEPARTURE]) {
+        if (matches_type(DepartureType::CRITICAL_DEPARTURE)) {
           return DepartureType::CRITICAL_DEPARTURE;
         }
-        if (output_.diagnostic_output[DepartureType::APPROACHING_DEPARTURE]) {
+        if (matches_type(DepartureType::APPROACHING_DEPARTURE)) {
           return DepartureType::APPROACHING_DEPARTURE;
         }
-        if (output_.diagnostic_output[DepartureType::NEAR_BOUNDARY]) {
+        if (matches_type(DepartureType::NEAR_BOUNDARY)) {
           return DepartureType::NEAR_BOUNDARY;
         }
         return DepartureType::NONE;


### PR DESCRIPTION
## Description

Add check if type exist in `diagnostic_output` before checking its content. 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Build and test autoware.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
