### PR TITLE
feat(mpc_lateral_controller): publish the wheel angle in the predicted trajectory

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
@@ -83,7 +83,7 @@ MPCTrajectory convertToMPCTrajectory(const Trajectory & input);
  * @param [in] input MPCTrajectory to be converted
  * @return output converted Trajectory msg
  */
-Trajectory convertToAutowareTrajectory(const MPCTrajectory & input);
+Trajectory convertToAutowareTrajectory(const MPCTrajectory & input, const double wheelbase = 0.0);
 
 /**
  * @brief calculate the arc length at each point of the given trajectory

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
@@ -81,6 +81,7 @@ MPCTrajectory convertToMPCTrajectory(const Trajectory & input);
 /**
  * @brief convert the given MPCTrajectory to a Trajectory msg
  * @param [in] input MPCTrajectory to be converted
+ * @param [in] wheelbase [m] wheelbase of the vehicle
  * @return output converted Trajectory msg
  */
 Trajectory convertToAutowareTrajectory(const MPCTrajectory & input, const double wheelbase = 0.0);

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -828,7 +828,8 @@ Trajectory MPC::calculatePredictedTrajectory(
   const auto clipped_trajectory =
     MPCUtils::clipTrajectoryByLength(predicted_mpc_trajectory, predicted_length);
 
-  const auto predicted_trajectory = MPCUtils::convertToAutowareTrajectory(clipped_trajectory);
+  const auto predicted_trajectory =
+    MPCUtils::convertToAutowareTrajectory(clipped_trajectory, m_vehicle_model_ptr->getWheelbase());
 
   return predicted_trajectory;
 }

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -275,7 +275,7 @@ MPCTrajectory convertToMPCTrajectory(const Trajectory & input)
   return output;
 }
 
-Trajectory convertToAutowareTrajectory(const MPCTrajectory & input)
+Trajectory convertToAutowareTrajectory(const MPCTrajectory & input, const double wheelbase)
 {
   Trajectory output;
   TrajectoryPoint p;
@@ -288,6 +288,9 @@ Trajectory convertToAutowareTrajectory(const MPCTrajectory & input)
       static_cast<decltype(p.longitudinal_velocity_mps)>(input.vx.at(i));
     p.time_from_start =
       rclcpp::Duration::from_seconds(input.relative_time.at(i) - input.relative_time.front());
+    if (wheelbase != 0.0) {
+      p.front_wheel_angle_rad = static_cast<float>(std::atan(input.smooth_k.at(i) * wheelbase));
+    }
     output.points.push_back(p);
     if (output.points.size() == output.points.max_size()) {
       break;


### PR DESCRIPTION
## Description

This PR populates the `front_wheel_angle_rad` field of the MPC predicted trajectory message.

Needed for https://github.com/autowarefoundation/autoware_universe/pull/11130

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
