### PR TITLE
fix(command_mode_decider): fix mode continuation condition

### DIFF
--- a/system/autoware_command_mode_decider_plugins/src/command_mode_decider.hpp
+++ b/system/autoware_command_mode_decider_plugins/src/command_mode_decider.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware_command_mode_decider/plugin.hpp>
 
+#include <unordered_set>
 #include <vector>
 
 namespace autoware::command_mode_decider
@@ -32,6 +33,13 @@ public:
 
   std::vector<uint16_t> decide(
     const RequestModeStatus & request, const CommandModeStatusTable & table) override;
+
+private:
+  std::vector<uint16_t> decide(
+    const RequestModeStatus & request, const CommandModeStatusTable & table,
+    const std::unordered_set<uint16_t> & last_modes) const;
+
+  std::unordered_set<uint16_t> last_modes_;
 };
 
 }  // namespace autoware::command_mode_decider


### PR DESCRIPTION
## Description

Fixed an issue where mode switch condition was checked even when the mode was continued.

## Related links

- https://github.com/tier4/autoware_universe/pull/2271

## How was this PR tested?

Check the MRM is not activated when switching to autonomous mode.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
