### PR TITLE
Fix/hdd monitor emmc storage type support

### DIFF
--- a/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -38,6 +38,20 @@
 #include <utility>
 #include <vector>
 
+namespace {
+
+bool is_non-scsi_device(const std::string & device_name)
+{
+  // cspell:disable
+  // clang-format off
+  return (boost::starts_with(device_name, "/dev/nvme") ||   // NVMe SSD
+          boost::starts_with(device_name, "/dev/mmcblk"));  // SD card, eMMC
+  // cspell:enable
+  // clang-format on
+}
+
+}  // namespace
+
 namespace bp = boost::process;
 
 HddMonitor::HddMonitor(const rclcpp::NodeOptions & options)
@@ -848,7 +862,7 @@ void HddMonitor::updateHddConnections()
           const std::regex pattern("\\d+$");
           hdd_param.second.disk_device_ =
             std::regex_replace(hdd_param.second.part_device_, pattern, "");
-        } else if (boost::starts_with(hdd_param.second.part_device_, "/dev/nvme")) {
+        } else if (is_non_scsi_device(hdd_param.second.part_device_)) {
           const std::regex pattern("p\\d+$");
           hdd_param.second.disk_device_ =
             std::regex_replace(hdd_param.second.part_device_, pattern, "");

--- a/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -40,7 +40,7 @@
 
 namespace {
 
-bool is_non-scsi_device(const std::string & device_name)
+bool is_non_scsi_device(const std::string & device_name)
 {
   // cspell:disable
   // clang-format off


### PR DESCRIPTION
## Description
Add "/dev/mmcblk" as a base for storage device file names, in addition to "/dev/sd" and "/dev/nvme" currently supported.
This addition enables the "hdd_monitor" node to retrieve statistics data about eMMC storage and SD cards.

WIthout this change, the "hdd_monitor" can't work on NVIDIA Jetson AGX Orin.

## Related links

**Parent Issue:**

- [hdd_monitor fails to retrieve statistics data from eMMC storage devices #11159](https://github.com/autowarefoundation/autoware_universe/issues/11159)

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-10979)


## How was this PR tested?

- Tested on NVIDIA Jetson AGX Orin with JetPack 6.2 (Ubuntu 22.4)
  - Statistics information about eMMC storage device is retrieved as expected.
- Tested on Intel PC with Ubuntu 22.4 (NVMe SSDs are installed)
  - There is no change related to the behavior of the "hdd_monitor" node.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
