### PR TITLE
fix(localization): use transient_local for initialpose3d

### DIFF
--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -110,7 +110,8 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
     "input/vector_map", rclcpp::QoS(10).transient_local(),
     std::bind(&SimplePlanningSimulator::on_map, this, _1));
   sub_init_pose_ = create_subscription<PoseWithCovarianceStamped>(
-    "input/initialpose", QoS{1}, std::bind(&SimplePlanningSimulator::on_initialpose, this, _1));
+    "input/initialpose", rclcpp::QoS(1).transient_local().reliable(),
+    std::bind(&SimplePlanningSimulator::on_initialpose, this, _1));
   sub_init_twist_ = create_subscription<TwistStamped>(
     "input/initialtwist", QoS{1}, std::bind(&SimplePlanningSimulator::on_initialtwist, this, _1));
   sub_manual_ackermann_cmd_ = create_subscription<Control>(

--- a/simulator/autoware_simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/autoware_simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -81,8 +81,8 @@ public:
       create_publisher<Control>("input/ackermann_control_command", rclcpp::QoS{1});
     pub_actuation_command_ =
       create_publisher<ActuationCommandStamped>("input/actuation_command", rclcpp::QoS{1});
-    pub_initialpose_ =
-      create_publisher<PoseWithCovarianceStamped>("input/initialpose", rclcpp::QoS{1});
+    pub_initialpose_ = create_publisher<PoseWithCovarianceStamped>(
+      "input/initialpose", rclcpp::QoS{1}.transient_local());
     pub_gear_cmd_ = create_publisher<GearCommand>("input/gear_command", rclcpp::QoS{1});
   }
 

--- a/system/autoware_component_state_monitor/config/topics.yaml
+++ b/system/autoware_component_state_monitor/config/topics.yaml
@@ -32,7 +32,7 @@
     topic: /initialpose3d
     topic_type: geometry_msgs/msg/PoseWithCovarianceStamped
     best_effort: false
-    transient_local: false
+    transient_local: true
     warn_rate: 0.0
     error_rate: 0.0
     timeout: 0.0


### PR DESCRIPTION
## Description

The `/initialpose3d` topic is only published when the pose is set via an API or plugin. Considering the timing of subscriber readiness, it should be set to transient_local.

refer: 

https://github.com/tier4/autoware_core/blob/awf-latest/localization/autoware_pose_initializer/README.md#L29-L30

<img width="1913" height="1359" alt="image" src="https://github.com/user-attachments/assets/07e3c921-90f6-4f2e-be69-26a6ab4cf4aa" />

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/609
- https://github.com/autowarefoundation/autoware_launch/pull/1602

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim
```
$ ros2 topic info /initialpose3d -v
Type: geometry_msgs/msg/PoseWithCovarianceStamped

Publisher count: 1

Node name: pose_initializer
Node namespace: /localization/util
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: PUBLISHER
GID: 01.0f.81.a8.10.df.dc.a0.00.00.00.00.00.00.15.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 3

Node name: ekf_localizer
Node namespace: /localization/pose_twist_fusion_filter
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: SUBSCRIPTION
GID: 01.0f.81.a8.1b.df.f9.9b.00.00.00.00.00.00.20.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: simple_planning_simulator
Node namespace: /simulation
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: SUBSCRIPTION
GID: 01.0f.81.a8.42.df.83.12.00.00.00.00.00.00.17.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: topic_state_monitor_initialpose3d
Node namespace: /system
Topic type: geometry_msgs/msg/PoseWithCovarianceStamped
Endpoint type: SUBSCRIPTION
GID: 01.0f.81.a8.71.dd.13.47.00.00.00.00.00.00.13.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): UNKNOWN
  Durability: TRANSIENT_LOCAL
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```


- 3925/3926
succeeded
[[PR check][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/75d4efc9-e431-5e1f-a49b-3caf9bf729b5?project_id=prd_jt)
- 34/34
succeeded
[[PR check][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/1bf10671-62b5-5304-b34b-afcaa4ca4831?project_id=prd_jt)
- 4/4
succeeded
[[PR check][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/105d5ce4-99f7-5f61-96f7-571a6b997cc7?project_id=prd_jt)
- 4/4
succeeded
[fix/initialpose3d_qos](https://evaluation.tier4.jp/evaluation/reports/949c52eb-2f45-5195-b9f5-e178734116c6?project_id=autoware_dev)



## Notes for reviewers

None.

## Interface changes

`initialpose3d` is published as transient_local

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
