### PR TITLE
fix(crosswalk): fix: incorrect inserted stop point calculation for restart suppression

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -1544,8 +1544,10 @@ void CrosswalkModule::planStop(
   // Check if the restart should be suppressed.
   const bool suppress_restart = checkRestartSuppression(ego_path, stop_factor);
   if (suppress_restart) {
-    const auto & ego_pose = planner_data_->current_odometry->pose;
-    stop_factor->stop_pose = ego_pose;
+    const auto & ego_pos = planner_data_->current_odometry->pose.position;
+    const double dist = calcSignedArcLength(ego_path.points, ego_pos, 0L);
+    const auto pose_opt = calcLongitudinalOffsetPose(ego_path.points, 0L, dist);
+    if (pose_opt.has_value()) stop_factor->stop_pose = pose_opt.value();
   }
 
   const SafetyFactorArray safety_factors = createSafetyFactorArray(stop_factor);


### PR DESCRIPTION
## Description

This PR fixes an issue in the stop point calculation during restart suppression, which occurs when the next stop position is within a configured threshold and the vehicle should remain stopped instead of restarting. Previously, the inserted stop point was calculated directly from the ego pose without projecting it onto the path, causing the planned trajectory to become distorted. The fix projects the ego position onto the path using `calcSignedArcLength` and `calcLongitudinalOffsetPose`, ensuring the stop point lies exactly on the path and preventing path deformation while maintaining the intended restart suppression behavior.

| BEFORE | AFTER |
| --- | --- |
|  <video src="https://github.com/user-attachments/assets/cf48a7ec-f679-4a08-a82d-b99e069d504f"/> |  <video src="https://github.com/user-attachments/assets/a2e38d66-ee00-4a9d-a287-377a728dc927"/> |

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [[PR check (OTA)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/52531604-1bbc-5447-b385-d510596c0cb4?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/14f1fea9-c80e-53e3-b1e5-eeb452a25740?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/6dde42d9-cc3f-5eea-ade8-b1c2271f0899?project_id=prd_jt)

## Notes for reviewers

We would like to address the issue of route distortion caused by embedding such stop points through the future introduction of a trajectory class.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
