### PR TITLE
refactor(diffusion_planner): fix `transform_and_select_rows`

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -87,7 +87,6 @@ using autoware::vehicle_info_utils::VehicleInfo;
 using builtin_interfaces::msg::Duration;
 using builtin_interfaces::msg::Time;
 using geometry_msgs::msg::Point;
-using preprocess::ColLaneIDMaps;
 using preprocess::TrafficSignalStamped;
 using rcl_interfaces::msg::SetParametersResult;
 using std_msgs::msg::ColorRGBA;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/lane_segments.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/lane_segments.hpp
@@ -97,16 +97,16 @@ public:
     const lanelet::ConstLanelets & current_lanes) const;
 
   /**
-   * @brief Transform and select columns based on proximity to a center point.
+   * @brief Get lane segments and transform them to ego-centric coordinates.
    *
    * @param transform_matrix Transformation matrix to apply to the points.
    * @param traffic_light_id_map Map of lanelet IDs to traffic signal information.
    * @param center_x X-coordinate of the center point.
    * @param center_y Y-coordinate of the center point.
    * @param m Maximum number of columns (segments) to select.
-   * @return Tuple of the transformed matrix and updated column ID mapping.
+   * @return Flattened vectors containing the transformed lane segments and speed limits.
    */
-  std::tuple<Eigen::MatrixXf, ColLaneIDMaps> transform_and_select_rows(
+  std::pair<std::vector<float>, std::vector<float>> get_lane_segments(
     const Eigen::Matrix4f & transform_matrix,
     const std::map<lanelet::Id, TrafficSignalStamped> & traffic_light_id_map, const float center_x,
     const float center_y, const int64_t m) const;
@@ -167,56 +167,6 @@ private:
   ColLaneIDMaps col_id_mapping_;
   const std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
 };
-
-/**
- * @brief Extracts lane tensor data from ego-centric lane segments.
- *
- * @param lane_segments_matrix Matrix containing ego-centric lane segment data.
- * @return A flattened vector of lane tensor data.
- */
-std::vector<float> extract_lane_tensor_data(const Eigen::MatrixXf & lane_segments_matrix);
-
-/**
- * @brief Extracts lane speed tensor data from ego-centric lane segments.
- *
- * @param lane_segments_matrix Matrix containing ego-centric lane segment data.
- * @return A flattened vector of lane speed tensor data.
- */
-std::vector<float> extract_lane_speed_tensor_data(const Eigen::MatrixXf & lane_segments_matrix);
-
-/**
- * @brief Sorts the columns by their squared distances in ascending order.
- *
- * @param distances Vector of columns with distances to be sorted.
- */
-inline void sort_indices_by_distance(std::vector<ColWithDistance> & distances)
-{
-  std::sort(distances.begin(), distances.end(), [&](auto & a, auto & b) {
-    return a.distance_squared < b.distance_squared;
-  });
-}
-
-/**
- * @brief Returns a one-hot encoded row vector for the traffic signal state.
- *
- * @param signal The traffic light group message.
- * @return Row vector with one-hot encoding for [green, amber, red, unknown].
- */
-Eigen::Matrix<float, 1, TRAFFIC_LIGHT_ONE_HOT_DIM> get_traffic_signal_row_vector(
-  const autoware_perception_msgs::msg::TrafficLightGroup & signal);
-
-/**
- * @brief Transforms selected rows of the output matrix using a transformation matrix.
- *
- * @param transform_matrix Transformation matrix to apply.
- * @param output_matrix Matrix to transform (in-place).
- * @param num_segments Number of segments to transform.
- * @param row_idx Index of the row to transform.
- * @param do_translation Whether to apply translation during the transformation.
- */
-void transform_selected_rows(
-  const Eigen::Matrix4f & transform_matrix, Eigen::MatrixXf & output_matrix, int64_t num_segments,
-  int64_t row_idx, bool do_translation = true);
 
 }  // namespace autoware::diffusion_planner::preprocess
 

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/lane_segments.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/lane_segments.hpp
@@ -155,9 +155,9 @@ private:
    * @param traffic_light_id_map Map of lanelet IDs to traffic signal information.
    * @param distances Vector of columns with distances, used to select columns.
    * @param m Maximum number of columns (segments) to select.
-   * @return Tuple of the transformed matrix and updated column ID mapping.
+   * @return The transformed matrix
    */
-  std::tuple<Eigen::MatrixXf, ColLaneIDMaps> transform_points_and_add_traffic_info(
+  Eigen::MatrixXf transform_points_and_add_traffic_info(
     const Eigen::Matrix4f & transform_matrix,
     const std::map<lanelet::Id, TrafficSignalStamped> & traffic_light_id_map,
     const std::vector<ColWithDistance> & distances, int64_t m) const;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -450,13 +450,10 @@ InputDataMap DiffusionPlanner::create_input_data()
 
   // map data on ego reference frame
   {
-    std::tuple<Eigen::MatrixXf, ColLaneIDMaps> matrix_mapping_tuple =
-      lane_segment_context_->transform_and_select_rows(
-        map_to_ego_transform, traffic_light_id_map_, center_x, center_y, LANES_SHAPE[1]);
-    const Eigen::MatrixXf & ego_centric_lane_segments = std::get<0>(matrix_mapping_tuple);
-    input_data_map["lanes"] = preprocess::extract_lane_tensor_data(ego_centric_lane_segments);
-    input_data_map["lanes_speed_limit"] =
-      preprocess::extract_lane_speed_tensor_data(ego_centric_lane_segments);
+    const auto [lanes, lanes_speed_limit] = lane_segment_context_->get_lane_segments(
+      map_to_ego_transform, traffic_light_id_map_, center_x, center_y, LANES_SHAPE[1]);
+    input_data_map["lanes"] = lanes;
+    input_data_map["lanes_speed_limit"] = lanes_speed_limit;
   }
 
   // route data on ego reference frame

--- a/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
@@ -46,12 +46,6 @@ Eigen::Matrix<float, 1, TRAFFIC_LIGHT_ONE_HOT_DIM> get_traffic_signal_row_vector
 void transform_selected_rows(
   const Eigen::Matrix4f & transform_matrix, Eigen::MatrixXf & output_matrix, int64_t num_segments,
   int64_t row_idx, bool do_translation = true);
-inline void sort_indices_by_distance(std::vector<ColWithDistance> & distances)
-{
-  std::sort(distances.begin(), distances.end(), [&](auto & a, auto & b) {
-    return a.distance_squared < b.distance_squared;
-  });
-}
 
 // LaneSegmentContext implementation
 LaneSegmentContext::LaneSegmentContext(const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr)
@@ -122,7 +116,9 @@ std::pair<std::vector<float>, std::vector<float>> LaneSegmentContext::get_lane_s
   // Step 1: Compute distances
   compute_distances(transform_matrix, distances, center_x, center_y, 100.0f);
   // Step 2: Sort indices by distance
-  sort_indices_by_distance(distances);
+  std::sort(distances.begin(), distances.end(), [](const auto & a, const auto & b) {
+    return a.distance_squared < b.distance_squared;
+  });
   // Step 3: Apply transformation to selected rows
   const auto [ego_centric_lane_segments, _] =
     transform_points_and_add_traffic_info(transform_matrix, traffic_light_id_map, distances, m);

--- a/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
@@ -35,7 +35,9 @@
 namespace autoware::diffusion_planner::preprocess
 {
 
-// Internal functions
+// Internal functions declaration
+namespace
+{
 Eigen::MatrixXf process_segments_to_matrix(
   const std::vector<LaneSegment> & lane_segments, ColLaneIDMaps & col_id_mapping);
 Eigen::MatrixXf process_segment_to_matrix(const LaneSegment & segment);
@@ -44,6 +46,7 @@ Eigen::Matrix<float, 1, TRAFFIC_LIGHT_ONE_HOT_DIM> get_traffic_signal_row_vector
 void transform_selected_rows(
   const Eigen::Matrix4f & transform_matrix, Eigen::MatrixXf & output_matrix, int64_t num_segments,
   int64_t row_idx, bool do_translation = true);
+}  // namespace
 
 // LaneSegmentContext implementation
 LaneSegmentContext::LaneSegmentContext(const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr)
@@ -284,6 +287,10 @@ LaneSegmentContext::transform_points_and_add_traffic_info(
   return {output_matrix, new_col_id_mapping};
 }
 
+// Internal functions implementation
+namespace
+{
+
 void transform_selected_rows(
   const Eigen::Matrix4f & transform_matrix, Eigen::MatrixXf & output_matrix, int64_t num_segments,
   int64_t row_idx, bool do_translation)
@@ -396,5 +403,7 @@ Eigen::MatrixXf process_segment_to_matrix(const LaneSegment & segment)
 
   return segment_data;
 }
+
+}  // namespace
 
 }  // namespace autoware::diffusion_planner::preprocess

--- a/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
@@ -111,7 +111,7 @@ std::pair<std::vector<float>, std::vector<float>> LaneSegmentContext::get_lane_s
 {
   if (map_lane_segments_matrix_.rows() != FULL_MATRIX_ROWS || m <= 0) {
     throw std::invalid_argument(
-      "Input matrix must have at least FULL_MATRIX_ROWS columns and m must be greater than 0.");
+      "Input matrix must have at least FULL_MATRIX_ROWS rows and m must be greater than 0.");
   }
   std::vector<ColWithDistance> distances;
   // Step 1: Compute distances

--- a/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
@@ -121,7 +121,7 @@ std::pair<std::vector<float>, std::vector<float>> LaneSegmentContext::get_lane_s
     return a.distance_squared < b.distance_squared;
   });
   // Step 3: Apply transformation to selected rows
-  const auto [ego_centric_lane_segments, _] =
+  const Eigen::MatrixXf ego_centric_lane_segments =
     transform_points_and_add_traffic_info(transform_matrix, traffic_light_id_map, distances, m);
 
   // Extract lane tensor data
@@ -236,8 +236,7 @@ void LaneSegmentContext::compute_distances(
   }
 }
 
-std::tuple<Eigen::MatrixXf, ColLaneIDMaps>
-LaneSegmentContext::transform_points_and_add_traffic_info(
+Eigen::MatrixXf LaneSegmentContext::transform_points_and_add_traffic_info(
   const Eigen::Matrix4f & transform_matrix,
   const std::map<lanelet::Id, TrafficSignalStamped> & traffic_light_id_map,
   const std::vector<ColWithDistance> & distances, int64_t m) const
@@ -256,7 +255,6 @@ LaneSegmentContext::transform_points_and_add_traffic_info(
   output_matrix.setZero();
 
   int64_t added_segments = 0;
-  ColLaneIDMaps new_col_id_mapping;
   for (auto distance : distances) {
     if (!distance.inside) {
       continue;
@@ -284,7 +282,7 @@ LaneSegmentContext::transform_points_and_add_traffic_info(
   }
 
   apply_transforms(transform_matrix, output_matrix, added_segments);
-  return {output_matrix, new_col_id_mapping};
+  return output_matrix;
 }
 
 // Internal functions implementation


### PR DESCRIPTION
## Description

This PR refactors the diffusion planner's lane segment processing by simplifying the API and consolidating data extraction logic. The changes focus on improving code organization and reducing complexity in the lane segment handling.

- Simplified the `transform_and_select_rows` method to directly return processed data vectors instead of intermediate matrices
- Consolidated lane tensor data extraction logic into the main processing method
- Removed unused utility functions and type aliases to reduce code complexity

## How was this PR tested?

run diffusion_planner

```bash
on_timer         11.7 ± 3.5 msec
create_input_data        3.4 ± 0.9 msec
do_inference_trt         7.0 ± 2.5 msec
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
