### PR TITLE
fix(boundary_departure): fix chattering critical departure MRM

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -74,7 +74,22 @@ private:
   void update_critical_departure_points(
     const std::vector<TrajectoryPoint> & raw_ref_traj, const double offset_from_ego);
 
-  std::unordered_map<DepartureType, bool> get_diagnostics(const double curr_vel);
+  /**
+   * @brief Evaluate boundary departure diagnostic status.
+   *
+   * Checks for each side whether the ego is near a boundary, approaching departure,
+   * or in a critical departure state. Returns a map of each departure type to its active status.
+   *
+   * - `NEAR_BOUNDARY` and `APPROACHING_DEPARTURE` are flagged based on type presence.
+   * - `CRITICAL_DEPARTURE` is flagged if any critical point lies within braking distance,
+   *   calculated using velocity, acceleration, jerk, and brake delay thresholds.
+   *
+   * @param ego_dist_on_traj Ego vehicle’s distance along the reference trajectory.
+   * @param curr_vel Current velocity of the ego vehicle.
+   * @return Map of `DepartureType` to boolean indicating active status.
+   */
+  std::unordered_map<DepartureType, bool> get_diagnostics(
+    const double ego_dist_on_traj, const double curr_vel);
 
   /**
    * @brief Check if critical departure has been continuously observed.


### PR DESCRIPTION
## Description

Fixed MRM chattering.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
