### PR TITLE
fix(boundary_departure): critical departure not cleared

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/config/boundary_departure_prevention.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/config/boundary_departure_prevention.param.yaml
@@ -17,7 +17,9 @@
       on_time_buffer_s:
         near_boundary: 0.15
         critical_departure: 0.15
-      off_time_buffer_s: 0.15
+      off_time_buffer_s:
+        near_boundary: 0.15
+        critical_departure: 0.15
 
       abnormality:
         normal:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/schema/boundary_departure_prevention.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/schema/boundary_departure_prevention.schema.json
@@ -88,11 +88,22 @@
           "required": ["near_boundary", "critical_departure"],
           "additionalProperties": false
         },
-
         "off_time_buffer_s": {
-          "type": "number",
-          "description": "Continuous detection time threshold to reset departure interval. [s]",
-          "default": 0.15
+          "type": "object",
+          "properties": {
+            "near_boundary": {
+              "type": "number",
+              "description": "Continuous detection time threshold to reset departure interval. [s]",
+              "default": 0.15
+            },
+            "critical_departure": {
+              "type": "number",
+              "description": "Continuous detection time threshold to reset critical departure. [s]",
+              "default": 0.15
+            }
+          },
+          "required": ["near_boundary", "critical_departure"],
+          "additionalProperties": false
         },
 
         "abnormality": {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -104,6 +104,21 @@ private:
    */
   bool is_continuous_critical_departure();
 
+  /**
+   * @brief Determine if critical departure condition is still active.
+   *
+   * This function checks whether a `CRITICAL_DEPARTURE` is currently observed
+   * in the closest projections and whether the system has recorded critical departure points.
+   *
+   * - If a critical departure is detected, the internal timestamp is updated, and `true` is
+   * returned.
+   * - If not, the function checks whether the absence of critical departure has persisted
+   *   beyond a configured time threshold (`off_time_buffer_s.critical_departure`).
+   *
+   * @return `true` if critical departure is still considered active, otherwise `false`.
+   */
+  bool is_critical_departure_persist();
+
   rclcpp::Clock::SharedPtr clock_ptr_;
 
   std::string module_name_;
@@ -126,6 +141,7 @@ private:
   double last_abnormality_fp_overlap_bound_time_{0.0};
   double last_abnormality_fp_no_overlap_bound_time_{0.0};
   double last_no_critical_dpt_time_{0.0};
+  double last_found_critical_dpt_time_{0.0};
 
   autoware_utils::InterProcessPollingSubscriber<Trajectory>::SharedPtr ego_pred_traj_polling_sub_;
   autoware_utils::InterProcessPollingSubscriber<Control>::SharedPtr control_cmd_polling_sub_;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
@@ -58,13 +58,14 @@ struct NodeParam
   double th_pt_shift_dist_m{1.0};
   double th_pt_shift_angle_rad{autoware_utils_math::deg2rad(2.0)};
   double th_goal_shift_dist_m{1.0};
-  struct
+  struct OnOffTimeBuffer
   {
     double near_boundary{0.15};
     double critical_departure{0.15};
-  } on_time_buffer_s;
+  };
 
-  double off_time_buffer_s{0.15};
+  OnOffTimeBuffer on_time_buffer_s;
+  OnOffTimeBuffer off_time_buffer_s;
 
   BDCParam bdc_param;
   std::unordered_set<DepartureType> slow_down_types;
@@ -96,7 +97,10 @@ struct NodeParam
       get_or_declare_parameter<double>(node, module_name + "on_time_buffer_s.critical_departure");
     on_time_buffer_s.near_boundary =
       get_or_declare_parameter<double>(node, module_name + "on_time_buffer_s.near_boundary");
-    off_time_buffer_s = get_or_declare_parameter<double>(node, module_name + "off_time_buffer_s");
+    off_time_buffer_s.critical_departure =
+      get_or_declare_parameter<double>(node, module_name + "off_time_buffer_s.critical_departure");
+    off_time_buffer_s.near_boundary =
+      get_or_declare_parameter<double>(node, module_name + "off_time_buffer_s.near_boundary");
 
     bdc_param.th_max_lateral_query_num =
       get_or_declare_parameter<int>(node, module_name + "th_max_lateral_query_num");


### PR DESCRIPTION
## Description

Adding off time buffer to clear critical departure points.

Before:

Critical departure points persist despite critical departure no longer detected.

https://github.com/user-attachments/assets/cdfd19df-2a98-4290-91c6-16f6c5cc4f7a

After:

Critical departure points cleared once critical departure no longer detected.

https://github.com/user-attachments/assets/26afe413-225b-4bbf-add4-1f9519c3df1e

Corresponding launcher: https://github.com/autowarefoundation/autoware_launch/pull/1606

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/004344b3-3901-5051-8533-e54e4212b773?project_id=prd_jt
https://evaluation.tier4.jp/evaluation/reports/56cb3142-e974-5975-bd57-75a4752b7367?project_id=prd_jt
https://evaluation.tier4.jp/evaluation/reports/17a0c33f-e8f3-554c-8eb7-5c8f14b30fea?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
