### PR TITLE
fix(motion_velocity_planner): remove unused function

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
@@ -27,36 +27,6 @@ namespace autoware::motion_velocity_planner::experimental::utils
 {
 
 /**
- * @brief Erase elements from an associative container if they match a given predicate.
- *
- * This function iterates over a `std::map` or `std::unordered_map` and removes all key-value
- * pairs for which the predicate returns true. The predicate must accept a `std::pair<Key, Value>`.
- *
- * @tparam Container Must be either `std::map` or `std::unordered_map`.
- * @tparam Predicate Unary function or lambda that returns true for elements to be removed.
- * @param container The map to remove elements from.
- * @param pred      The predicate used to test elements for removal.
- */
-template <
-  typename Container, typename Predicate,
-  typename = std::enable_if_t<
-    std::is_same_v<
-      Container, std::map<typename Container::key_type, typename Container::mapped_type>> ||
-    std::is_same_v<
-      Container,
-      std::unordered_map<typename Container::key_type, typename Container::mapped_type>>>>
-void erase_if(Container & container, Predicate pred)
-{
-  for (auto it = container.begin(); it != container.end();) {
-    if (pred(*it)) {  // For map, *it is a std::pair, so pred should handle pair<Key, Value>
-      it = container.erase(it);
-    } else {
-      ++it;
-    }
-  }
-}
-
-/**
  * @brief Remove elements from a sequential container based on a predicate.
  *
  * This utility function uses `std::remove_if` followed by `erase` to remove all elements


### PR DESCRIPTION
## Description

Removed an unused function based on cppcheck
```
planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp:48:6: style: The function 'erase_if' is never used. [unusedFunction]
void erase_if(Container & container, Predicate pred)
     ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
