### PR TITLE
fix(motion_velocity_planner): remove unused function

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/debug.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/debug.cpp
@@ -84,24 +84,6 @@ inline ColorRGBA grey(float a = 0.99)
 
 namespace autoware::motion_velocity_planner::experimental::debug
 {
-Marker create_ego_sides_marker(
-  const EgoSides & ego_sides_from_footprints, Marker marker, std::string && ns,
-  const double base_link_z)
-{
-  marker.ns = ns;
-  marker.points.reserve(ego_sides_from_footprints.size() * 4);
-  const auto to_geom = [base_link_z](const auto & pt) { return to_msg(pt.to_3d(base_link_z)); };
-  for (const auto & ego_footprint_sides : ego_sides_from_footprints) {
-    const auto & left = ego_footprint_sides.left;
-    marker.points.push_back(to_geom(left.first));
-    marker.points.push_back(to_geom(left.second));
-    const auto & right = ego_footprint_sides.right;
-    marker.points.push_back(to_geom(right.first));
-    marker.points.push_back(to_geom(right.second));
-  }
-
-  return marker;
-}
 
 template <typename T>
 Marker create_projections_to_bound_marker(


### PR DESCRIPTION
## Description

Removed an unused function based on cppcheck

```
planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/debug.cpp:87:8: style: The function 'create_ego_sides_marker' is never used. [unusedFunction]
Marker create_ego_sides_marker(
       ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
