### PR TITLE
feat(boundary_departure): support addition parameters for dynamic reconfiguration 

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -205,7 +205,6 @@ void BoundaryDeparturePreventionModule::update_parameters(
 
   update_param(parameters, module_name + "th_pt_shift.goal_dist_m", pp.th_goal_shift_dist_m);
 
-  // Cutoff times
   update_param(parameters, module_name + "th_cutoff_time_s.predicted_path",
                pp.bdc_param.th_cutoff_time_predicted_path_s);
   update_param(parameters, module_name + "th_cutoff_time_s.near_boundary",
@@ -213,7 +212,6 @@ void BoundaryDeparturePreventionModule::update_parameters(
   update_param(parameters, module_name + "th_cutoff_time_s.departure",
                pp.bdc_param.th_cutoff_time_departure_s);
 
-  // On/off time buffers
   update_param(parameters, module_name + "on_time_buffer_s.critical_departure",
                pp.on_time_buffer_s.critical_departure);
   update_param(parameters, module_name + "on_time_buffer_s.near_boundary",
@@ -223,7 +221,6 @@ void BoundaryDeparturePreventionModule::update_parameters(
   update_param(parameters, module_name + "off_time_buffer_s.near_boundary",
                pp.off_time_buffer_s.near_boundary);
 
-  // Slow down types
   const std::string ns_slow_down{module_name + "slow_down_behavior.enable."};
 
   bool enable_slow_down_near_bound = pp.slow_down_types.count(DepartureType::NEAR_BOUNDARY);
@@ -290,7 +287,9 @@ void BoundaryDeparturePreventionModule::update_parameters(
   update_diag(DepartureType::APPROACHING_DEPARTURE, "approaching_departure");
   update_diag(DepartureType::CRITICAL_DEPARTURE, "critical_departure");
 
-  boundary_departure_checker_ptr_->setParam(pp.bdc_param);
+  if (boundary_departure_checker_ptr_) {
+    boundary_departure_checker_ptr_->setParam(pp.bdc_param);
+  }
 }
 
 void BoundaryDeparturePreventionModule::subscribe_topics(rclcpp::Node & node)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -195,6 +195,101 @@ void BoundaryDeparturePreventionModule::update_parameters(
     parameters, lon_tracking_ns + "extra_margin_m",
     longitudinal_config.lon_tracking.extra_margin_m);
   configs.insert_or_assign(AbnormalityType::LONGITUDINAL, longitudinal_config);
+
+  // Point/goal shift thresholds
+  update_param(parameters, module_name + "th_pt_shift.dist_m", pp.th_pt_shift_dist_m);
+
+  auto th_pt_shift_angle_deg = autoware_utils_math::rad2deg(pp.th_pt_shift_angle_rad);
+  update_param(parameters, module_name + "th_pt_shift.angle_deg", th_pt_shift_angle_deg);
+  pp.th_pt_shift_angle_rad = autoware_utils_math::deg2rad(th_pt_shift_angle_deg);
+
+  update_param(parameters, module_name + "th_pt_shift.goal_dist_m", pp.th_goal_shift_dist_m);
+
+  // Cutoff times
+  update_param(parameters, module_name + "th_cutoff_time_s.predicted_path",
+               pp.bdc_param.th_cutoff_time_predicted_path_s);
+  update_param(parameters, module_name + "th_cutoff_time_s.near_boundary",
+               pp.bdc_param.th_cutoff_time_near_boundary_s);
+  update_param(parameters, module_name + "th_cutoff_time_s.departure",
+               pp.bdc_param.th_cutoff_time_departure_s);
+
+  // On/off time buffers
+  update_param(parameters, module_name + "on_time_buffer_s.critical_departure",
+               pp.on_time_buffer_s.critical_departure);
+  update_param(parameters, module_name + "on_time_buffer_s.near_boundary",
+               pp.on_time_buffer_s.near_boundary);
+  update_param(parameters, module_name + "off_time_buffer_s.critical_departure",
+               pp.off_time_buffer_s.critical_departure);
+  update_param(parameters, module_name + "off_time_buffer_s.near_boundary",
+               pp.off_time_buffer_s.near_boundary);
+
+  // Slow down types
+  const std::string ns_slow_down{module_name + "slow_down_behavior.enable."};
+
+  bool enable_slow_down_near_bound = pp.slow_down_types.count(DepartureType::NEAR_BOUNDARY);
+  if (update_param(parameters, ns_slow_down + "slow_down_near_boundary", enable_slow_down_near_bound)) {
+    if (enable_slow_down_near_bound)
+      pp.slow_down_types.insert(DepartureType::NEAR_BOUNDARY);
+    else
+      pp.slow_down_types.erase(DepartureType::NEAR_BOUNDARY);
+  }
+
+  bool enable_approaching_dpt = pp.slow_down_types.count(DepartureType::APPROACHING_DEPARTURE);
+  if (update_param(parameters, ns_slow_down + "slow_down_before_departure", enable_approaching_dpt)) {
+    if (enable_approaching_dpt)
+      pp.slow_down_types.insert(DepartureType::APPROACHING_DEPARTURE);
+    else
+      pp.slow_down_types.erase(DepartureType::APPROACHING_DEPARTURE);
+  }
+
+  bool enable_critical_dpt = pp.slow_down_types.count(DepartureType::CRITICAL_DEPARTURE);
+  if (update_param(parameters, ns_slow_down + "stop_before_departure", enable_critical_dpt)) {
+    if (enable_critical_dpt)
+      pp.slow_down_types.insert(DepartureType::CRITICAL_DEPARTURE);
+    else
+      pp.slow_down_types.erase(DepartureType::CRITICAL_DEPARTURE);
+  }
+
+  // Trigger thresholds
+  const std::string ns_th_trigger{module_name + "slow_down_behavior.th_trigger."};
+
+  auto th_vel_min_kmph = autoware_utils_math::mps2kmph(pp.bdc_param.th_trigger.th_vel_mps.min);
+  update_param(parameters, ns_th_trigger + "th_vel_kmph.min", th_vel_min_kmph);
+  pp.bdc_param.th_trigger.th_vel_mps.min = autoware_utils_math::kmph2mps(th_vel_min_kmph);
+
+  auto th_vel_max_kmph = autoware_utils_math::mps2kmph(pp.bdc_param.th_trigger.th_vel_mps.max);
+  update_param(parameters, ns_th_trigger + "th_vel_kmph.max", th_vel_max_kmph);
+  pp.bdc_param.th_trigger.th_vel_mps.max = autoware_utils_math::kmph2mps(th_vel_max_kmph);
+
+  update_param(parameters, ns_th_trigger + "th_acc_mps2.min", pp.bdc_param.th_trigger.th_acc_mps2.min);
+  update_param(parameters, ns_th_trigger + "th_acc_mps2.max", pp.bdc_param.th_trigger.th_acc_mps2.max);
+
+  update_param(parameters, ns_th_trigger + "th_jerk_mps3.min", pp.bdc_param.th_trigger.th_jerk_mps3.min);
+  update_param(parameters, ns_th_trigger + "th_jerk_mps3.max", pp.bdc_param.th_trigger.th_jerk_mps3.max);
+
+  update_param(parameters, ns_th_trigger + "brake_delay_s", pp.bdc_param.th_trigger.brake_delay_s);
+  update_param(parameters, ns_th_trigger + "dist_error_m", pp.bdc_param.th_trigger.dist_error_m);
+
+  const std::string ns_dist_to_bound{ns_th_trigger + "th_dist_to_boundary_m."};
+  const std::string ns_dist_to_bound_left{ns_dist_to_bound + "left."};
+  const std::string ns_dist_to_bound_right{ns_dist_to_bound + "right."};
+
+  update_param(parameters, ns_dist_to_bound_left + "min", pp.bdc_param.th_trigger.th_dist_to_boundary_m.left.min);
+  update_param(parameters, ns_dist_to_bound_left + "max", pp.bdc_param.th_trigger.th_dist_to_boundary_m.left.max);
+  update_param(parameters, ns_dist_to_bound_right + "min", pp.bdc_param.th_trigger.th_dist_to_boundary_m.right.min);
+  update_param(parameters, ns_dist_to_bound_right + "max", pp.bdc_param.th_trigger.th_dist_to_boundary_m.right.max);
+
+  // Diagnostic levels
+  const auto update_diag = [&](DepartureType type, const std::string & key) {
+    auto level = static_cast<int8_t>(pp.diagnostic_level.at(type));
+    if (update_param(parameters, module_name + "diagnostic." + key, level)) {
+      pp.diagnostic_level[type] = static_cast<int8_t>(level);
+    }
+  };
+  update_diag(DepartureType::NEAR_BOUNDARY, "near_boundary");
+  update_diag(DepartureType::APPROACHING_DEPARTURE, "approaching_departure");
+  update_diag(DepartureType::CRITICAL_DEPARTURE, "critical_departure");
+
   boundary_departure_checker_ptr_->setParam(pp.bdc_param);
 }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -205,26 +205,33 @@ void BoundaryDeparturePreventionModule::update_parameters(
 
   update_param(parameters, module_name + "th_pt_shift.goal_dist_m", pp.th_goal_shift_dist_m);
 
-  update_param(parameters, module_name + "th_cutoff_time_s.predicted_path",
-               pp.bdc_param.th_cutoff_time_predicted_path_s);
-  update_param(parameters, module_name + "th_cutoff_time_s.near_boundary",
-               pp.bdc_param.th_cutoff_time_near_boundary_s);
-  update_param(parameters, module_name + "th_cutoff_time_s.departure",
-               pp.bdc_param.th_cutoff_time_departure_s);
+  update_param(
+    parameters, module_name + "th_cutoff_time_s.predicted_path",
+    pp.bdc_param.th_cutoff_time_predicted_path_s);
+  update_param(
+    parameters, module_name + "th_cutoff_time_s.near_boundary",
+    pp.bdc_param.th_cutoff_time_near_boundary_s);
+  update_param(
+    parameters, module_name + "th_cutoff_time_s.departure",
+    pp.bdc_param.th_cutoff_time_departure_s);
 
-  update_param(parameters, module_name + "on_time_buffer_s.critical_departure",
-               pp.on_time_buffer_s.critical_departure);
-  update_param(parameters, module_name + "on_time_buffer_s.near_boundary",
-               pp.on_time_buffer_s.near_boundary);
-  update_param(parameters, module_name + "off_time_buffer_s.critical_departure",
-               pp.off_time_buffer_s.critical_departure);
-  update_param(parameters, module_name + "off_time_buffer_s.near_boundary",
-               pp.off_time_buffer_s.near_boundary);
+  update_param(
+    parameters, module_name + "on_time_buffer_s.critical_departure",
+    pp.on_time_buffer_s.critical_departure);
+  update_param(
+    parameters, module_name + "on_time_buffer_s.near_boundary", pp.on_time_buffer_s.near_boundary);
+  update_param(
+    parameters, module_name + "off_time_buffer_s.critical_departure",
+    pp.off_time_buffer_s.critical_departure);
+  update_param(
+    parameters, module_name + "off_time_buffer_s.near_boundary",
+    pp.off_time_buffer_s.near_boundary);
 
   const std::string ns_slow_down{module_name + "slow_down_behavior.enable."};
 
   bool enable_slow_down_near_bound = pp.slow_down_types.count(DepartureType::NEAR_BOUNDARY);
-  if (update_param(parameters, ns_slow_down + "slow_down_near_boundary", enable_slow_down_near_bound)) {
+  if (update_param(
+        parameters, ns_slow_down + "slow_down_near_boundary", enable_slow_down_near_bound)) {
     if (enable_slow_down_near_bound)
       pp.slow_down_types.insert(DepartureType::NEAR_BOUNDARY);
     else
@@ -232,7 +239,8 @@ void BoundaryDeparturePreventionModule::update_parameters(
   }
 
   bool enable_approaching_dpt = pp.slow_down_types.count(DepartureType::APPROACHING_DEPARTURE);
-  if (update_param(parameters, ns_slow_down + "slow_down_before_departure", enable_approaching_dpt)) {
+  if (update_param(
+        parameters, ns_slow_down + "slow_down_before_departure", enable_approaching_dpt)) {
     if (enable_approaching_dpt)
       pp.slow_down_types.insert(DepartureType::APPROACHING_DEPARTURE);
     else
@@ -258,11 +266,15 @@ void BoundaryDeparturePreventionModule::update_parameters(
   update_param(parameters, ns_th_trigger + "th_vel_kmph.max", th_vel_max_kmph);
   pp.bdc_param.th_trigger.th_vel_mps.max = autoware_utils_math::kmph2mps(th_vel_max_kmph);
 
-  update_param(parameters, ns_th_trigger + "th_acc_mps2.min", pp.bdc_param.th_trigger.th_acc_mps2.min);
-  update_param(parameters, ns_th_trigger + "th_acc_mps2.max", pp.bdc_param.th_trigger.th_acc_mps2.max);
+  update_param(
+    parameters, ns_th_trigger + "th_acc_mps2.min", pp.bdc_param.th_trigger.th_acc_mps2.min);
+  update_param(
+    parameters, ns_th_trigger + "th_acc_mps2.max", pp.bdc_param.th_trigger.th_acc_mps2.max);
 
-  update_param(parameters, ns_th_trigger + "th_jerk_mps3.min", pp.bdc_param.th_trigger.th_jerk_mps3.min);
-  update_param(parameters, ns_th_trigger + "th_jerk_mps3.max", pp.bdc_param.th_trigger.th_jerk_mps3.max);
+  update_param(
+    parameters, ns_th_trigger + "th_jerk_mps3.min", pp.bdc_param.th_trigger.th_jerk_mps3.min);
+  update_param(
+    parameters, ns_th_trigger + "th_jerk_mps3.max", pp.bdc_param.th_trigger.th_jerk_mps3.max);
 
   update_param(parameters, ns_th_trigger + "brake_delay_s", pp.bdc_param.th_trigger.brake_delay_s);
   update_param(parameters, ns_th_trigger + "dist_error_m", pp.bdc_param.th_trigger.dist_error_m);
@@ -271,10 +283,18 @@ void BoundaryDeparturePreventionModule::update_parameters(
   const std::string ns_dist_to_bound_left{ns_dist_to_bound + "left."};
   const std::string ns_dist_to_bound_right{ns_dist_to_bound + "right."};
 
-  update_param(parameters, ns_dist_to_bound_left + "min", pp.bdc_param.th_trigger.th_dist_to_boundary_m.left.min);
-  update_param(parameters, ns_dist_to_bound_left + "max", pp.bdc_param.th_trigger.th_dist_to_boundary_m.left.max);
-  update_param(parameters, ns_dist_to_bound_right + "min", pp.bdc_param.th_trigger.th_dist_to_boundary_m.right.min);
-  update_param(parameters, ns_dist_to_bound_right + "max", pp.bdc_param.th_trigger.th_dist_to_boundary_m.right.max);
+  update_param(
+    parameters, ns_dist_to_bound_left + "min",
+    pp.bdc_param.th_trigger.th_dist_to_boundary_m.left.min);
+  update_param(
+    parameters, ns_dist_to_bound_left + "max",
+    pp.bdc_param.th_trigger.th_dist_to_boundary_m.left.max);
+  update_param(
+    parameters, ns_dist_to_bound_right + "min",
+    pp.bdc_param.th_trigger.th_dist_to_boundary_m.right.min);
+  update_param(
+    parameters, ns_dist_to_bound_right + "max",
+    pp.bdc_param.th_trigger.th_dist_to_boundary_m.right.max);
 
   // Diagnostic levels
   const auto update_diag = [&](DepartureType type, const std::string & key) {


### PR DESCRIPTION
## Description

Support additional parameters for dynamic reconfiguration for boundary departure.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Build and run autoware, and test changing parameters around.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
