### PR TITLE
fix(autoware_control_command_gate): solve ignoredReturnValue warning

### DIFF
--- a/control/autoware_control_command_gate/src/common/control_command_filter.cpp
+++ b/control/autoware_control_command_gate/src/common/control_command_filter.cpp
@@ -124,7 +124,7 @@ void VehicleCmdFilter::limitActualSteerDiff(const double current_steer_angle, Co
 
 void VehicleCmdFilter::limitLateralSteer(Control & input) const
 {
-  float steer_cmd_limit = std::abs(getSteerLim());
+  float steer_limit = std::abs(getSteerLim());
 
   // TODO(Horibe): support steering greater than PI/2. Now the lateral acceleration
   // calculation does not support bigger steering value than PI/2 due to tan/atan calculation.
@@ -134,11 +134,11 @@ void VehicleCmdFilter::limitLateralSteer(Control & input) const
                  "check the steering angle limit."
               << std::endl;
 
-    steer_cmd_limit = M_PI_2f;
+    steer_limit = M_PI_2f;
   }
 
   input.lateral.steering_tire_angle =
-    std::clamp(input.lateral.steering_tire_angle, -steer_cmd_limit, steer_cmd_limit);
+    std::clamp(input.lateral.steering_tire_angle, -steer_limit, steer_limit);
 }
 
 void VehicleCmdFilter::limitLateralSteerRate(const double dt, Control & input) const

--- a/control/autoware_control_command_gate/src/common/control_command_filter.cpp
+++ b/control/autoware_control_command_gate/src/common/control_command_filter.cpp
@@ -124,21 +124,21 @@ void VehicleCmdFilter::limitActualSteerDiff(const double current_steer_angle, Co
 
 void VehicleCmdFilter::limitLateralSteer(Control & input) const
 {
-  const float steer_limit = getSteerLim();
-
-  input.lateral.steering_tire_angle =
-    std::clamp(input.lateral.steering_tire_angle, -steer_limit, steer_limit);
+  float steer_cmd_limit = std::abs(getSteerCmdLim());
 
   // TODO(Horibe): support steering greater than PI/2. Now the lateral acceleration
   // calculation does not support bigger steering value than PI/2 due to tan/atan calculation.
   if (std::abs(input.lateral.steering_tire_angle) > M_PI_2f) {
-    std::cerr << "[vehicle_Cmd_gate] limitLateralSteer(): steering limit is set to pi/2 since the "
+    std::cerr << "VehicleCmdFilter::limitLateralSteer(): steering limit is set to pi/2 since the "
                  "current filtering logic can not handle the steering larger than pi/2. Please "
                  "check the steering angle limit."
               << std::endl;
 
-    std::clamp(input.lateral.steering_tire_angle, -M_PI_2f, M_PI_2f);
+    steer_cmd_limit = M_PI_2f;
   }
+
+  input.lateral.steering_tire_angle =
+    std::clamp(input.lateral.steering_tire_angle, -steer_cmd_limit, steer_cmd_limit);
 }
 
 void VehicleCmdFilter::limitLateralSteerRate(const double dt, Control & input) const

--- a/control/autoware_control_command_gate/src/common/control_command_filter.cpp
+++ b/control/autoware_control_command_gate/src/common/control_command_filter.cpp
@@ -124,7 +124,7 @@ void VehicleCmdFilter::limitActualSteerDiff(const double current_steer_angle, Co
 
 void VehicleCmdFilter::limitLateralSteer(Control & input) const
 {
-  float steer_cmd_limit = std::abs(getSteerCmdLim());
+  float steer_cmd_limit = std::abs(getSteerLim());
 
   // TODO(Horibe): support steering greater than PI/2. Now the lateral acceleration
   // calculation does not support bigger steering value than PI/2 due to tan/atan calculation.


### PR DESCRIPTION
## Description

Fixed `ignoredReturnValue` warning by cppcheck

```
control/autoware_control_command_gate/src/common/control_command_filter.cpp:140:10: warning: Return value of function std::clamp() is not used. [ignoredReturnValue]
    std::clamp(input.lateral.steering_tire_angle, -M_PI_2f, M_PI_2f);
         ^
```

See https://github.com/autowarefoundation/autoware_universe/blob/d15567798f40a0041858dc8970f4f0c426882079/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_filter.cpp#L129-L146

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
