### PR TITLE
fix(autoware_command_mode_decider): remove unused function

### DIFF
--- a/system/autoware_command_mode_decider/src/command_mode_decider_base.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_base.cpp
@@ -24,16 +24,6 @@
 namespace autoware::command_mode_decider
 {
 
-void logging_mode_change(
-  const rclcpp::Logger & logger, const std::string & name, uint16_t prev, uint16_t next)
-{
-  if (prev != next) {
-    const auto prev_text = std::to_string(prev);
-    const auto next_text = std::to_string(next);
-    RCLCPP_INFO_STREAM(logger, name << " mode changed: " << prev_text << " -> " << next_text);
-  }
-}
-
 std::string text(const std::vector<uint16_t> & modes)
 {
   std::string result;


### PR DESCRIPTION
## Description

Removed unused function based on cppcheck

```
system/autoware_command_mode_decider/src/command_mode_decider_base.cpp:27:6: style: The function 'logging_mode_change' is never used. [unusedFunction]
void logging_mode_change(
     ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
