### PR TITLE
fix(autoware_diffusion_planner): remove unused function

### DIFF
--- a/planning/autoware_diffusion_planner/src/conversion/lanelet.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/lanelet.cpp
@@ -31,14 +31,6 @@
 #include <vector>
 namespace autoware::diffusion_planner
 {
-// Compute Euclidean distance between two LanePoints
-inline float euclidean_distance(const LanePoint & p1, const LanePoint & p2)
-{
-  float dx = p2.x() - p1.x();
-  float dy = p2.y() - p1.y();
-  float dz = p2.z() - p1.z();
-  return std::sqrt(dx * dx + dy * dy + dz * dz);
-}
 
 std::vector<LanePoint> interpolate_points(const std::vector<LanePoint> & input, size_t num_points)
 {


### PR DESCRIPTION
## Description

Removed unused function based on cppcheck

```
planning/autoware_diffusion_planner/src/conversion/lanelet.cpp:35:14: style: The function 'euclidean_distance' is never used. [unusedFunction]
inline float euclidean_distance(const LanePoint & p1, const LanePoint & p2)
             ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
