### PR TITLE
fix(behavior_velocity_planner): remove unused function

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
@@ -59,14 +59,6 @@ std::vector<lanelet::Id> find_lane_ids_upto(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & path, const lanelet::Id lane_id);
 
 /**
- * @brief obtain the index where the footprint on the path intersects with `line` for the first time
- * on the interval of `interpolated_path_info`
- */
-std::optional<size_t> get_first_index_intersects_line(
-  const lanelet::ConstLineString2d & line, const InterpolatedPathInfo & interpolated_path_info,
-  const autoware_utils::LinearRing2d & footprint, const double vehicle_length);
-
-/**
  * @brief generate a linestring consisting of two points of the entry part of `lanelet`
  * @note returned linestring is from left to right of `lanelet`'s boundary
  */

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -359,27 +359,6 @@ std::vector<lanelet::Id> find_lane_ids_upto(
   return lane_ids;
 }
 
-std::optional<size_t> get_first_index_intersects_line(
-  const lanelet::ConstLineString2d & line, const InterpolatedPathInfo & interpolated_path_info,
-  const autoware_utils::LinearRing2d & footprint, const double vehicle_length)
-{
-  const auto & path_ip = interpolated_path_info.path;
-  const auto [lane_start, lane_end] = interpolated_path_info.lane_id_interval;
-  const size_t vehicle_length_idx = static_cast<size_t>(vehicle_length / interpolated_path_info.ds);
-  const size_t start =
-    static_cast<size_t>(std::max<int>(0, static_cast<int>(lane_start) - vehicle_length_idx));
-  const auto line2d = line.basicLineString();
-  for (auto i = start; i <= lane_end; ++i) {
-    const auto & base_pose = path_ip.points.at(i).point.pose;
-    const auto path_footprint =
-      autoware_utils::transform_vector(footprint, autoware_utils::pose2transform(base_pose));
-    if (boost::geometry::intersects(path_footprint, line2d)) {
-      return std::make_optional<size_t>(i);
-    }
-  }
-  return std::nullopt;
-}
-
 lanelet::ConstLineString3d get_entry_line(const lanelet::ConstLanelet & lanelet)
 {
   return lanelet::ConstLineString3d{


### PR DESCRIPTION
## Description

Remove an unused function

```
planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp:362:23: style: The function 'get_first_index_intersects_line' is never used. [unusedFunction]
std::optional<size_t> get_first_index_intersects_line(
                      ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
