### PR TITLE
fix(behavior_path_planner): remove unused function

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/util.hpp
@@ -64,14 +64,6 @@ std::vector<double> calc_curvature_from_trajectory(
   const autoware_planning_msgs::msg::Trajectory & trajectory);
 
 /**
- * @brief Calculate curvature values from point array
- * @param points Input point array
- * @return Vector of curvature values for each point
- */
-std::vector<double> calc_curvature_from_points(
-  const std::vector<geometry_msgs::msg::Point> & points);
-
-/**
  * @brief Find target pose along path at specified longitudinal distance
  * @param centerline_path Centerline path to search along
  * @param start_pose Starting pose

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
@@ -200,51 +200,6 @@ std::vector<double> calc_curvature_from_trajectory(
   return curvatures;
 }
 
-std::vector<double> calc_curvature_from_points(
-  const std::vector<geometry_msgs::msg::Point> & points)
-{
-  using autoware_utils::calc_curvature;
-
-  std::vector<double> curvatures;
-
-  if (points.size() < 3) {
-    // Cannot calculate curvature with less than 3 points
-    curvatures.resize(points.size(), 0.0);
-    return curvatures;
-  }
-
-  curvatures.reserve(points.size());
-
-  for (size_t i = 0; i < points.size(); ++i) {
-    try {
-      if (i == 0) {
-        // First point: use next 2 points
-        const auto & p1 = points[0];
-        const auto & p2 = points[1];
-        const auto & p3 = points[2];
-        curvatures.push_back(calc_curvature(p1, p2, p3));
-      } else if (i == points.size() - 1) {
-        // Last point: use previous 2 points
-        const auto & p1 = points[i - 2];
-        const auto & p2 = points[i - 1];
-        const auto & p3 = points[i];
-        curvatures.push_back(calc_curvature(p1, p2, p3));
-      } else {
-        // Middle points: use surrounding points
-        const auto & p1 = points[i - 1];
-        const auto & p2 = points[i];
-        const auto & p3 = points[i + 1];
-        curvatures.push_back(calc_curvature(p1, p2, p3));
-      }
-    } catch (const std::runtime_error & e) {
-      // Set curvature to 0 if points are too close
-      curvatures.push_back(0.0);
-    }
-  }
-
-  return curvatures;
-}
-
 Pose find_target_pose_along_path(
   const PathWithLaneId & centerline_path, const Pose & start_pose,
   const double longitudinal_distance)


### PR DESCRIPTION
## Description

Removed an unused function

```
planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp:203:21: style: The function 'calc_curvature_from_points' is never used. [unusedFunction]
std::vector<double> calc_curvature_from_points(
                    ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
