### PR TITLE
fix(behavior_path_planner): narrow down variable scope

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -378,7 +378,6 @@ std::optional<std::vector<geometry_msgs::msg::Point>> convert_arc_to_clothoid(
   }
 
   double radius = arc_segment.radius;
-  bool is_clockwise = arc_segment.is_clockwise;
 
   // Clothoid parameters
   double A = A_min;
@@ -394,6 +393,8 @@ std::optional<std::vector<geometry_msgs::msg::Point>> convert_arc_to_clothoid(
   std::vector<ClothoidSegment> segments;
 
   if (total_angle >= 2.0 * alpha_clothoid) {
+    bool is_clockwise = arc_segment.is_clockwise;
+
     // Case A: CAC(A, L, θ)
     double theta_arc = total_angle - 2.0 * alpha_clothoid;
 


### PR DESCRIPTION
## Description

This is based on cppcheck warning:

```
planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp:381:8: style: The scope of the variable 'is_clockwise' can be reduced. [variableScope]
  bool is_clockwise = arc_segment.is_clockwise;
       ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
