### PR TITLE
fix(autoware_boundary_departure_checker): remove unused function

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
@@ -350,28 +350,6 @@ ProjectionsToBound get_closest_boundary_segments_from_side(
   const EgoSides & ego_sides_from_footprints);
 
 /**
- * @brief Estimate braking distance using jerk, acceleration, and braking delay constraints.
- *
- * This function calculates how far a vehicle will travel while slowing down from an initial
- * velocity to a target velocity, considering:
- * - A first phase where deceleration increases gradually (jerk-limited).
- * - A second phase of constant deceleration.
- * - An initial delay before braking begins.
- *
- * The output is useful in planning safe stopping behavior under motion constraints.
- *
- * @param v_init            Initial velocity (m/s).
- * @param v_end             Target (final) velocity after braking (m/s).
- * @param acc               Constant deceleration value (must be positive).
- * @param jerk              Jerk value (rate of change of acceleration), assumed positive.
- * @param t_braking_delay   Delay before braking begins (s).
- * @return Total braking distance (meters).
- */
-double compute_braking_distance(
-  const double v_init, const double v_end, const double acc, const double jerk,
-  double t_braking_delay);
-
-/**
  * @brief Generate filtered and sorted departure points from lateral projections to road
  * boundaries.
  *

--- a/common/autoware_boundary_departure_checker/src/utils.cpp
+++ b/common/autoware_boundary_departure_checker/src/utils.cpp
@@ -608,24 +608,6 @@ ProjectionsToBound get_closest_boundary_segments_from_side(
   return side;
 }
 
-double compute_braking_distance(
-  double v_init, double v_end, double acc, double jerk, double t_braking_delay)
-{
-  // Phase 1: jerk phase
-  const double t1 = acc / jerk;
-  const double d1 = std::max(v_init * t1 - (acc / 6.0) * t1 * t1, 0.0);
-
-  // Midpoint velocity after jerk phase
-  const double v_mid = std::max(v_init - (acc / 2.0) * t1, 0.0);
-
-  // Phase 2: constant deceleration
-  const double dv2 = std::max(v_mid - v_end, 0.0);
-  const double t2 = dv2 / acc;
-  const double d2 = ((v_mid + v_end) / 2.0) * t2;
-
-  return d1 + d2 + v_init * t_braking_delay;
-}
-
 DeparturePoints cluster_by_distance(const DeparturePoints & departure_points)
 {
   DeparturePoints filtered_points;


### PR DESCRIPTION
## Description

Removed an unused function
```
common/autoware_boundary_departure_checker/src/utils.cpp:611:8: style: The function 'compute_braking_distance' is never used. [unusedFunction]
double compute_braking_distance(
       ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
