### PR TITLE
fix(autoware_default_adapi_universe): remove unused functions

### DIFF
--- a/system/autoware_default_adapi_universe/src/manual_control.cpp
+++ b/system/autoware_default_adapi_universe/src/manual_control.cpp
@@ -150,22 +150,6 @@ void ManualControlNode::enable_pedals_commands()
     [this](const PedalsCommand & msg) { pub_pedals_->publish(msg); });
 }
 
-void ManualControlNode::enable_acceleration_commands()
-{
-  // TODO(isamu-takagi): Currently not supported.
-  sub_acceleration_ = create_subscription<AccelerationCommand>(
-    ns_ + "/command/acceleration", rclcpp::QoS(1).best_effort(),
-    [](const AccelerationCommand & msg) { (void)msg; });
-}
-
-void ManualControlNode::enable_velocity_commands()
-{
-  // TODO(isamu-takagi): Currently not supported.
-  sub_velocity_ = create_subscription<VelocityCommand>(
-    ns_ + "/command/velocity", rclcpp::QoS(1).best_effort(),
-    [](const VelocityCommand & msg) { (void)msg; });
-}
-
 void ManualControlNode::enable_common_commands()
 {
   using autoware::default_adapi::command_conversion::convert;

--- a/system/autoware_default_adapi_universe/src/manual_control.hpp
+++ b/system/autoware_default_adapi_universe/src/manual_control.hpp
@@ -73,8 +73,6 @@ private:
   void disable_all_commands();
   void enable_common_commands();
   void enable_pedals_commands();
-  void enable_acceleration_commands();
-  void enable_velocity_commands();
   rclcpp::Subscription<OperatorHeartbeat>::SharedPtr sub_heartbeat_;
   rclcpp::Subscription<PedalsCommand>::SharedPtr sub_pedals_;
   rclcpp::Subscription<AccelerationCommand>::SharedPtr sub_acceleration_;


### PR DESCRIPTION
## Description

Removed unused functions
```
system/autoware_default_adapi_universe/src/manual_control.cpp:153:25: style: The function 'enable_acceleration_commands' is never used. [unusedFunction]
void ManualControlNode::enable_acceleration_commands()
                        ^
system/autoware_default_adapi_universe/src/manual_control.cpp:161:25: style: The function 'enable_velocity_commands' is never used. [unusedFunction]
void ManualControlNode::enable_velocity_commands()
                        ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
