### PR TITLE
fix(tier4_planning_factor_rviz_plugin): remove unused function

### DIFF
--- a/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp
+++ b/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp
@@ -84,11 +84,6 @@ public:
     marker_common_.addMessage(markers_ptr);
   }
 
-  void delete_marker(rviz_default_plugins::displays::MarkerID marker_id)
-  {
-    marker_common_.deleteMarker(marker_id);
-  }
-
 private:
   void processMessage(
     const autoware_internal_planning_msgs::msg::PlanningFactorArray::ConstSharedPtr msg) override;


### PR DESCRIPTION
## Description

Removed unused function
```
visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp:87:8: style: The function 'delete_marker' is never used. [unusedFunction]
  void delete_marker(rviz_default_plugins::displays::MarkerID marker_id)
       ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
