### PR TITLE
fix(autoware_boundary_departure_checker): add missing dependency to magic_enum

### DIFF
--- a/common/autoware_boundary_departure_checker/package.xml
+++ b/common/autoware_boundary_departure_checker/package.xml
@@ -30,6 +30,7 @@
   <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>magic_enum</depend>
   <depend>nav_msgs</depend>
   <depend>range-v3</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
## Description
This adds missing dependency to magic_enum for autoware_boundary_departure_checker package which is used in https://github.com/autowarefoundation/autoware_universe/blob/63a591c657aed45c22584b23afc1667a4323fd3b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/data_structs.hpp#L26

## Related links


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
