### PR TITLE
fix(bpp): namespace of the processing time topic

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_manager_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_manager_interface.cpp
@@ -60,7 +60,7 @@ void SceneModuleManagerInterface::initInterface(
     pub_virtual_wall_ = node->create_publisher<MarkerArray>("~/virtual_wall/" + name_, 20);
     pub_drivable_lanes_ = node->create_publisher<MarkerArray>("~/drivable_lanes/" + name_, 20);
     pub_processing_time_ = node->create_publisher<autoware_utils::ProcessingTimeDetail>(
-      "~/processing_time/" + name_, 20);
+      "~/debug/processing_time_detail_ms/" + name_, 20);
   }
 
   // planning factor


### PR DESCRIPTION
## Description

Fixed the namespace of the topic for processing time debug information to align that of bvp.

NOTE: When I check the logpacker configuration file, the bpp processing time isn’t recorded in the rosbag when using the previous namespace.

- [X2 logpacker config (TIER IV INTERNAL LINK)](http://github.com/tier4/pilot-auto.x2/blob/main/ansible/playbooks/templates/logpacker/logpacker_config_x2.yaml.jinja2)
- [XX1 logpacker config (TIER IV INTRENAL LINK)](https://github.com/tier4/pilot-auto.xx1/blob/main/ansible/playbooks/templates/logpacker/logpacker_config.yaml.jinja2)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Modifications

| Version | Topic Type | Topic Name | Message Type | Description |
|:--------|:-----------|:-----------|:--------------|:------------|
| Old | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/processing_time/bidirectional_traffic` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for bidirectional traffic module |
| New | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/processing_time_detail_ms/bidirectional_traffic` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for bidirectional traffic module |
| Old | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/processing_time/goal_planner` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for goal planner module |
| New | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/processing_time_detail_ms/goal_planner` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for goal planner module |
| Old | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/processing_time/lane_change_left` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for left lane change module |
| New | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/processing_time_detail_ms/lane_change_left` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for left lane change module |
| Old | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/processing_time/lane_change_right` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for right lane change module |
| New | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/processing_time_detail_ms/lane_change_right` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for right lane change module |
| Old | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/processing_time/side_shift` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for side shift module |
| New | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/processing_time_detail_ms/side_shift` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for side shift module |
| Old | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/processing_time/start_planner` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for start planner module |
| New | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/processing_time_detail_ms/start_planner` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for start planner module |
| Old | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/processing_time/static_obstacle_avoidance` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for static obstacle avoidance module |
| New | Pub | `/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/processing_time_detail_ms/static_obstacle_avoidance` | `autoware_internal_debug_msgs/msg/ProcessingTimeTree` | Processing time for static obstacle avoidance module |

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
