### PR TITLE
fix(autoware_behavior_path_start_planner_module): remove unused function

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/clothoid_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/clothoid_pull_out.hpp
@@ -116,20 +116,6 @@ std::optional<std::vector<geometry_msgs::msg::Point>> convert_arc_to_clothoid(
   double L_min, double point_interval);
 
 /**
- * @brief Improved clothoid conversion function with endpoint correction
- * @param arc_segment Arc segment to convert
- * @param start_pose Starting pose
- * @param initial_velocity Initial velocity
- * @param wheel_base Vehicle wheel base
- * @param max_steer_angle_rate Maximum steering angle rate
- * @param point_interval Interval between points
- * @return Optional clothoid path points with correction (nullopt if conversion fails)
- */
-std::optional<std::vector<geometry_msgs::msg::Point>> convert_arc_to_clothoid_with_correction(
-  const ArcSegment & arc_segment, const geometry_msgs::msg::Pose & start_pose,
-  double initial_velocity, double wheel_base, double max_steer_angle_rate, double point_interval);
-
-/**
  * @brief Create straight path to end pose
  * @param start_pose Starting pose
  * @param forward_distance Forward distance


### PR DESCRIPTION
## Description

Removed an unused fuction
```
planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp:460:55: style: The function 'convert_arc_to_clothoid_with_correction' is never used. [unusedFunction]
std::optional<std::vector<geometry_msgs::msg::Point>> convert_arc_to_clothoid_with_correction(
                                                      ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
