### PR TITLE
fix(autoware_behavior_path_start_planner_module): remove unused function

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/util.hpp
@@ -56,14 +56,6 @@ std::optional<PathWithLaneId> extractCollisionCheckSection(
   const PullOutPath & path, const double collision_check_distance_from_end);
 
 /**
- * @brief Calculate curvature values from trajectory points
- * @param trajectory Input trajectory
- * @return Vector of curvature values for each trajectory point
- */
-std::vector<double> calc_curvature_from_trajectory(
-  const autoware_planning_msgs::msg::Trajectory & trajectory);
-
-/**
  * @brief Find target pose along path at specified longitudinal distance
  * @param centerline_path Centerline path to search along
  * @param start_pose Starting pose

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
@@ -160,46 +160,6 @@ struct PathEvaluationResult
 
 }  // anonymous namespace
 
-std::vector<double> calc_curvature_from_trajectory(
-  const autoware_planning_msgs::msg::Trajectory & trajectory)
-{
-  using autoware_utils::calc_curvature;
-
-  std::vector<double> curvatures;
-
-  if (trajectory.points.size() < 3) {
-    // Cannot calculate curvature with less than 3 points
-    curvatures.resize(trajectory.points.size(), 0.0);
-    return curvatures;
-  }
-
-  curvatures.reserve(trajectory.points.size());
-
-  for (size_t i = 0; i < trajectory.points.size(); ++i) {
-    if (i == 0) {
-      // First point: use next 2 points
-      const auto & p1 = trajectory.points[0].pose.position;
-      const auto & p2 = trajectory.points[1].pose.position;
-      const auto & p3 = trajectory.points[2].pose.position;
-      curvatures.push_back(calc_curvature(p1, p2, p3));
-    } else if (i == trajectory.points.size() - 1) {
-      // Last point: use previous 2 points
-      const auto & p1 = trajectory.points[i - 2].pose.position;
-      const auto & p2 = trajectory.points[i - 1].pose.position;
-      const auto & p3 = trajectory.points[i].pose.position;
-      curvatures.push_back(calc_curvature(p1, p2, p3));
-    } else {
-      // Middle points: use surrounding points
-      const auto & p1 = trajectory.points[i - 1].pose.position;
-      const auto & p2 = trajectory.points[i].pose.position;
-      const auto & p3 = trajectory.points[i + 1].pose.position;
-      curvatures.push_back(calc_curvature(p1, p2, p3));
-    }
-  }
-
-  return curvatures;
-}
-
 Pose find_target_pose_along_path(
   const PathWithLaneId & centerline_path, const Pose & start_pose,
   const double longitudinal_distance)


### PR DESCRIPTION
## Description

Removed an unused fuction
```
planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp:163:21: style: The function 'calc_curvature_from_trajectory' is never used. [unusedFunction]
std::vector<double> calc_curvature_from_trajectory(
                    ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
