### PR TITLE
fix(autoware_behavior_velocity_blind_spot_module): remove unused function

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -226,22 +226,6 @@ std::optional<lanelet::LineString3d> generate_blind_ego_side_path_boundary_befor
   return std::make_optional<lanelet::LineString3d>(lanelet::InvalId, points);
 }
 
-/**
- * @brief get the sibling lanelet of `intersection_lanelet` whose turn_direction is straight
- */
-std::optional<lanelet::ConstLanelet> sibling_straight_lanelet(
-  const lanelet::ConstLanelet & intersection_lanelet,
-  const lanelet::routing::RoutingGraphConstPtr routing_graph_ptr)
-{
-  for (const auto & sibling_lanelet : autoware::experimental::lanelet2_utils::sibling_lanelets(
-         intersection_lanelet, routing_graph_ptr)) {
-    if (autoware::experimental::lanelet2_utils::is_straight_direction(sibling_lanelet)) {
-      return sibling_lanelet;
-    }
-  }
-  return std::nullopt;
-}
-
 static std::optional<size_t> getDuplicatedPointIdx(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
   const geometry_msgs::msg::Point & point)
@@ -520,17 +504,6 @@ std::optional<lanelet::LineString3d> generate_virtual_ego_straight_path_after_tu
   const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction,
   const double ego_width)
 {
-  /*
-  if (const auto sibling_straight_lanelet_opt =
-        helper::sibling_straight_lanelet(intersection_lanelet, routing_graph_ptr);
-      sibling_straight_lanelet_opt) {
-    const auto & sibling_straight_lanelet = sibling_straight_lanelet_opt.value();
-    const auto & target_linestring = (turn_direction == TurnDirection::Left)
-                                       ? sibling_straight_lanelet.leftBound()
-                                       : sibling_straight_lanelet.rightBound();
-    return remove_const(target_linestring);
-  }
-  */
   const double extend_length = lanelet::utils::getLaneletLength3d(intersection_lanelet);
 
   const auto path_linestring = to_bg2d(path.points);


### PR DESCRIPTION
## Description

Removed an unused fuction
```
planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp:232:38: style: The function 'sibling_straight_lanelet' is never used. [unusedFunction]
std::optional<lanelet::ConstLanelet> sibling_straight_lanelet(
                                     ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
