### PR TITLE
fix(boundary_departure): explicitly delete diagnotics ptr after module's destruction

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -44,6 +44,7 @@ public:
   {
     return RequiredSubscriptionInfo{};
   }
+  ~BoundaryDeparturePreventionModule() override { updater_ptr_.reset(); }
 
 private:
   // === Interface and inputs validation ====


### PR DESCRIPTION
## Description

While running the internal evaluator, boundary departure module randomly crashes.
```
[openscenario_interpreter_node-3] [component_container_mt-37] *** SIGABRT (@0x3e800000d4f) received by PID 3407 (TID 0x7f9df0fc7640) from PID 3407; stack trace: ***
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e3667c4d6 google::(anonymous namespace)::FailureSignalHandler()
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e35f32520 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e35f869fc pthread_kill
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e35f32476 raise
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e35f187f3 abort
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e361dbb9e (unknown)
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e361e720c (unknown)
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e361e7277 std::terminate()
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e361e74d8 __cxa_throw
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e361db7ac (unknown)
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9ce6ece79d std::__cxx11::basic_string<>::_M_construct<>()
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9ce6edab1e _ZZN8autoware23motion_velocity_planner12experimental33BoundaryDeparturePreventionModule4initERN6rclcpp4NodeERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEENKUlRN18diagnostic_updater23DiagnosticStatusWrapperEE_clESG_
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9ce6f4e1c1 diagnostic_updater::Updater::update()
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9ce6edead5 rclcpp::GenericTimer<>::execute_callback()
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e364f9ffe rclcpp::Executor::execute_any_executable()
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e36500432 rclcpp::executors::MultiThreadedExecutor::run()
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e36215253 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-37]     @     0x7f9e35f84ac3 (unknown)
```


A segmentation fault could occur in the `BoundaryDeparturePreventionModule` during node shutdown or when the component is unloaded from a container.

This was caused by a use-after-free race condition. The `diagnostic_updater`'s callback, which captures the `this` pointer, was sometimes executed after the `BoundaryDeparturePreventionModule` instance had been destroyed. This led to the callback attempting to access freed memory via a dangling pointer, causing the crash. Due to its nature as a race condition, this bug was difficult to reproduce consistently.

This PR resolves the issue by implementing a custom destructor for the `BoundaryDeparturePreventionModule`.

In the destructor, `updater_ptr_.reset()` is called explicitly. This ensures that the diagnostic_updater and its associated callback are destroyed and de-registered before any other class members. This safely severs the connection and guarantees the callback cannot be invoked on a partially or fully destroyed object.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

```
Verified that the component can be loaded and unloaded repeatedly from a component container without crashing.
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
