### PR TITLE
feat(planning_factor_rviz_plugin): change some property

### DIFF
--- a/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.cpp
+++ b/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.cpp
@@ -173,11 +173,13 @@ void PlanningFactorRvizPlugin::processMessage(
         break;
     }
 
-    for (const auto & safety_factor : factor.safety_factors.factors) {
-      const auto color = safety_factor.is_safe ? getGreen(0.999) : getRed(0.999);
-      for (const auto & point : safety_factor.points) {
-        const auto safety_factor_marker = createTargetMarker(i++, point, color, factor.module);
-        add_marker(std::make_shared<visualization_msgs::msg::MarkerArray>(safety_factor_marker));
+    if (show_safety_factors_.getBool()) {
+      for (const auto & safety_factor : factor.safety_factors.factors) {
+        const auto color = safety_factor.is_safe ? getGreen(0.999) : getRed(0.999);
+        for (const auto & point : safety_factor.points) {
+          const auto safety_factor_marker = createTargetMarker(i++, point, color, factor.module);
+          add_marker(std::make_shared<visualization_msgs::msg::MarkerArray>(safety_factor_marker));
+        }
       }
     }
   }

--- a/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.cpp
+++ b/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.cpp
@@ -159,7 +159,7 @@ void PlanningFactorRvizPlugin::processMessage(
       case autoware_internal_planning_msgs::msg::PlanningFactor::STOP:
         for (const auto & control_point : factor.control_points) {
           const auto virtual_wall = createStopVirtualWallMarker(
-            control_point.pose, text, msg->header.stamp, i++, baselink2front_.getFloat());
+            control_point.pose, text, msg->header.stamp, i++, baselink2front_);
           add_marker(std::make_shared<visualization_msgs::msg::MarkerArray>(virtual_wall));
         }
         break;
@@ -167,7 +167,7 @@ void PlanningFactorRvizPlugin::processMessage(
       case autoware_internal_planning_msgs::msg::PlanningFactor::SLOW_DOWN:
         for (const auto & control_point : factor.control_points) {
           const auto virtual_wall = createSlowDownVirtualWallMarker(
-            control_point.pose, text, msg->header.stamp, i++, baselink2front_.getFloat());
+            control_point.pose, text, msg->header.stamp, i++, baselink2front_);
           add_marker(std::make_shared<visualization_msgs::msg::MarkerArray>(virtual_wall));
         }
         break;

--- a/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp
+++ b/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rviz_common/display.hpp>
+#include <rviz_common/properties/bool_property.hpp>
 #include <rviz_common/properties/float_property.hpp>
 #include <rviz_default_plugins/displays/marker/marker_common.hpp>
 #include <rviz_default_plugins/displays/marker_array/marker_array_display.hpp>
@@ -38,6 +39,7 @@ public:
   PlanningFactorRvizPlugin()
   : marker_common_{this},
     baselink2front_{"Baselink To Front", 0.0, "Length between base link to front.", this},
+    show_safety_factors_{"Show Safety Factors", true, "Display safety factor markers", this},
     topic_name_{"planning_factors"}
   {
   }
@@ -62,6 +64,16 @@ public:
   {
     RosTopicDisplay::Display::load(config);
     marker_common_.load(config);
+    bool show_safety_factors;
+    if (config.mapGetBool("show_safety_factors", &show_safety_factors)) {
+      show_safety_factors_.setValue(show_safety_factors);
+    }
+  }
+
+  void save(rviz_common::Config config) const override
+  {
+    RosTopicDisplay::Display::save(config);
+    config.mapSetValue("show_safety_factors", show_safety_factors_.getBool());
   }
 
   void update(float wall_dt, float ros_dt) override { marker_common_.update(wall_dt, ros_dt); }
@@ -91,6 +103,7 @@ private:
   rviz_default_plugins::displays::MarkerCommon marker_common_;
 
   rviz_common::properties::FloatProperty baselink2front_;
+  rviz_common::properties::BoolProperty show_safety_factors_;
 
   std::string topic_name_;
 };

--- a/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp
+++ b/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp
@@ -38,7 +38,6 @@ class PlanningFactorRvizPlugin
 public:
   PlanningFactorRvizPlugin()
   : marker_common_{this},
-    baselink2front_{"Baselink To Front", 0.0, "Length between base link to front.", this},
     show_safety_factors_{"Show Safety Factors", true, "Display safety factor markers", this},
     topic_name_{"planning_factors"}
   {
@@ -57,7 +56,7 @@ public:
     const auto vehicle_info =
       autoware::vehicle_info_utils::VehicleInfoUtils(*rviz_ros_node_.lock()->get_raw_node())
         .getVehicleInfo();
-    baselink2front_.setValue(vehicle_info.max_longitudinal_offset_m);
+    baselink2front_ = vehicle_info.max_longitudinal_offset_m;
   }
 
   void load(const rviz_common::Config & config) override
@@ -102,7 +101,7 @@ private:
 
   rviz_default_plugins::displays::MarkerCommon marker_common_;
 
-  rviz_common::properties::FloatProperty baselink2front_;
+  double baselink2front_ = 0;
   rviz_common::properties::BoolProperty show_safety_factors_;
 
   std::string topic_name_;


### PR DESCRIPTION
## Description
This PR modifies the properties of the rviz plugin to be more practical for using a PlanningFactor-based virtual wall.
A boolean property allows you to choose whether to visualize only the virtual wall or to also visualize markers that mark the target object.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
