### PR TITLE
build: restore install and build contents from cache

### DIFF
--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -123,12 +123,14 @@ jobs:
           echo "::notice::BUILD_TYPE_CUDA_STATE=$build_type_cuda_state"
         shell: bash
 
-      - name: Prepare build_depends.repos file
-        uses: ./.github/actions/combine-repos-action
+      - name: Restore install and build contents
+        uses: actions/cache/restore@v4
+        id: cache
         with:
-          base_file: build_depends_humble.repos
-          overlay_file: build_depends_nightly.repos
-          output_file: build_depends.repos
+          path: |
+            install
+            build
+          key: workspace-${{ runner.arch }}-${{ env.rosdistro }}
 
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}


### PR DESCRIPTION
## Description

This PR fetches the `install` and `build` directories from a previously generated cache (see https://github.com/autowarefoundation/autoware_universe/pull/11133).

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10932

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
