### PR TITLE
feat(blind_spot): add the flag to ignore non vru

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/config/blind_spot.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/config/blind_spot.param.yaml
@@ -7,6 +7,11 @@
       minimum_default_velocity: 1.388 # [m/s]
       collision_judge_debounce: 0.5 # [s]
       critical_stopline_margin: 1.0 # [m]
+      detect_non_vru:
+        car: false
+        truck: false
+        bus: false
+        trailer: false
       brake:
         critical:
           deceleration: -6.0 # [m/ss]

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/parameter.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/parameter.hpp
@@ -30,6 +30,13 @@ struct PlannerParam
   double minimum_default_velocity{};
   double collision_judge_debounce{};
   double critical_stopline_margin{};
+  struct DetectNonVRU
+  {
+    bool car{};
+    bool truck{};
+    bool bus{};
+    bool trailer{};
+  } detect_non_vru{};
   struct Brake
   {
     struct Critical

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/parameter.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/parameter.cpp
@@ -35,6 +35,11 @@ PlannerParam PlannerParam::init(rclcpp::Node & node, const std::string & ns)
     get_or_declare_parameter<double>(node, ns + ".collision_judge_debounce");
   param.critical_stopline_margin =
     get_or_declare_parameter<double>(node, ns + ".critical_stopline_margin");
+  param.detect_non_vru.car = get_or_declare_parameter<bool>(node, ns + ".detect_non_vru.car");
+  param.detect_non_vru.truck = get_or_declare_parameter<bool>(node, ns + ".detect_non_vru.truck");
+  param.detect_non_vru.bus = get_or_declare_parameter<bool>(node, ns + ".detect_non_vru.bus");
+  param.detect_non_vru.trailer =
+    get_or_declare_parameter<bool>(node, ns + ".detect_non_vru.trailer");
   param.brake.critical.deceleration =
     get_or_declare_parameter<double>(node, ns + ".brake.critical.deceleration");
   param.brake.critical.jerk = get_or_declare_parameter<double>(node, ns + ".brake.critical.jerk");

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -393,18 +393,41 @@ BlindSpotModule::filter_attention_objects(const lanelet::BasicPolygon2d & attent
 bool BlindSpotModule::isTargetObjectType(
   const autoware_perception_msgs::msg::PredictedObject & object) const
 {
+  auto detect_non_vru = [&]() {
+    if (
+      object.classification.at(0).label ==
+        autoware_perception_msgs::msg::ObjectClassification::CAR &&
+      planner_param_.detect_non_vru.car) {
+      return true;
+    }
+    if (
+      object.classification.at(0).label ==
+        autoware_perception_msgs::msg::ObjectClassification::TRUCK &&
+      planner_param_.detect_non_vru.truck) {
+      return true;
+    }
+    if (
+      object.classification.at(0).label ==
+        autoware_perception_msgs::msg::ObjectClassification::BUS &&
+      planner_param_.detect_non_vru.bus) {
+      return true;
+    }
+    if (
+      object.classification.at(0).label ==
+        autoware_perception_msgs::msg::ObjectClassification::TRAILER &&
+      planner_param_.detect_non_vru.trailer) {
+      return true;
+    }
+    return false;
+  };
   if (
-    object.classification.at(0).label == autoware_perception_msgs::msg::ObjectClassification::CAR ||
-    object.classification.at(0).label ==
-      autoware_perception_msgs::msg::ObjectClassification::TRUCK ||
-    object.classification.at(0).label ==
-      autoware_perception_msgs::msg::ObjectClassification::TRAILER ||
     object.classification.at(0).label ==
       autoware_perception_msgs::msg::ObjectClassification::BICYCLE ||
     object.classification.at(0).label ==
       autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN ||
     object.classification.at(0).label ==
-      autoware_perception_msgs::msg::ObjectClassification::MOTORCYCLE) {
+      autoware_perception_msgs::msg::ObjectClassification::MOTORCYCLE ||
+    detect_non_vru()) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Description

add the flag to `detect_non_vru` since previous blind_spot module did not react to them

## Related links

https://github.com/autowarefoundation/autoware_launch/pull/1612

https://tier4.atlassian.net/browse/RT0-38916

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/9bd05859-a240-5b75-afc5-e0b7be6484cd?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/e9fc319e-324a-5520-95e1-e4cd64335667?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/f824b442-c02e-5582-b80a-cb877237d48e?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
