### PR TITLE
refactor(launch):  topic remapping for object recognition and point cloud input to planning/control module

### DIFF
--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -52,6 +52,8 @@
   <let name="operation_mode_transition_manager_plugin" value="OperationModeTransitionManager" unless="$(var use_control_command_gate)"/>
 
   <!-- topic remap -->
+  <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output_control_cmd" default="/control/command/control_cmd"/>
   <arg name="output_gear_cmd" default="/control/command/gear_cmd"/>
   <arg name="output_turn_indicators_cmd" default="/control/command/turn_indicators_cmd"/>
@@ -245,10 +247,10 @@
       <group if="$(var launch_autonomous_emergency_braking)">
         <load_composable_node target="/control/control_check_container">
           <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
-            <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+            <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
             <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
             <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
-            <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+            <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
             <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
             <param from="$(var aeb_param_path)"/>
             <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
@@ -262,8 +264,8 @@
         <load_composable_node target="/control/control_check_container">
           <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
             <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-            <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-            <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+            <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
+            <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
             <param from="$(var collision_detector_param_path)"/>
           </composable_node>
         </load_composable_node>
@@ -274,7 +276,7 @@
         <load_composable_node target="/control/control_check_container">
           <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
             <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
-            <remap from="input/obstacle_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+            <remap from="input/obstacle_pointcloud" to="$(var input_pointcloud_topic_name)"/>
             <remap from="input/reference_trajectory" to="/planning/trajectory"/>
             <remap from="input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
             <remap from="input/odometry" to="/localization/kinematic_state"/>
@@ -289,7 +291,7 @@
       <group if="$(var launch_predicted_path_checker)">
         <load_composable_node target="/control/control_check_container">
           <composable_node pkg="autoware_predicted_path_checker" plugin="autoware::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
-            <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+            <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
             <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
             <remap from="~/input/current_accel" to="/localization/acceleration"/>
             <remap from="~/input/odometry" to="/localization/kinematic_state"/>
@@ -304,7 +306,9 @@
 
     <!-- control evaluator -->
     <group if="$(var launch_control_evaluator)">
-      <include file="$(find-pkg-share autoware_control_evaluator)/launch/control_evaluator.launch.xml"/>
+      <include file="$(find-pkg-share autoware_control_evaluator)/launch/control_evaluator.launch.xml">
+        <arg name="input_objects_topic_name" value="$(var input_objects_topic_name)"/>
+      </include>
     </group>
   </group>
 </launch>

--- a/launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/planning.launch.xml
@@ -41,6 +41,8 @@
         <arg name="container_type" value="component_container_mt"/>
         <arg name="input_trajectory" value="/planning/scenario_planning/velocity_smoother/trajectory"/>
         <arg name="output_trajectory" value="/planning/trajectory"/>
+        <arg name="input_objects_topic_name" value="/perception/object_recognition/objects"/>
+        <arg name="input_pointcloud_topic_name" value="/perception/obstacle_segmentation/pointcloud"/>
         <arg name="planning_validator_param_path" value="$(var planning_validator_param_path)"/>
         <arg name="planning_validator_latency_checker_param_path" value="$(var planning_validator_latency_checker_param_path)"/>
         <arg name="planning_validator_trajectory_checker_param_path" value="$(var planning_validator_trajectory_checker_param_path)"/>
@@ -51,7 +53,9 @@
 
     <!-- planning evaluator -->
     <group>
-      <include file="$(find-pkg-share autoware_planning_evaluator)/launch/planning_evaluator.launch.xml"/>
+      <include file="$(find-pkg-share autoware_planning_evaluator)/launch/planning_evaluator.launch.xml">
+        <arg name="input_objects_topic_name" value="/perception/object_recognition/objects"/>
+      </include>
     </group>
 
     <!-- mission remaining distance and time calculator -->

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
@@ -1,6 +1,8 @@
 <launch>
   <arg name="enable_all_modules_auto_mode"/>
   <arg name="is_simulation"/>
+  <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
 
   <!-- lane_driving scenario -->
   <group>
@@ -15,6 +17,8 @@
           <arg name="is_simulation" value="$(var is_simulation)"/>
           <!-- This condition should be true if run_out module is enabled and its detection method is Points -->
           <arg name="launch_compare_map_pipeline" value="false"/>
+          <arg name="input_objects_topic_name" value="$(var input_objects_topic_name)"/>
+          <arg name="input_pointcloud_topic_name" value="$(var input_pointcloud_topic_name)"/>
         </include>
       </group>
     </group>
@@ -25,6 +29,8 @@
       <group>
         <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml">
           <arg name="container_type" value="component_container_mt"/>
+          <arg name="input_objects_topic_name" value="$(var input_objects_topic_name)"/>
+          <arg name="input_pointcloud_topic_name" value="$(var input_pointcloud_topic_name)"/>
         </include>
       </group>
     </group>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -4,6 +4,8 @@
   <arg name="input_virtual_traffic_light_topic_name" default="/awapi/tmp/virtual_traffic_light_states"/>
   <arg name="input_vector_map_topic_name" default="/map/vector_map"/>
   <arg name="input_pointcloud_map_topic_name" default="/map/pointcloud_map"/>
+  <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="enable_all_modules_auto_mode"/>
   <arg name="is_simulation"/>
 
@@ -183,8 +185,8 @@
       <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
       <remap from="~/input/vehicle_odometry" to="/localization/kinematic_state"/>
       <remap from="~/input/accel" to="/localization/acceleration"/>
-      <remap from="~/input/dynamic_objects" to="/perception/object_recognition/objects"/>
-      <remap from="~/input/no_ground_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+      <remap from="~/input/dynamic_objects" to="$(var input_objects_topic_name)"/>
+      <remap from="~/input/no_ground_pointcloud" to="$(var input_pointcloud_topic_name)"/>
       <remap from="~/input/compare_map_filtered_pointcloud" to="compare_map_filtered/pointcloud"/>
       <remap from="~/input/vector_map_inside_area_filtered_pointcloud" to="vector_map_inside_area_filtered/pointcloud"/>
       <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity_default"/>
@@ -230,7 +232,7 @@
       <composable_node pkg="autoware_behavior_path_planner" plugin="autoware::behavior_path_planner::BehaviorPathPlannerNode" name="behavior_path_planner" namespace="">
         <remap from="~/input/route" to="$(var input_route_topic_name)"/>
         <remap from="~/input/vector_map" to="$(var input_vector_map_topic_name)"/>
-        <remap from="~/input/perception" to="/perception/object_recognition/objects"/>
+        <remap from="~/input/perception" to="$(var input_objects_topic_name)"/>
         <remap from="~/input/occupancy_grid_map" to="/perception/occupancy_grid_map/map"/>
         <remap from="~/input/costmap" to="/planning/scenario_planning/parking/costmap_generator/occupancy_grid"/>
         <remap from="~/input/traffic_signals" to="$(var input_traffic_light_topic_name)"/>
@@ -299,7 +301,7 @@
         <remap from="map" to="$(var input_pointcloud_map_topic_name)"/>
         <remap from="kinematic_state" to="/localization/kinematic_state"/>
         <remap from="map_loader_service" to="/map/get_differential_pointcloud_map"/>
-        <remap from="input" to="/perception/obstacle_segmentation/pointcloud"/>
+        <remap from="input" to="$(var input_pointcloud_topic_name)"/>
         <remap from="output" to="compare_map_filtered/pointcloud"/>
         <!-- params -->
         <param from="$(var compare_map_filter_param_path)"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="interface_input_topic" default="/planning/scenario_planning/lane_driving/behavior_planning/path"/>
   <arg name="interface_output_topic" default="/planning/scenario_planning/lane_driving/trajectory"/>
 
@@ -126,7 +128,7 @@
           <!-- topic remap -->
           <remap from="~/input/path" to="path_smoother/path"/>
           <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+          <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
           <remap from="~/output/path" to="path_optimizer/trajectory"/>
           <!-- params -->
           <param from="$(var common_param_path)"/>
@@ -173,8 +175,8 @@
         <remap from="~/input/vector_map" to="/map/vector_map"/>
         <remap from="~/input/vehicle_odometry" to="/localization/kinematic_state"/>
         <remap from="~/input/accel" to="/localization/acceleration"/>
-        <remap from="~/input/dynamic_objects" to="/perception/object_recognition/objects"/>
-        <remap from="~/input/no_ground_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+        <remap from="~/input/dynamic_objects" to="$(var input_objects_topic_name)"/>
+        <remap from="~/input/no_ground_pointcloud" to="$(var input_pointcloud_topic_name)"/>
         <remap from="~/input/traffic_signals" to="/perception/traffic_light_recognition/traffic_signals"/>
         <remap from="~/input/virtual_traffic_light_states" to="/perception/virtual_traffic_light_states"/>
         <remap from="~/input/occupancy_grid" to="/perception/occupancy_grid_map/map"/>
@@ -213,8 +215,8 @@
       <composable_node pkg="autoware_surround_obstacle_checker" plugin="autoware::surround_obstacle_checker::SurroundObstacleCheckerNode" name="surround_obstacle_checker" namespace="">
         <!-- topic remap -->
         <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-        <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-        <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+        <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
+        <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
         <remap from="~/output/max_velocity" to="/planning/scenario_planning/max_velocity_candidates"/>
         <remap from="~/output/velocity_limit_clear_command" to="/planning/scenario_planning/clear_velocity_limit"/>
         <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/parking.launch.xml
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
+
   <!-- parking scenario -->
   <group if="$(var launch_parking_module)">
     <push-ros-namespace namespace="parking"/>
@@ -6,8 +9,8 @@
     <node_container pkg="rclcpp_components" exec="$(var container_type)" name="parking_container" namespace="" output="screen">
       <composable_node pkg="autoware_costmap_generator" plugin="autoware::costmap_generator::CostmapGenerator" name="costmap_generator" namespace="">
         <!-- topic remap -->
-        <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-        <remap from="~/input/points_no_ground" to="/perception/obstacle_segmentation/pointcloud"/>
+        <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
+        <remap from="~/input/points_no_ground" to="$(var input_pointcloud_topic_name)"/>
         <remap from="~/input/vector_map" to="/map/vector_map"/>
         <remap from="~/input/scenario" to="/planning/scenario_planning/scenario"/>
         <remap from="~/output/grid_map" to="costmap_generator/grid_map"/>

--- a/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
+++ b/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
@@ -5,7 +5,6 @@
   <arg name="launch_rear_collision_checker" default="true"/>
   <arg name="launch_modules_list_end" default="&quot;&quot;]"/>
   <arg name="planning_validator_launch_modules" default="["/>
-
   <let
     name="planning_validator_launch_modules"
     value="$(eval &quot;'$(var planning_validator_launch_modules)' + 'autoware::planning_validator::LatencyChecker, '&quot;)"

--- a/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
+++ b/planning/planning_validator/autoware_planning_validator/launch/planning_validator.launch.xml
@@ -5,6 +5,7 @@
   <arg name="launch_rear_collision_checker" default="true"/>
   <arg name="launch_modules_list_end" default="&quot;&quot;]"/>
   <arg name="planning_validator_launch_modules" default="["/>
+
   <let
     name="planning_validator_launch_modules"
     value="$(eval &quot;'$(var planning_validator_launch_modules)' + 'autoware::planning_validator::LatencyChecker, '&quot;)"
@@ -32,8 +33,9 @@
   <arg name="planning_validator_trajectory_checker_param_path"/>
   <arg name="planning_validator_intersection_collision_checker_param_path"/>
   <arg name="planning_validator_rear_collision_checker_param_path"/>
-  <arg name="input_trajectory" default="/planning/scenario_planning/velocity_smoother/trajectory"/>
-  <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
+  <arg name="input_trajectory_topic_name" default="/planning/scenario_planning/velocity_smoother/trajectory"/>
+  <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="input_route_topic_name" default="/planning/mission_planning/route"/>
   <arg name="input_vector_map_topic_name" default="/map/vector_map"/>
   <arg name="output_trajectory" default="/planning/trajectory"/>
@@ -42,8 +44,9 @@
     <node_container pkg="rclcpp_components" exec="$(var container_type)" name="planning_validator_container" namespace="" args="" output="both">
       <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
       <composable_node pkg="autoware_planning_validator" plugin="autoware::planning_validator::PlanningValidatorNode" name="planning_validator" namespace="">
-        <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
-        <remap from="~/input/trajectory" to="$(var input_trajectory)"/>
+        <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
+        <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
+        <remap from="~/input/trajectory" to="$(var input_trajectory_topic_name)"/>
         <remap from="~/input/lanelet_map_bin" to="$(var input_vector_map_topic_name)"/>
         <remap from="~/input/route" to="$(var input_route_topic_name)"/>
         <remap from="~/input/kinematics" to="/localization/kinematic_state"/>


### PR DESCRIPTION
## Description

This PR parameterizes perception-related topic names in Autoware launch files. It replaces hardcoded topic names `/perception/object_recognition/objects` and `/perception/obstacle_segmentation/pointcloud` with configurable arguments, enabling dynamic topic name configuration based on perception filter usage.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- [x] run psim
- [x] PASS TIERIV INTERNAL SCENARIOS
  - [x] https://evaluation.tier4.jp/evaluation/reports/90bd351c-7159-5bb6-be12-115904c1fd98?project_id=prd_jt
  - [x] https://evaluation.tier4.jp/evaluation/reports/126a1b6e-8186-5599-a80e-ca82678495b3?project_id=prd_jt
  - [x] https://evaluation.tier4.jp/evaluation/reports/ba1c44a9-1c0c-5ea5-92b7-2339448da81e?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Modifications

| Version | Topic Type | Topic Name                                                 | Message Type                                      | Description                                           |
| :------ | :--------- | :--------------------------------------------------------- | :------------------------------------------------ | :---------------------------------------------------- |
| Old     | Sub        | `/perception/object_recognition/objects` (hardcoded)       | `autoware_perception_msgs::msg::PredictedObjects` | Object recognition results topic                      |
| New     | Sub        | `$(var input_objects_topic_name)` (configurable)           | `autoware_perception_msgs::msg::PredictedObjects` | Object recognition results topic (configurable)       |
| Old     | Sub        | `/perception/obstacle_segmentation/pointcloud` (hardcoded) | `sensor_msgs/PointCloud2`                         | Obstacle segmentation pointcloud topic                |
| New     | Sub        | `$(var input_pointcloud_topic_name)` (configurable)        | `sensor_msgs/PointCloud2`                         | Obstacle segmentation pointcloud topic (configurable) |

<!-- ### ROS Parameter Changes

#### Additions

| Change type | Parameter Name                | Type     | Default Value                                  | Description                               |
| :---------- | :---------------------------- | :------- | :--------------------------------------------- | :---------------------------------------------------------------- |
| Added       | `input_objects_topic_name`    | `string` | `/perception/object_recognition/objects`       | Argument to configure object recognition topic name               |
| Added       | `input_pointcloud_topic_name` | `string` | `/perception/obstacle_segmentation/pointcloud` | Argument to configure obstacle segmentation pointcloud topic name | -->

## Effects on system behavior

- No behavioral changes for existing configurations since default values match the previously hardcoded values
- This change improves system flexibility and enables support for different perception pipeline configurations without requiring code modifications.
