### PR TITLE
fix(autoware_multi_object_tracker): update isConfident method signature and logic for time handling

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/tracker_base.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/model/tracker_base.hpp
@@ -103,8 +103,8 @@ public:
   void getPositionCovarianceEigenSq(
     const rclcpp::Time & time, double & major_axis_sq, double & minor_axis_sq) const;
   bool isConfident(
-    const rclcpp::Time & time, const AdaptiveThresholdCache & cache,
-    const std::optional<geometry_msgs::msg::Pose> & ego_pose) const;
+    const AdaptiveThresholdCache & cache, const std::optional<geometry_msgs::msg::Pose> & ego_pose,
+    const std::optional<rclcpp::Time> & time) const;
   bool isExpired(
     const rclcpp::Time & time, const AdaptiveThresholdCache & cache,
     const std::optional<geometry_msgs::msg::Pose> & ego_pose) const;

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/pass_through_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/pass_through_tracker.cpp
@@ -78,6 +78,7 @@ bool PassThroughTracker::getTrackedObject(
 {
   using autoware_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   object = object_;
+  object.time = time;
 
   object.pose_covariance[XYZRPY_COV_IDX::X_X] = 0.0;
   object.pose_covariance[XYZRPY_COV_IDX::X_Y] = 0.0;

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/tracker_base.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/tracker_base.cpp
@@ -374,9 +374,9 @@ bool Tracker::isConfident(
   }
   rclcpp::Time time_to_check;
   if (!time) {
-    // add 150ms extrapolation time to the latest measurement time
+    // add 200ms extrapolation time to the latest measurement time
     // to consider the velocity uncertainty
-    const rclcpp::Duration extrapolate_time = rclcpp::Duration::from_seconds(0.15);
+    const rclcpp::Duration extrapolate_time = rclcpp::Duration::from_seconds(0.2);
     time_to_check = object_.time + extrapolate_time;
   } else {
     // use the given time

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/tracker_base.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/tracker_base.cpp
@@ -364,18 +364,28 @@ double Tracker::computeAdaptiveThreshold(
 }
 
 bool Tracker::isConfident(
-  const rclcpp::Time & time, const AdaptiveThresholdCache & cache,
-  const std::optional<geometry_msgs::msg::Pose> & ego_pose) const
+  const AdaptiveThresholdCache & cache, const std::optional<geometry_msgs::msg::Pose> & ego_pose,
+  const std::optional<rclcpp::Time> & time = std::nullopt) const
 {
   // check the number of measurements. if the measurement is too small, definitely not confident
   const int count = getTotalMeasurementCount();
   if (count < 2) {
     return false;
   }
+  rclcpp::Time time_to_check;
+  if (!time) {
+    // add 150ms extrapolation time to the latest measurement time
+    // to consider the velocity uncertainty
+    const rclcpp::Duration extrapolate_time = rclcpp::Duration::from_seconds(0.15);
+    time_to_check = object_.time + extrapolate_time;
+  } else {
+    // use the given time
+    time_to_check = *time;
+  }
 
   double major_axis_sq = 0.0;
   double minor_axis_sq = 0.0;
-  getPositionCovarianceEigenSq(time, major_axis_sq, minor_axis_sq);
+  getPositionCovarianceEigenSq(time_to_check, major_axis_sq, minor_axis_sq);
 
   // if the covariance is very small, the tracker is confident
   constexpr double STRONG_COV_THRESHOLD = 0.28;
@@ -396,11 +406,11 @@ bool Tracker::isConfident(
 }
 
 bool Tracker::isExpired(
-  const rclcpp::Time & now, const AdaptiveThresholdCache & cache,
+  const rclcpp::Time & time, const AdaptiveThresholdCache & cache,
   const std::optional<geometry_msgs::msg::Pose> & ego_pose) const
 {
   // check the number of no measurements
-  const double elapsed_time = getElapsedTimeFromLastUpdate(now);
+  const double elapsed_time = getElapsedTimeFromLastUpdate(time);
 
   // if the last measurement is too old, the tracker is expired
   constexpr double EXPIRED_TIME_THRESHOLD = 1.0;  // [sec]
@@ -424,7 +434,7 @@ bool Tracker::isExpired(
     // if the tracker covariance is too large, the tracker is expired
     double major_axis_sq = 0.0;
     double minor_axis_sq = 0.0;
-    getPositionCovarianceEigenSq(now, major_axis_sq, minor_axis_sq);
+    getPositionCovarianceEigenSq(time, major_axis_sq, minor_axis_sq);
     // major_cov: base_threshold is 2.8, fallback threshold is 3.8;
     // minor_cov: base_threshold is 2.7, fallback threshold is 3.7;
     const double major_cov_threshold = computeAdaptiveThreshold(2.8, 3.8, cache, ego_pose);

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/unknown_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/unknown_tracker.cpp
@@ -228,6 +228,7 @@ bool UnknownTracker::getTrackedObject(
 
   // get the object
   object = object_;
+  object.time = time;
 
   if (enable_velocity_estimation_) {
     // predict from motion model

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -383,7 +383,7 @@ void TrackerProcessor::mergeOverlappedTracker(const rclcpp::Time & time)
   // Second pass: merge overlapping trackers
   for (size_t i = 0; i < valid_trackers.size(); ++i) {
     auto & data1 = valid_trackers[i];
-    if (!data1.is_valid || !data1.tracker->isConfident(time, adaptive_threshold_cache_, ego_pose_))
+    if (!data1.is_valid || !data1.tracker->isConfident(adaptive_threshold_cache_, ego_pose_, time))
       continue;
 
     // Find nearby trackers using R-tree
@@ -463,7 +463,7 @@ bool TrackerProcessor::canMergeOverlappedTarget(
   }
 
   // 1. if the other is not confident, do not remove the target
-  if (!other.isConfident(time, adaptive_threshold_cache_, ego_pose_)) {
+  if (!other.isConfident(adaptive_threshold_cache_, ego_pose_, time)) {
     return false;
   }
 
@@ -512,7 +512,7 @@ void TrackerProcessor::getTrackedObjects(
   types::DynamicObject tracked_object;
   for (const auto & tracker : list_tracker_) {
     // check if the tracker is confident, if not, skip
-    if (!tracker->isConfident(time, adaptive_threshold_cache_, ego_pose_)) continue;
+    if (!tracker->isConfident(adaptive_threshold_cache_, ego_pose_, std::nullopt)) continue;
     // Get the tracked object, extrapolated to the given time
     constexpr bool to_publish = true;
     if (tracker->getTrackedObject(time, tracked_object, to_publish)) {
@@ -535,7 +535,7 @@ void TrackerProcessor::getTentativeObjects(
   types::DynamicObject tracked_object;
   for (const auto & tracker : list_tracker_) {
     // check if the tracker is confident, if so, skip
-    if (tracker->isConfident(time, adaptive_threshold_cache_, ego_pose_)) continue;
+    if (tracker->isConfident(adaptive_threshold_cache_, ego_pose_, std::nullopt)) continue;
     // Get the tracked object, extrapolated to the given time
     constexpr bool to_publish = false;
     if (tracker->getTrackedObject(time, tracked_object, to_publish)) {


### PR DESCRIPTION
## Description

isConfident is a method to determine whether the tracker is confident enough to be used for the following purpose.
- merge trackers
- publish

When extrapolation time is long (only when `enable_delay_compensation` is true), the position covariance becomes larger.
To make a fair and stable outcome, the function is enabled to choose given time, depends on its purpose.
- specific time (for merge trackers)
- last tracker time + constant interval (for publish)

The constant interval is used to consider motion (velocity) uncertainty into the position uncertainty.

## Related links

Related with PR https://github.com/autowarefoundation/autoware_universe/pull/11230

## How was this PR tested?

This test is over https://github.com/autowarefoundation/autoware_universe/pull/11230

Before

https://github.com/user-attachments/assets/4d7fca0d-c890-472c-a2d5-9bc5d6fdeadb


After

https://github.com/user-attachments/assets/697be767-593c-4595-b628-e31cc14d4ca6


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
