### PR TITLE
fix(diffusion_planner): change the order of width and length

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
@@ -76,7 +76,7 @@ struct AgentState
   // Construct a new instance filling all elements by `0.0f`.
   AgentState() = default;
 
-  explicit AgentState(TrackedObject & object);
+  explicit AgentState(const TrackedObject & object);
 
   /**
    * @brief Construct a new instance with specified values.

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -41,7 +41,7 @@ AgentLabel get_model_label(const autoware_perception_msgs::msg::TrackedObject & 
   }
 }
 
-AgentState::AgentState(TrackedObject & object)
+AgentState::AgentState(const TrackedObject & object)
 {
   position_ = object.kinematics.pose_with_covariance.pose.position;
   shape_ = object.shape;
@@ -118,8 +118,8 @@ void AgentState::apply_transform(const Eigen::Matrix4f & transform)
     sin_yaw(),
     vx(),
     vy(),
-    length(),
     width(),
+    length(),
     static_cast<float>(label_ == AgentLabel::VEHICLE),
     static_cast<float>(label_ == AgentLabel::PEDESTRIAN),
     static_cast<float>(label_ == AgentLabel::BICYCLE),


### PR DESCRIPTION
## Description

This PR fixes the order of width and length parameters in the diffusion planner to match the original implementation from the upstream repository.

- Original Diffusion Planner
  - https://github.com/ZhengYinan-AIR/Diffusion-Planner/blob/5659e494250523a603902e1c3dca0651d2e4c6fa/diffusion_planner/data_process/agent_process.py#L252-L253
- tier4/DiffusionPlanner
  - https://github.com/tier4/Diffusion-Planner/blob/bb38c7215fba922c7fbd02919f0c46663af15792/ros_scripts/parse_rosbag.py#L184-L185

## How was this PR tested?

run diffusion planner

See https://github.com/autowarefoundation/autoware_universe/pull/11110

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
