### PR TITLE
chore(accel_brake_map_calibrator): change output topic name of accel_brake_map_calibrator

### DIFF
--- a/vehicle/autoware_accel_brake_map_calibrator/launch/accel_brake_map_calibrator.launch.xml
+++ b/vehicle/autoware_accel_brake_map_calibrator/launch/accel_brake_map_calibrator.launch.xml
@@ -18,6 +18,12 @@
     <remap from="~/input/actuation_status" to="/vehicle/status/actuation_status"/>
     <remap from="~/input/actuation_cmd" to="/control/command/actuation_cmd"/>
     <remap from="~/input/update_map_dir" to="~/update_map_dir"/>
+    <remap from="~/output/update_suggest" to="~/update_suggest"/>
+    <remap from="~/output/update_raw_map" to="~/update_raw_map"/>
+    <remap from="~/output/debug_values" to="~/debug_values"/>
+    <remap from="~/output/current_map_error" to="~/current_map_error"/>
+    <remap from="~/output/updated_map_error" to="~/updated_map_error"/>
+    <remap from="~/output/map_error_ratio" to="~/map_error_ratio"/>
     <param name="csv_default_map_dir" value="$(var csv_default_map_dir)"/>
     <param name="csv_calibrated_map_dir" value="$(var csv_calibrated_map_dir)"/>
     <param name="output_log_file" value="$(find-pkg-share autoware_accel_brake_map_calibrator)/config/log.csv"/>


### PR DESCRIPTION
## Description

remove output suffix from accel_brake_map_calibrator's output topic

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
