### PR TITLE
feat(stop_mode_operator): shift gear to park on stop mode

### DIFF
--- a/control/autoware_stop_mode_operator/CMakeLists.txt
+++ b/control/autoware_stop_mode_operator/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   "src/stop_mode_operator.cpp"
+  "src/continuous_condition.cpp"
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/control/autoware_stop_mode_operator/README.md
+++ b/control/autoware_stop_mode_operator/README.md
@@ -1,3 +1,8 @@
 # autoware_stop_mode_operator
 
 This package publishes a stop command used when stop mode is selected.
+
+## Auto parking
+
+If `enable_auto_parking` is set to `true`, automatically shifts gear to parking when route is unset/arrived and the vehicle is stopped.
+Since the stop mode needs to work independently of localization, velocity should be taken from vehicle status instead of kinematic state.

--- a/control/autoware_stop_mode_operator/config/default.param.yaml
+++ b/control/autoware_stop_mode_operator/config/default.param.yaml
@@ -2,3 +2,4 @@
   ros__parameters:
     rate: 30.0
     stop_hold_acceleration: -1.5
+    enable_auto_parking: true

--- a/control/autoware_stop_mode_operator/src/continuous_condition.cpp
+++ b/control/autoware_stop_mode_operator/src/continuous_condition.cpp
@@ -1,0 +1,38 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "continuous_condition.hpp"
+
+namespace autoware::stop_mode_operator
+{
+
+void ContinuousCondition::update(const rclcpp::Time & stamp, bool condition)
+{
+  if (!condition) {
+    start_stamp_ = std::nullopt;
+  }
+  if (!start_stamp_) {
+    start_stamp_ = stamp;
+  }
+}
+
+bool ContinuousCondition::check(const rclcpp::Time & stamp, double duration) const
+{
+  if (!start_stamp_) {
+    return false;
+  }
+  return duration <= (stamp - *start_stamp_).seconds();
+}
+
+}  // namespace autoware::stop_mode_operator

--- a/control/autoware_stop_mode_operator/src/continuous_condition.hpp
+++ b/control/autoware_stop_mode_operator/src/continuous_condition.hpp
@@ -1,0 +1,37 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef CONTINUOUS_CONDITION_HPP_
+#define CONTINUOUS_CONDITION_HPP_
+
+#include <rclcpp/time.hpp>
+
+#include <optional>
+
+namespace autoware::stop_mode_operator
+{
+
+class ContinuousCondition
+{
+public:
+  void update(const rclcpp::Time & stamp, bool condition);
+  bool check(const rclcpp::Time & stamp, double duration) const;
+
+private:
+  std::optional<rclcpp::Time> start_stamp_;
+};
+
+}  // namespace autoware::stop_mode_operator
+
+#endif  // CONTINUOUS_CONDITION_HPP_

--- a/control/autoware_stop_mode_operator/src/stop_mode_operator.cpp
+++ b/control/autoware_stop_mode_operator/src/stop_mode_operator.cpp
@@ -20,7 +20,11 @@ namespace autoware::stop_mode_operator
 StopModeOperator::StopModeOperator(const rclcpp::NodeOptions & options)
 : Node("stop_mode_operator", options)
 {
+  current_steering_.steering_tire_angle = 0.0f;
+  current_route_state_.state = RouteState::UNKNOWN;
+
   stop_hold_acceleration_ = declare_parameter<double>("stop_hold_acceleration");
+  enable_auto_parking_ = declare_parameter<bool>("enable_auto_parking");
 
   const auto control_qos = rclcpp::QoS(5);
   const auto durable_qos = rclcpp::QoS(1).transient_local();
@@ -33,11 +37,24 @@ StopModeOperator::StopModeOperator(const rclcpp::NodeOptions & options)
   sub_steering_ = create_subscription<SteeringReport>(
     "/vehicle/status/steering_status", 1,
     [this](SteeringReport::SharedPtr msg) { current_steering_ = *msg; });
+  sub_velocity_ = create_subscription<VelocityReport>(
+    "/vehicle/status/velocity_status", 1, [this](VelocityReport::SharedPtr msg) {
+      vehicle_stop_check_.update(now(), std::abs(msg->longitudinal_velocity) < 1e-3);
+    });
+  sub_route_state_ = create_subscription<RouteState>(
+    "/planning/route_state", 1, [this](RouteState::SharedPtr msg) { current_route_state_ = *msg; });
 
   const auto period = rclcpp::Rate(declare_parameter<double>("rate")).period();
-  timer_ = rclcpp::create_timer(this, get_clock(), period, [this]() { publish_control_command(); });
+  timer_ = rclcpp::create_timer(this, get_clock(), period, [this]() { on_timer(); });
 
-  publish_trigger_command();
+  publish_turn_indicators_command();
+  publish_hazard_lights_command();
+}
+
+void StopModeOperator::on_timer()
+{
+  publish_control_command();
+  publish_gear_command();
 }
 
 void StopModeOperator::publish_control_command()
@@ -52,22 +69,38 @@ void StopModeOperator::publish_control_command()
   pub_control_->publish(control);
 }
 
-void StopModeOperator::publish_trigger_command()
+void StopModeOperator::publish_gear_command()
 {
-  const auto stamp = now();
+  bool parking = false;
 
-  GearCommand gear;
-  gear.stamp = stamp;
-  gear.command = GearCommand::NONE;
-  pub_gear_->publish(gear);
+  if (enable_auto_parking_) {
+    const bool parking_vehicle_stop = vehicle_stop_check_.check(now(), 1.0);
+    const bool parking_route_state = current_route_state_.state == RouteState::UNSET ||
+                                     current_route_state_.state == RouteState::ARRIVED;
+    parking = parking_route_state && parking_vehicle_stop;
+  }
 
+  if (last_parking_ != parking) {
+    GearCommand gear;
+    gear.stamp = now();
+    gear.command = parking ? GearCommand::PARK : GearCommand::NONE;
+    pub_gear_->publish(gear);
+  }
+  last_parking_ = parking;
+}
+
+void StopModeOperator::publish_turn_indicators_command()
+{
   TurnIndicatorsCommand turn_indicators;
-  turn_indicators.stamp = stamp;
+  turn_indicators.stamp = now();
   turn_indicators.command = TurnIndicatorsCommand::DISABLE;
   pub_turn_indicators_->publish(turn_indicators);
+}
 
+void StopModeOperator::publish_hazard_lights_command()
+{
   HazardLightsCommand hazard_lights;
-  hazard_lights.stamp = stamp;
+  hazard_lights.stamp = now();
   hazard_lights.command = HazardLightsCommand::DISABLE;
   pub_hazard_lights_->publish(hazard_lights);
 }

--- a/control/autoware_stop_mode_operator/src/stop_mode_operator.hpp
+++ b/control/autoware_stop_mode_operator/src/stop_mode_operator.hpp
@@ -15,22 +15,30 @@
 #ifndef STOP_MODE_OPERATOR_HPP_
 #define STOP_MODE_OPERATOR_HPP_
 
+#include "continuous_condition.hpp"
+
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
+#include <autoware_planning_msgs/msg/route_state.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
+
+#include <optional>
 
 namespace autoware::stop_mode_operator
 {
 
 using autoware_control_msgs::msg::Control;
+using autoware_planning_msgs::msg::RouteState;
 using autoware_vehicle_msgs::msg::GearCommand;
 using autoware_vehicle_msgs::msg::HazardLightsCommand;
 using autoware_vehicle_msgs::msg::SteeringReport;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
+using autoware_vehicle_msgs::msg::VelocityReport;
 
 class StopModeOperator : public rclcpp::Node
 {
@@ -38,18 +46,28 @@ public:
   explicit StopModeOperator(const rclcpp::NodeOptions & options);
 
 private:
+  void on_timer();
   void publish_control_command();
-  void publish_trigger_command();
+  void publish_gear_command();
+  void publish_turn_indicators_command();
+  void publish_hazard_lights_command();
+
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Publisher<Control>::SharedPtr pub_control_;
   rclcpp::Publisher<GearCommand>::SharedPtr pub_gear_;
   rclcpp::Publisher<TurnIndicatorsCommand>::SharedPtr pub_turn_indicators_;
   rclcpp::Publisher<HazardLightsCommand>::SharedPtr pub_hazard_lights_;
   rclcpp::Subscription<SteeringReport>::SharedPtr sub_steering_;
+  rclcpp::Subscription<VelocityReport>::SharedPtr sub_velocity_;
+  rclcpp::Subscription<RouteState>::SharedPtr sub_route_state_;
 
   SteeringReport current_steering_;
+  RouteState current_route_state_;
+  ContinuousCondition vehicle_stop_check_;
+  std::optional<bool> last_parking_;
 
   double stop_hold_acceleration_;
+  bool enable_auto_parking_;
 };
 
 }  // namespace autoware::stop_mode_operator


### PR DESCRIPTION
## Description

Shift gear to park on stop mode. This is to be consistent with shift_decider behavior. 

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-38870)

## How was this PR tested?

1. Drive the vehicle in autonomous mode using planning simulator.
1. Check that the gear is parking when the vehicle goals.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
