### PR TITLE
fix(behavior_velocity_traffic_light_module): modify the way the parameter is used

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -221,7 +221,7 @@ bool TrafficLightModule::willTrafficLightTurnRedBeforeReachingStopLine(
                                               ? distance_to_stop_line / ego_velocity
                                               : planner_param_.v2i_required_time_to_departure;
 
-  double seconds = predicted_passing_stop_line_time - planner_param_.v2i_last_time_allowed_to_pass;
+  double seconds = predicted_passing_stop_line_time + planner_param_.v2i_last_time_allowed_to_pass;
 
   rclcpp::Time now = clock_->now();
   // find stop signal from looking_tl_state_.predictions by using isTrafficSignalStop


### PR DESCRIPTION
## Description

The parameter sign was incorrect, so it has been corrected.

## Related links

- [TIER IV Slack](https://star4.slack.com/archives/C074CCKN35E/p1755837017797749?thread_ts=1754964298.664629&cid=C074CCKN35E)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
