### PR TITLE
fix(blind_spot): filter non-vru based on lateral clearance

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
@@ -144,7 +144,7 @@ private:
    * @brief filter objects whose position is inside the attention_area and whose type is target type
    */
   std::vector<autoware_perception_msgs::msg::PredictedObject> filter_attention_objects(
-    const lanelet::BasicPolygon2d & attention_area) const;
+    const lanelet::BasicPolygon2d & attention_area, const double lateral_gap) const;
 
   /**
    * @brief Check if object is belong to targeted classes
@@ -152,6 +152,8 @@ private:
    * @return True when object belong to targeted classes
    */
   bool isTargetObjectType(const autoware_perception_msgs::msg::PredictedObject & object) const;
+
+  static bool isVRUObjectType(const autoware_perception_msgs::msg::PredictedObject & object);
 
   /**
    * @brief compute the deceleration and jerk for collision stop from `ttc`

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
@@ -153,7 +153,7 @@ private:
    */
   bool isTargetObjectType(const autoware_perception_msgs::msg::PredictedObject & object) const;
 
-  static bool isVRUObjectType(const autoware_perception_msgs::msg::PredictedObject & object);
+  static bool is_vru_object_type(const autoware_perception_msgs::msg::PredictedObject & object);
 
   /**
    * @brief compute the deceleration and jerk for collision stop from `ttc`

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
@@ -18,7 +18,6 @@
 #include <autoware/lanelet2_utils/intersection.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
-#include <tl_expected/expected.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 
@@ -146,19 +145,14 @@ std::optional<StopPoints> generate_stop_points(
 /**
  * @brief Calculate the minimum lateral gap from the ego vehicle's side to the relevant road
  * boundary just before a turn.
- * @details This function determines the relevant side of the ego vehicle based on the turn
- * direction and extracts the corresponding road boundary (left boundary for a left turn, right for
- * a right turn) from the provided lanelets. It then uses an R-tree for an efficient spatial search
- * to find the shortest distance between the vehicle's side and that boundary.
  * @param[in] ego_footprint The 2D geometric footprint of the ego vehicle.
  * @param[in] last_lanelets_before_turning The lanelets the vehicle occupies just before the turn,
  * used to define the blind spot area boundary.
  * @param[in] turn_direction The direction of the upcoming turn (left/right), which determines the
  * relevant vehicle side and road boundary.
- * @return A tl::expected containing the minimum lateral distance in meters on success, or an error
- * string on failure.
+ * @return An optional value containing the minimum lateral distance in meters on success.
  */
-tl::expected<double, std::string> calc_ego_to_blind_spot_lanelet_lateral_gap(
+std::optional<double> calc_ego_to_blind_spot_lanelet_lateral_gap(
   const autoware_utils::LinearRing2d & footprint,
   const lanelet::ConstLanelets & lanelets_before_turning,
   const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
@@ -144,25 +144,23 @@ std::optional<StopPoints> generate_stop_points(
   autoware_internal_planning_msgs::msg::PathWithLaneId * path);
 
 /**
- * @brief Calculate the distance from the ego vehicle's footprint to the last lanelet's blind spot
- * boundary.
- *
- * @param[in] footprint The ego vehicle's footprint represented as a 2D polygon (must contain
- * exactly 7 points).
- * @param[in] last_lanelet_before_turning The last lanelet before the vehicle starts turning.
- * @param[in] turn_direction The turn direction (Left or Right) used to determine which side of the
- * footprint to measure.
- *
- * @return
- * - `tl::expected<double, std::string>`:
- *    - On success: The minimum distance [m] from the ego vehicle's side to the corresponding road
- * boundary.
- *    - On error: An unexpected result with a string describing the error, e.g. when the footprint
- * size is invalid.
+ * @brief Calculate the minimum lateral gap from the ego vehicle's side to the relevant road
+ * boundary just before a turn.
+ * @details This function determines the relevant side of the ego vehicle based on the turn
+ * direction and extracts the corresponding road boundary (left boundary for a left turn, right for
+ * a right turn) from the provided lanelets. It then uses an R-tree for an efficient spatial search
+ * to find the shortest distance between the vehicle's side and that boundary.
+ * @param[in] ego_footprint The 2D geometric footprint of the ego vehicle.
+ * @param[in] last_lanelets_before_turning The lanelets the vehicle occupies just before the turn,
+ * used to define the blind spot area boundary.
+ * @param[in] turn_direction The direction of the upcoming turn (left/right), which determines the
+ * relevant vehicle side and road boundary.
+ * @return A tl::expected containing the minimum lateral distance in meters on success, or an error
+ * string on failure.
  */
-tl::expected<double, std::string> calc_ego_to_last_blind_spot_lanelet_dist(
+tl::expected<double, std::string> calc_ego_to_blind_spot_lanelet_lateral_gap(
   const autoware_utils::LinearRing2d & footprint,
-  const lanelet::ConstLanelet & last_lanelet_before_turning,
+  const lanelet::ConstLanelets & lanelets_before_turning,
   const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction);
 }  // namespace autoware::behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
@@ -18,6 +18,7 @@
 #include <autoware/lanelet2_utils/intersection.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
+#include <tl_expected/expected.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 
@@ -26,6 +27,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -141,6 +143,27 @@ std::optional<StopPoints> generate_stop_points(
   const double ego_nearest_yaw_threshold,
   autoware_internal_planning_msgs::msg::PathWithLaneId * path);
 
+/**
+ * @brief Calculate the distance from the ego vehicle's footprint to the last lanelet's blind spot
+ * boundary.
+ *
+ * @param[in] footprint The ego vehicle's footprint represented as a 2D polygon (must contain
+ * exactly 7 points).
+ * @param[in] last_lanelet_before_turning The last lanelet before the vehicle starts turning.
+ * @param[in] turn_direction The turn direction (Left or Right) used to determine which side of the
+ * footprint to measure.
+ *
+ * @return
+ * - `tl::expected<double, std::string>`:
+ *    - On success: The minimum distance [m] from the ego vehicle's side to the corresponding road
+ * boundary.
+ *    - On error: An unexpected result with a string describing the error, e.g. when the footprint
+ * size is invalid.
+ */
+tl::expected<double, std::string> calc_ego_to_last_blind_spot_lanelet_dist(
+  const autoware_utils::LinearRing2d & footprint,
+  const lanelet::ConstLanelet & last_lanelet_before_turning,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction);
 }  // namespace autoware::behavior_velocity_planner
 
 #endif  // AUTOWARE__BEHAVIOR_VELOCITY_BLIND_SPOT_MODULE__UTIL_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -396,7 +396,7 @@ BlindSpotModule::filter_attention_objects(
     // if object is not VRU, check lateral clearance
     if (
       is_within_attention_area &&
-      (isVRUObjectType(object) || object.shape.dimensions.y < lateral_gap)) {
+      (is_vru_object_type(object) || object.shape.dimensions.y < lateral_gap)) {
       result.push_back(object);
     }
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -197,8 +197,8 @@ BlindSpotDecision BlindSpotModule::modifyPathVelocityDetail(PathWithLaneId * pat
   const auto ego_footprint = autoware_utils::transform_vector(
     planner_data_->vehicle_info_.createFootprint(),
     autoware_utils::pose2transform(planner_data_->current_odometry->pose));
-  const auto ego_to_blind_side_lat_gap_opt = calc_ego_to_last_blind_spot_lanelet_dist(
-    ego_footprint, last_blind_spot_lanelet_before_turning, turn_direction_);
+  const auto ego_to_blind_side_lat_gap_opt = calc_ego_to_blind_spot_lanelet_lateral_gap(
+    ego_footprint, blind_spot_lanelets_before_turning, turn_direction_);
 
   const auto attention_objects = filter_attention_objects(
     lanelet::utils::to2D(attention_area).basicPolygon(),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -446,7 +446,8 @@ bool BlindSpotModule::isTargetObjectType(
   return false;
 }
 
-bool BlindSpotModule::isVRUObjectType(const autoware_perception_msgs::msg::PredictedObject & object)
+bool BlindSpotModule::is_vru_object_type(
+  const autoware_perception_msgs::msg::PredictedObject & object)
 {
   return object.classification.at(0).label ==
            autoware_perception_msgs::msg::ObjectClassification::BICYCLE ||

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -194,8 +194,15 @@ BlindSpotDecision BlindSpotModule::modifyPathVelocityDetail(PathWithLaneId * pat
   const auto & ego_passage_time_interval = ego_passage_time_interval_opt.value();
   debug_data_.ego_passage_interval = ego_passage_time_interval;
 
-  const auto attention_objects =
-    filter_attention_objects(lanelet::utils::to2D(attention_area).basicPolygon());
+  const auto ego_footprint = autoware_utils::transform_vector(
+    planner_data_->vehicle_info_.createFootprint(),
+    autoware_utils::pose2transform(planner_data_->current_odometry->pose));
+  const auto ego_to_blind_side_lat_gap_opt = calc_ego_to_last_blind_spot_lanelet_dist(
+    ego_footprint, last_blind_spot_lanelet_before_turning, turn_direction_);
+
+  const auto attention_objects = filter_attention_objects(
+    lanelet::utils::to2D(attention_area).basicPolygon(),
+    ego_to_blind_side_lat_gap_opt.value_or(std::numeric_limits<double>::max()));
 
   const auto unsafe_objects = collect_unsafe_objects(
     attention_objects, ego_intersection_path_lanelet, ego_passage_time_interval);
@@ -373,7 +380,8 @@ std::vector<UnsafeObject> BlindSpotModule::collect_unsafe_objects(
 }
 
 std::vector<autoware_perception_msgs::msg::PredictedObject>
-BlindSpotModule::filter_attention_objects(const lanelet::BasicPolygon2d & attention_area) const
+BlindSpotModule::filter_attention_objects(
+  const lanelet::BasicPolygon2d & attention_area, const double lateral_gap) const
 {
   std::vector<autoware_perception_msgs::msg::PredictedObject> result;
   for (const auto & object : planner_data_->predicted_objects->objects) {
@@ -382,8 +390,13 @@ BlindSpotModule::filter_attention_objects(const lanelet::BasicPolygon2d & attent
     }
     const auto & position = object.kinematics.initial_pose_with_covariance.pose.position;
     // NOTE: use position of the object because vru object polygon around blind_spot is unstable
-    if (boost::geometry::within(
-          autoware_utils_geometry::Point2d{position.x, position.y}, attention_area)) {
+    const auto is_within_attention_area = boost::geometry::within(
+      autoware_utils_geometry::Point2d{position.x, position.y}, attention_area);
+
+    // if object is not VRU, check lateral clearance
+    if (
+      is_within_attention_area &&
+      (isVRUObjectType(object) || object.shape.dimensions.y < lateral_gap)) {
       result.push_back(object);
     }
   }
@@ -431,6 +444,16 @@ bool BlindSpotModule::isTargetObjectType(
     return true;
   }
   return false;
+}
+
+bool BlindSpotModule::isVRUObjectType(const autoware_perception_msgs::msg::PredictedObject & object)
+{
+  return object.classification.at(0).label ==
+           autoware_perception_msgs::msg::ObjectClassification::BICYCLE ||
+         object.classification.at(0).label ==
+           autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN ||
+         object.classification.at(0).label ==
+           autoware_perception_msgs::msg::ObjectClassification::MOTORCYCLE;
 }
 
 std::pair<double, double> BlindSpotModule::compute_decel_and_jerk_from_ttc(const double ttc) const

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -685,7 +685,7 @@ std::optional<StopPoints> generate_stop_points(
     std::nullopt, stop_points_list.instant_stopline, stop_points_list.critical_stopline};
 }
 
-tl::expected<double, std::string> calc_ego_to_blind_spot_lanelet_lateral_gap(
+std::optional<double> calc_ego_to_blind_spot_lanelet_lateral_gap(
   const autoware_utils::LinearRing2d & ego_footprint,
   const lanelet::ConstLanelets & last_lanelets_before_turning,
   const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction)
@@ -711,13 +711,13 @@ tl::expected<double, std::string> calc_ego_to_blind_spot_lanelet_lateral_gap(
   }
 
   if (line.size() < 2) {
-    return tl::make_unexpected("Not enough points in lanelet boundary.");
+    return std::nullopt;
   }
 
   std::vector<autoware_utils::Segment2d> segments;
   segments.reserve(line.size() - 1);
-  for (size_t i = 0; i + 1 < line.size(); ++i) {
-    segments.emplace_back(line[i], line[i + 1]);
+  for (const auto & [p1, p2] : ranges::views::zip(line, line | ranges::views::drop(1))) {
+    segments.emplace_back(p1, p2);
   }
 
   bg::index::rtree<autoware_utils::Segment2d, bg::index::rstar<16>> segments_before_turning{

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -20,6 +20,7 @@
 #include <autoware/lanelet2_utils/topology.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <range/v3/all.hpp>
 
 #include <boost/geometry/algorithms/area.hpp>
@@ -689,15 +690,14 @@ tl::expected<double, std::string> calc_ego_to_blind_spot_lanelet_lateral_gap(
   const lanelet::ConstLanelets & last_lanelets_before_turning,
   const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction)
 {
-  if (ego_footprint.size() != 7) {
-    return tl::make_unexpected("Unexpected ego_footprint's size.");
-  }
-
-  // left front is 6, left back is 4, right_front is 1, right_back is 3
-  const auto front_idx = (turn_direction == TurnDirection::Left) ? 6 : 1;
-  const auto back_idx = (turn_direction == TurnDirection::Left) ? 4 : 3;
+  const auto front_idx = (turn_direction == TurnDirection::Left)
+                           ? vehicle_info_utils::VehicleInfo::FrontLeftIndex
+                           : vehicle_info_utils::VehicleInfo::FrontRightIndex;
+  const auto rear_idx = (turn_direction == TurnDirection::Left)
+                          ? vehicle_info_utils::VehicleInfo::RearLeftIndex
+                          : vehicle_info_utils::VehicleInfo::RearRightIndex;
   const auto ego_side =
-    autoware_utils::Segment2d{ego_footprint[front_idx], ego_footprint[back_idx]};
+    autoware_utils::Segment2d{ego_footprint[front_idx], ego_footprint[rear_idx]};
 
   std::vector<autoware_utils::Point2d> line;
   for (const auto & ll : last_lanelets_before_turning) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -699,15 +699,19 @@ tl::expected<double, std::string> calc_ego_to_blind_spot_lanelet_lateral_gap(
   const auto ego_side =
     autoware_utils::Segment2d{ego_footprint[front_idx], ego_footprint[back_idx]};
 
-  autoware_utils::LineString2d line;
+  std::vector<autoware_utils::Point2d> line;
   for (const auto & ll : last_lanelets_before_turning) {
     const auto & attention_area_road_boundary = lanelet::utils::to2D(
       (turn_direction == TurnDirection::Left) ? ll.leftBound() : ll.rightBound());
     const auto ll_2d = lanelet::utils::to2D(attention_area_road_boundary);
 
     for (const auto & ls : ll_2d) {
-      line.push_back(autoware_utils::Point2d{ls.x(), ls.y()});
+      line.emplace_back(ls.x(), ls.y());
     }
+  }
+
+  if (line.size() < 2) {
+    return tl::make_unexpected("Not enough points in lanelet boundary.");
   }
 
   std::vector<autoware_utils::Segment2d> segments;


### PR DESCRIPTION
## Description

The blind spot module currently slows down the vehicle whenever an object overlaps with the attention area.
This can result in false positives when an object’s width is larger than the available lateral clearance.

VRUs (pedestrians, bicycles, motorcycles): Their size is generally small, and they have more flexibility to squeeze through narrow gaps. Prediction noise may also cause their detected size to fluctuate, but this is acceptable. The current logic continues to handle VRUs as before.

Non-VRUs (e.g., cars): Their maneuverability is limited and they cannot realistically pass through gaps smaller than their width, which leads to unnecessary stop in the current approach.

<img width="1032" height="644" alt="image" src="https://github.com/user-attachments/assets/22c1a5a8-a705-4da7-be40-7eb6b74f99e6" />


### Fix

This PR updates the blind spot check only for non-VRUs by comparing the lateral clearance with the object’s width.

If the clearance is smaller than the object’s width, the object is assumed unable to pass through and is ignored for safety decisions.

VRU handling remains unchanged.

This reduces unnecessary slowdowns for non-VRUs, while keeping conservative behavior for VRUs.

## Related links

[TIER IV Internal Link - Issue's ticket](https://tier4.atlassian.net/browse/RT0-39023)
[TIER IV Internal Link - Issue's ticket](https://tier4.atlassian.net/browse/RT0-39024)

## How was this PR tested?

### Test 1: Perception reproducers

Testing when the gap is smaller than the width of non-vru targets

https://github.com/user-attachments/assets/297b3e10-56e4-446e-8ad4-824e42338be2


When there's sufficient gap for non-vru targets to pass through

https://github.com/user-attachments/assets/4172f316-2d0f-418d-ad9e-3ef5ca743358

2. [Evaluator]

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/400cdad4-c9f7-508d-8bd4-31ee73a9579b?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/52bbf013-e911-5cf9-b3b8-4bfe2afd2318?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/b73a1489-19b5-5d35-8a96-e095bea30964?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
