### PR TITLE
fix[autoware_trajectory_follower_node]: change plot label of data[25] from calculated to feedback

### DIFF
--- a/control/autoware_trajectory_follower_node/config/plot_juggler_trajectory_follower.xml
+++ b/control/autoware_trajectory_follower_node/config/plot_juggler_trajectory_follower.xml
@@ -202,7 +202,7 @@
         </transform>
        </curve>
        <curve name="/control/trajectory_follower/longitudinal/diagnostic/data[25]" color="#ff7f0e">
-        <transform alias="calculated" name="Scale/Offset">
+        <transform alias="feedback" name="Scale/Offset">
          <options value_scale="1.0" time_offset="0" value_offset="0"/>
         </transform>
        </curve>


### PR DESCRIPTION
## Description
Change the label name of `longitudinal/diagnostic/data[25]` in the Longitudinal Controller Info section.
Because this will mislead the user into thinking that this is an acc command.
`longitudinal/diagnostic/data[25]` is actually the acc feedback (measured acc).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
