### PR TITLE
feat(goal_planner): ignore parked object in bus_stop

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_searcher.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_searcher.hpp
@@ -62,6 +62,11 @@ public:
 
   bool bus_stop_area_available() const { return !bus_stop_area_polygons_.empty(); }
 
+  const lanelet::BasicPolygons2d & bus_stop_area_polygons() const
+  {
+    return bus_stop_area_polygons_;
+  }
+
 private:
   GoalSearcher(
     const GoalPlannerParameters & parameters, const LinearRing2d & vehicle_footprint,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -62,6 +62,27 @@ using autoware_utils::calc_offset_pose;
 using autoware_utils::create_marker_color;
 using nav_msgs::msg::OccupancyGrid;
 
+namespace
+{
+autoware_perception_msgs::msg::PredictedObjects remove_objects_in_bus_stop_area(
+  const autoware_perception_msgs::msg::PredictedObjects & static_objects,
+  const lanelet::BasicPolygons2d & bus_stop_areas)
+{
+  autoware_perception_msgs::msg::PredictedObjects filtered;
+  for (const auto & static_object : static_objects.objects) {
+    const auto & pose = static_object.kinematics.initial_pose_with_covariance.pose;
+    const auto poly = autoware_utils_geometry::to_polygon2d(pose, static_object.shape);
+    const auto is_around_bus_stop_area = std::any_of(
+      bus_stop_areas.begin(), bus_stop_areas.end(),
+      [&](const auto & area) { return boost::geometry::intersects(poly, area); });
+    if (!is_around_bus_stop_area) {
+      filtered.objects.push_back(static_object);
+    }
+  }
+  return filtered;
+}
+}  // namespace
+
 namespace autoware::behavior_path_planner
 {
 GoalPlannerModule::GoalPlannerModule(
@@ -773,10 +794,16 @@ void GoalPlannerModule::updateData()
   debug_data_.collision_check = collision_check_map;
   // update to latest state
   // extract static and dynamic objects in extraction polygon for path collision check
-  const auto dynamic_target_objects = goal_planner_utils::extract_dynamic_objects(
+  const auto dynamic_target_objects_all = goal_planner_utils::extract_dynamic_objects(
     *(planner_data_->dynamic_object), *(planner_data_->route_handler), parameters_,
     planner_data_->parameters.vehicle_width, planner_data_->self_odometry->pose.pose,
     std::ref(debug_data_.objects_extraction_polygon));
+  const auto & dynamic_target_objects =
+    parameters_.bus_stop_area.use_bus_stop_area
+      ? remove_objects_in_bus_stop_area(
+          dynamic_target_objects_all, goal_searcher.bus_stop_area_polygons())
+      : dynamic_target_objects_all;
+
   const auto static_target_objects = utils::path_safety_checker::filterObjectsByVelocity(
     dynamic_target_objects, parameters_.th_moving_object_velocity);
 


### PR DESCRIPTION
## Description

if the flag `bus_stop_area.use_bus_stop_area` is true, the objects overlapping with the designated bus_stop_area are ignore in goal_planner, to delegate the stopping feature to obstacle_stop

https://github.com/user-attachments/assets/3c77f1c4-b645-4c58-87b9-5ff39d872cb9

## Related links

https://tier4.atlassian.net/browse/RT0-38852

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/50a59408-4c69-5df3-92c5-264159ec6718?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/66ae64d3-ce26-59bd-932c-5c707eb0ea29?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/e8bc3d48-716f-559a-b589-68fcde6057c7?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
