### PR TITLE
fix(start_planner): clothoid collision check offset parameter

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
@@ -521,14 +521,15 @@ Generate smooth paths using clothoid curves that provide continuous curvature tr
 
 #### parameters for clothoid pull out
 
-| Name                                      | Unit    | Type   | Description                                                                              | Default value     |
-| :---------------------------------------- | :------ | :----- | :--------------------------------------------------------------------------------------- | :---------------- |
-| enable_clothoid_fallback                  | [-]     | bool   | flag whether to enable clothoid path search when no path is found with collision margins | true              |
-| clothoid_initial_velocity                 | [m/s]   | double | initial velocity for clothoid path                                                       | 1.0               |
-| clothoid_acceleration                     | [m/s²]  | double | acceleration for clothoid path                                                           | 1.0               |
-| clothoid_max_steer_angles_deg             | [deg]   | double | maximum steer angles to try                                                              | [5.0, 10.0, 20.0] |
-| clothoid_max_steer_angle_rate_deg_per_sec | [deg/s] | double | maximum steer angle rate                                                                 | 10.0              |
-| check_clothoid_path_lane_departure        | [-]     | bool   | flag whether to check if clothoid path footprints are out of lane                        | true              |
+| Name                                       | Unit    | Type   | Description                                                                              | Default value     |
+| :----------------------------------------- | :------ | :----- | :--------------------------------------------------------------------------------------- | :---------------- |
+| enable_clothoid_fallback                   | [-]     | bool   | flag whether to enable clothoid path search when no path is found with collision margins | true              |
+| clothoid_initial_velocity                  | [m/s]   | double | initial velocity for clothoid path                                                       | 1.0               |
+| clothoid_acceleration                      | [m/s²]  | double | acceleration for clothoid path                                                           | 1.0               |
+| clothoid_max_steer_angles_deg              | [deg]   | double | maximum steer angles to try                                                              | [5.0, 10.0, 20.0] |
+| clothoid_max_steer_angle_rate_deg_per_sec  | [deg/s] | double | maximum steer angle rate                                                                 | 10.0              |
+| clothoid_collision_check_distance_from_end | [m]     | double | collision check distance from end for clothoid planner                                   | 0.0               |
+| check_clothoid_path_lane_departure         | [-]     | bool   | flag whether to check if clothoid path footprints are out of lane                        | true              |
 
 ## **backward pull out start point search**
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -51,6 +51,7 @@
       clothoid_acceleration: 1.0      # [m/s^2] acceleration for clothoid path
       clothoid_max_steer_angles_deg: [5.0, 10.0, 20.0]  # [deg] maximum steer angles to try
       clothoid_max_steer_angle_rate_deg_per_sec: 10.0   # [deg/s] maximum steer angle rate
+      clothoid_collision_check_distance_from_end: 0.0  # [m] collision check distance from end for clothoid planner
       check_clothoid_path_lane_departure: true  # enable lane departure check for clothoid path
 
       # search start pose backward
@@ -125,7 +126,7 @@
           # detection range
           object_check_forward_distance: 10.0
           object_check_backward_distance: 100.0
-          ignore_object_velocity_threshold: 1.0
+          ignore_object_velocity_threshold: 0.25
           # ObjectTypesToCheck
           object_types_to_check:
             check_car: true

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/data_structs.hpp
@@ -318,6 +318,7 @@ struct StartPlannerParameters
   double clothoid_acceleration{0.0};
   std::vector<double> clothoid_max_steer_angles_deg{};
   double clothoid_max_steer_angle_rate_deg_per_sec{0.0};
+  double clothoid_collision_check_distance_from_end{0.0};
   bool check_clothoid_path_lane_departure{true};  // enable lane departure check for clothoid path
 
   // search start pose backward

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -1429,12 +1429,13 @@ std::optional<PullOutPath> ClothoidPullOut::plan(
     temp_pull_out_path.end_pose = target_pose;
 
     if (isPullOutPathCollided(
-          temp_pull_out_path, planner_data, parameters_.shift_collision_check_distance_from_end)) {
+          temp_pull_out_path, planner_data,
+          parameters_.clothoid_collision_check_distance_from_end)) {
       RCLCPP_INFO(
         rclcpp::get_logger("ClothoidPullOut"),
         "Collision detected for steer angle %.2f deg with margin %.2f m. Continuing to next "
         "candidate.",
-        rad2deg(steer_angle), parameters_.shift_collision_check_distance_from_end);
+        rad2deg(steer_angle), parameters_.clothoid_collision_check_distance_from_end);
       planner_debug_data.conditions_evaluation.emplace_back("collision");
       continue;
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/data_structs.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/data_structs.cpp
@@ -100,6 +100,8 @@ StartPlannerParameters StartPlannerParameters::init(rclcpp::Node & node)
       get_or_declare_parameter<std::vector<double>>(node, ns + "clothoid_max_steer_angles_deg");
     p.clothoid_max_steer_angle_rate_deg_per_sec =
       get_or_declare_parameter<double>(node, ns + "clothoid_max_steer_angle_rate_deg_per_sec");
+    p.clothoid_collision_check_distance_from_end =
+      get_or_declare_parameter<double>(node, ns + "clothoid_collision_check_distance_from_end");
     p.check_clothoid_path_lane_departure =
       get_or_declare_parameter<bool>(node, ns + "check_clothoid_path_lane_departure");
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/manager.cpp
@@ -140,6 +140,9 @@ void StartPlannerModuleManager::updateModuleParams(
     update_param<double>(
       parameters, ns + "clothoid_max_steer_angle_rate_deg_per_sec",
       p->clothoid_max_steer_angle_rate_deg_per_sec);
+    update_param<double>(
+      parameters, ns + "clothoid_collision_check_distance_from_end",
+      p->clothoid_collision_check_distance_from_end);
     update_param<bool>(
       parameters, ns + "check_clothoid_path_lane_departure", p->check_clothoid_path_lane_departure);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -1981,7 +1981,8 @@ void StartPlannerModule::setDebugData()
   {
     std::map<PlannerType, double> collision_check_distances = {
       {PlannerType::SHIFT, parameters_->shift_collision_check_distance_from_end},
-      {PlannerType::GEOMETRIC, parameters_->geometric_collision_check_distance_from_end}};
+      {PlannerType::GEOMETRIC, parameters_->geometric_collision_check_distance_from_end},
+      {PlannerType::CLOTHOID, parameters_->clothoid_collision_check_distance_from_end}};
 
     double collision_check_distance_from_end = collision_check_distances[status_.planner_type];
     const auto collision_check_end_pose = autoware::motion_utils::calcLongitudinalOffsetPose(


### PR DESCRIPTION
## Description

parameter change [PR](https://github.com/autowarefoundation/autoware_launch/pull/1621) should be merged together

This PR fixes an issue where the clothoid pull-out functionality was incorrectly using `shift_collision_check_distance_from_end` parameter for collision checking, and adds a dedicated parameter `clothoid_collision_check_distance_from_end` for proper configuration.

- Added the new dedicated parameter `clothoid_collision_check_distance_from_end` to configuration files, data structures, and parameter handling
- Adjusted the default `ignore_object_velocity_threshold` from 1.0 to 0.25 m/s for more sensitive object detection(default value was updated in autoware_launch repository before)

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- run psim

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                               | Type     | Default Value | Description                                            |
| :---------- | :------------------------------------------- | :------- | :------------ | :----------------------------------------------------- |
| Added       | `clothoid_collision_check_distance_from_end` | `double` | `0.0`         | collision check distance from end for clothoid planner |

#### Modifications

| Version | Parameter Name                     | Type     | Default Value | Description                             |
| :------ | :--------------------------------- | :------- | :------------ | :-------------------------------------- |
| Old     | `ignore_object_velocity_threshold` | `double` | `1.0`         | velocity threshold for ignoring objects |
| New     | `ignore_object_velocity_threshold` | `double` | `0.25`        | velocity threshold for ignoring objects |

## Effects on system behavior

None.
