### PR TITLE
fix(multi object tracker): bug fix of object position from tracker state vector

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -50,12 +50,14 @@ private:
       2.7416e-5;  // [rad^2/s^2] uncertain slip angle change rate, 0.3 deg/s
     double q_cov_slip_rate_max = 0.03046;  // [rad^2/s^2] uncertain slip angle change rate, 10 deg/s
     double q_max_slip_angle = 0.5236;      // [rad] max slip angle, 30deg
-    double lf_ratio = 0.3;     // [-] ratio of the distance from the center to the front wheel
-    double lr_ratio = 0.25;    // [-] ratio of the distance from the center to the rear wheel
-    double lf_min = 1.0;       // [m] minimum distance from the center to the front wheel
-    double lr_min = 1.0;       // [m] minimum distance from the center to the rear wheel
-    double max_vel = 27.8;     // [m/s] maximum velocity, 100km/h
-    double max_slip = 0.5236;  // [rad] maximum slip angle, 30deg
+    double lf_ratio = 0.3;   // [-] ratio of the distance from the center to the front wheel
+    double lr_ratio = 0.25;  // [-] ratio of the distance from the center to the rear wheel
+    double lf_min = 1.0;     // [m] minimum distance from the center to the front wheel
+    double lr_min = 1.0;     // [m] minimum distance from the center to the rear wheel
+    double wheel_base_ratio_inv =
+      1 / (lf_ratio + lr_ratio);  // [-] inverse of the sum of lf_ratio and lr_ratio
+    double max_vel = 27.8;        // [m/s] maximum velocity, 100km/h
+    double max_slip = 0.5236;     // [rad] maximum slip angle, 30deg
     double max_reverse_vel =
       -1.389;  // [m/s] maximum reverse velocity, -5km/h. The value is expected to be negative
     double wheel_pos_ratio =

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -60,6 +60,8 @@ void BicycleMotionModel::setMotionParams(
   motion_params_.lr_min = bicycle_state.wheel_pos_rear_min;
   motion_params_.lf_ratio = bicycle_state.wheel_pos_ratio_front;
   motion_params_.lr_ratio = bicycle_state.wheel_pos_ratio_rear;
+  motion_params_.wheel_base_ratio_inv =
+    1.0 / (bicycle_state.wheel_pos_ratio_front + bicycle_state.wheel_pos_ratio_rear);
 
   motion_params_.wheel_pos_ratio =
     (motion_params_.lf_ratio + motion_params_.lr_ratio) / motion_params_.lr_ratio;
@@ -340,11 +342,11 @@ bool BicycleMotionModel::limitStates()
     // rotate the object orientation by 180 degrees
     // replace X1 and Y1 with X2 and Y2
     const double x_center =
-      (X_t(IDX::X1) * motion_params_.lf_ratio + X_t(IDX::X2) * motion_params_.lr_ratio) /
-      (motion_params_.lr_ratio + motion_params_.lf_ratio);
+      (X_t(IDX::X1) * motion_params_.lf_ratio + X_t(IDX::X2) * motion_params_.lr_ratio) *
+      motion_params_.wheel_base_ratio_inv;
     const double y_center =
-      (X_t(IDX::Y1) * motion_params_.lf_ratio + X_t(IDX::Y2) * motion_params_.lr_ratio) /
-      (motion_params_.lr_ratio + motion_params_.lf_ratio);
+      (X_t(IDX::Y1) * motion_params_.lf_ratio + X_t(IDX::Y2) * motion_params_.lr_ratio) *
+      motion_params_.wheel_base_ratio_inv;
     const double x1_rel = X_t(IDX::X1) - x_center;
     const double y1_rel = X_t(IDX::Y1) - y_center;
     const double x2_rel = X_t(IDX::X2) - x_center;
@@ -582,10 +584,10 @@ bool BicycleMotionModel::getPredictedState(
   const double wheel_base_inv_sq = wheel_base_inv * wheel_base_inv;
 
   // set position
-  pose.position.x = (X(IDX::X1) * motion_params_.lf_ratio + X(IDX::X2) * motion_params_.lr_ratio) /
-                    (motion_params_.lr_ratio + motion_params_.lf_ratio);
-  pose.position.y = (X(IDX::Y1) * motion_params_.lf_ratio + X(IDX::Y2) * motion_params_.lr_ratio) /
-                    (motion_params_.lr_ratio + motion_params_.lf_ratio);
+  pose.position.x = (X(IDX::X1) * motion_params_.lf_ratio + X(IDX::X2) * motion_params_.lr_ratio) *
+                    motion_params_.wheel_base_ratio_inv;
+  pose.position.y = (X(IDX::Y1) * motion_params_.lf_ratio + X(IDX::Y2) * motion_params_.lr_ratio) *
+                    motion_params_.wheel_base_ratio_inv;
   // do not change z
 
   // set orientation

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -81,8 +81,6 @@ bool BicycleMotionModel::initialize(
 {
   double lr = length * motion_params_.lr_ratio;
   double lf = length * motion_params_.lf_ratio;
-  lr = std::max(lr, motion_params_.lr_min);
-  lf = std::max(lf, motion_params_.lf_min);
   const double x1 = x - lr * std::cos(yaw);
   const double y1 = y - lr * std::sin(yaw);
   const double x2 = x + lf * std::cos(yaw);
@@ -145,8 +143,6 @@ bool BicycleMotionModel::updateStatePoseHead(
   // convert the state to the bicycle model state
   double lr = length * motion_params_.lr_ratio;
   double lf = length * motion_params_.lf_ratio;
-  lr = std::max(lr, motion_params_.lr_min);
-  lf = std::max(lf, motion_params_.lf_min);
   const double cos_yaw = std::cos(yaw);
   const double sin_yaw = std::sin(yaw);
   const double x1 = x - lr * cos_yaw;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -586,8 +586,10 @@ bool BicycleMotionModel::getPredictedState(
   const double wheel_base_inv_sq = wheel_base_inv * wheel_base_inv;
 
   // set position
-  pose.position.x = 0.5 * (X(IDX::X1) + X(IDX::X2));
-  pose.position.y = 0.5 * (X(IDX::Y1) + X(IDX::Y2));
+  pose.position.x = (X(IDX::X1) * motion_params_.lr_ratio + X(IDX::X2) * motion_params_.lf_ratio) /
+                    (motion_params_.lr_ratio + motion_params_.lf_ratio);
+  pose.position.y = (X(IDX::Y1) * motion_params_.lr_ratio + X(IDX::Y2) * motion_params_.lf_ratio) /
+                    (motion_params_.lr_ratio + motion_params_.lf_ratio);
   // do not change z
 
   // set orientation

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -81,8 +81,8 @@ bool BicycleMotionModel::initialize(
   const std::array<double, 36> & pose_cov, const double & vel_long, const double & vel_long_cov,
   const double & vel_lat, const double & vel_lat_cov, const double & length)
 {
-  double lr = length * motion_params_.lr_ratio;
-  double lf = length * motion_params_.lf_ratio;
+  const double lr = length * motion_params_.lr_ratio;
+  const double lf = length * motion_params_.lf_ratio;
   const double x1 = x - lr * std::cos(yaw);
   const double y1 = y - lr * std::sin(yaw);
   const double x2 = x + lf * std::cos(yaw);
@@ -143,8 +143,8 @@ bool BicycleMotionModel::updateStatePoseHead(
   if (!checkInitialized()) return false;
 
   // convert the state to the bicycle model state
-  double lr = length * motion_params_.lr_ratio;
-  double lf = length * motion_params_.lf_ratio;
+  const double lr = length * motion_params_.lr_ratio;
+  const double lf = length * motion_params_.lf_ratio;
   const double cos_yaw = std::cos(yaw);
   const double sin_yaw = std::sin(yaw);
   const double x1 = x - lr * cos_yaw;
@@ -205,8 +205,8 @@ bool BicycleMotionModel::updateStatePoseHeadVel(
   if (!checkInitialized()) return false;
 
   // convert the state to the bicycle model state
-  double lr = length * motion_params_.lr_ratio;
-  double lf = length * motion_params_.lf_ratio;
+  const double lr = length * motion_params_.lr_ratio;
+  const double lf = length * motion_params_.lf_ratio;
   const double cos_yaw = std::cos(yaw);
   const double sin_yaw = std::sin(yaw);
   const double x1 = x - lr * cos_yaw;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -340,10 +340,10 @@ bool BicycleMotionModel::limitStates()
     // rotate the object orientation by 180 degrees
     // replace X1 and Y1 with X2 and Y2
     const double x_center =
-      (X_t(IDX::X1) * motion_params_.lr_ratio + X_t(IDX::X2) * motion_params_.lf_ratio) /
+      (X_t(IDX::X1) * motion_params_.lf_ratio + X_t(IDX::X2) * motion_params_.lr_ratio) /
       (motion_params_.lr_ratio + motion_params_.lf_ratio);
     const double y_center =
-      (X_t(IDX::Y1) * motion_params_.lr_ratio + X_t(IDX::Y2) * motion_params_.lf_ratio) /
+      (X_t(IDX::Y1) * motion_params_.lf_ratio + X_t(IDX::Y2) * motion_params_.lr_ratio) /
       (motion_params_.lr_ratio + motion_params_.lf_ratio);
     const double x1_rel = X_t(IDX::X1) - x_center;
     const double y1_rel = X_t(IDX::Y1) - y_center;
@@ -582,9 +582,9 @@ bool BicycleMotionModel::getPredictedState(
   const double wheel_base_inv_sq = wheel_base_inv * wheel_base_inv;
 
   // set position
-  pose.position.x = (X(IDX::X1) * motion_params_.lr_ratio + X(IDX::X2) * motion_params_.lf_ratio) /
+  pose.position.x = (X(IDX::X1) * motion_params_.lf_ratio + X(IDX::X2) * motion_params_.lr_ratio) /
                     (motion_params_.lr_ratio + motion_params_.lf_ratio);
-  pose.position.y = (X(IDX::Y1) * motion_params_.lr_ratio + X(IDX::Y2) * motion_params_.lf_ratio) /
+  pose.position.y = (X(IDX::Y1) * motion_params_.lf_ratio + X(IDX::Y2) * motion_params_.lr_ratio) /
                     (motion_params_.lr_ratio + motion_params_.lf_ratio);
   // do not change z
 


### PR DESCRIPTION
## Description
After https://github.com/autowarefoundation/autoware_universe/pull/11230, detected object and the tracked object position is shifted.
This is due to a faulty implementation of object center position calculation from the tracker state vector.

Before fix
<img width="1219" height="1136" alt="Screenshot from 2025-08-26 16-50-46" src="https://github.com/user-attachments/assets/9b0b3d0d-11c9-475e-9646-c4f386f20bab" />

Red: detected object
Blue: tracked object

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

tested by planning simulator

After fix

<img width="1219" height="1136" alt="Screenshot from 2025-08-26 16-58-47" src="https://github.com/user-attachments/assets/ba013b73-7065-4a82-bb18-08e2db2f8465" />



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
