### PR TITLE
fix(blind_spot): cut virtual blind lines up to intersection lanelet's bound

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
@@ -123,7 +123,8 @@ std::optional<lanelet::LineString3d> generate_virtual_ego_straight_path_after_tu
  */
 lanelet::LineString3d clip_virtual_line_to_intersection_bound(
   const lanelet::BasicPoint3d & virtual_line_start, const lanelet::BasicPoint3d & virtual_line_end,
-  const lanelet::ConstLanelet & intersection_lanelet);
+  const lanelet::ConstLanelet & intersection_lanelet,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction);
 
 /**
  * @brief generate a polygon representing the Path along the intersection lane, with given

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/util.hpp
@@ -98,8 +98,8 @@ generate_blind_side_lanelets_before_turning(
  */
 lanelet::ConstLineString3d generate_virtual_blind_side_boundary_after_turning(
   const lanelet::ConstLanelet & outermost_lanelet,
-  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction,
-  const double extend_length);
+  const lanelet::ConstLanelet & intersection_lanelet,
+  const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction);
 
 /**
  * @brief generate virtual LineString which is normal to the entry line of `intersection_lanelet`,
@@ -112,6 +112,18 @@ std::optional<lanelet::LineString3d> generate_virtual_ego_straight_path_after_tu
   const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
   const autoware::experimental::lanelet2_utils::TurnDirection & turn_direction,
   const double ego_width);
+
+/**
+ * @brief Clip a virtual line so it ends at the farthest intersected point with the given
+ * intersection lanelet’s bounds.
+ *
+ * @return lanelet::LineString3d A linestring containing the start point and either:
+ *         - the original end point (if no intersected points found), or
+ *         - the farthest intersected point with intersection lanelet's bounds.
+ */
+lanelet::LineString3d clip_virtual_line_to_intersection_bound(
+  const lanelet::BasicPoint3d & virtual_line_start, const lanelet::BasicPoint3d & virtual_line_end,
+  const lanelet::ConstLanelet & intersection_lanelet);
 
 /**
  * @brief generate a polygon representing the Path along the intersection lane, with given

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -128,8 +128,7 @@ BlindSpotDecision BlindSpotModule::modifyPathVelocityDetail(PathWithLaneId * pat
   const auto & last_blind_spot_lanelet_before_turning = blind_spot_lanelets_before_turning.back();
   if (!virtual_blind_lane_boundary_after_turning_) {
     virtual_blind_lane_boundary_after_turning_ = generate_virtual_blind_side_boundary_after_turning(
-      last_blind_spot_lanelet_before_turning, turn_direction_,
-      lanelet::utils::getLaneletLength3d(assigned_lanelet));
+      last_blind_spot_lanelet_before_turning, assigned_lanelet, turn_direction_);
   }
   const auto & virtual_blind_lane_boundary_after_turning =
     virtual_blind_lane_boundary_after_turning_.value();


### PR DESCRIPTION
## Description

cut `virtual_blind_lane_boundary_after_turning` and ``virtual_ego_straight_path_after_turning` so that it doesn't exceed intersection lanelet's boundary.

| Before | After |
|:---:|:----:|
|  <img width="2243" height="752" alt="image" src="https://github.com/user-attachments/assets/3651cedd-3fde-4d87-a349-701bbd93eb0b" /> |  <img width="2251" height="492" alt="image" src="https://github.com/user-attachments/assets/2bc3c868-d70a-4690-8ee6-44f34775bfdf" /> |
| <img width="1040" height="1469" alt="image" src="https://github.com/user-attachments/assets/d4303362-bc55-4277-ad8b-ce7685f14536" />    | <img width="937" height="1008" alt="image" src="https://github.com/user-attachments/assets/439a6c56-0a5f-4ca5-b1bb-6178bc3c8c05" /> |
| <img width="1919" height="933" alt="image" src="https://github.com/user-attachments/assets/03b4a2a4-39cc-45f5-b067-b455b1f245b9" />  | <img width="1598" height="870" alt="image" src="https://github.com/user-attachments/assets/a100e36b-ba26-43a1-81fa-9cc64ee1264e" /> |


## Related links

**Parent Issue:**

- [TIER IV Internal Link - Issue's ticket](https://tier4.atlassian.net/browse/RT0-39021) 

## How was this PR tested?

- Perception reproducer

| Before | After |
|:---:|:----:|
| <img width="2819" height="1529" alt="cap- 2025-08-27-11-27-45" src="https://github.com/user-attachments/assets/aa80c791-db77-436b-90c5-374963b1fe45" />   | <img width="2819" height="1529" alt="cap- 2025-08-27-11-29-15" src="https://github.com/user-attachments/assets/ff3480fa-a7e2-43e8-8e85-70adea7e2698" /> |
| Object became blind spot target | Object is excluded from blind spot target |

- Internal evaluation

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/369e033b-3f4e-5552-9b25-5b43ab8a6455?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/c1b33777-37d7-5f6f-a9ce-58e3ca06211d?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/8a7093dc-554a-53e7-ac5a-1ea900d6b8d7?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
