### PR TITLE
fix(rear_collision_checker): correct deviation judgment logic from current driving lane

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
@@ -321,7 +321,7 @@ auto check_shift_behavior(
       }
     }
 
-    if (i < nearest_idx) {
+    if (distance < max_longitudinal_offset) {
       continue;
     }
 


### PR DESCRIPTION
## Description

In the previous implementation, collision checking was triggered even when the path behind the ego deviated into an adjacent lane, although such cases should not require detection. This was because the logic relied on index-based checks to determine whether trajectory points were located behind the ego, which sometimes caused unnecessary collision detection due to discretization errors. In this PR, the distance between each point and the ego is calculated as a continuous value, and collision detection is now performed only when a deviation into an adjacent lane occurs in front of the ego’s front. This refinement eliminates false detections caused by index-based errors and ensures more accurate behavior.

For example, as shown in the video, the system incorrectly focused on the left side (highlighted in pink) immediately after the current lane switched.

| BEFORE | AFTER |
| --- | --- |
|  <video src="https://github.com/user-attachments/assets/2b68258d-58bc-4c26-9f60-f9e59893c21e"/> |  <video src="https://github.com/user-attachments/assets/331fb52e-f63a-462b-8217-18989e018b67"/> |

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [[PR check (OTA)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/f5bb1c6a-bcca-563a-b0fc-7f2054b8ece3?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/c04affb2-3417-5fcb-9ebb-ace92728daf9?project_id=prd_jt)
- [x] [[PR check (OTA)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/1b3f7826-a243-56e2-b057-faa6d4a8d391?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
