### PR TITLE
fix: turn signal decider indexing from the end of the path

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -599,11 +599,11 @@ geometry_msgs::msg::Pose TurnSignalDecider::get_required_end_point(
     autoware::motion_utils::resamplePoseVector(converted_centerline, resampling_arclength);
 
   const double terminal_yaw = tf2::getYaw(resampled_centerline.back().orientation);
-  for (size_t i = 0; i < resampled_centerline.size(); ++i) {
-    const double yaw = tf2::getYaw(resampled_centerline.at(i).orientation);
+  for (auto itr = resampled_centerline.rbegin(); itr != resampled_centerline.rend(); ++itr) {
+    const double yaw = tf2::getYaw(itr->orientation);
     const double yaw_diff = autoware_utils::normalize_radian(yaw - terminal_yaw);
-    if (std::fabs(yaw_diff) < autoware_utils::deg2rad(intersection_angle_threshold_deg_)) {
-      return resampled_centerline.at(i);
+    if (std::fabs(yaw_diff) >= autoware_utils::deg2rad(intersection_angle_threshold_deg_)) {
+      return *itr;
     }
   }
 


### PR DESCRIPTION
## Description


### **Problem Statement**
For merging lanes that appear geometrically straight, the required section becomes very small and is easily overwritten. However, these merging lanes are deliberately labeled with turning signals during map creation and should maintain high priority.

### **Proposed Solution**
This PR introduces modifications to the algorithm for determining the end index of turning lanelets.

## Algorithm Comparison

### **Original Design**
- **Direction**: Forward iteration (start → end)
- **Process**: 
  1. Loop from the start of the lanelet
  2. Find the index where route yaw angle becomes close to the end point
  3. Define sections:
     - **Required section**: `start → selected index`
     - **Desired section**: `selected index → end`
- **Edge case**: When all points deviate from the last index → entire lanelet becomes "required section"

### **Current Design** 
- **Direction**: Backward iteration (end → start)
- **Process**:
  1. Loop from the back of the lanelet
  2. Find the index where route yaw angle deviates from the end point
  3. Define sections:
     - **Required section**: `start → selected index`
     - **Desired section**: `selected index → end`
- **Edge case**: When all points do NOT deviate from the last index → entire lanelet becomes "required section"


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
