### PR TITLE
feat(autoware_compare_map_segmentation): add lanelet elevation filter

### DIFF
--- a/perception/autoware_compare_map_segmentation/CMakeLists.txt
+++ b/perception/autoware_compare_map_segmentation/CMakeLists.txt
@@ -28,6 +28,10 @@ add_library(${PROJECT_NAME} SHARED
   src/voxel_based_compare_map_filter/node.cpp
   src/voxel_distance_based_compare_map_filter/node.cpp
   src/compare_elevation_map_filter/node.cpp
+  src/voxel_grid_map_loader/voxel_grid_map_loader.cpp
+  src/lanelet_elevation_filter/node.cpp
+  src/lanelet_elevation_filter/lanelet_elevation_filter.cpp
+  src/lanelet_elevation_filter/grid_processor.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}
@@ -45,8 +49,18 @@ ament_target_dependencies(${PROJECT_NAME}
   rclcpp_components
   sensor_msgs
   autoware_utils
+  autoware_internal_debug_msgs
   autoware_map_msgs
+  autoware_lanelet2_extension
+  geometry_msgs
+  lanelet2_core
+  lanelet2_projection
+  lanelet2_routing
   nav_msgs
+  std_msgs
+  tf2
+  tf2_ros
+  visualization_msgs
 )
 
 if(OPENMP_FOUND)
@@ -81,6 +95,11 @@ rclcpp_components_register_node(${PROJECT_NAME}
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::compare_map_segmentation::CompareElevationMapFilterComponent"
   EXECUTABLE compare_elevation_map_filter_node)
+
+# -- Lanelet Elevation Filter --
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::compare_map_segmentation::LaneletElevationFilterComponent"
+  EXECUTABLE lanelet_elevation_filter_node)
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/perception/autoware_compare_map_segmentation/README.md
+++ b/perception/autoware_compare_map_segmentation/README.md
@@ -32,6 +32,12 @@ For each point of input pointcloud, the filter use `getCentroidIndexAt` combine 
 
 This filter is a combination of the distance_based_compare_map_filter and voxel_based_approximate_compare_map_filter. The filter loads the map point cloud, which can be loaded statically at the beginning or dynamically during vehicle movement, and creates a voxel grid and a k-d tree of the map point cloud. The filter uses the getCentroidIndexAt function in combination with the getGridCoordinates function from the VoxelGrid class to find input points that are inside the voxel grid and removes them. For points that do not belong to any voxel grid, they are compared again with the map point cloud using the radiusSearch function of the k-d tree and are removed if they are close enough to the map.
 
+### Lanelet Elevation Filter
+
+The Lanelet Elevation Filter filters point clouds based on lanelet elevation information. It creates a grid-based elevation map from lanelet data and filters out points that deviate significantly from the expected road surface height. This filter is useful for removing floating objects, overpass structures, and other non-road elements that should not be considered for ground-level navigation.
+
+The filter processes lanelet maps to extract elevation information at regular grid intervals and uses this information to validate incoming point cloud data. Points that are too far above or below the expected lanelet surface elevation are filtered out.
+
 ## Inputs / Outputs
 
 ### Compare Elevation Map Filter
@@ -56,6 +62,32 @@ This filter is a combination of the distance_based_compare_map_filter and voxel_
 | `map_layer_name`     | string | elevation map layer name                                                        | elevation     |
 | `map_frame`          | float  | frame_id of the map that is temporarily used before elevation_map is subscribed | map           |
 | `height_diff_thresh` | float  | Remove points whose height difference is below this value [m]                   | 0.15          |
+
+### Lanelet Elevation Filter
+
+#### Input
+
+| Name                     | Type                                     | Description              |
+| ------------------------ | ---------------------------------------- | ------------------------ |
+| `~/input/pointcloud`     | `sensor_msgs::msg::PointCloud2`         | input point cloud        |
+| `~/input/lanelet_map`    | `autoware_map_msgs::msg::LaneletMapBin` | lanelet map              |
+
+#### Output
+
+| Name                      | Type                                     | Description                      |
+| ------------------------- | ---------------------------------------- | -------------------------------- |
+| `~/output/pointcloud`     | `sensor_msgs::msg::PointCloud2`         | filtered point cloud             |
+| `~/debug/elevation_markers` | `visualization_msgs::msg::MarkerArray` | elevation grid visualization     |
+
+#### Parameters
+
+| Name                     | Type   | Description                                                              | Default value |
+| :----------------------- | :----- | :----------------------------------------------------------------------- | :------------ |
+| `grid_resolution`        | double | Grid cell size in meters for elevation processing                       | 1.0           |
+| `height_threshold`       | double | Maximum height difference from lanelet elevation (meters)               | 2.0           |
+| `sampling_distance`      | double | Distance between sampled points along lanelet boundaries (meters)       | 0.5           |
+| `target_frame`           | string | Target coordinate frame for processing                                   | map           |
+| `enable_debug_markers`   | bool   | Enable elevation grid visualization markers for RViz                     | false         |
 
 ### Other Filters
 

--- a/perception/autoware_compare_map_segmentation/config/lanelet_elevation_filter.param.yaml
+++ b/perception/autoware_compare_map_segmentation/config/lanelet_elevation_filter.param.yaml
@@ -1,0 +1,12 @@
+# Lanelet Elevation Filter Configuration
+
+/**:
+  ros__parameters:
+    # Grid processing parameters
+    grid_resolution: 1.0          # Grid cell size in meters
+    height_threshold: 2.0         # Maximum height difference from lanelet elevation (meters)
+    sampling_distance: 0.5        # Distance between sampled points along lanelet boundaries (meters)
+    target_frame: "map"           # Target coordinate frame for processing
+    
+    # Debug/Visualization parameters
+    enable_debug: false           # Enable debug mode (includes elevation markers and processing time publisher)

--- a/perception/autoware_compare_map_segmentation/launch/lanelet_elevation_filter.launch.xml
+++ b/perception/autoware_compare_map_segmentation/launch/lanelet_elevation_filter.launch.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="input_pointcloud" default="/perception/object_recognition/detection/pointcloud_map_filtered/pointcloud"/>
+  <arg name="input_lanelet_map" default="/map/vector_map"/>
+  <arg name="output_pointcloud" default="/perception/object_recognition/detection/pointcloud_map_filtered/pointcloud_lanelet_filtered"/>
+  
+  <arg name="config_file" default="$(find-pkg-share autoware_compare_map_segmentation)/config/lanelet_elevation_filter.param.yaml"/>
+  
+  <node pkg="autoware_compare_map_segmentation" exec="lanelet_elevation_filter_node" name="lanelet_elevation_filter" output="screen">
+    <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+    <remap from="~/input/lanelet_map" to="$(var input_lanelet_map)"/>
+    <remap from="~/output/pointcloud" to="$(var output_pointcloud)"/>
+    
+    <param from="$(var config_file)"/>
+  </node>
+</launch>

--- a/perception/autoware_compare_map_segmentation/launch/lanelet_elevation_filter.launch.xml
+++ b/perception/autoware_compare_map_segmentation/launch/lanelet_elevation_filter.launch.xml
@@ -7,9 +7,9 @@
   <arg name="config_file" default="$(find-pkg-share autoware_compare_map_segmentation)/config/lanelet_elevation_filter.param.yaml"/>
   
   <node pkg="autoware_compare_map_segmentation" exec="lanelet_elevation_filter_node" name="lanelet_elevation_filter" output="screen">
-    <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+    <remap from="input" to="$(var input_pointcloud)"/>
     <remap from="~/input/lanelet_map" to="$(var input_lanelet_map)"/>
-    <remap from="~/output/pointcloud" to="$(var output_pointcloud)"/>
+    <remap from="output" to="$(var output_pointcloud)"/>
     
     <param from="$(var config_file)"/>
   </node>

--- a/perception/autoware_compare_map_segmentation/package.xml
+++ b/perception/autoware_compare_map_segmentation/package.xml
@@ -25,14 +25,24 @@
   <depend>autoware_pointcloud_preprocessor</depend>
   <depend>autoware_test_utils</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_lanelet2_extension</depend>
   <depend>diagnostic_updater</depend>
   <depend>grid_map_pcl</depend>
   <depend>grid_map_ros</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>lanelet2_projection</depend>
+  <depend>lanelet2_routing</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/autoware_compare_map_segmentation/schema/lanelet_elevation_filter.schema.json
+++ b/perception/autoware_compare_map_segmentation/schema/lanelet_elevation_filter.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Lanelet Elevation Filter",
+  "type": "object",
+  "definitions": {
+    "lanelet_elevation_filter": {
+      "type": "object",
+      "properties": {
+        "grid_resolution": {
+          "type": "number",
+          "default": "1.0",
+          "description": "Grid cell size in meters for elevation processing"
+        },
+        "height_threshold": {
+          "type": "number",
+          "default": "2.0",
+          "description": "Maximum height difference from lanelet elevation in meters"
+        },
+        "sampling_distance": {
+          "type": "number",
+          "default": "0.5",
+          "description": "Distance between sampled points along lanelet boundaries in meters"
+        },
+        "target_frame": {
+          "type": "string",
+          "default": "map",
+          "description": "Target coordinate frame for processing"
+        },
+        "enable_debug": {
+          "type": "boolean",
+          "default": "false",
+          "description": "Enable debug mode including elevation markers and processing time publisher"
+        }
+      },
+      "required": [
+        "grid_resolution",
+        "height_threshold",
+        "sampling_distance",
+        "target_frame",
+        "enable_debug"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/lanelet_elevation_filter"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/grid_processor.cpp
+++ b/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/grid_processor.cpp
@@ -1,0 +1,268 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "grid_processor.hpp"
+
+#include <lanelet2_core/geometry/Lanelet.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace autoware::compare_map_segmentation
+{
+
+GridProcessor::GridProcessor(double grid_resolution) 
+: grid_resolution_(grid_resolution), inv_grid_resolution_(1.0 / grid_resolution)
+{
+}
+
+void GridProcessor::processLanelets(const lanelet::LaneletMapPtr & lanelet_map)
+{
+  reset();
+  
+  if (!lanelet_map) {
+    return;
+  }
+
+  // Process all lanelets in the map
+  for (const auto & lanelet : lanelet_map->laneletLayer) {
+    processLaneletBoundary(lanelet);
+  }
+  
+  calculateGridStatistics();
+}
+
+GridIndex GridProcessor::getGridIndex(double x, double y) const
+{
+  // Use precomputed inverse resolution for speed
+  GridIndex index;
+  index.x = static_cast<int>(x * inv_grid_resolution_);
+  index.y = static_cast<int>(y * inv_grid_resolution_);
+  
+  // Handle negative coordinates correctly
+  if (x < 0.0 && (x * inv_grid_resolution_) != index.x) index.x--;
+  if (y < 0.0 && (y * inv_grid_resolution_) != index.y) index.y--;
+  
+  return index;
+}
+
+void GridProcessor::addPointToGrid(double x, double y, double z)
+{
+  GridIndex index = getGridIndex(x, y);
+  
+  auto it = grid_cells_.find(index);
+  if (it == grid_cells_.end()) {
+    grid_cells_[index] = GridCell();
+  }
+  
+  geometry_msgs::msg::Point point;
+  point.x = x;
+  point.y = y;
+  point.z = z;
+  
+  grid_cells_[index].points.push_back(point);
+}
+
+void GridProcessor::processLaneletBoundary(const lanelet::Lanelet & lanelet)
+{
+  double sampling_distance = grid_resolution_ * 0.5;  // Sample at half grid resolution
+  
+  // Sample points from left boundary
+  auto left_points = samplePointsFromLineString(lanelet.leftBound(), sampling_distance);
+  for (const auto & point : left_points) {
+    addPointToGrid(point.x, point.y, point.z);
+  }
+  
+  // Sample points from right boundary
+  auto right_points = samplePointsFromLineString(lanelet.rightBound(), sampling_distance);
+  for (const auto & point : right_points) {
+    addPointToGrid(point.x, point.y, point.z);
+  }
+  
+  // Sample points from centerline if available
+  if (lanelet.hasAttribute(lanelet::AttributeName::Subtype)) {
+    try {
+      auto centerline = lanelet.centerline();
+      auto center_points = samplePointsFromLineString(centerline, sampling_distance);
+      for (const auto & point : center_points) {
+        addPointToGrid(point.x, point.y, point.z);
+      }
+    } catch (...) {
+      // Centerline might not be available, continue without it
+    }
+  }
+}
+
+std::vector<geometry_msgs::msg::Point> GridProcessor::samplePointsFromLineString(
+  const lanelet::ConstLineString3d & linestring, double sampling_distance) const
+{
+  std::vector<geometry_msgs::msg::Point> sampled_points;
+  
+  if (linestring.size() < 2) {
+    return sampled_points;
+  }
+  
+  for (size_t i = 0; i < linestring.size() - 1; ++i) {
+    const auto & start_point = linestring[i];
+    const auto & end_point = linestring[i + 1];
+    
+    double dx = end_point.x() - start_point.x();
+    double dy = end_point.y() - start_point.y();
+    double dz = end_point.z() - start_point.z();
+    double segment_length = std::sqrt(dx * dx + dy * dy);
+    
+    if (segment_length < 1e-6) {
+      continue;
+    }
+    
+    int num_samples = static_cast<int>(segment_length / sampling_distance) + 1;
+    
+    for (int j = 0; j <= num_samples; ++j) {
+      double ratio = static_cast<double>(j) / num_samples;
+      
+      geometry_msgs::msg::Point point;
+      point.x = start_point.x() + ratio * dx;
+      point.y = start_point.y() + ratio * dy;
+      point.z = start_point.z() + ratio * dz;
+      
+      sampled_points.push_back(point);
+    }
+  }
+  
+  return sampled_points;
+}
+
+void GridProcessor::calculateGridStatistics()
+{
+  for (auto & [index, cell] : grid_cells_) {
+    if (cell.points.empty()) {
+      continue;
+    }
+    
+    // Calculate average height in single pass
+    double sum_z = 0.0;
+    const size_t num_points = cell.points.size();
+    
+    for (size_t i = 0; i < num_points; ++i) {
+      sum_z += cell.points[i].z;
+    }
+    
+    cell.average_height = sum_z / num_points;
+    cell.is_valid = true;
+    
+    // Clear points vector to save memory after statistics calculation
+    cell.points.clear();
+    cell.points.shrink_to_fit();
+  }
+}
+
+double GridProcessor::getElevationAtPoint(double x, double y) const
+{
+  GridIndex index = getGridIndex(x, y);
+  
+  // Check cache first
+  auto cache_it = elevation_cache_.find(index);
+  if (cache_it != elevation_cache_.end()) {
+    return cache_it->second;
+  }
+  
+  auto it = grid_cells_.find(index);
+  if (it != grid_cells_.end() && it->second.is_valid) {
+    // Cache the direct result
+    double elevation = it->second.average_height;
+    elevation_cache_[index] = elevation;
+    return elevation;
+  }
+  
+  // For missing cells, use fast nearest neighbor instead of expensive interpolation
+  double min_distance = std::numeric_limits<double>::max();
+  double nearest_elevation = 0.0;
+  bool found_neighbor = false;
+  
+  // Check immediate neighbors only (3x3 grid)
+  for (int dx = -1; dx <= 1; ++dx) {
+    for (int dy = -1; dy <= 1; ++dy) {
+      if (dx == 0 && dy == 0) continue;
+      
+      GridIndex neighbor_index;
+      neighbor_index.x = index.x + dx;
+      neighbor_index.y = index.y + dy;
+      
+      auto neighbor_it = grid_cells_.find(neighbor_index);
+      if (neighbor_it != grid_cells_.end() && neighbor_it->second.is_valid) {
+        // Use Manhattan distance for speed (avoid sqrt)
+        double distance = std::abs(dx) + std::abs(dy);
+        
+        if (distance < min_distance) {
+          min_distance = distance;
+          nearest_elevation = neighbor_it->second.average_height;
+          found_neighbor = true;
+        }
+      }
+    }
+  }
+  
+  double result = found_neighbor ? nearest_elevation : 0.0;
+  elevation_cache_[index] = result;
+  return result;
+}
+
+bool GridProcessor::isPointValid(double x, double y, double z, double threshold) const
+{
+  double expected_elevation = getElevationAtPoint(x, y);
+  double height_difference = std::abs(z - expected_elevation);
+  return height_difference <= threshold;
+}
+
+void GridProcessor::reset()
+{
+  grid_cells_.clear();
+  elevation_cache_.clear();
+}
+
+std::vector<std::pair<GridIndex, GridCell>> GridProcessor::getGridCells() const
+{
+  std::vector<std::pair<GridIndex, GridCell>> result;
+  result.reserve(grid_cells_.size());
+  
+  for (const auto & [index, cell] : grid_cells_) {
+    if (cell.is_valid) {
+      result.emplace_back(index, cell);
+    }
+  }
+  
+  return result;
+}
+
+std::pair<double, double> GridProcessor::getGridBounds() const
+{
+  if (grid_cells_.empty()) {
+    return {0.0, 0.0};
+  }
+  
+  double min_elevation = std::numeric_limits<double>::max();
+  double max_elevation = std::numeric_limits<double>::lowest();
+  
+  for (const auto & [index, cell] : grid_cells_) {
+    if (cell.is_valid) {
+      min_elevation = std::min(min_elevation, cell.average_height);
+      max_elevation = std::max(max_elevation, cell.average_height);
+    }
+  }
+  
+  return {min_elevation, max_elevation};
+}
+
+}  // namespace autoware::compare_map_segmentation

--- a/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/grid_processor.cpp
+++ b/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/grid_processor.cpp
@@ -46,7 +46,6 @@ void GridProcessor::processLanelets(const lanelet::LaneletMapPtr & lanelet_map)
 
 GridIndex GridProcessor::getGridIndex(double x, double y) const
 {
-  // Use precomputed inverse resolution for speed
   GridIndex index;
   index.x = static_cast<int>(x * inv_grid_resolution_);
   index.y = static_cast<int>(y * inv_grid_resolution_);
@@ -93,15 +92,13 @@ void GridProcessor::processLaneletBoundary(const lanelet::Lanelet & lanelet)
   
   // Sample points from centerline if available
   if (lanelet.hasAttribute(lanelet::AttributeName::Subtype)) {
-    try {
-      auto centerline = lanelet.centerline();
-      auto center_points = samplePointsFromLineString(centerline, sampling_distance);
-      for (const auto & point : center_points) {
-        addPointToGrid(point.x, point.y, point.z);
-      }
-    } catch (...) {
-      // Centerline might not be available, continue without it
+    
+    auto centerline = lanelet.centerline();
+    auto center_points = samplePointsFromLineString(centerline, sampling_distance);
+    for (const auto & point : center_points) {
+      addPointToGrid(point.x, point.y, point.z);
     }
+    
   }
 }
 
@@ -186,7 +183,6 @@ double GridProcessor::getElevationAtPoint(double x, double y) const
     return elevation;
   }
   
-  // For missing cells, use fast nearest neighbor instead of expensive interpolation
   double min_distance = std::numeric_limits<double>::max();
   double nearest_elevation = 0.0;
   bool found_neighbor = false;
@@ -202,9 +198,7 @@ double GridProcessor::getElevationAtPoint(double x, double y) const
       
       auto neighbor_it = grid_cells_.find(neighbor_index);
       if (neighbor_it != grid_cells_.end() && neighbor_it->second.is_valid) {
-        // Use Manhattan distance for speed (avoid sqrt)
         double distance = std::abs(dx) + std::abs(dy);
-        
         if (distance < min_distance) {
           min_distance = distance;
           nearest_elevation = neighbor_it->second.average_height;

--- a/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/grid_processor.hpp
+++ b/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/grid_processor.hpp
@@ -1,0 +1,95 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET_ELEVATION_FILTER__GRID_PROCESSOR_HPP_
+#define LANELET_ELEVATION_FILTER__GRID_PROCESSOR_HPP_
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/geometry/Point.h>
+
+#include <geometry_msgs/msg/point.hpp>
+
+#include <vector>
+#include <unordered_map>
+
+namespace autoware::compare_map_segmentation
+{
+
+  struct GridCell {
+    std::vector<geometry_msgs::msg::Point> points;
+    double average_height = 0.0;
+    bool is_valid = false;
+  };
+
+struct GridIndex
+{
+  int x;
+  int y;
+
+  bool operator==(const GridIndex & other) const
+  {
+    return x == other.x && y == other.y;
+  }
+};
+
+struct GridIndexHash
+{
+  std::size_t operator()(const GridIndex & index) const
+  {
+    return std::hash<int>()(index.x) ^ (std::hash<int>()(index.y) << 1);
+  }
+};
+
+class GridProcessor
+{
+public:
+  explicit GridProcessor(double grid_resolution);
+
+  void processLanelets(const lanelet::LaneletMapPtr & lanelet_map);
+  
+  double getElevationAtPoint(double x, double y) const;
+  
+  bool isPointValid(double x, double y, double z, double threshold) const;
+  
+  void reset();
+  
+  // Debug/Visualization methods
+  std::vector<std::pair<GridIndex, GridCell>> getGridCells() const;
+  
+  std::pair<double, double> getGridBounds() const;
+
+private:
+  double grid_resolution_;
+  double inv_grid_resolution_;  // Precomputed 1/grid_resolution for performance
+  std::unordered_map<GridIndex, GridCell, GridIndexHash> grid_cells_;
+  
+  // Performance optimization: cache for elevation lookups
+  mutable std::unordered_map<GridIndex, double, GridIndexHash> elevation_cache_;
+  
+  GridIndex getGridIndex(double x, double y) const;
+  
+  void addPointToGrid(double x, double y, double z);
+  
+  void calculateGridStatistics();
+  
+  void processLaneletBoundary(const lanelet::Lanelet & lanelet);
+  
+  std::vector<geometry_msgs::msg::Point> samplePointsFromLineString(
+    const lanelet::ConstLineString3d & linestring, double sampling_distance) const;
+};
+
+}  // namespace autoware::compare_map_segmentation
+
+#endif  // LANELET_ELEVATION_FILTER__GRID_PROCESSOR_HPP_

--- a/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/lanelet_elevation_filter.cpp
+++ b/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/lanelet_elevation_filter.cpp
@@ -1,0 +1,148 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lanelet_elevation_filter.hpp"
+
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+
+#include <visualization_msgs/msg/marker.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+
+namespace autoware::compare_map_segmentation
+{
+
+LaneletElevationFilter::LaneletElevationFilter(const LaneletElevationFilterParams & params)
+: params_(params), map_initialized_(false)
+{
+  grid_processor_ = std::make_shared<GridProcessor>(params_.grid_resolution);
+}
+
+void LaneletElevationFilter::setLaneletMap(
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & map_msg)
+{
+  try {
+    lanelet_map_ = std::make_shared<lanelet::LaneletMap>();
+    lanelet::utils::conversion::fromBinMsg(*map_msg, lanelet_map_);
+    
+    initializeGridFromMap();
+    map_initialized_ = true;
+  } catch (const std::exception & e) {
+    throw std::runtime_error("Failed to convert lanelet map: " + std::string(e.what()));
+  }
+}
+
+void LaneletElevationFilter::initializeGridFromMap()
+{
+  if (!lanelet_map_) {
+    return;
+  }
+  
+  grid_processor_->processLanelets(lanelet_map_);
+}
+
+visualization_msgs::msg::MarkerArray LaneletElevationFilter::createDebugMarkers(const rclcpp::Time & stamp) const
+{
+  visualization_msgs::msg::MarkerArray marker_array;
+  
+  if (!map_initialized_ || !grid_processor_) {
+    return marker_array;
+  }
+  
+  auto grid_cells = grid_processor_->getGridCells();
+  auto [min_elevation, max_elevation] = grid_processor_->getGridBounds();
+  
+  if (grid_cells.empty() || std::abs(max_elevation - min_elevation) < 1e-6) {
+    return marker_array;
+  }
+  
+  // Create grid visualization markers
+  for (size_t i = 0; i < grid_cells.size(); ++i) {
+    const auto & [index, cell] = grid_cells[i];
+    
+    visualization_msgs::msg::Marker marker;
+    marker.header.frame_id = params_.target_frame;
+    marker.header.stamp = stamp;
+    marker.ns = "elevation_grid";
+    marker.id = static_cast<int>(i);
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.action = visualization_msgs::msg::Marker::ADD;
+    
+    // Set position (center of grid cell)
+    marker.pose.position.x = index.x * params_.grid_resolution + params_.grid_resolution * 0.5;
+    marker.pose.position.y = index.y * params_.grid_resolution + params_.grid_resolution * 0.5;
+    marker.pose.position.z = cell.average_height;
+    
+    marker.pose.orientation.x = 0.0;
+    marker.pose.orientation.y = 0.0;
+    marker.pose.orientation.z = 0.0;
+    marker.pose.orientation.w = 1.0;
+    
+    // Set scale
+    marker.scale.x = params_.grid_resolution * 0.9;  // Slightly smaller for visibility
+    marker.scale.y = params_.grid_resolution * 0.9;
+    marker.scale.z = 0.1;  // Thin cube to represent surface
+    
+    // Color based on elevation (blue = low, red = high)
+    double elevation_ratio = (cell.average_height - min_elevation) / (max_elevation - min_elevation);
+    marker.color.r = static_cast<float>(elevation_ratio);
+    marker.color.g = 0.0f;
+    marker.color.b = static_cast<float>(1.0 - elevation_ratio);
+    marker.color.a = 0.7f;  // Semi-transparent
+    
+    marker.lifetime = rclcpp::Duration::from_seconds(1.0);
+    
+    marker_array.markers.push_back(marker);
+  }
+  
+  // Add elevation scale marker
+  visualization_msgs::msg::Marker scale_marker;
+  scale_marker.header.frame_id = params_.target_frame;
+  scale_marker.header.stamp = stamp;
+  scale_marker.ns = "elevation_scale";
+  scale_marker.id = 0;
+  scale_marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+  scale_marker.action = visualization_msgs::msg::Marker::ADD;
+  
+  // Position scale text
+  scale_marker.pose.position.x = 0.0;
+  scale_marker.pose.position.y = 0.0;
+  scale_marker.pose.position.z = max_elevation + 2.0;
+  
+  scale_marker.pose.orientation.x = 0.0;
+  scale_marker.pose.orientation.y = 0.0;
+  scale_marker.pose.orientation.z = 0.0;
+  scale_marker.pose.orientation.w = 1.0;
+  
+  scale_marker.scale.z = 1.0;  // Text size
+  
+  scale_marker.color.r = 1.0f;
+  scale_marker.color.g = 1.0f;
+  scale_marker.color.b = 1.0f;
+  scale_marker.color.a = 1.0f;
+  
+  scale_marker.text = "Elevation: " + 
+                      std::to_string(min_elevation) + "m (blue) - " + 
+                      std::to_string(max_elevation) + "m (red)";
+  
+  scale_marker.lifetime = rclcpp::Duration::from_seconds(1.0);
+  
+  marker_array.markers.push_back(scale_marker);
+  
+  return marker_array;
+}
+
+}  // namespace autoware::compare_map_segmentation

--- a/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/lanelet_elevation_filter.hpp
+++ b/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/lanelet_elevation_filter.hpp
@@ -1,0 +1,64 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET_ELEVATION_FILTER__LANELET_ELEVATION_FILTER_HPP_
+#define LANELET_ELEVATION_FILTER__LANELET_ELEVATION_FILTER_HPP_
+
+#include "grid_processor.hpp"
+
+#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <memory>
+
+namespace autoware::compare_map_segmentation
+{
+
+struct LaneletElevationFilterParams
+{
+  double grid_resolution;
+  double height_threshold;
+  double sampling_distance;
+  std::string target_frame;
+  bool enable_debug;
+};
+
+class LaneletElevationFilter
+{
+public:
+  explicit LaneletElevationFilter(const LaneletElevationFilterParams & params);
+
+  void setLaneletMap(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & map_msg);
+  
+  // Debug/Visualization methods
+  visualization_msgs::msg::MarkerArray createDebugMarkers(const rclcpp::Time & stamp) const;
+  
+  // Accessor for grid processor (for direct filtering)
+  std::shared_ptr<GridProcessor> getGridProcessor() const { return grid_processor_; }
+
+private:
+  LaneletElevationFilterParams params_;
+  std::shared_ptr<GridProcessor> grid_processor_;
+  lanelet::LaneletMapPtr lanelet_map_;
+  bool map_initialized_;
+  
+  void initializeGridFromMap();
+};
+
+}  // namespace autoware::compare_map_segmentation
+
+#endif  // LANELET_ELEVATION_FILTER__LANELET_ELEVATION_FILTER_HPP_

--- a/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/node.cpp
@@ -1,0 +1,244 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "node.hpp"
+
+#include <autoware_utils/ros/parameter.hpp>
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+
+#include <pcl/common/io.h>
+#include <pcl/point_types.h>
+
+#include <chrono>
+#include <memory>
+
+namespace autoware::compare_map_segmentation
+{
+
+LaneletElevationFilterComponent::LaneletElevationFilterComponent(const rclcpp::NodeOptions & node_options)
+: Filter("LaneletElevationFilter", node_options)
+{
+  loadParameters();
+  
+  // Initialize the filter
+  filter_ = std::make_unique<LaneletElevationFilter>(params_);
+  
+  // Initialize timing utilities following fusion node pattern
+  stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
+  
+  // Initialize debug publisher if enabled
+  if (params_.enable_debug) {
+    try {
+      // Initialize DebugPublisher following fusion node pattern
+      debug_publisher_ = std::make_unique<autoware_utils::DebugPublisher>(this, get_name());
+      
+      // Initialize debug markers publisher
+      debug_markers_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
+        "~/debug/elevation_grid_markers", rclcpp::QoS(1).transient_local());
+        
+      RCLCPP_INFO(this->get_logger(), "Debug publishers initialized");
+    } catch (const std::exception & e) {
+      RCLCPP_WARN(this->get_logger(), "Failed to initialize debug publishers: %s", e.what());
+      params_.enable_debug = false; // Disable debug mode if initialization fails
+    }
+  }
+
+  // Subscribe to lanelet map
+  map_sub_ = this->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
+    "~/input/lanelet_map", rclcpp::QoS(1).transient_local(),
+    std::bind(&LaneletElevationFilterComponent::onMap, this, std::placeholders::_1));
+
+  RCLCPP_INFO(this->get_logger(), "LaneletElevationFilter has been initialized.");
+  
+  printParameters();
+}
+
+void LaneletElevationFilterComponent::printParameters()
+{
+  RCLCPP_INFO(this->get_logger(), "=== Lanelet Elevation Filter Configuration ===");
+  RCLCPP_INFO(this->get_logger(), "Grid resolution: %.2f m", params_.grid_resolution);
+  RCLCPP_INFO(this->get_logger(), "Height threshold: %.2f m", params_.height_threshold);
+  RCLCPP_INFO(this->get_logger(), "Sampling distance: %.2f m", params_.sampling_distance);
+  RCLCPP_INFO(this->get_logger(), "Target frame: %s", params_.target_frame.c_str());
+  RCLCPP_INFO(this->get_logger(), "Debug mode: %s", params_.enable_debug ? "enabled" : "disabled");
+}
+
+void LaneletElevationFilterComponent::loadParameters()
+{
+  // Load parameters with default values
+  params_.grid_resolution = this->declare_parameter<double>("grid_resolution", 1.0);
+  params_.height_threshold = this->declare_parameter<double>("height_threshold", 2.0);
+  params_.sampling_distance = this->declare_parameter<double>("sampling_distance", 0.5);
+  params_.target_frame = this->declare_parameter<std::string>("target_frame", "map");
+  params_.enable_debug = this->declare_parameter<bool>("enable_debug", false);
+  
+  // Validate parameters
+  if (params_.grid_resolution <= 0.0) {
+    throw std::invalid_argument("grid_resolution must be positive");
+  }
+  if (params_.height_threshold <= 0.0) {
+    throw std::invalid_argument("height_threshold must be positive");
+  }
+  if (params_.sampling_distance <= 0.0) {
+    throw std::invalid_argument("sampling_distance must be positive");
+  }
+}
+
+void LaneletElevationFilterComponent::filter(
+  const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
+  PointCloud2 & output)
+{
+  // Start timing for debug if enabled - do this FIRST
+  if (params_.enable_debug && stop_watch_ptr_) {
+    stop_watch_ptr_->tic("processing_time");
+  }
+
+  if (!input) {
+    RCLCPP_ERROR(this->get_logger(), "Input point cloud is null");
+    return;
+  }
+
+  if (!filter_) {
+    // If filter is not initialized, pass through the input
+    output = *input;
+    return;
+  }
+  
+  if (!filter_->getGridProcessor()) {
+    RCLCPP_ERROR(this->get_logger(), "Grid processor is not initialized");
+    output = *input;
+    return;
+  }
+  
+  // Use similar direct processing as other filters
+  int point_step = input->point_step;
+  
+  // Check if the input has valid fields
+  if (input->fields.empty()) {
+    RCLCPP_ERROR(this->get_logger(), "Input point cloud has no fields");
+    output = *input;
+    return;
+  }
+  
+  int x_idx = pcl::getFieldIndex(*input, "x");
+  int y_idx = pcl::getFieldIndex(*input, "y"); 
+  int z_idx = pcl::getFieldIndex(*input, "z");
+  
+  if (x_idx == -1 || y_idx == -1 || z_idx == -1) {
+    RCLCPP_ERROR(this->get_logger(), "Input point cloud missing x, y, or z fields");
+    output = *input;
+    return;
+  }
+  
+  int offset_x = input->fields[x_idx].offset;
+  int offset_y = input->fields[y_idx].offset;
+  int offset_z = input->fields[z_idx].offset;
+
+  output.data.resize(input->data.size());
+  output.point_step = point_step;
+  size_t output_size = 0;
+  
+  const double height_threshold = params_.height_threshold;
+  
+  for (size_t global_offset = 0; global_offset < input->data.size(); global_offset += point_step) {
+    pcl::PointXYZ point{};
+    std::memcpy(&point.x, &input->data[global_offset + offset_x], sizeof(float));
+    std::memcpy(&point.y, &input->data[global_offset + offset_y], sizeof(float));
+    std::memcpy(&point.z, &input->data[global_offset + offset_z], sizeof(float));
+    
+    // Check if point is finite and within elevation threshold
+    if (!std::isfinite(point.x) || !std::isfinite(point.y) || !std::isfinite(point.z)) {
+      continue;
+    }
+    
+    try {
+      if (filter_->getGridProcessor()->isPointValid(point.x, point.y, point.z, height_threshold)) {
+        std::memcpy(&output.data[output_size], &input->data[global_offset], point_step);
+        output_size += point_step;
+      }
+    } catch (const std::exception & e) {
+      // If there's an error with grid processing, include the point to be safe
+      std::memcpy(&output.data[output_size], &input->data[global_offset], point_step);
+      output_size += point_step;
+    }
+  }
+  
+  // Set output cloud properties
+  output.header = input->header;
+  output.fields = input->fields;
+  output.data.resize(output_size);
+  output.height = input->height;
+  output.width = output_size / point_step / output.height;
+  output.row_step = output_size / output.height;
+  output.is_bigendian = input->is_bigendian;
+  output.is_dense = input->is_dense;
+
+  // Publish processing time for debug if available
+  if (params_.enable_debug && debug_publisher_ && stop_watch_ptr_) {
+    try {
+      const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
+      
+      // Create Float64Stamped message following fusion node pattern
+      autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
+      processing_time_msg.stamp = input->header.stamp;
+      processing_time_msg.data = processing_time_ms;
+      
+      debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+        "debug/processing_time_ms", processing_time_msg);
+      
+      RCLCPP_DEBUG(this->get_logger(), "Published processing time: %.2f ms", processing_time_ms);
+    } catch (const std::exception & e) {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000,
+        "Failed to publish debug processing time: %s", e.what());
+    }
+  }
+}
+
+void LaneletElevationFilterComponent::onMap(
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & msg)
+{
+  try {
+    RCLCPP_INFO(this->get_logger(), "Received lanelet map, processing...");
+    
+    const auto start_time = this->now();
+    
+    // Set the lanelet map in the filter
+    filter_->setLaneletMap(msg);
+    const auto end_time = this->now();
+    
+    const auto processing_time = (end_time - start_time).seconds() * 1000.0;
+    
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Lanelet map processed successfully in %.2f ms", processing_time);
+    
+    // Publish debug markers created by the lanelet elevation filter
+    if (params_.enable_debug && debug_markers_pub_) {
+      auto marker_array = filter_->createDebugMarkers(this->now());
+      if (!marker_array.markers.empty()) {
+        debug_markers_pub_->publish(marker_array);
+        RCLCPP_INFO(this->get_logger(), "Published %zu debug elevation markers", 
+                   marker_array.markers.size());
+      }
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to process lanelet map: %s", e.what());
+  }
+}
+
+} // namespace autoware::compare_map_segmentation
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::compare_map_segmentation::LaneletElevationFilterComponent)

--- a/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/node.hpp
+++ b/perception/autoware_compare_map_segmentation/src/lanelet_elevation_filter/node.hpp
@@ -1,0 +1,78 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET_ELEVATION_FILTER__NODE_HPP_
+#define LANELET_ELEVATION_FILTER__NODE_HPP_
+
+#include "lanelet_elevation_filter.hpp"
+
+#include <autoware/pointcloud_preprocessor/filter.hpp>
+#include <autoware_utils/ros/debug_publisher.hpp>
+#include <autoware_utils/system/stop_watch.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <memory>
+#include <string>
+#include <chrono>
+
+namespace autoware::compare_map_segmentation
+{
+
+class LaneletElevationFilterComponent : public autoware::pointcloud_preprocessor::Filter
+{
+  using PointCloud2 = sensor_msgs::msg::PointCloud2;
+  using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
+  using IndicesPtr = pcl::IndicesPtr;
+
+public:
+  explicit LaneletElevationFilterComponent(const rclcpp::NodeOptions & node_options);
+
+private:
+  // Filter implementation
+  void filter(
+    const PointCloud2ConstPtr & input, [[maybe_unused]] const IndicesPtr & indices,
+    PointCloud2 & output) override;
+
+  // Map handling
+  void onMap(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & msg);
+
+  // Parameters and state
+  LaneletElevationFilterParams params_;
+  std::unique_ptr<LaneletElevationFilter> filter_;
+  
+  // Map subscription
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
+  
+  // Debug publishers
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_markers_pub_;
+  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_;
+  
+  // Timing utilities
+  std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
+  
+  // Parameter loading
+  void loadParameters();
+  
+  // Debug functions
+  void printParameters();
+};
+
+}  // namespace autoware::compare_map_segmentation
+
+#endif  // LANELET_ELEVATION_FILTER__NODE_HPP_


### PR DESCRIPTION
### Description

The new lanelet_elevation_filter package filters point clouds based on lanelet elevation information. It first creates a grid-based elevation map from lanelet data, then filters out points that deviate significantly from the expected road surface height.

#### Why do we need this package?

After the compare map filter operation, and just before the euclidean clustering operation, the low_height_cropbox operation ([link](https://github.com/autowarefoundation/autoware_universe/blob/main/perception/autoware_euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.py?utm_source=chatgpt.com#L37)
) is applied to the point cloud. This useful step removes unnecessary points left over from the voxel-based compare map filter, such as dynamic changes (e.g., branches of trees). Otherwise, these objects can cause undesired braking.

However, the problem is that the crop box operation is performed on the static local base_link frame. If the road plane changes along the direction of travel, the algorithm cannot handle these changes properly.

When the road is sloped, especially for long-range points, valid points may be incorrectly removed by the crop box filter. To address this, I designed a filter based on lanelet data that adapts to road surface changes.

As shown in the illustration below, there is a gap between the crop box polygon and the actual road surface.

#### Basic illustration of the problem

Points in the gap between the crop box polygon and the actual road surface are removed.

<img width="797" height="302" alt="Untitled Diagram drawio" src="https://github.com/user-attachments/assets/6c3b589a-b394-4e2c-b8df-211f9d949aa2" />

#### Real-world samples

In some cases, the crop box polygon does not align with the road surface, resulting in the removal of valid vehicle points.

For example, in the opposite slope case compared to the previous illustration, the real road surface lies above the crop box polygon.

[https://github.com/user-attachments/assets/67ff897e-5ab0-4b96-ba8d-45a643c490f6](https://github.com/user-attachments/assets/67ff897e-5ab0-4b96-ba8d-45a643c490f6?utm_source=chatgpt.com)

#### Sample image
<img width="1460" height="721" alt="fail_case_2" src="https://github.com/user-attachments/assets/0a33a575-dea1-4428-8e8a-8a40227ac289" />

#### Debug marker visualization
<img width="1542" height="797" alt="Screenshot from 2025-08-28 13-01-39" src="https://github.com/user-attachments/assets/915a5904-3b37-4ecb-82ff-ed78eb5ddfb8" />

#### Future steps

Replace the low_height_cropbox operation ([link](https://github.com/autowarefoundation/autoware_universe/blob/main/perception/autoware_euclidean_cluster/launch/voxel_grid_based_euclidean_cluster.launch.py?utm_source=chatgpt.com#L37)) with this package.

Update autoware_launch accordingly.

#### Performance

Euclidean clustering takes around 10k points before operation, overall processing time for this package is approximately 1 ms.

- Large input size: ~200,000 points → processing time: ~17 ms

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Adjust input point cloud and lanelet topics. 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

No effect observed.

None.
