### PR TITLE
feat(pose_instability_detector): make pose_instability_detector filtered by dimensions

### DIFF
--- a/localization/autoware_pose_instability_detector/config/pose_instability_detector.param.yaml
+++ b/localization/autoware_pose_instability_detector/config/pose_instability_detector.param.yaml
@@ -13,3 +13,11 @@
     pose_estimator_lateral_tolerance: 0.11        # [m]
     pose_estimator_vertical_tolerance: 0.11       # [m]
     pose_estimator_angular_tolerance: 0.0175      # [rad]
+
+    enable_validation:
+      position_x: true
+      position_y: true
+      position_z: true
+      angle_x: false
+      angle_y: false
+      angle_z: true

--- a/localization/autoware_pose_instability_detector/include/autoware/pose_instability_detector/pose_instability_detector.hpp
+++ b/localization/autoware_pose_instability_detector/include/autoware/pose_instability_detector/pose_instability_detector.hpp
@@ -28,6 +28,7 @@
 
 namespace autoware::pose_instability_detector
 {
+
 class PoseInstabilityDetector : public rclcpp::Node
 {
   using Quaternion = geometry_msgs::msg::Quaternion;
@@ -94,6 +95,8 @@ private:
   std::optional<Odometry> latest_odometry_ = std::nullopt;
   std::optional<Odometry> prev_odometry_ = std::nullopt;
   std::deque<TwistWithCovarianceStamped> twist_buffer_;
+
+  std::vector<bool> enable_validation_flags_;  // must be 6D for x, y, z, roll, pitch, yaw
 };
 }  // namespace autoware::pose_instability_detector
 

--- a/localization/autoware_pose_instability_detector/schema/pose_instability_detector.schema.json
+++ b/localization/autoware_pose_instability_detector/schema/pose_instability_detector.schema.json
@@ -65,6 +65,43 @@
           "default": 0.0175,
           "minimum": 0.0,
           "description": "The tolerance of roll angle of pose estimator (rad)."
+        },
+        "enable_validation": {
+          "type": "object",
+          "properties": {
+            "position_x": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable validation for x dimension of the pose position."
+            },
+            "position_y": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable validation for y dimension of the pose position."
+            },
+            "position_z": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable validation for z dimension of the pose position."
+            },
+            "angle_x": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable validation for x dimension (roll) of the pose orientation."
+            },
+            "angle_y": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable validation for y dimension (pitch) of the pose orientation."
+            },
+            "angle_z": {
+              "type": "boolean",
+              "default": true,
+              "description": "Enable validation for z dimension (yaw) of the pose orientation."
+            }
+          },
+          "required": ["position_x", "position_y", "position_z", "angle_x", "angle_y", "angle_z"],
+          "additionalProperties": false
         }
       },
       "required": [

--- a/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
+++ b/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
@@ -49,6 +49,15 @@ PoseInstabilityDetector::PoseInstabilityDetector(const rclcpp::NodeOptions & opt
   pose_estimator_angular_tolerance_(
     this->declare_parameter<double>("pose_estimator_angular_tolerance"))
 {
+  // Define enable flags
+  enable_validation_flags_ = {
+    this->declare_parameter<bool>("enable_validation.position_x"),
+    this->declare_parameter<bool>("enable_validation.position_y"),
+    this->declare_parameter<bool>("enable_validation.position_z"),
+    this->declare_parameter<bool>("enable_validation.angle_x"),
+    this->declare_parameter<bool>("enable_validation.angle_y"),
+    this->declare_parameter<bool>("enable_validation.angle_z")};
+
   // Define subscribers, publishers and a timer.
   odometry_sub_ = this->create_subscription<Odometry>(
     "~/input/odometry", 10,
@@ -156,9 +165,12 @@ void PoseInstabilityDetector::callback_timer()
   bool all_ok = true;
 
   for (size_t i = 0; i < values.size(); ++i) {
-    const bool ok = (std::abs(values[i]) < thresholds[i]);
+    const bool ok = (std::abs(values[i]) < thresholds[i]) | !enable_validation_flags_[i];
     all_ok &= ok;
     diagnostic_msgs::msg::KeyValue kv;
+    kv.key = labels[i] + ":validation_enabled";
+    kv.value = enable_validation_flags_[i] ? "True" : "False";
+    status.values.push_back(kv);
     kv.key = labels[i] + ":threshold";
     kv.value = std::to_string(thresholds[i]);
     status.values.push_back(kv);

--- a/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
+++ b/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
@@ -165,7 +165,7 @@ void PoseInstabilityDetector::callback_timer()
   bool all_ok = true;
 
   for (size_t i = 0; i < values.size(); ++i) {
-    const bool ok = (std::abs(values[i]) < thresholds[i]) | !enable_validation_flags_[i];
+    const bool ok = (std::abs(values[i]) < thresholds[i]) || !enable_validation_flags_[i];
     all_ok &= ok;
     diagnostic_msgs::msg::KeyValue kv;
     kv.key = labels[i] + ":validation_enabled";


### PR DESCRIPTION
## Description

This PR adds a new parameter `enable_validation` to the pose_instability_detector so that the validation can be toggled by each dimension (x, y, z, roll, pitch and yaw).

This feature is added so that the instability checking for roll and pitch is not reliable for some vehicles.

## Related links

Changes to autoware_launch: https://github.com/autowarefoundation/autoware_launch/pull/1630

## How was this PR tested?

Checked that the `rqt_runtime_monitor` looks like this

<img width="648" height="698" alt="Screenshot from 2025-09-01 16-23-47" src="https://github.com/user-attachments/assets/9335fbb0-54c4-48f6-8781-eca71e437d8b" />


Checked that the `ros2 param dump /localization/pose_twist_fusion_filter/pose_instability_detector` looks like this

<img width="921" height="874" alt="Screenshot from 2025-09-01 16-16-35" src="https://github.com/user-attachments/assets/76aaf908-0371-4f2f-aba0-21cf294a4eb4" />

Checked that `colcon test` passes.


## Notes for reviewers

This PR should me merged with https://github.com/autowarefoundation/autoware_launch/pull/1630.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

Below `enable_validation`

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `position_x`   | `bool` | `true`         | Enable validation for x dimension |
| Added | `position_y`   | `bool` | `true`         | Enable validation for y dimension |
| Added | `position_z`   | `bool` | `true`         | Enable validation for z dimension |
| Added | `angle_x`   | `bool` | `false`         | Enable validation for roll dimension |
| Added | `angle_y`   | `bool` | `false`         | Enable validation for pitch dimension |
| Added | `angle_z`   | `bool` | `true`         | Enable validation for yaw dimension |

## Effects on system behavior

If some dimension is set `false` then it will be ignored when summaring the diagnostics level.