### PR TITLE
fix(autoware_default_adapi_universe): comment out unused functions

### DIFF
--- a/system/autoware_default_adapi_universe/src/manual_control.cpp
+++ b/system/autoware_default_adapi_universe/src/manual_control.cpp
@@ -24,6 +24,9 @@ namespace autoware::default_adapi
 ManualControlNode::ManualControlNode(const rclcpp::NodeOptions & options)
 : Node("manual_control", options)
 {
+  // NOTE: Do not enable interfaces for velocity and acceleration mode in the constructor.
+  //       Enable the comment out process and enable interface when the service is called.
+
   using std::placeholders::_1;
   using std::placeholders::_2;
 
@@ -115,8 +118,19 @@ void ManualControlNode::on_select_mode(
       res->status.success = true;
       break;
     case ManualControlMode::ACCELERATION:
+      disable_all_commands();
+      // TODO(isamu-takagi): Uncomment when supporting.
+      // enable_common_commands();
+      // enable_acceleration_commands();
+      update_mode_status(ManualControlMode::DISABLED);
+      res->status.success = false;
+      res->status.message = "The selected control mode is not supported.";
+      break;
     case ManualControlMode::VELOCITY:
       disable_all_commands();
+      // TODO(isamu-takagi): Uncomment when supporting.
+      // enable_common_commands();
+      // enable_velocity_commands();
       update_mode_status(ManualControlMode::DISABLED);
       res->status.success = false;
       res->status.message = "The selected control mode is not supported.";
@@ -150,14 +164,18 @@ void ManualControlNode::enable_pedals_commands()
     [this](const PedalsCommand & msg) { pub_pedals_->publish(msg); });
 }
 
+// TODO(isamu-takagi): This function is reserved for future support.
+/*
 void ManualControlNode::enable_acceleration_commands()
 {
-  // TODO(isamu-takagi): Currently not supported.
   sub_acceleration_ = create_subscription<AccelerationCommand>(
     ns_ + "/command/acceleration", rclcpp::QoS(1).best_effort(),
     [](const AccelerationCommand & msg) { (void)msg; });
 }
+*/
 
+// TODO(isamu-takagi): This function is reserved for future support.
+/*
 void ManualControlNode::enable_velocity_commands()
 {
   // TODO(isamu-takagi): Currently not supported.
@@ -165,6 +183,7 @@ void ManualControlNode::enable_velocity_commands()
     ns_ + "/command/velocity", rclcpp::QoS(1).best_effort(),
     [](const VelocityCommand & msg) { (void)msg; });
 }
+*/
 
 void ManualControlNode::enable_common_commands()
 {

--- a/system/autoware_default_adapi_universe/src/manual_control.hpp
+++ b/system/autoware_default_adapi_universe/src/manual_control.hpp
@@ -73,8 +73,9 @@ private:
   void disable_all_commands();
   void enable_common_commands();
   void enable_pedals_commands();
-  void enable_acceleration_commands();
-  void enable_velocity_commands();
+  // TODO(isamu-takagi): These functions are reserved for future support.
+  // void enable_acceleration_commands();
+  // void enable_velocity_commands();
   rclcpp::Subscription<OperatorHeartbeat>::SharedPtr sub_heartbeat_;
   rclcpp::Subscription<PedalsCommand>::SharedPtr sub_pedals_;
   rclcpp::Subscription<AccelerationCommand>::SharedPtr sub_acceleration_;


### PR DESCRIPTION
## Description

Commented out the unused function for https://github.com/autowarefoundation/autoware_universe/pull/11192.

## Related links

**Parent Issue:**

None

## How was this PR tested?

None

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
