### PR TITLE
feat(bpp, lane_change): enable prepare phase check even when ego is preparing

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
@@ -1314,6 +1314,19 @@ The following parameters are used to configure terminal lane change path feature
 | `collision_check.yaw_diff_threshold`                     | [rad] | double  | Maximum yaw difference between predicted ego pose and predicted object pose when executing rss-based collision checking                                                                                    | 3.1416        |
 | `collision_check.th_incoming_object_yaw`                 | [rad] | double  | Maximum yaw difference between current ego pose and current object pose. Objects with a yaw difference exceeding this value are excluded from the safety check.                                            | 2.3562        |
 
+#### safety constraints when ego is in prepare phase
+
+| Name                                                       | Unit    | Type   | Description                                                                                                                                                    | Default value |
+| :--------------------------------------------------------- | ------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `safety_check.prepare.expected_front_deceleration`         | [m/s^2] | double | The front object's maximum deceleration when the front vehicle perform sudden braking. (\*1)                                                                   | -1.0          |
+| `safety_check.prepare.expected_rear_deceleration`          | [m/s^2] | double | The rear object's maximum deceleration when the rear vehicle perform sudden braking. (\*1)                                                                     | -1.0          |
+| `safety_check.prepare.rear_vehicle_reaction_time`          | [s]     | double | The reaction time of the rear vehicle driver which starts from the driver noticing the sudden braking of the front vehicle until the driver step on the brake. | 1.0           |
+| `safety_check.prepare.rear_vehicle_safety_time_margin`     | [s]     | double | The time buffer for the rear vehicle to come into complete stop when its driver perform sudden braking.                                                        | 0.8           |
+| `safety_check.prepare.lateral_distance_max_threshold`      | [m]     | double | The lateral distance threshold that is used to determine whether lateral distance between two object is enough and whether lane change is safe.                | 0.5           |
+| `safety_check.prepare.longitudinal_distance_min_threshold` | [m]     | double | The longitudinal distance threshold that is used to determine whether longitudinal distance between two object is enough and whether lane change is safe.      | 1.0           |
+| `safety_check.prepare.longitudinal_velocity_delta_time`    | [m]     | double | The time multiplier that is used to compute the actual gap between vehicle at each predicted points (not RSS distance)                                         | 0.0           |
+| `safety_check.prepare.extended_polygon_policy`             | [-]     | string | Policy used to determine the polygon shape for the safety check. Available options are: `rectangle` or `along-path`.                                           | `rectangle`   |
+
 #### safety constraints during lane change path is computed
 
 | Name                                                         | Unit    | Type   | Description                                                                                                                                                    | Default value |

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -52,6 +52,15 @@
         allow_loose_check_for_cancel: true
         enable_target_lane_bound_check: true
         stopped_object_velocity_threshold: 1.0 # [m/s]
+        prepare:                                        # RSS parameters used during the prepare phase, regardless of whether the ego is searching for a safe path, canceling, or transitioning to another state.
+          expected_front_deceleration: -1.0             # [m/s2]
+          expected_rear_deceleration: -1.0              # [m/s2]
+          rear_vehicle_reaction_time: 1.0               # [s]
+          rear_vehicle_safety_time_margin: 0.8          # [s]
+          lateral_distance_max_threshold: 0.5           # [m]
+          longitudinal_distance_min_threshold: 1.0      # [m]
+          longitudinal_velocity_delta_time: 0.0         # [s]
+          extended_polygon_policy: "along-path"         # [-] available options are `rectangle` or `along-path`
         execution:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -1.0
@@ -124,10 +133,6 @@
 
       # collision check
       collision_check:
-        enable_for_prepare_phase:
-          general_lanes: false
-          intersection: true
-          turns: true
         prediction_time_resolution: 0.5
         th_incoming_object_yaw: 2.3562 # [rad]
         yaw_diff_threshold: 3.1416 # [rad]

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -166,15 +166,12 @@ protected:
 
   bool is_colliding(
     const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
-    const std::vector<PoseWithVelocityStamped> & ego_predicted_path,
-    const RSSparams & selected_rss_param, const bool check_prepare_phase,
+    const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const RSSparams & rss_param,
     CollisionCheckDebugMap & debug_data) const;
 
   double get_max_velocity_for_safety_check() const;
 
   bool is_ego_stuck() const;
-
-  bool check_prepare_phase() const;
 
   void set_stop_pose(
     const double arc_length_to_stop_pose, PathWithLaneId & path, const std::string & reason = "");

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/parameters.hpp
@@ -88,9 +88,6 @@ struct CancelParameters
 
 struct CollisionCheckParameters
 {
-  bool enable_for_prepare_phase_in_general_lanes{false};
-  bool enable_for_prepare_phase_in_intersection{true};
-  bool enable_for_prepare_phase_in_turns{true};
   bool check_current_lane{true};
   bool check_other_lanes{true};
   bool use_all_predicted_paths{false};
@@ -110,6 +107,7 @@ struct SafetyParameters
   RSSparams rss_params_for_parked{};
   RSSparams rss_params_for_abort{};
   RSSparams rss_params_for_stuck{};
+  RSSparams rss_params_for_prepare{};
   ObjectTypesToCheck target_object_types{};
   CollisionCheckParameters collision_check{};
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -137,14 +137,6 @@ LCParamPtr LaneChangeModuleManager::set_params(rclcpp::Node * node, const std::s
       *node, parameter("safety_check.lane_expansion.right_offset"));
 
     // collision check
-    p.safety.collision_check.enable_for_prepare_phase_in_general_lanes =
-      get_or_declare_parameter<bool>(
-        *node, parameter("collision_check.enable_for_prepare_phase.general_lanes"));
-    p.safety.collision_check.enable_for_prepare_phase_in_intersection =
-      get_or_declare_parameter<bool>(
-        *node, parameter("collision_check.enable_for_prepare_phase.intersection"));
-    p.safety.collision_check.enable_for_prepare_phase_in_turns = get_or_declare_parameter<bool>(
-      *node, parameter("collision_check.enable_for_prepare_phase.turns"));
     p.safety.collision_check.check_current_lane =
       get_or_declare_parameter<bool>(*node, parameter("collision_check.check_current_lanes"));
     p.safety.collision_check.check_other_lanes =
@@ -177,6 +169,7 @@ LCParamPtr LaneChangeModuleManager::set_params(rclcpp::Node * node, const std::s
       params.extended_polygon_policy = get_or_declare_parameter<std::string>(
         *node, parameter(prefix + ".extended_polygon_policy"));
     };
+    set_rss_params(p.safety.rss_params_for_prepare, "safety_check.prepare");
     set_rss_params(p.safety.rss_params, "safety_check.execution");
     set_rss_params(p.safety.rss_params_for_parked, "safety_check.parked");
     set_rss_params(p.safety.rss_params_for_abort, "safety_check.cancel");
@@ -452,15 +445,6 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
   {
     const std::string ns = "lane_change.collision_check.";
     update_param<bool>(
-      parameters, ns + "enable_for_prepare_phase.general_lanes",
-      p->safety.collision_check.enable_for_prepare_phase_in_general_lanes);
-    update_param<bool>(
-      parameters, ns + "enable_for_prepare_phase.intersection",
-      p->safety.collision_check.enable_for_prepare_phase_in_intersection);
-    update_param<bool>(
-      parameters, ns + "enable_for_prepare_phase.turns",
-      p->safety.collision_check.enable_for_prepare_phase_in_turns);
-    update_param<bool>(
       parameters, ns + "check_current_lanes", p->safety.collision_check.check_current_lane);
     update_param<bool>(
       parameters, ns + "check_other_lanes", p->safety.collision_check.check_other_lanes);
@@ -548,6 +532,7 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
     }
   };
 
+  update_rss_params("lane_change.safety_check.prepare.", p->safety.rss_params_for_prepare);
   update_rss_params("lane_change.safety_check.execution.", p->safety.rss_params);
   update_rss_params("lane_change.safety_check.parked.", p->safety.rss_params_for_parked);
   update_rss_params("lane_change.safety_check.cancel.", p->safety.rss_params_for_abort);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1735,18 +1735,10 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
   constexpr auto is_safe = true;
   constexpr auto is_object_behind_ego = true;
 
-  const auto is_check_prepare_phase = check_prepare_phase();
-
   const auto all_paths_collide = [&](const auto & objects) {
-    const auto stopped_obj_vel_th = lane_change_parameters_->safety.th_stopped_object_velocity;
     return ranges::all_of(ego_predicted_paths, [&](const auto & ego_predicted_path) {
       const auto check_for_collision = [&](const auto & object) {
-        const auto selected_rss_param = (object.initial_twist.linear.x <= stopped_obj_vel_th)
-                                          ? lane_change_parameters_->safety.rss_params_for_parked
-                                          : rss_params;
-        return is_colliding(
-          lane_change_path, object, ego_predicted_path, selected_rss_param, is_check_prepare_phase,
-          debug_data);
+        return is_colliding(lane_change_path, object, ego_predicted_path, rss_params, debug_data);
       };
       return ranges::any_of(objects, check_for_collision);
     });
@@ -1765,8 +1757,7 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
 
 bool NormalLaneChange::is_colliding(
   const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
-  const std::vector<PoseWithVelocityStamped> & ego_predicted_path,
-  const RSSparams & selected_rss_param, const bool check_prepare_phase,
+  const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const RSSparams & rss_param,
   CollisionCheckDebugMap & debug_data) const
 {
   constexpr auto is_colliding{true};
@@ -1792,27 +1783,42 @@ bool NormalLaneChange::is_colliding(
   constexpr auto hysteresis_factor{1.0};
   const auto safety_check_max_vel = get_max_velocity_for_safety_check();
   const auto & bpp_param = *common_data_ptr_->bpp_param_ptr;
+  const auto th_yaw_diff = common_data_ptr_->lc_param_ptr->safety.collision_check.th_yaw_diff;
+  const auto prepare_duration = lane_change_path.info.duration.prepare;
 
-  const double velocity_threshold = lane_change_parameters_->safety.th_stopped_object_velocity;
-  const double prepare_duration = lane_change_path.info.duration.prepare;
-  const double start_time = check_prepare_phase ? 0.0 : prepare_duration;
+  auto & debug = current_debug_data.second;
+  debug.ego_predicted_path = ego_predicted_path;
+  debug.current_obj_pose = obj.initial_pose;
+
+  const auto & th_stopped_obj_vel = lane_change_parameters_->safety.th_stopped_object_velocity;
+  const auto & lane_changing_phase_rss_param =
+    (obj.initial_twist.linear.x <= th_stopped_obj_vel)
+      ? lane_change_parameters_->safety.rss_params_for_parked
+      : rss_param;
 
   for (const auto & obj_path : obj.predicted_paths) {
-    utils::path_safety_checker::PredictedPathWithPolygon predicted_obj_path;
-    predicted_obj_path.confidence = obj_path.confidence;
-    std::copy_if(
-      obj_path.path.begin(), obj_path.path.end(), std::back_inserter(predicted_obj_path.path),
-      [&](const auto & entry) {
-        return !(
-          entry.time < start_time ||
-          (entry.time < prepare_duration && entry.velocity < velocity_threshold));
-      });
+    debug.obj_predicted_path = obj_path.path;
 
-    const auto collided_polygons = utils::path_safety_checker::get_collided_polygons(
-      lane_change_path.path, ego_predicted_path, obj, predicted_obj_path, bpp_param.vehicle_info,
-      selected_rss_param, hysteresis_factor, safety_check_max_vel,
-      common_data_ptr_->lc_param_ptr->safety.collision_check.th_yaw_diff,
-      current_debug_data.second);
+    std::vector<autoware_utils_geometry::Polygon2d> collided_polygons{};
+    collided_polygons.reserve(obj_path.path.size());
+    for (const auto & obj_pose_with_poly : obj_path.path) {
+      if (obj_pose_with_poly.time < prepare_duration) {
+        continue;
+      }
+
+      CollisionCheckDebug * debug_ptr = collided_polygons.empty() ? &debug : nullptr;
+      const auto & selected_rss_param =
+        obj_pose_with_poly.time < prepare_duration
+          ? common_data_ptr_->lc_param_ptr->safety.rss_params_for_prepare
+          : lane_changing_phase_rss_param;
+
+      if (
+        const auto collided_polygon_opt = check_collision(
+          lane_change_path.path, bpp_param.vehicle_info, ego_predicted_path, obj_pose_with_poly,
+          selected_rss_param, th_yaw_diff, safety_check_max_vel, hysteresis_factor, debug_ptr)) {
+        collided_polygons.push_back(*collided_polygon_opt);
+      }
+    }
 
     if (collided_polygons.empty()) {
       utils::path_safety_checker::updateCollisionCheckDebugMap(
@@ -1929,32 +1935,6 @@ void NormalLaneChange::updateStopTime()
   }
 
   stop_watch_.tic("stop_time");
-}
-
-bool NormalLaneChange::check_prepare_phase() const
-{
-  const auto & route_handler = getRouteHandler();
-
-  const auto check_in_general_lanes =
-    lane_change_parameters_->safety.collision_check.enable_for_prepare_phase_in_general_lanes;
-
-  lanelet::ConstLanelet current_lane;
-  if (!route_handler->getClosestLaneletWithinRoute(getEgoPose(), &current_lane)) {
-    RCLCPP_DEBUG(
-      logger_, "Unable to get current lane. Default to %s.",
-      (check_in_general_lanes ? "true" : "false"));
-    return check_in_general_lanes;
-  }
-
-  const auto check_in_intersection =
-    lane_change_parameters_->safety.collision_check.enable_for_prepare_phase_in_intersection &&
-    common_data_ptr_->transient_data.in_intersection;
-
-  const auto check_in_turns =
-    lane_change_parameters_->safety.collision_check.enable_for_prepare_phase_in_turns &&
-    common_data_ptr_->transient_data.in_turn_direction_lane;
-
-  return check_in_intersection || check_in_turns || check_in_general_lanes;
 }
 
 void NormalLaneChange::update_dist_from_intersection()

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1802,10 +1802,6 @@ bool NormalLaneChange::is_colliding(
     std::vector<autoware_utils_geometry::Polygon2d> collided_polygons{};
     collided_polygons.reserve(obj_path.path.size());
     for (const auto & obj_pose_with_poly : obj_path.path) {
-      if (obj_pose_with_poly.time < prepare_duration) {
-        continue;
-      }
-
       CollisionCheckDebug * debug_ptr = collided_polygons.empty() ? &debug : nullptr;
       const auto & selected_rss_param =
         obj_pose_with_poly.time < prepare_duration

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -72,11 +72,11 @@ bool isTargetObjectFront(
 Polygon2d createExtendedPolygon(
   const Pose & base_link_pose, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const double lon_length, const double lat_margin, const bool is_stopped_obj,
-  CollisionCheckDebug & debug);
+  CollisionCheckDebug * debug = nullptr);
 
 Polygon2d createExtendedPolygon(
   const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const double lon_length,
-  const double lat_margin, const bool is_stopped_obj, CollisionCheckDebug & debug);
+  const double lat_margin, const bool is_stopped_obj, CollisionCheckDebug * debug = nullptr);
 
 /**
  * @brief Converts path (path with velocity stamped) to predicted path.
@@ -195,6 +195,13 @@ bool checkCollision(
   const PredictedPathWithPolygon & target_object_path,
   const BehaviorPathPlannerParameters & common_parameters, const RSSparams & rss_parameters,
   const double hysteresis_factor, const double yaw_difference_th, CollisionCheckDebug & debug);
+
+std::optional<Polygon2d> check_collision(
+  const PathWithLaneId & planned_path, const VehicleInfo & vehicle_info,
+  const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
+  const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const RSSparams & rss_parameters,
+  const double yaw_difference_th, const double max_velocity_limit, const double hysteresis_factor,
+  CollisionCheckDebug * debug = nullptr);
 
 /**
  * @brief Iterate the points in the ego and target's predicted path and

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_safety_check.cpp
@@ -175,7 +175,6 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
   vehicle_info.max_longitudinal_offset_m = 4.0;
   vehicle_info.vehicle_width_m = 2.0;
   vehicle_info.rear_overhang_m = 1.0;
-  CollisionCheckDebug debug;
 
   {
     Pose ego_pose;
@@ -186,8 +185,8 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
     const double lat_margin = 2.0;
     const bool is_stopped_object = false;
 
-    const auto polygon = createExtendedPolygon(
-      ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object, debug);
+    const auto polygon =
+      createExtendedPolygon(ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 
@@ -214,8 +213,8 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
     const double lat_margin = 2.0;
     const bool is_stopped_object = false;
 
-    const auto polygon = createExtendedPolygon(
-      ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object, debug);
+    const auto polygon =
+      createExtendedPolygon(ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 
@@ -242,8 +241,8 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedEgoPolygon)
     const double lat_margin = 2.0;
     const bool is_stopped_object = false;
 
-    const auto polygon = createExtendedPolygon(
-      ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object, debug);
+    const auto polygon =
+      createExtendedPolygon(ego_pose, vehicle_info, lon_length, lat_margin, is_stopped_object);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 
@@ -291,12 +290,10 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, createExtendedObjPolygon)
     const double lat_margin = 2.0;
     const bool is_stopped_object = false;
 
-    CollisionCheckDebug debug;
-
     PoseWithVelocityAndPolygonStamped obj_pose_with_poly(
       0.0, obj_pose, 0.0, autoware_utils::to_polygon2d(obj_pose, shape));
     const auto polygon =
-      createExtendedPolygon(obj_pose_with_poly, lon_length, lat_margin, is_stopped_object, debug);
+      createExtendedPolygon(obj_pose_with_poly, lon_length, lat_margin, is_stopped_object);
 
     EXPECT_EQ(polygon.outer().size(), static_cast<unsigned int>(5));
 


### PR DESCRIPTION
## Description

1. Currently, the safety check is disabled during the prepare phase, except in cases such as when the ego is in turn-direction lanes or intersections. When disabled, the first few seconds of safety checks are skipped.
   - This is usually not an issue if both vehicles are moving. However, if the ego is stopped while the target vehicle is moving, the skipped safety checks can create a potential near-miss situation, since the initial seconds are incorrectly considered “safe.”
   - This PR fixes the issue by enabling the safety check during the prepare phase.

3. Previously, the prepare phase reused the same RSS parameters as the lane change phase. This made lane changes difficult to execute, as the extended ego polygon (both laterally and longitudinally) frequently overlapped during preparation.
   - In this PR, the RSS parameters for the prepare phase are explicitly defined, allowing parameter tuning and correct calculation of the lateral gap.

Launcher's PR: https://github.com/autowarefoundation/autoware_launch/pull/1631

## Related links

**Parent Issue:**

[TIER IV Internal link - Issue's link](https://tier4.atlassian.net/browse/RT0-39121)

## How was this PR tested?

### 1. Logging simulator

### Before PR

Notice that the target vehicle with **green** bounding box is considered safe, even when ego is close by. 

<img width="533" height="242" alt="screenshot-20250902-073549Z" src="https://github.com/user-attachments/assets/8e60cc7e-ce30-4e8a-a52f-de90e1adddec" />

https://github.com/user-attachments/assets/bb2223ef-d8fc-4e63-b53f-1243c176fb8c

### After PR 

Object remains unsafe 

<img width="849" height="519" alt="image" src="https://github.com/user-attachments/assets/a02e6470-a02a-46d0-bd0d-e4f0154f0f42" />


https://github.com/user-attachments/assets/288a901e-6179-4d8b-8a7a-43231f408a03

### 2. Internal evaluator

1. [TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/e96e6c26-a63d-54fd-9faa-1242a13b4f0f?project_id=prd_jt)
2. [TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/da8f7335-92ec-5101-bb27-2564fd26d540?project_id=prd_jt)
3. [TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/17486faa-5ed2-5e95-82a3-855a096e4edf?project_id=prd_jt) 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

🔴⬆️ -->

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Removed | `enable_for_prepare_phase.general_lanes`   | `bool` | `false`         | Param description |
| Removed | `enable_for_prepare_phase.intersection`   | `bool` | `true`         | Param description |
| Removed | `enable_for_prepare_phase.turns`   | `bool` | `true`         | Param description |


| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `safety_check.prepare.expected_front_deceleration`   | `double` | `-1.0`         | The front object's maximum deceleration when the front vehicle perform sudden braking. |
| Added | `safety_check.prepare.expected_rear_deceleration`   | `double` | `-1.0`         | The rear object's maximum deceleration when the rear vehicle perform sudden braking. |
| Added | `safety_check.prepare.rear_vehicle_reaction_time`   | `double` | `1.0`         | The reaction time of the rear vehicle driver which starts from the driver noticing the sudden braking of the front vehicle until the driver step on the brake. |
| Added | `safety_check.prepare.rear_vehicle_safety_time_margin`   | `double` | `0.8`         | The time buffer for the rear vehicle to come into complete stop when its driver perform sudden braking. |
| Added | `safety_check.prepare.lateral_distance_max_threshold`   | `double` | `0.5`         | The lateral distance threshold that is used to determine whether lateral distance between two object is enough and whether lane change is safe. |
| Added | `safety_check.prepare.longitudinal_distance_min_threshold`   | `double` | `1.0`         | The longitudinal distance threshold that is used to determine whether longitudinal distance between two object is enough and whether lane change is safe. |
| Added | `safety_check.prepare.longitudinal_velocity_delta_time`   | `double` | `0.0`         | The time multiplier that is used to compute the actual gap between vehicle at each predicted points (not RSS distance) |
| Added | `safety_check.prepare.extended_polygon_policy`   | `string` | `along-path`         | Policy used to determine the polygon shape for the safety check. Available options are: `rectangle` or `along-path`. |

<!-- ⬇️🔴

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
