### PR TITLE
fix(autoware_pointcloud_preprocessor): update transform frame for cor…

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_node.cpp
@@ -189,7 +189,7 @@ void CropBoxFilterComponent::faster_filter(
 
   // Note that tf_input_orig_frame_ is the input frame, while tf_input_frame_ is the frame of the
   // crop box
-  output.header.frame_id = tf_input_frame_;
+  output.header.frame_id = tf_output_frame_;
 
   output.height = 1;
   output.fields = input->fields;
@@ -279,7 +279,7 @@ void CropBoxFilterComponent::publish_crop_box_polygon()
   const double z2 = param_.max_z;
 
   geometry_msgs::msg::PolygonStamped polygon_msg;
-  polygon_msg.header.frame_id = tf_input_frame_;
+  polygon_msg.header.frame_id = tf_output_frame_;
   polygon_msg.header.stamp = get_clock()->now();
   polygon_msg.polygon.points.push_back(generatePoint(x1, y1, z1));
   polygon_msg.polygon.points.push_back(generatePoint(x2, y2, z1));

--- a/sensing/autoware_pointcloud_preprocessor/src/filter.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/filter.cpp
@@ -423,7 +423,7 @@ void autoware::pointcloud_preprocessor::Filter::faster_input_indices_callback(
   // For performance reason, defer the transform computation.
   // Do not use pcl_ros::transformPointCloud(). It's too slow due to the unnecessary copy.
   TransformInfo transform_info;
-  if (!calculate_transform_matrix(tf_input_frame_, *cloud, transform_info)) return;
+  if (!calculate_transform_matrix(tf_output_frame_, *cloud, transform_info)) return;
 
   // Need setInputCloud() here because we have to extract x/y/z
   IndicesPtr vindices;


### PR DESCRIPTION
…rect functionality

## Description
The cropbox filter doesn't filter the self points properly.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Before;
![issue_before](https://github.com/user-attachments/assets/f1625429-391a-4395-88f3-6004548f0928)

After;
![issue_after](https://github.com/user-attachments/assets/c8bccad1-2d38-4428-a1d5-b31af114f133)



None.
