### PR TITLE
fix(gpu_monitor): Report GPU Usage successfully on NVIDIA Jetson AGX Orin

### DIFF
--- a/system/autoware_system_monitor/src/gpu_monitor/tegra_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/tegra_gpu_monitor.cpp
@@ -170,7 +170,12 @@ void GPUMonitor::getTempNames()
 
 void GPUMonitor::getLoadNames()
 {
-  const fs::path root("/sys/devices");
+  // Both Jetson AGX Xavier and Orin provide a symbolic link with the same name
+  // "/sys/devices/platform/gpu.0", which points to a platform-specific
+  // device file.
+  // Xavier also provides another symbolic link "/sys/devices/gpu.0",
+  // but Orin does not.
+  const fs::path root("/sys/devices/platform");
 
   for (const fs::path & path :
        boost::make_iterator_range(fs::directory_iterator(root), fs::directory_iterator())) {


### PR DESCRIPTION
## Description

Read GPU load value from "/sys/devices/platform/gpu.0" instead of "/sys/devices/gpu.0".
* Jetson Orin provides only "/sys/devices/platform/gpu.0".
* Jetson Xavier provides both "/sys/devices/platform/gpu.0" and "/sys/devices/gpu.0".

The current implementation reads from "/sys/devices/gpu.0", but it is not provided on Jetson Orin.
As the result, the "gpu_monitor" node fails to report GPU load on Jetson Orin.

This PR fixes the problem by reading from "/sys/devices/platform/gpu.0".

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/11325

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-10616)


## How was this PR tested?

- The "gpu_monitor" was tested on NVIDIA Jetson AGX Orin
- The "gpu_monitor" reports "GPU Usage" successfully to the "/diagnostics" topic.
- The reported "GPU Usage" reflects the load of GPU in percentage (0.0 - 100.0).
  - When a graphics sample like "ico" is executed, the value of "GPU Usage" goes up.
  - When the GPU is idle, the value of "GPU Usage" is 0.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
