### PR TITLE
refactor(diffusion_planner): fix to use `lane_segments_`

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/dimensions.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/dimensions.hpp
@@ -28,8 +28,6 @@ inline constexpr int64_t POINTS_PER_SEGMENT = 20;  //!< Number of points in each
 // Number of columns in a segment matrix
 // (X,Y,dX,dY,LeftBoundX,LeftBoundY,RightBoundX,RightBoundY,TrafficLightEncoding(Dim5),Speed Limit)
 inline constexpr int64_t TRAFFIC_LIGHT_ONE_HOT_DIM = 5;
-inline constexpr int64_t SEGMENT_POINT_DIM = 8 + TRAFFIC_LIGHT_ONE_HOT_DIM;
-inline constexpr int64_t FULL_MATRIX_ROWS = SEGMENT_POINT_DIM + 3;
 
 inline constexpr int64_t EGO_AGENT_PAST_IDX_X = 0;
 inline constexpr int64_t EGO_AGENT_PAST_IDX_Y = 1;
@@ -51,9 +49,7 @@ inline constexpr int64_t TRAFFIC_LIGHT_YELLOW = 9;
 inline constexpr int64_t TRAFFIC_LIGHT_RED = 10;
 inline constexpr int64_t TRAFFIC_LIGHT_WHITE = 11;
 inline constexpr int64_t TRAFFIC_LIGHT_NO_TRAFFIC_LIGHT = 12;
-inline constexpr int64_t SPEED_LIMIT = 13;
-inline constexpr int64_t LANE_ID = 14;
-inline constexpr int64_t TURN_DIRECTION = 15;
+inline constexpr int64_t SEGMENT_POINT_DIM = 13;
 
 inline constexpr int64_t INPUT_T = 20;
 inline constexpr int64_t OUTPUT_T = 80;  // Output timestamp number

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/lane_segments.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/preprocessing/lane_segments.hpp
@@ -163,6 +163,7 @@ private:
     const std::vector<ColWithDistance> & distances, int64_t m) const;
 
   // variables
+  std::vector<autoware::diffusion_planner::LaneSegment> lane_segments_;
   Eigen::MatrixXd map_lane_segments_matrix_;
   ColLaneIDMaps col_id_mapping_;
   const std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;

--- a/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
@@ -91,13 +91,14 @@ std::pair<std::vector<float>, std::vector<float>> LaneSegmentContext::get_route_
       0, added_route_segments * POINTS_PER_SEGMENT, SEGMENT_POINT_DIM, POINTS_PER_SEGMENT) =
       map_lane_segments_matrix_.block(0, row_idx, SEGMENT_POINT_DIM, POINTS_PER_SEGMENT);
 
-    const int64_t turn_direction = lane_segments_[row_idx / POINTS_PER_SEGMENT].turn_direction;
+    const int64_t seg_idx = row_idx / POINTS_PER_SEGMENT;
+    const int64_t turn_direction = lane_segments_[seg_idx].turn_direction;
     add_traffic_light_one_hot_encoding_to_segment(
       traffic_light_id_map, full_route_segment_matrix, row_idx, added_route_segments,
       turn_direction);
 
     speed_limit_vector[added_route_segments] =
-      lane_segments_[row_idx / POINTS_PER_SEGMENT].speed_limit_mps.value_or(0.0f);
+      lane_segments_[seg_idx].speed_limit_mps.value_or(0.0f);
     ++added_route_segments;
   }
   // Transform the route segments.

--- a/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
@@ -55,14 +55,13 @@ uint8_t identify_current_light_status(
 LaneSegmentContext::LaneSegmentContext(const std::shared_ptr<lanelet::LaneletMap> & lanelet_map_ptr)
 : lanelet_map_ptr_(lanelet_map_ptr)
 {
-  const std::vector<autoware::diffusion_planner::LaneSegment> lane_segments =
-    convert_to_lane_segments(lanelet_map_ptr_, POINTS_PER_SEGMENT);
+  lane_segments_ = convert_to_lane_segments(lanelet_map_ptr_, POINTS_PER_SEGMENT);
 
-  if (lane_segments.empty()) {
+  if (lane_segments_.empty()) {
     throw std::runtime_error("No lane segments found in the map");
   }
 
-  map_lane_segments_matrix_ = process_segments_to_matrix(lane_segments, col_id_mapping_);
+  map_lane_segments_matrix_ = process_segments_to_matrix(lane_segments_, col_id_mapping_);
 }
 
 std::pair<std::vector<float>, std::vector<float>> LaneSegmentContext::get_route_segments(
@@ -92,12 +91,13 @@ std::pair<std::vector<float>, std::vector<float>> LaneSegmentContext::get_route_
       0, added_route_segments * POINTS_PER_SEGMENT, SEGMENT_POINT_DIM, POINTS_PER_SEGMENT) =
       map_lane_segments_matrix_.block(0, row_idx, SEGMENT_POINT_DIM, POINTS_PER_SEGMENT);
 
-    const int64_t turn_direction = map_lane_segments_matrix_(TURN_DIRECTION, row_idx);
+    const int64_t turn_direction = lane_segments_[row_idx / POINTS_PER_SEGMENT].turn_direction;
     add_traffic_light_one_hot_encoding_to_segment(
       traffic_light_id_map, full_route_segment_matrix, row_idx, added_route_segments,
       turn_direction);
 
-    speed_limit_vector[added_route_segments] = map_lane_segments_matrix_(SPEED_LIMIT, row_idx);
+    speed_limit_vector[added_route_segments] =
+      lane_segments_[row_idx / POINTS_PER_SEGMENT].speed_limit_mps.value_or(0.0f);
     ++added_route_segments;
   }
   // Transform the route segments.
@@ -113,9 +113,9 @@ std::pair<std::vector<float>, std::vector<float>> LaneSegmentContext::get_lane_s
   const std::map<lanelet::Id, TrafficSignalStamped> & traffic_light_id_map, const float center_x,
   const float center_y, const int64_t m) const
 {
-  if (map_lane_segments_matrix_.rows() != FULL_MATRIX_ROWS || m <= 0) {
+  if (map_lane_segments_matrix_.rows() != SEGMENT_POINT_DIM || m <= 0) {
     throw std::invalid_argument(
-      "Input matrix must have at least FULL_MATRIX_ROWS rows and m must be greater than 0.");
+      "Input matrix must have at least SEGMENT_POINT_DIM rows and m must be greater than 0.");
   }
   // Step 1: Compute distances
   std::vector<ColWithDistance> distances = compute_distances(transform_matrix, center_x, center_y);
@@ -140,7 +140,8 @@ std::pair<std::vector<float>, std::vector<float>> LaneSegmentContext::get_lane_s
   const auto total_speed_points = LANES_SPEED_LIMIT_SHAPE[1];
   std::vector<float> lane_speed_vector(total_speed_points);
   for (int64_t i = 0; i < total_speed_points; ++i) {
-    lane_speed_vector[i] = ego_centric_lane_segments(SPEED_LIMIT, i * POINTS_PER_SEGMENT);
+    const int64_t row_idx = distances[i].index / POINTS_PER_SEGMENT;
+    lane_speed_vector[i] = lane_segments_[row_idx].speed_limit_mps.value_or(0.0f);
   }
 
   return {lane_tensor_data, lane_speed_vector};
@@ -259,7 +260,7 @@ Eigen::MatrixXd LaneSegmentContext::transform_points_and_add_traffic_info(
   const std::vector<ColWithDistance> & distances, int64_t m) const
 {
   if (
-    map_lane_segments_matrix_.rows() != FULL_MATRIX_ROWS ||
+    map_lane_segments_matrix_.rows() != SEGMENT_POINT_DIM ||
     map_lane_segments_matrix_.cols() % POINTS_PER_SEGMENT != 0) {
     throw std::invalid_argument("input_matrix size mismatch");
   }
@@ -268,7 +269,7 @@ Eigen::MatrixXd LaneSegmentContext::transform_points_and_add_traffic_info(
     static_cast<int64_t>(map_lane_segments_matrix_.cols() / POINTS_PER_SEGMENT);
   const int64_t num_segments = std::min(m, n_total_segments);
 
-  Eigen::MatrixXd output_matrix(FULL_MATRIX_ROWS, m * POINTS_PER_SEGMENT);
+  Eigen::MatrixXd output_matrix(SEGMENT_POINT_DIM, m * POINTS_PER_SEGMENT);
   output_matrix.setZero();
 
   int64_t added_segments = 0;
@@ -284,13 +285,13 @@ Eigen::MatrixXd LaneSegmentContext::transform_points_and_add_traffic_info(
     }
 
     // get POINTS_PER_SEGMENT rows corresponding to a single segment
-    output_matrix.block<FULL_MATRIX_ROWS, POINTS_PER_SEGMENT>(
+    output_matrix.block<SEGMENT_POINT_DIM, POINTS_PER_SEGMENT>(
       0, added_segments * POINTS_PER_SEGMENT) =
-      map_lane_segments_matrix_.block<FULL_MATRIX_ROWS, POINTS_PER_SEGMENT>(
+      map_lane_segments_matrix_.block<SEGMENT_POINT_DIM, POINTS_PER_SEGMENT>(
         0, col_idx_in_original_map);
 
     const int64_t turn_direction =
-      map_lane_segments_matrix_(TURN_DIRECTION, col_idx_in_original_map);
+      lane_segments_[col_idx_in_original_map / POINTS_PER_SEGMENT].turn_direction;
     add_traffic_light_one_hot_encoding_to_segment(
       traffic_light_id_map, output_matrix, col_idx_in_original_map, added_segments, turn_direction);
 
@@ -419,9 +420,10 @@ Eigen::MatrixXd process_segments_to_matrix(
   Eigen::MatrixXd stacked_matrix(rows, cols);
 
   int64_t current_row = 0;
-  for (const auto & mat : all_segment_matrices) {
+  for (int64_t i = 0; i < static_cast<int64_t>(lane_segments.size()); ++i) {
+    const auto & mat = all_segment_matrices[i];
     stacked_matrix.middleRows(current_row, mat.rows()) = mat;
-    const auto id = static_cast<int64_t>(mat(0, LANE_ID));
+    const auto id = lane_segments[i].id;
     col_id_mapping.lane_id_to_matrix_col.emplace(id, current_row);
     col_id_mapping.matrix_col_to_lane_id.emplace(current_row, id);
     current_row += POINTS_PER_SEGMENT;
@@ -448,7 +450,7 @@ Eigen::MatrixXd process_segment_to_matrix(const LaneSegment & segment)
       "POINTS_PER_SEGMENT points");
   }
 
-  Eigen::MatrixXd segment_data(POINTS_PER_SEGMENT, FULL_MATRIX_ROWS);
+  Eigen::MatrixXd segment_data(POINTS_PER_SEGMENT, SEGMENT_POINT_DIM);
   segment_data.setZero();
 
   // Build each row
@@ -463,9 +465,6 @@ Eigen::MatrixXd process_segment_to_matrix(const LaneSegment & segment)
     segment_data(i, LB_Y) = left_boundaries[i].y();
     segment_data(i, RB_X) = right_boundaries[i].x();
     segment_data(i, RB_Y) = right_boundaries[i].y();
-    segment_data(i, SPEED_LIMIT) = segment.speed_limit_mps.value_or(0.0f);
-    segment_data(i, LANE_ID) = static_cast<float>(segment.id);
-    segment_data(i, TURN_DIRECTION) = segment.turn_direction;
   }
 
   return segment_data;


### PR DESCRIPTION
## Description

This PR refactors the diffusion planner to use the `lane_segments_` member variable directly instead of extracting data from the matrix representation, improving code clarity and reducing redundant data storage.

- Store lane segments as a member variable and access segment properties directly from the original data structure
- Remove redundant storage of speed limit, lane ID, and turn direction in the matrix representation
- Update matrix dimension constants to reflect the reduced data storage requirements

## How was this PR tested?

Run `autoware_diffusion_planner`

### Processing Time

* Before
  * create_input_data        1.0 ± 0.4 msec
* After
  * create_input_data        1.0 ± 0.5 msec

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
