### PR TITLE
refactor(boundary_departure): move visualization marker functions to …

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -132,6 +132,21 @@ private:
    */
   bool is_critical_departure_persist();
 
+  /**
+   * @brief Generates and publishes visualization markers for virtual walls and debugging.
+   */
+  void publish_visualization_markers();
+
+  /**
+   * @brief Helper function for virtual walls
+   */
+  void publish_virtual_walls(const rclcpp::Time & current_time);
+
+  /**
+   * @brief Helper function for debug markers
+   */
+  void publish_debug_markers(const rclcpp::Time & current_time);
+
   rclcpp::Clock::SharedPtr clock_ptr_;
 
   std::string module_name_;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/debug.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/debug.cpp
@@ -234,11 +234,10 @@ Marker create_departure_interval_marker(
 }
 
 MarkerArray create_debug_marker_array(
-  const Output & output, const Trajectory & ego_traj, const rclcpp::Clock::SharedPtr & clock_ptr,
+  const Output & output, const Trajectory & ego_traj, const rclcpp::Time & curr_time,
   const double base_link_z, const NodeParam & node_param)
 {
   const auto line_list = visualization_msgs::msg::Marker::LINE_LIST;
-  const auto curr_time = clock_ptr->now();
   const auto color = color::green();
   const auto m_scale = create_marker_scale(0.05, 0, 0);
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/debug.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/debug.hpp
@@ -25,7 +25,7 @@ Marker create_departure_points_marker(
   const double base_link_z);
 
 MarkerArray create_debug_marker_array(
-  const Output & output, const Trajectory & ego_traj, const rclcpp::Clock::SharedPtr & clock_ptr,
+  const Output & output, const Trajectory & ego_traj, const rclcpp::Time & curr_time,
   const double base_link_z, const NodeParam & node_param);
 }  // namespace autoware::motion_velocity_planner::experimental::debug
 


### PR DESCRIPTION
## Description

Minor refactoring as effort to reduce the size of the plan funtions.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. Build success.
2. Run PSIM.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
