### PR TITLE
feat(cpu_monitor): Enable CPU temperature warning and error only on NVIDIA Tegra platforms

### DIFF
--- a/system/autoware_system_monitor/CMakeLists.txt
+++ b/system/autoware_system_monitor/CMakeLists.txt
@@ -49,6 +49,12 @@ else()
   set(CMAKE_CPU_PLATFORM "unknown")
 endif()
 
+# Enable temperature diagnostics only for Tegra platforms,
+# where thermal throttling can't be detected.
+if(CMAKE_CPU_PLATFORM STREQUAL "tegra")
+  add_definitions(-DENABLE_TEMPERATURE_DIAGNOSTICS)
+endif()
+
 if(NVML_FOUND)
   set(CMAKE_GPU_PLATFORM "nvml")
   add_definitions(-D_GPU_NVML_)

--- a/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp
@@ -72,8 +72,8 @@ CPUMonitorBase::CPUMonitorBase(const std::string & node_name, const rclcpp::Node
       "usage_avg", true,
       rcl_interfaces::msg::ParameterDescriptor().set__read_only(true).set__description(
         "Use average CPU usage across all processors. Cannot be changed after initialization."))),
-// Warning/Error about temperature used to be implemented,
-// but they were removed in favor of warning/error about thermal throttling.
+// Warning/Error about temperature is enabled only on platforms where
+// more reliable thermal throttling diagnostics is unavailable.
 #ifdef ENABLE_TEMPERATURE_DIAGNOSTICS
   temperature_warn_(
     declare_parameter<int>(
@@ -172,8 +172,8 @@ void CPUMonitorBase::checkTemperature()
       ifs.close();
 
       int core_level = DiagStatus::OK;
-// Warning/Error about temperature used to be implemented,
-// but they were removed in favor of warning/error about thermal throttling.
+// Warning/Error about temperature is enabled only on platforms where
+// more reliable thermal throttling diagnostics is unavailable.
 #ifdef ENABLE_TEMPERATURE_DIAGNOSTICS
       if (temperature >= temperature_error_) {
         core_level = DiagStatus::ERROR;


### PR DESCRIPTION
## Description
Enable CPU temperature warning and error only on NVIDIA Tegra platforms.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/11334

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-11033)

## How was this PR tested?

- All of CI workflows pass
- CPU Temperature warning/error are reported on NVIDIA Jetson AGX Orin.
- CPU Temperature warning/error are NOT reported on Intel CPU PC.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
