### PR TITLE
feat(RTC, behavior_velocity_planner): set manual RTC via the lanelet map

### DIFF
--- a/planning/autoware_rtc_interface/README.md
+++ b/planning/autoware_rtc_interface/README.md
@@ -6,6 +6,10 @@ RTC Interface is an interface to publish the decision status of behavior plannin
 
 ## Inner-workings / Algorithms
 
+The RTC Interface works by creating a communication channel between a behavior planning module and the rest of the autonomous driving system.
+The planning module uses the interface to publish its current status, such as whether it is safe to proceed or if it is waiting for an external command.
+Other modules can then subscribe to this status information and send commands to the behavior planning module, such as "activate" or "deactivate".
+
 ### Usage example
 
 ```c++
@@ -20,6 +24,9 @@ while (...) {
   // Get safety status of the module corresponding to the module id
   const bool safe = ...
 
+  // Get the current state of the module
+  const uint8_t state = ...
+
   // Get distance to the object corresponding to the module id
   const double start_distance = ...
   const double finish_distance = ...
@@ -28,7 +35,7 @@ while (...) {
   const rclcpp::Time stamp = ...
 
   // Update status
-  rtc_interface.updateCooperateStatus(uuid, safe, start_distance, finish_distance, stamp);
+  rtc_interface.updateCooperateStatus(uuid, safe, state, start_distance, finish_distance, stamp);
 
   if (rtc_interface.isActivated(uuid)) {
     // Execute planning
@@ -51,7 +58,7 @@ rtc_interface.removeCooperateStatus(uuid);
 ### RTCInterface (Constructor)
 
 ```c++
-autoware::rtc_interface::RTCInterface(rclcpp::Node & node, const std::string & name);
+autoware::rtc_interface::RTCInterface(rclcpp::Node & node, const std::string & name, const bool enable_rtc = false);
 ```
 
 #### Description
@@ -64,6 +71,7 @@ A constructor for `autoware::rtc_interface::RTCInterface`.
 - `name` : Name of cooperate status array topic and cooperate commands service
   - Cooperate status array topic name : `~/{name}/cooperate_status`
   - Cooperate commands service name : `~/{name}/cooperate_commands`
+- `enable_rtc`: A boolean indicating whether RTC is enabled or not by default.
 
 #### Output
 
@@ -105,6 +113,8 @@ If cooperate status corresponding to `uuid` is not registered yet, add new coope
 - `start_distance` : Distance to the start object from ego vehicle
 - `finish_distance` : Distance to the finish object from ego vehicle
 - `stamp` : Time stamp
+- `requested`: A boolean indicating whether a request has been made.
+- `override_rtc_auto_mode`: An optional boolean to override the RTC mode (true forces AUTO, false forces MANUAL).
 
 #### Output
 

--- a/planning/autoware_rtc_interface/include/autoware/rtc_interface/rtc_interface.hpp
+++ b/planning/autoware_rtc_interface/include/autoware/rtc_interface/rtc_interface.hpp
@@ -52,9 +52,20 @@ class RTCInterface
 public:
   RTCInterface(rclcpp::Node * node, const std::string & name, const bool enable_rtc = true);
   void publishCooperateStatus(const rclcpp::Time & stamp);
+  /// @brief update the cooperate status of the module identified by the given UUID
+  /// @param[in] uuid unique ID of the module
+  /// @param[in] safe new value for the "safe" field
+  /// @param[in] state new value for the "state" field
+  /// @param[in] start_distance new value for the "start_distance" field
+  /// @param[in] finish_distance new value for the "finish_distance" field
+  /// @param[in] stamp new value for the "stamp" field
+  /// @param[in] requested new value for the "requested" field (default to false)
+  /// @param[in] override_rtc_auto_mode optional value of the "auto_mode" field (if not set, the
+  /// "auto_mode" is only true if enable_rtc was false at initialization)
   void updateCooperateStatus(
     const UUID & uuid, const bool safe, const uint8_t state, const double start_distance,
-    const double finish_distance, const rclcpp::Time & stamp, const bool requested = false);
+    const double finish_distance, const rclcpp::Time & stamp, const bool requested = false,
+    const std::optional<bool> & override_rtc_auto_mode = std::nullopt);
   void removeCooperateStatus(const UUID & uuid);
   void removeExpiredCooperateStatus();
   void clearCooperateStatus();

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -246,7 +246,8 @@ void RTCInterface::onTimer()
 
 void RTCInterface::updateCooperateStatus(
   const UUID & uuid, const bool safe, const uint8_t state, const double start_distance,
-  const double finish_distance, const rclcpp::Time & stamp, const bool requested)
+  const double finish_distance, const rclcpp::Time & stamp, const bool requested,
+  const std::optional<bool> & override_rtc_auto_mode)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   // Find registered status which has same uuid
@@ -266,7 +267,7 @@ void RTCInterface::updateCooperateStatus(
     status.state.type = State::WAITING_FOR_EXECUTION;
     status.start_distance = start_distance;
     status.finish_distance = finish_distance;
-    status.auto_mode = is_auto_mode_enabled_;
+    status.auto_mode = override_rtc_auto_mode.value_or(is_auto_mode_enabled_);
     registered_status_.statuses.push_back(status);
 
     if (state != State::WAITING_FOR_EXECUTION)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/README.md
@@ -348,6 +348,15 @@ In the `common` namespace, the following parameters are defined.
 | `enable_rtc`                  | [-]  | bool   | if true, the scene modules should be approved by (request to cooperate)rtc function. if false, the module can be run without approval from rtc. |
 | `lost_detection_timeout`      | [s]  | double | Time to keep an object after its detection is lost                                                                                              |
 
+#### Map-based forced RTC
+
+RTC can be enabled for specific crosswalks in the lanelet map such that even if `enable_rtc` is set to `false`, approval will be required for crossing the corresponding crosswalks.
+The following attribute should be added to the crosswalk lanelet in the map file:
+
+```xml
+<tag k='rtc_approval_required_v1' v='crosswalk' />
+```
+
 ## Known Issues
 
 - The yield decision may be sometimes aggressive or conservative depending on the case.

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
@@ -219,9 +219,13 @@ void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
         node_, road_lanelet_id, crosswalk_lanelet_id, reg_elem_id, lanelet_map_ptr, p, logger,
         clock_, time_keeper_, planning_factor_interface_));
     generate_uuid(crosswalk_lanelet_id);
+    std::optional<bool> override_rtc_auto_mode;
+    if (crosswalk_lanelet_id == 163) {
+      override_rtc_auto_mode = false;
+    }
     updateRTCStatus(
       getUUID(crosswalk_lanelet_id), true, State::WAITING_FOR_EXECUTION,
-      std::numeric_limits<double>::lowest(), path.header.stamp);
+      std::numeric_limits<double>::lowest(), path.header.stamp, override_rtc_auto_mode);
   };
 
   const auto crosswalk_reg_elem_map = planning_utils::getRegElemMapOnPath<Crosswalk>(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
@@ -219,9 +219,18 @@ void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
         node_, road_lanelet_id, crosswalk_lanelet_id, reg_elem_id, lanelet_map_ptr, p, logger,
         clock_, time_keeper_, planning_factor_interface_));
     generate_uuid(crosswalk_lanelet_id);
+    const auto crosswalk_ll = lanelet_map_ptr->laneletLayer.get(crosswalk_lanelet_id);
     std::optional<bool> override_rtc_auto_mode;
-    if (crosswalk_lanelet_id == 163) {
-      override_rtc_auto_mode = false;
+    const auto key = "rtc_approval_required_v1";
+    if (crosswalk_ll.hasAttribute(key)) {
+      std::stringstream manual_modules(crosswalk_ll.attribute(key).value());
+      std::string manual_module;
+      // modules are listed in the attribute value, separated by a comma
+      while (std::getline(manual_modules, manual_module, ',')) {
+        if (manual_module == "crosswalk") {
+          override_rtc_auto_mode = false;
+        }
+      }
     }
     updateRTCStatus(
       getUUID(crosswalk_lanelet_id), true, State::WAITING_FOR_EXECUTION,

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -17,6 +17,7 @@
 #include "occluded_crosswalk.hpp"
 #include "parked_vehicles_stop.hpp"
 
+#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/path_utilization.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/motion_utils/distance/distance.hpp>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/README.md
@@ -258,6 +258,17 @@ While ego is creeping, yellow intersection_wall appears in front ego.
 
 ![occlusion-wo-tl-creeping](./docs/occlusion-wo-tl-creeping.png)
 
+### Map-based forced RTC
+
+RTC can be enabled for specific intersection lanelets such that even if approval is not required by default, it will be required before crossing the corresponding intersection lanelets.
+The following attribute should be added to the crosswalk lanelet in the map file:
+
+```xml
+<tag k='rtc_approval_required_v1' v='intersection' />
+```
+
+The value can be set to `intersection`, `intersection_occlusion`, or `intersection,intersection_occlusion`, to adjust which modules will require approvals.
+
 ## Traffic signal specific behavior
 
 ### Collision detection

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/README.md
@@ -261,7 +261,7 @@ While ego is creeping, yellow intersection_wall appears in front ego.
 ### Map-based forced RTC
 
 RTC can be enabled for specific intersection lanelets such that even if approval is not required by default, it will be required before crossing the corresponding intersection lanelets.
-The following attribute should be added to the crosswalk lanelet in the map file:
+The following attribute should be added to the lanelet in intersection in the map file:
 
 ```xml
 <tag k='rtc_approval_required_v1' v='intersection' />

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
@@ -24,6 +24,7 @@
 #include <limits>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -363,12 +364,29 @@ void IntersectionModuleManager::launchNewModules(
     /* set RTC status as non_occluded status initially */
     const UUID uuid = getUUID(new_module->getModuleId());
     const auto occlusion_uuid = new_module->getOcclusionUUID();
+    std::optional<bool> override_rtc_auto_mode;
+    std::optional<bool> override_occlusion_rtc_auto_mode;
+    constexpr auto key = "rtc_approval_required_v1";
+    if (ll.hasAttribute(key)) {
+      std::stringstream manual_modules(ll.attribute(key).value());
+      std::string manual_module;
+      // modules are listed in the attribute value, separated by a comma
+      while (std::getline(manual_modules, manual_module, ',')) {
+        if (manual_module == "intersection") {
+          override_rtc_auto_mode = false;
+        }
+        if (manual_module == "intersection_occlusion") {
+          override_occlusion_rtc_auto_mode = false;
+        }
+      }
+    }
     rtc_interface_.updateCooperateStatus(
       uuid, true, State::WAITING_FOR_EXECUTION, std::numeric_limits<double>::lowest(),
-      std::numeric_limits<double>::lowest(), clock_->now());
+      std::numeric_limits<double>::lowest(), clock_->now(), false, override_rtc_auto_mode);
     occlusion_rtc_interface_.updateCooperateStatus(
       occlusion_uuid, true, State::WAITING_FOR_EXECUTION, std::numeric_limits<double>::lowest(),
-      std::numeric_limits<double>::lowest(), clock_->now());
+      std::numeric_limits<double>::lowest(), clock_->now(), false,
+      override_occlusion_rtc_auto_mode);
     registerModule(std::move(new_module));
   }
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
@@ -103,9 +103,10 @@ protected:
 
   void updateRTCStatus(
     const UUID & uuid, const bool safe, const uint8_t state, const double distance,
-    const Time & stamp)
+    const Time & stamp, const std::optional<bool> override_rtc_auto_mode = std::nullopt)
   {
-    rtc_interface_.updateCooperateStatus(uuid, safe, state, distance, distance, stamp);
+    rtc_interface_.updateCooperateStatus(
+      uuid, safe, state, distance, distance, stamp, false, override_rtc_auto_mode);
   }
 
   void removeRTCStatus(const UUID & uuid) { rtc_interface_.removeCooperateStatus(uuid); }


### PR DESCRIPTION
## Description

This PR enables the use of lanelet attributes to force some modules to use the manual RTC mode when going through the corresponding lanelet.


https://github.com/user-attachments/assets/a675d168-35b9-4206-bb9d-afe34e5c5400



## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-10926)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
