### PR TITLE
fix(lane_change): include stopping object beside ego as target

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
@@ -1134,6 +1134,25 @@ where
 
 If none of the sampled accelerations pass the safety check, the lane change path will be canceled, subject to the [hysteresis check](#preventing-oscillating-paths-when-unsafe).
 
+!!! note
+
+    Applying this fix allows the vehicle to change lanes more easily behind a leading object.
+
+!!! warning
+
+    Although the safety check assumes deceleration, it actually executes the **original path velocity**.
+
+    The behavior module assumes that downstream modules (e.g., obstacle stop, cruise planner) will handle actual velocity adjustments.
+    Because of this, **deceleration sampling is applied only to leading objects**, not trailing or adjacent ones.
+
+    * For **leading objects**, secondary safety layers exist — for example, obstacle stop or cruise planner modules that can modify the velocity profile in response to sudden deceleration.
+    * For **trailing or nearby objects**, such mechanisms do not exist (obstacle stop and cruise do not apply to trailing objects).
+
+    Therefore, applying deceleration sampling in these cases could lead to **false negatives**, i.e.: the safety check would assume ego is decelerating, when in reality, ego cannot decelerate.
+
+    In practice, other modules (e.g., run out) may occasionally cause ego to decelerate, indirectly affecting safety check behavior for trailing objects. However, these activations are **situation-dependent** and **not guaranteed**.
+    Hence, **no deceleration sampling** is applied to trailing objects.
+
 #### Cancel
 
 Cancelling lane change is possible as long as the ego vehicle is in the prepare phase and has not started deviating from the current lane center line.

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -157,7 +157,7 @@ protected:
 
   bool isValidPath(const PathWithLaneId & path) const override;
 
-  std::optional<ExtendedPredictedObject> find_colliding_object_if_all_paths_collide(
+  std::optional<std::vector<ExtendedPredictedObject>> find_colliding_object_if_all_paths_collide(
     const LaneChangePath & lane_change_path,
     const std::vector<std::vector<PoseWithVelocityStamped>> & ego_predicted_paths,
     const ExtendedPredictedObjects & objects,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -157,6 +157,13 @@ protected:
 
   bool isValidPath(const PathWithLaneId & path) const override;
 
+  std::optional<ExtendedPredictedObject> find_colliding_object_if_all_paths_collide(
+    const LaneChangePath & lane_change_path,
+    const std::vector<std::vector<PoseWithVelocityStamped>> & ego_predicted_paths,
+    const ExtendedPredictedObjects & objects,
+    const utils::path_safety_checker::RSSparams & rss_params,
+    CollisionCheckDebugMap & debug_dataconst, const bool is_approved) const;
+
   PathSafetyStatus isLaneChangePathSafe(
     const LaneChangePath & lane_change_path,
     const std::vector<std::vector<PoseWithVelocityStamped>> & ego_predicted_paths,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
@@ -323,7 +323,8 @@ struct EgoObjectProximity
       return false;
     }
 
-    return ego_dist_to_terminal_end->max >= object_dist_to_terminal_end->min;
+    return ego_dist_to_terminal_end->max >= object_dist_to_terminal_end->min &&
+           ego_dist_to_terminal_end->min <= object_dist_to_terminal_end->max;
   }
 };
 }  // namespace autoware::behavior_path_planner::lane_change

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
@@ -224,6 +224,8 @@ struct TransientData
     current_dist_buffer;  // distance buffer computed backward from current lanes' terminal end
   MinMaxValue
     next_dist_buffer;  // distance buffer computed backward  from target lanes' terminal end
+  MinMaxValue ego_to_terminal_end_proximity;
+
   double dist_to_terminal_end{
     std::numeric_limits<double>::min()};  // distance from ego base link to the current lanes'
                                           // terminal end
@@ -308,6 +310,22 @@ struct CommonData
   }
 };
 using CommonDataPtr = std::shared_ptr<CommonData>;
+
+struct EgoObjectProximity
+{
+  bool is_ahead_of_ego{false};
+  std::optional<MinMaxValue> ego_dist_to_terminal_end;
+  std::optional<MinMaxValue> object_dist_to_terminal_end;
+
+  [[nodiscard]] bool is_overlapping() const
+  {
+    if (!ego_dist_to_terminal_end || !object_dist_to_terminal_end) {
+      return false;
+    }
+
+    return ego_dist_to_terminal_end->max >= object_dist_to_terminal_end->min;
+  }
+};
 }  // namespace autoware::behavior_path_planner::lane_change
 
 namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -476,5 +476,8 @@ bool is_valid_start_point(const lane_change::CommonDataPtr & common_data_ptr, co
 std::vector<PoseWithVelocityStamped> convert_to_predicted_path(
   const CommonDataPtr & common_data_ptr, const lane_change::TrajectoryGroup & frenet_candidate,
   [[maybe_unused]] const size_t deceleration_sampling_num);
+
+bool is_moving_object(
+  const CommonDataPtr & common_data_ptr, const ExtendedPredictedObject & object);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -54,8 +54,10 @@ using autoware_perception_msgs::msg::PredictedPath;
 using autoware_utils::LineString2d;
 using autoware_utils::Polygon2d;
 using behavior_path_planner::lane_change::CommonDataPtr;
+using behavior_path_planner::lane_change::EgoObjectProximity;
 using behavior_path_planner::lane_change::LanesPolygon;
 using behavior_path_planner::lane_change::LCParamPtr;
+using behavior_path_planner::lane_change::MinMaxValue;
 using behavior_path_planner::lane_change::ModuleType;
 using behavior_path_planner::lane_change::PathSafetyStatus;
 using behavior_path_planner::lane_change::TargetLaneLeadingObjects;
@@ -255,7 +257,10 @@ bool is_same_lane_with_prev_iteration(
   const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & current_lanes,
   const lanelet::ConstLanelets & target_lanes);
 
-bool is_ahead_of_ego(
+MinMaxValue calc_polygon_dist_range_from_terminal_end(
+  const PathWithLaneId & path, const autoware_utils_geometry::Polygon2d & polygon);
+
+EgoObjectProximity calc_ego_object_proximity(
   const CommonDataPtr & common_data_ptr, const PathWithLaneId & path,
   const ExtendedPredictedObject & object);
 
@@ -383,7 +388,7 @@ bool has_overtaking_turn_lane_object(
  */
 bool filter_target_lane_objects(
   const CommonDataPtr & common_data_ptr, const ExtendedPredictedObject & object,
-  const double dist_ego_to_current_lanes_center, const bool ahead_of_ego,
+  const double dist_ego_to_current_lanes_center, const EgoObjectProximity & ego_object_proximity,
   const bool before_terminal, TargetLaneLeadingObjects & leading_objects,
   ExtendedPredictedObjects & trailing_objects);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -199,6 +199,10 @@ void NormalLaneChange::update_transient_data(const bool is_approved)
   transient_data.current_footprint = utils::lane_change::get_ego_footprint(
     common_data_ptr_->get_ego_pose(), common_data_ptr_->bpp_param_ptr->vehicle_info);
 
+  transient_data.ego_to_terminal_end_proximity =
+    utils::lane_change::calc_polygon_dist_range_from_terminal_end(
+      common_data_ptr_->current_lanes_path, transient_data.current_footprint);
+
   const auto & ego_lane = common_data_ptr_->lanes_ptr->ego_lane;
   const auto & route_handler_ptr = common_data_ptr_->route_handler_ptr;
   transient_data.in_intersection = utils::lane_change::is_within_intersection(
@@ -1001,11 +1005,13 @@ FilteredLanesObjects NormalLaneChange::filter_objects() const
     const auto is_before_terminal =
       utils::lane_change::is_before_terminal(common_data_ptr_, current_lanes_ref_path, ext_object);
 
-    const auto ahead_of_ego =
-      utils::lane_change::is_ahead_of_ego(common_data_ptr_, current_lanes_ref_path, ext_object);
+    const auto ego_object_proximity = utils::lane_change::calc_ego_object_proximity(
+      common_data_ptr_, current_lanes_ref_path, ext_object);
+
+    const auto ahead_of_ego = ego_object_proximity.is_ahead_of_ego;
 
     if (utils::lane_change::filter_target_lane_objects(
-          common_data_ptr_, ext_object, dist_ego_to_current_lanes_center, ahead_of_ego,
+          common_data_ptr_, ext_object, dist_ego_to_current_lanes_center, ego_object_proximity,
           is_before_terminal, target_lane_leading, filtered_objects.target_lane_trailing)) {
       continue;
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -53,6 +53,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <unordered_set>
 
 namespace autoware::behavior_path_planner
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -684,7 +684,31 @@ bool is_same_lane_with_prev_iteration(
          (prev_target_lanes.back().id() == prev_target_lanes.back().id());
 }
 
-bool is_ahead_of_ego(
+MinMaxValue calc_polygon_dist_range_from_terminal_end(
+  const PathWithLaneId & path, const autoware_utils_geometry::Polygon2d & polygon)
+{
+  MinMaxValue dist_from_terminal_end;
+
+  const auto & vertices = polygon.outer();
+  if (path.points.empty() || vertices.empty()) {
+    return {};
+  }
+
+  dist_from_terminal_end.max = -std::numeric_limits<double>::infinity();
+  dist_from_terminal_end.min = std::numeric_limits<double>::infinity();
+
+  for (const auto & vertex : vertices) {
+    const auto vertex_pt = autoware_utils::create_point(vertex.x(), vertex.y(), 0.0);
+    const auto dist_to_end = autoware::motion_utils::calcSignedArcLength(
+      path.points, vertex_pt, path.points.back().point.pose.position);
+    dist_from_terminal_end.min = std::min(dist_to_end, dist_from_terminal_end.min);
+    dist_from_terminal_end.max = std::max(dist_to_end, dist_from_terminal_end.max);
+  }
+
+  return dist_from_terminal_end;
+}
+
+EgoObjectProximity calc_ego_object_proximity(
   const CommonDataPtr & common_data_ptr, const PathWithLaneId & path,
   const ExtendedPredictedObject & object)
 {
@@ -693,27 +717,24 @@ bool is_ahead_of_ego(
     ego_info.max_longitudinal_offset_m + ego_info.rear_overhang_m, object.shape.dimensions.x);
 
   // we don't always have to check the distance accurately.
+  EgoObjectProximity ego_obj_proximity;
   if (std::abs(object.dist_from_ego) > lon_dev) {
-    return object.dist_from_ego >= 0.0;
+    ego_obj_proximity.is_ahead_of_ego = object.dist_from_ego >= 0.0;
+    return ego_obj_proximity;
   }
 
-  const auto & current_footprint = common_data_ptr->transient_data.current_footprint.outer();
-  auto ego_min_dist_to_end = std::numeric_limits<double>::max();
-  for (const auto & ego_edge_point : current_footprint) {
-    const auto ego_edge = autoware_utils::create_point(ego_edge_point.x(), ego_edge_point.y(), 0.0);
-    const auto dist_to_end = autoware::motion_utils::calcSignedArcLength(
-      path.points, ego_edge, path.points.back().point.pose.position);
-    ego_min_dist_to_end = std::min(dist_to_end, ego_min_dist_to_end);
+  ego_obj_proximity.ego_dist_to_terminal_end =
+    common_data_ptr->transient_data.ego_to_terminal_end_proximity;
+  ego_obj_proximity.object_dist_to_terminal_end =
+    calc_polygon_dist_range_from_terminal_end(path, object.initial_polygon);
+
+  if (ego_obj_proximity.ego_dist_to_terminal_end && ego_obj_proximity.object_dist_to_terminal_end) {
+    ego_obj_proximity.is_ahead_of_ego =
+      (ego_obj_proximity.ego_dist_to_terminal_end->min >=
+       ego_obj_proximity.object_dist_to_terminal_end->min);
   }
 
-  auto current_min_dist_to_end = std::numeric_limits<double>::max();
-  for (const auto & polygon_p : object.initial_polygon.outer()) {
-    const auto obj_p = autoware_utils::create_point(polygon_p.x(), polygon_p.y(), 0.0);
-    const auto dist_ego_to_obj = autoware::motion_utils::calcSignedArcLength(
-      path.points, obj_p, path.points.back().point.pose.position);
-    current_min_dist_to_end = std::min(dist_ego_to_obj, current_min_dist_to_end);
-  }
-  return ego_min_dist_to_end - current_min_dist_to_end >= 0.0;
+  return ego_obj_proximity;
 }
 
 bool is_before_terminal(
@@ -886,7 +907,7 @@ bool has_overtaking_turn_lane_object(
 
 bool filter_target_lane_objects(
   const CommonDataPtr & common_data_ptr, const ExtendedPredictedObject & object,
-  const double dist_ego_to_current_lanes_center, const bool ahead_of_ego,
+  const double dist_ego_to_current_lanes_center, const EgoObjectProximity & ego_object_proximity,
   const bool before_terminal, TargetLaneLeadingObjects & leading_objects,
   ExtendedPredictedObjects & trailing_objects)
 {
@@ -904,6 +925,8 @@ bool filter_target_lane_objects(
     return std::abs(lateral) > (vehicle_width / 2);
   });
 
+  const auto ahead_of_ego = ego_object_proximity.is_ahead_of_ego;
+
   const auto is_stopped = velocity_filter(
     object.initial_twist, -std::numeric_limits<double>::epsilon(), stopped_obj_vel_th);
   if (is_lateral_far && before_terminal) {
@@ -913,7 +936,7 @@ bool filter_target_lane_objects(
        object_path_overlaps_lanes(object, lanes_polygon.target));
 
     if (overlapping_with_target_lanes) {
-      if (!ahead_of_ego && !is_stopped) {
+      if ((!ahead_of_ego && !is_stopped) || ego_object_proximity.is_overlapping()) {
         trailing_objects.push_back(object);
         return true;
       }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -731,7 +731,7 @@ EgoObjectProximity calc_ego_object_proximity(
   if (ego_obj_proximity.ego_dist_to_terminal_end && ego_obj_proximity.object_dist_to_terminal_end) {
     ego_obj_proximity.is_ahead_of_ego =
       (ego_obj_proximity.ego_dist_to_terminal_end->min >=
-       ego_obj_proximity.object_dist_to_terminal_end->min);
+       ego_obj_proximity.object_dist_to_terminal_end->max);
   }
 
   return ego_obj_proximity;
@@ -1205,5 +1205,11 @@ bool is_valid_start_point(const lane_change::CommonDataPtr & common_data_ptr, co
   // Check the target lane because the previous approved path might be shifted by avoidance module
   return boost::geometry::covered_by(lc_start_point, target_neighbor_poly) ||
          boost::geometry::covered_by(lc_start_point, target_lane_poly);
+}
+
+bool is_moving_object(const CommonDataPtr & common_data_ptr, const ExtendedPredictedObject & object)
+{
+  return object.initial_twist.linear.x >
+         common_data_ptr->lc_param_ptr->safety.th_stopped_object_velocity;
 }
 }  // namespace autoware::behavior_path_planner::utils::lane_change


### PR DESCRIPTION
## Description

Stopping object behind ego vehicle is ignored during safety check. This sometimes create an issue if object temporarily stops beside ego vehicle, as shown in the following video, where there is a split moment while the object is not moving, the object classification turned purple, meaning it is not treated as target lane object.

https://github.com/user-attachments/assets/bbea15e7-47a4-4d99-b5d4-ce10a5b14b35

<img width="2111" height="1034" alt="image" src="https://github.com/user-attachments/assets/a134b2e5-5d45-4112-8ba8-50052b4457ad" />

This PR aims to fix this by considering the object as stopping object if it overlaps with ego side.

| Before | After |
|:-:|:-:|
| <img width="1497" height="891" alt="before" src="https://github.com/user-attachments/assets/307d4c25-2a83-4b43-b6c1-142eac0b3423" /> | <img width="1497" height="894" alt="after" src="https://github.com/user-attachments/assets/35beb61d-3a7a-40cd-93d7-b58ca6733698" /> |


## Related links

**Parent Issue:**

- [TIER IV Internal link - Issue's ticket](https://tier4.atlassian.net/browse/RT0-38894)
  - ⚠️ : This PR wont totally solve this ticket.

## How was this PR tested?

#### 1. Logging simulator

https://github.com/user-attachments/assets/5279df06-bd65-4f42-b527-f0f08d793272 

The object remains target lane object (dark blue square).

#### 2. Internal degradation check

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/fdb9d3d8-4fe3-5939-879c-a1346b775981?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/3df7d95f-4bc9-5563-9b2e-c7ecfba56b74?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/4ff527fc-06fc-5888-a199-2389cec3e35d?project_id=prd_jt)

## Notes for reviewers

To ensure no degradation, [this PR](https://github.com/autowarefoundation/autoware_launch/pull/1653) is necessary.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
