### PR TITLE
feat(obstacle_slow_down): add curve margin feature

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
@@ -54,6 +54,9 @@
           pedestrian: true
           pointcloud: false
 
+        # Previously and ideally, the min_lat_margin was 0.
+        # However, the objects whose lateral margin is between 0 and 'wheel_off_track_scale times wheel_off_track' are ignored by the obstacle_slow_down module unexpectedly due to the current implementation.
+        # Therefore, we set the min_lat_margin to a large negative value temporarily.
         min_lat_margin: -10.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
@@ -36,7 +36,7 @@
                 max_lat_margin: 1.0
                 min_ego_velocity: 4.0
                 max_ego_velocity: 8.0
-            wheel_off_track_scale: 0.0
+            wheel_off_track_scale: 0.0 # scale factor for additional stop margin against ego's wheel off-track. Even if this value is set to 0.0, the planner considers the nominal wheel off-track.
           # car.left.moving.min_ego_velocity: 3.0  # example specific override
 
         moving_object_speed_threshold: 0.5 # [m/s] how fast the object needs to move to be considered as "moving"

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
@@ -36,6 +36,7 @@
                 max_lat_margin: 1.0
                 min_ego_velocity: 4.0
                 max_ego_velocity: 8.0
+            wheel_off_track_scale: 0.0
           # car.left.moving.min_ego_velocity: 3.0  # example specific override
 
         moving_object_speed_threshold: 0.5 # [m/s] how fast the object needs to move to be considered as "moving"
@@ -53,7 +54,7 @@
           pedestrian: true
           pointcloud: false
 
-        min_lat_margin: 0.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
+        min_lat_margin: -10.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -309,7 +309,7 @@ VelocityPlanningResult ObstacleSlowDownModule::plan(
 
   stop_watch_.tic();
   debug_data_ptr_ = std::make_shared<DebugData>();
-  decimated_traj_polys_ = std::nullopt;
+  trajectory_polygon_for_lateral_dist_map.clear();
 
   // calculate collision points with trajectory with lateral stop margin
   // NOTE: For additional margin, hysteresis is not divided by two.
@@ -403,12 +403,14 @@ ObstacleSlowDownModule::filter_slow_down_obstacle_for_predicted_object(
       continue;
     }
 
-    // 2. precise filtering
-    const auto & decimated_traj_polys = get_decimated_traj_polys(
+    // 2. calc lateral distance to trajectory polygon
+    const auto & traj_polys_for_lat_dist = get_trajectory_polygon(
       traj_points, current_pose, vehicle_info, ego_nearest_dist_threshold,
-      ego_nearest_yaw_threshold, trajectory_polygon_collision_check);
+      ego_nearest_yaw_threshold, trajectory_polygon_collision_check,
+      slow_down_planning_param_.get_object_param(object->predicted_object.classification.front())
+        .wheel_off_track_scale);
     const double dist_from_obj_poly_to_traj_poly =
-      object->get_dist_to_traj_poly(decimated_traj_polys);
+      utils::calc_dist_to_traj_poly(object->predicted_object, traj_polys_for_lat_dist);
     const auto slow_down_obstacle = create_slow_down_obstacle_for_predicted_object(
       traj_points, decimated_traj_polys_with_lat_margin, object, predicted_objects_stamp,
       dist_from_obj_poly_to_traj_poly);
@@ -1032,8 +1034,8 @@ double ObstacleSlowDownModule::calculate_slow_down_velocity(
   const SlowDownObstacle & obstacle, const std::optional<SlowDownOutput> & prev_output,
   const Motion obstacle_motion) const
 {
-  const auto & p = slow_down_planning_param_.get_object_param(
-    obstacle.classification, obstacle.side, obstacle_motion);
+  const auto & p = slow_down_planning_param_.get_object_param(obstacle.classification)
+                     .get_velocity_param(obstacle.side, obstacle_motion);
   const double stable_dist_from_obj_poly_to_traj_poly = [&]() {
     if (prev_output) {
       return autoware::signal_processing::lowpassFilter(
@@ -1053,22 +1055,24 @@ double ObstacleSlowDownModule::calculate_slow_down_velocity(
   return slow_down_vel;
 }
 
-std::vector<Polygon2d> ObstacleSlowDownModule::get_decimated_traj_polys(
+std::vector<Polygon2d> ObstacleSlowDownModule::get_trajectory_polygon(
   const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & current_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const double ego_nearest_dist_threshold, const double ego_nearest_yaw_threshold,
-  const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check) const
+  const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check,
+  double off_track_scale) const
 {
-  if (!decimated_traj_polys_) {
+  if (trajectory_polygon_for_lateral_dist_map.count(off_track_scale) == 0) {
     const auto & p = trajectory_polygon_collision_check;
     const auto decimated_traj_points = utils::decimate_trajectory_points_from_ego(
       traj_points, current_pose, ego_nearest_dist_threshold, ego_nearest_yaw_threshold,
       p.decimate_trajectory_step_length, p.goal_extended_trajectory_length);
-    decimated_traj_polys_ = polygon_utils::create_one_step_polygons(
+    auto traj_polys = polygon_utils::create_one_step_polygons(
       decimated_traj_points, vehicle_info, current_pose, 0.0, p.enable_to_consider_current_pose,
-      p.time_to_convergence, p.decimate_trajectory_step_length);
+      p.time_to_convergence, p.decimate_trajectory_step_length, off_track_scale);
+    trajectory_polygon_for_lateral_dist_map.emplace(off_track_scale, std::move(traj_polys));
   }
-  return *decimated_traj_polys_;
+  return trajectory_polygon_for_lateral_dist_map.at(off_track_scale);
 }
 
 }  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -309,7 +309,7 @@ VelocityPlanningResult ObstacleSlowDownModule::plan(
 
   stop_watch_.tic();
   debug_data_ptr_ = std::make_shared<DebugData>();
-  trajectory_polygon_for_lateral_dist_map.clear();
+  trajectory_polygon_for_lateral_dist_map_.clear();
 
   // calculate collision points with trajectory with lateral stop margin
   // NOTE: For additional margin, hysteresis is not divided by two.
@@ -1062,7 +1062,7 @@ std::vector<Polygon2d> ObstacleSlowDownModule::get_trajectory_polygon(
   const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check,
   double off_track_scale) const
 {
-  if (trajectory_polygon_for_lateral_dist_map.count(off_track_scale) == 0) {
+  if (trajectory_polygon_for_lateral_dist_map_.count(off_track_scale) == 0) {
     const auto & p = trajectory_polygon_collision_check;
     const auto decimated_traj_points = utils::decimate_trajectory_points_from_ego(
       traj_points, current_pose, ego_nearest_dist_threshold, ego_nearest_yaw_threshold,
@@ -1070,9 +1070,9 @@ std::vector<Polygon2d> ObstacleSlowDownModule::get_trajectory_polygon(
     auto traj_polys = polygon_utils::create_one_step_polygons(
       decimated_traj_points, vehicle_info, current_pose, 0.0, p.enable_to_consider_current_pose,
       p.time_to_convergence, p.decimate_trajectory_step_length, off_track_scale);
-    trajectory_polygon_for_lateral_dist_map.emplace(off_track_scale, std::move(traj_polys));
+    trajectory_polygon_for_lateral_dist_map_.emplace(off_track_scale, std::move(traj_polys));
   }
-  return trajectory_polygon_for_lateral_dist_map.at(off_track_scale);
+  return trajectory_polygon_for_lateral_dist_map_.at(off_track_scale);
 }
 
 }  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
@@ -93,7 +93,8 @@ private:
   mutable std::shared_ptr<DebugData> debug_data_ptr_;
   bool need_to_clear_velocity_limit_{false};
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
-  mutable std::optional<std::vector<Polygon2d>> decimated_traj_polys_{std::nullopt};
+  mutable std::unordered_map<double, std::vector<Polygon2d>>
+    trajectory_polygon_for_lateral_dist_map{};
 
   std::vector<autoware::motion_velocity_planner::SlowDownPointData>
   convert_point_cloud_to_slow_down_points(
@@ -139,11 +140,12 @@ private:
   double calculate_slow_down_velocity(
     const SlowDownObstacle & obstacle, const std::optional<SlowDownOutput> & prev_output,
     const Motion obstacle_motion) const;
-  std::vector<Polygon2d> get_decimated_traj_polys(
+  std::vector<Polygon2d> get_trajectory_polygon(
     const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & current_pose,
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
     const double ego_nearest_dist_threshold, const double ego_nearest_yaw_threshold,
-    const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check) const;
+    const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check,
+    double off_track_scale) const;
 };
 }  // namespace autoware::motion_velocity_planner
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
@@ -94,7 +94,7 @@ private:
   bool need_to_clear_velocity_limit_{false};
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
   mutable std::unordered_map<double, std::vector<Polygon2d>>
-    trajectory_polygon_for_lateral_dist_map{};
+    trajectory_polygon_for_lateral_dist_map_{};
 
   std::vector<autoware::motion_velocity_planner::SlowDownPointData>
   convert_point_cloud_to_slow_down_points(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/parameters.hpp
@@ -125,18 +125,20 @@ static const std::unordered_map<Motion, std::string> motion_to_string_map = {
 struct ObjectTypeSpecificParams
 {
   std::array<
-    std::array<VelocityInterpolationParam, static_cast<size_t>(Side::Count)>,
-    static_cast<size_t>(Motion::Count)>
-    params;
+    std::array<VelocityInterpolationParam, static_cast<size_t>(Motion::Count)>,
+    static_cast<size_t>(Side::Count)>
+    velocity_params;
+  double wheel_off_track_scale{};
 
-  VelocityInterpolationParam & get_param(const Side side, const Motion motion)
+  VelocityInterpolationParam & get_velocity_param(const Side side, const Motion motion)
   {
-    return params[static_cast<size_t>(side)][static_cast<size_t>(motion)];
+    return velocity_params[static_cast<size_t>(side)][static_cast<size_t>(motion)];
   }
 
-  [[nodiscard]] VelocityInterpolationParam get_param(const Side side, const Motion motion) const
+  [[nodiscard]] VelocityInterpolationParam get_velocity_param(
+    const Side side, const Motion motion) const
   {
-    return params[static_cast<size_t>(side)][static_cast<size_t>(motion)];
+    return velocity_params[static_cast<size_t>(side)][static_cast<size_t>(motion)];
   }
 };
 
@@ -190,7 +192,7 @@ struct SlowDownPlanningParam
       ObjectTypeSpecificParams param{};
       for (const auto side : {Side::Left, Side::Right}) {
         for (const auto motion : {Motion::Moving, Motion::Static}) {
-          auto & p = param.get_param(side, motion);
+          auto & p = param.get_velocity_param(side, motion);
           p.min_lat_margin = get_object_parameter<double>(
             node, param_prefix, type_str, to_param_name(side, motion, "min_lat_margin"));
           p.max_lat_margin = get_object_parameter<double>(
@@ -201,15 +203,16 @@ struct SlowDownPlanningParam
             node, param_prefix, type_str, to_param_name(side, motion, "max_ego_velocity"));
         }
       }
+      param.wheel_off_track_scale =
+        get_object_parameter<double>(node, param_prefix, type_str, "wheel_off_track_scale");
       object_type_specific_param_per_object_type.emplace(type_str, param);
     }
   }
 
-  VelocityInterpolationParam get_object_param(
-    const ObjectClassification label, const Side side, const Motion motion) const
+  const ObjectTypeSpecificParams & get_object_param(const ObjectClassification label) const
   {
     const auto & type_str = object_types_maps.at(label.label);
-    return object_type_specific_param_per_object_type.at(type_str).get_param(side, motion);
+    return object_type_specific_param_per_object_type.at(type_str);
   }
 };
 }  // namespace autoware::motion_velocity_planner


### PR DESCRIPTION
## Description
Added a lateral distance offset feature for curves.
For more details, please refer to the same feature in the obstacle_stop module: https://github.com/autowarefoundation/autoware_core/pull/619

## Related links
launch: https://github.com/autowarefoundation/autoware_launch/pull/1638
obstacle_stop: https://github.com/autowarefoundation/autoware_core/pull/619

## How was this PR tested?
tier4 scenario test
psim with the paremeters, `medium_bus`, `wheel_off_track_scale: 1.0`
<img width="3840" height="2160" alt="Screenshot from 2025-09-10 10-32-04" src="https://github.com/user-attachments/assets/4419b117-9ae6-4847-8e23-494bfcce851c" />

## Notes for reviewers
depends to https://github.com/autowarefoundation/autoware_core/pull/628

## Interface changes
None.

## Effects on system behavior

None.
