### PR TITLE
feat(planning_factor_rviz_plugin): add wall visualization of UNKNOWN behavior

### DIFF
--- a/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.cpp
+++ b/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.cpp
@@ -171,6 +171,14 @@ void PlanningFactorRvizPlugin::processMessage(
           add_marker(std::make_shared<visualization_msgs::msg::MarkerArray>(virtual_wall));
         }
         break;
+
+      case autoware_internal_planning_msgs::msg::PlanningFactor::UNKNOWN:
+        for (const auto & control_point : factor.control_points) {
+          const auto virtual_wall = createSlowDownVirtualWallMarker(
+            control_point.pose, text, msg->header.stamp, i++, baselink2front_);
+          add_marker(std::make_shared<visualization_msgs::msg::MarkerArray>(virtual_wall));
+        }
+        break;
     }
 
     if (show_safety_factors_.getBool()) {


### PR DESCRIPTION
## Description
This PR add wall visualization for planning factors with behavior set to UNKNWN in vriz.
This will display walls for obstacle_cruise as before.

## Related links

## How was this PR tested?
- psim
- [CommonScenario_Basic](https://evaluation.tier4.jp/evaluation/reports/134ef6bd-a349-511f-a5f4-5b1c73d0930e?project_id=prd_jt)
- [ControlDLRCommon_Basic](https://evaluation.tier4.jp/evaluation/reports/ea542c7e-7937-54fd-b4d3-3474872cf425?project_id=prd_jt)
- [FuncVerificationScenario_Basic](https://evaluation.tier4.jp/evaluation/reports/c7243bff-ad3a-5270-b6b2-fe5fb6dfb0ac?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
