### PR TITLE
refactor(pipeline_latency_monitor): change log level from WARN to DEBUG for negative latency values

### DIFF
--- a/system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.cpp
+++ b/system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.cpp
@@ -278,7 +278,7 @@ void PipelineLatencyMonitorNode::update_history(
   std::deque<ProcessData> & history, const rclcpp::Time & timestamp, double value)
 {
   if (value < 0.0) {
-    RCLCPP_WARN_THROTTLE(
+    RCLCPP_DEBUG_THROTTLE(
       get_logger(), *this->get_clock(), 30000,
       "Negative latency value detected: %.6f, treating as 0.0", value);
     value = 0.0;


### PR DESCRIPTION
## Description

Negative latency warning messages like 
```
Negative latency value detected: -75.329322, treating as 0.0
```
are being output periodically and cluttering the terminal output. This change suppresses WARN-level logging when negative values are calculated to reduce log noise.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
