### PR TITLE
fix(run_out): do not keep stop for non-collisions

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/decision.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/decision.cpp
@@ -112,7 +112,7 @@ bool condition_to_keep_stop(
     return false;
   }
   if (
-    collision &&
+    collision && collision->type != CollisionType::pass_first_no_collision &&
     collision->ego_time_interval.first_intersection.arc_length < keep_stop_distance_range) {
     explanation << "keep stop since found collision "
                 << collision->ego_time_interval.first_intersection.arc_length << "m ahead ("


### PR DESCRIPTION
## Description

This PR fixes a bug that cause the `run_out` to insert stop points even when ego has time to pass before an incoming object.

The "keep stop" feature of the `run_out` module is meant to keep the ego vehicle stopped when a collision is detected in a short range ahead.
Currently, there is a bug and ego keeps stopped even if the collision is of type `pass_first_no_collision`  (i.e,. ego completely has time to pass before the arrival of the object).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim + reproducer

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
