### PR TITLE
ci: use github hosted runner for arm

### DIFF
--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -33,7 +33,7 @@ jobs:
   build-and-test-daily-arm64:
     uses: ./.github/workflows/build-and-test-reusable.yaml
     with:
-      runner: "['self-hosted', 'Linux', 'ARM64']"
+      runner: "['ubuntu-22.04-arm']"
       container: ghcr.io/autowarefoundation/autoware:universe-devel
       container-suffix: ""
       build-pre-command: taskset --cpu-list 0-6
@@ -45,7 +45,7 @@ jobs:
   build-and-test-daily-arm64-cuda:
     uses: ./.github/workflows/build-and-test-reusable.yaml
     with:
-      runner: "['self-hosted', 'Linux', 'ARM64']"
+      runner: "['ubuntu-22.04-arm']"
       container: ghcr.io/autowarefoundation/autoware:universe-devel
       container-suffix: -cuda
       build-pre-command: taskset --cpu-list 0-6

--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -21,7 +21,7 @@ jobs:
   build-and-test-differential-arm64:
     needs: make-sure-label-is-present
     if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-22.04-arm
     container: ${{ matrix.container }}${{ matrix.container-suffix }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description
This updates the workflows for arm64 to use GitHub hosted runners instead of self-hosted runners since we are no longer using self-hosted runners.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/11334

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://github.com/autowarefoundation/autoware_universe/actions/runs/17765450327

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
