### PR TITLE
fix(diffusion_planner): fixed `const` to `constexpr`

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/lanelet.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/lanelet.hpp
@@ -63,12 +63,12 @@ struct LaneSegment
   int64_t turn_direction;
   int64_t traffic_light_id;
 
-  static const int64_t TURN_DIRECTION_NONE = -1;
-  static const int64_t TURN_DIRECTION_STRAIGHT = 0;
-  static const int64_t TURN_DIRECTION_LEFT = 1;
-  static const int64_t TURN_DIRECTION_RIGHT = 2;
+  static constexpr int64_t TURN_DIRECTION_NONE = -1;
+  static constexpr int64_t TURN_DIRECTION_STRAIGHT = 0;
+  static constexpr int64_t TURN_DIRECTION_LEFT = 1;
+  static constexpr int64_t TURN_DIRECTION_RIGHT = 2;
 
-  static const int64_t TRAFFIC_LIGHT_ID_NONE = -1;
+  static constexpr int64_t TRAFFIC_LIGHT_ID_NONE = -1;
 
   LaneSegment(
     int64_t id, Polyline polyline, bool is_intersection,


### PR DESCRIPTION
## Description

Fix the following error in debug build:

```bash
/usr/bin/ld: libautoware_diffusion_planner_component.so: undefined reference to `autoware::diffusion_planner::LaneSegment::TURN_DIRECTION_LEFT'
/usr/bin/ld: libautoware_diffusion_planner_component.so: undefined reference to `autoware::diffusion_planner::LaneSegment::TURN_DIRECTION_STRAIGHT'
/usr/bin/ld: libautoware_diffusion_planner_component.so: undefined reference to `autoware::diffusion_planner::LaneSegment::TURN_DIRECTION_RIGHT'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/test_diffusion_planner.dir/build.make:1045: test_diffusion_planner] エラー 1
gmake[1]: *** [CMakeFiles/Makefile2:213: CMakeFiles/test_diffusion_planner.dir/all] エラー 2
gmake: *** [Makefile:146: all] エラー 2
---
Failed   <<< autoware_diffusion_planner [4min 40s, exited with code 2]
```

## How was this PR tested?

Build `autoware_diffusion_planner` for both debug and release modes.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
