### PR TITLE
fix(goal_planner): smooth goal connection for goal_planner

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
@@ -87,14 +87,15 @@ PathWithLaneId DefaultFixedGoalPlanner::modifyPathForSmoothGoalConnection(
     }
   }
   double goal_search_radius{planner_data->parameters.refine_goal_search_radius_range};
+  const double output_path_interval{planner_data->parameters.output_path_interval};
   // TODO(shen): define in the parameter
   constexpr double range_reduce_by{1.0};  // set a reasonable value, 10% - 20% of the
                                           // refine_goal_search_radius_range is recommended
   bool is_valid_path{false};
   autoware_internal_planning_msgs::msg::PathWithLaneId refined_path;
   while (goal_search_radius >= 0 && !is_valid_path) {
-    refined_path =
-      utils::refinePathForGoal(goal_search_radius, M_PI * 0.5, path, refined_goal, goal_lane_id);
+    refined_path = utils::refinePathForGoal(
+      goal_search_radius, M_PI * 0.5, output_path_interval, path, refined_goal, goal_lane_id);
     if (isPathValid(refined_path, planner_data)) {
       is_valid_path = true;
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
@@ -79,11 +79,12 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, setGoal)
     3.5, M_PI * 0.5, path, path.points.back().point.pose, 5, &path_with_goal);
 
   // Check if skipped lane ids by smooth skip connection are filled in output path.
-  EXPECT_EQ(path_with_goal.points.size(), 4U);
+  EXPECT_EQ(path_with_goal.points.size(), 5U);
   ASSERT_THAT(path_with_goal.points.at(0).lane_ids, testing::ElementsAre(0));
   ASSERT_THAT(path_with_goal.points.at(1).lane_ids, testing::ElementsAre(1));
   ASSERT_THAT(path_with_goal.points.at(2).lane_ids, testing::ElementsAre(2, 3, 4, 5));
-  ASSERT_THAT(path_with_goal.points.at(3).lane_ids, testing::ElementsAre(5));
+  ASSERT_THAT(path_with_goal.points.at(3).lane_ids, testing::ElementsAre(2, 3, 4, 5));
+  ASSERT_THAT(path_with_goal.points.at(4).lane_ids, testing::ElementsAre(5));
 }
 
 TEST(BehaviorPathPlanningUtilitiesBehaviorTest, expandLanelets)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
@@ -79,12 +79,14 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, setGoal)
     3.5, M_PI * 0.5, 2.0, path, path.points.back().point.pose, 5, &path_with_goal);
 
   // Check if skipped lane ids by smooth skip connection are filled in output path.
-  EXPECT_EQ(path_with_goal.points.size(), 5U);
+  EXPECT_EQ(path_with_goal.points.size(), 7U);
   ASSERT_THAT(path_with_goal.points.at(0).lane_ids, testing::ElementsAre(0));
   ASSERT_THAT(path_with_goal.points.at(1).lane_ids, testing::ElementsAre(1));
-  ASSERT_THAT(path_with_goal.points.at(2).lane_ids, testing::ElementsAre(2, 3, 4, 5));
-  ASSERT_THAT(path_with_goal.points.at(3).lane_ids, testing::ElementsAre(2, 3, 4, 5));
-  ASSERT_THAT(path_with_goal.points.at(4).lane_ids, testing::ElementsAre(5));
+  ASSERT_THAT(path_with_goal.points.at(2).lane_ids, testing::ElementsAre(1));
+  ASSERT_THAT(path_with_goal.points.at(3).lane_ids, testing::ElementsAre(1));
+  ASSERT_THAT(path_with_goal.points.at(4).lane_ids, testing::ElementsAre(2, 3, 4, 5));
+  ASSERT_THAT(path_with_goal.points.at(5).lane_ids, testing::ElementsAre(2, 3, 4, 5));
+  ASSERT_THAT(path_with_goal.points.at(6).lane_ids, testing::ElementsAre(5));
 }
 
 TEST(BehaviorPathPlanningUtilitiesBehaviorTest, expandLanelets)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
@@ -76,7 +76,7 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, setGoal)
 
   PathWithLaneId path_with_goal;
   autoware::behavior_path_planner::utils::set_goal(
-    3.5, M_PI * 0.5, path, path.points.back().point.pose, 5, &path_with_goal);
+    3.5, M_PI * 0.5, 2.0, path, path.points.back().point.pose, 5, &path_with_goal);
 
   // Check if skipped lane ids by smooth skip connection are filled in output path.
   EXPECT_EQ(path_with_goal.points.size(), 5U);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/utils.hpp
@@ -229,14 +229,16 @@ std::optional<lanelet::ConstLanelet> getLeftLanelet(
  * from the goal posture information is also inserted for the smooth connection of the goal pose.
  * @param [in] search_radius_range distance on path to be modified for goal insertion
  * @param [in] search_rad_range [unused]
+ * @param [in] output_path_interval interval of output path
  * @param [in] input original path
  * @param [in] goal original goal pose
  * @param [in] goal_lane_id [unused]
  * @param [in] output_ptr output path with modified points for the goal
  */
 bool set_goal(
-  const double search_radius_range, const double search_rad_range, const PathWithLaneId & input,
-  const Pose & goal, const int64_t goal_lane_id, PathWithLaneId * output_ptr);
+  const double search_radius_range, const double search_rad_range,
+  const double output_path_interval, const PathWithLaneId & input, const Pose & goal,
+  const int64_t goal_lane_id, PathWithLaneId * output_ptr);
 
 /**
  * @brief Recreate the goal pose to prevent the goal point being too far from the lanelet, which
@@ -252,14 +254,16 @@ const Pose refineGoal(const Pose & goal, const lanelet::ConstLanelet & goal_lane
  * @brief Recreate the path with a given goal pose.
  * @param search_radius_range Searching radius.
  * @param search_rad_range Searching angle.
+ * @param output_path_interval Interval of output path.
  * @param input Input path.
  * @param goal Goal pose.
  * @param goal_lane_id Lane ID of goal lanelet.
  * @return Recreated path
  */
 PathWithLaneId refinePathForGoal(
-  const double search_radius_range, const double search_rad_range, const PathWithLaneId & input,
-  const Pose & goal, const int64_t goal_lane_id);
+  const double search_radius_range, const double search_rad_range,
+  const double output_path_interval, const PathWithLaneId & input, const Pose & goal,
+  const int64_t goal_lane_id);
 
 bool isAllowedGoalModification(const std::shared_ptr<RouteHandler> & route_handler);
 bool checkOriginalGoalIsInShoulder(const std::shared_ptr<RouteHandler> & route_handler);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
@@ -275,7 +275,7 @@ TEST_F(BehaviorPathPlanningUtilTest, refinePathForGoal)
     const double search_radius_range = 1.0;
     const auto refined_path =
       refinePathForGoal(search_radius_range, search_rad_range, path, goal_pose, goal_lane_id);
-    EXPECT_EQ(refined_path.points.size(), 7);
+    EXPECT_EQ(refined_path.points.size(), 8);
     EXPECT_DOUBLE_EQ(refined_path.points.back().point.longitudinal_velocity_mps, 0.0);
     EXPECT_DOUBLE_EQ(refined_path.points.back().point.pose.position.x, 5.2);
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
@@ -269,12 +269,13 @@ TEST_F(BehaviorPathPlanningUtilTest, refinePathForGoal)
 
   auto path = generateTrajectory<PathWithLaneId>(10, 1.0, 3.0);
   const double search_rad_range = M_PI;
+  const double output_path_interval = 2.0;
   const auto goal_pose = createPose(5.2, 0.0, 0.0, 0.0, 0.0, 0.0);
   const int64_t goal_lane_id = 5;
   {
     const double search_radius_range = 1.0;
-    const auto refined_path =
-      refinePathForGoal(search_radius_range, search_rad_range, path, goal_pose, goal_lane_id);
+    const auto refined_path = refinePathForGoal(
+      search_radius_range, search_rad_range, output_path_interval, path, goal_pose, goal_lane_id);
     EXPECT_EQ(refined_path.points.size(), 8);
     EXPECT_DOUBLE_EQ(refined_path.points.back().point.longitudinal_velocity_mps, 0.0);
     EXPECT_DOUBLE_EQ(refined_path.points.back().point.pose.position.x, 5.2);


### PR DESCRIPTION
## Description
This PR improves the smoothness of the goal planner's path.
-  additional waypoints have been added to prevent the path from making sharp turns right before reaching the goal.
- longer bbackwward path is now retained, preventing sudden path changes (https://github.com/autowarefoundation/autoware_launch/pull/1645).

## Related links

## How was this PR tested?
- [CommonScenario_Basic](https://evaluation.tier4.jp/evaluation/reports/09ce0158-03b8-5020-b830-97900fd397ed?project_id=prd_jt)
- [FuncVerificationScenario_Basic](https://evaluation.tier4.jp/evaluation/reports/28bb6548-9af6-5aba-b158-2f15c87713bb?project_id=prd_jt)
- [ControlDLRCommon_Basic](https://evaluation.tier4.jp/evaluation/reports/d6cabbd7-4bd9-5865-af13-6d65c1c1c75b?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
