### PR TITLE
feat(autoware_lanelet2_utils): porting functions from lanelet2_extension to autoware_lanelet2_utils package (replacing usage) in perception component 

### DIFF
--- a/perception/autoware_detected_object_validation/package.xml
+++ b/perception/autoware_detected_object_validation/package.xml
@@ -18,6 +18,7 @@
   <build_depend>libopencv-dev</build_depend>
 
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter_base.cpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter_base.cpp
@@ -20,6 +20,7 @@
 #include "autoware_utils/geometry/geometry.hpp"
 
 #include <Eigen/Core>
+#include <autoware/lanelet2_utils/geometry.hpp>
 
 #include <autoware_perception_msgs/msg/detected_object.hpp>
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
@@ -640,7 +641,7 @@ bool ObjectLaneletFilterBase<ObjsMsgType, ObjMsgType>::isSameDirectionWithLanele
       continue;
     }
 
-    const double lane_yaw = lanelet::utils::getLaneletAngle(
+    const double lane_yaw = autoware::experimental::lanelet2_utils::get_lanelet_angle(
       box_and_lanelet.second.lanelet, object.kinematics.pose_with_covariance.pose.position);
     const double delta_yaw = object_velocity_yaw - lane_yaw;
     const double normalized_delta_yaw = autoware_utils::normalize_radian(delta_yaw);

--- a/perception/autoware_map_based_prediction/package.xml
+++ b/perception/autoware_map_based_prediction/package.xml
@@ -19,6 +19,7 @@
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -17,6 +17,7 @@
 #include "map_based_prediction/utils.hpp"
 
 #include <autoware/interpolation/linear_interpolation.hpp>
+#include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/motion_utils/resample/resample.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
@@ -344,8 +345,8 @@ void replaceObjectYawWithLaneletsYaw(
   double sum_x = 0.0;
   double sum_y = 0.0;
   for (const auto & current_lanelet : current_lanelets) {
-    const auto lanelet_angle =
-      lanelet::utils::getLaneletAngle(current_lanelet.lanelet, pose_with_cov.pose.position);
+    const auto lanelet_angle = autoware::experimental::lanelet2_utils::get_lanelet_angle(
+      current_lanelet.lanelet, pose_with_cov.pose.position);
     sum_x += std::cos(lanelet_angle);
     sum_y += std::sin(lanelet_angle);
   }
@@ -1251,7 +1252,8 @@ Maneuver MapBasedPredictionNode::predictObjectManeuverByLatDiffDistance(
   lanelet::ConstLanelet prev_lanelet = prev_lanelets.front();
   double closest_prev_yaw = std::numeric_limits<double>::max();
   for (const auto & lanelet : prev_lanelets) {
-    const double lane_yaw = lanelet::utils::getLaneletAngle(lanelet, prev_pose.position);
+    const double lane_yaw =
+      autoware::experimental::lanelet2_utils::get_lanelet_angle(lanelet, prev_pose.position);
     const double delta_yaw = tf2::getYaw(prev_pose.orientation) - lane_yaw;
     const double normalized_delta_yaw = autoware_utils::normalize_radian(delta_yaw);
     if (normalized_delta_yaw < closest_prev_yaw) {

--- a/perception/autoware_map_based_prediction/src/utils.cpp
+++ b/perception/autoware_map_based_prediction/src/utils.cpp
@@ -14,6 +14,7 @@
 
 #include "map_based_prediction/utils.hpp"
 
+#include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
@@ -47,8 +48,8 @@ double calcAbsYawDiffBetweenLaneletAndObject(
   const TrackedObject & object, const lanelet::ConstLanelet & lanelet)
 {
   const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-  const double lane_yaw =
-    lanelet::utils::getLaneletAngle(lanelet, object.kinematics.pose_with_covariance.pose.position);
+  const double lane_yaw = autoware::experimental::lanelet2_utils::get_lanelet_angle(
+    lanelet, object.kinematics.pose_with_covariance.pose.position);
   const double delta_yaw = object_yaw - lane_yaw;
   const double normalized_delta_yaw = autoware_utils::normalize_radian(delta_yaw);
   const double abs_norm_delta = std::fabs(normalized_delta_yaw);
@@ -243,7 +244,8 @@ double calculateLocalLikelihood(
 
   // compute yaw difference between the object and lane
   const double obj_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-  const double lane_yaw = lanelet::utils::getLaneletAngle(current_lanelet, obj_point);
+  const double lane_yaw =
+    autoware::experimental::lanelet2_utils::get_lanelet_angle(current_lanelet, obj_point);
   const double delta_yaw = obj_yaw - lane_yaw;
   const double abs_norm_delta_yaw = std::fabs(autoware_utils::normalize_radian(delta_yaw));
 
@@ -332,7 +334,7 @@ bool checkCloseLaneletCondition(
 
   // Step2. Calculate the angle difference between the lane angle and obstacle angle
   const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-  const double lane_yaw = lanelet::utils::getLaneletAngle(
+  const double lane_yaw = autoware::experimental::lanelet2_utils::get_lanelet_angle(
     lanelet.second, object.kinematics.pose_with_covariance.pose.position);
   const double delta_yaw = object_yaw - lane_yaw;
   const double normalized_delta_yaw = autoware_utils::normalize_radian(delta_yaw);

--- a/perception/autoware_radar_object_tracker/package.xml
+++ b/perception/autoware_radar_object_tracker/package.xml
@@ -15,6 +15,7 @@
 
   <depend>autoware_kalman_filter</depend>
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_utils_geometry</depend>

--- a/perception/autoware_radar_object_tracker/src/utils/radar_object_tracker_utils.cpp
+++ b/perception/autoware_radar_object_tracker/src/utils/radar_object_tracker_utils.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware_radar_object_tracker/utils/radar_object_tracker_utils.hpp"
 
+#include <autoware/lanelet2_utils/geometry.hpp>
+
 #include <string>
 #include <utility>
 #include <vector>
@@ -80,7 +82,7 @@ bool checkCloseLaneletCondition(
   }
 
   const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
-  const double lane_yaw = lanelet::utils::getLaneletAngle(
+  const double lane_yaw = autoware::experimental::lanelet2_utils::get_lanelet_angle(
     lanelet.second, object.kinematics.pose_with_covariance.pose.position);
   double object_motion_yaw = object_yaw;
   bool velocity_is_reverted = object.kinematics.twist_with_covariance.twist.linear.x < 0.0;
@@ -142,7 +144,7 @@ bool hasValidVelocityDirectionToLanelet(
   const double object_vel = std::hypot(object_vel_x, object_vel_y);
 
   for (const auto & lanelet : lanelets) {
-    const double lane_yaw = lanelet::utils::getLaneletAngle(
+    const double lane_yaw = autoware::experimental::lanelet2_utils::get_lanelet_angle(
       lanelet, object.kinematics.pose_with_covariance.pose.position);
     const double delta_yaw = object_vel_yaw_global - lane_yaw;
     const double normalized_delta_yaw = autoware_utils_math::normalize_radian(delta_yaw);


### PR DESCRIPTION
## Description
Ported following functions:
1. getClosestSegment
2. getLaneletAngle
by replacing usage in Autoware Universe **(perception component).**
## Related links
autoware_core [PR #621](https://github.com/autowarefoundation/autoware_core/pull/621)
autoware_universe (planning component) PR #11374  
autoware_universe (perception component) PR TBD

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
