### PR TITLE
feat(autoware_lanelet2_utils): porting functions from lanelet2_extension to autoware_lanelet2_utils package (replacing usage) in localization component

### DIFF
--- a/localization/yabloc/yabloc_pose_initializer/package.xml
+++ b/localization/yabloc/yabloc_pose_initializer/package.xml
@@ -18,6 +18,7 @@
 
   <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/camera_pose_initializer_core.cpp
@@ -14,6 +14,7 @@
 
 #include "yabloc_pose_initializer/camera/camera_pose_initializer.hpp"
 
+#include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
@@ -135,7 +136,8 @@ std::optional<double> CameraPoseInitializer::estimate_pose(
   lanelet::ConstLanelets current_lanelets;
   std::optional<double> lane_angle_rad = std::nullopt;
   if (lanelet::utils::query::getCurrentLanelets(const_lanelets_, query_pose, &current_lanelets)) {
-    lane_angle_rad = lanelet::utils::getLaneletAngle(current_lanelets.front(), query_pose.position);
+    lane_angle_rad = autoware::experimental::lanelet2_utils::get_lanelet_angle(
+      current_lanelets.front(), query_pose.position);
   }
 
   cv::Mat projected_image = projector_module_->project_image(segmented_image);


### PR DESCRIPTION
## Description
Ported following functions:
1. getClosestSegment
2. getLaneletAngle
by replacing usage in Autoware Universe **(localization component).**
## Related links
autoware_core [PR #621](https://github.com/autowarefoundation/autoware_core/pull/621)
autoware_universe (planning component) PR #11374  
autoware_universe (perception component) PR #11387 

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
