### PR TITLE
feat(diffusion_planner): add acceleration

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -14,6 +14,7 @@
     build_only: false
     batch_size: 1
     temperature: [0.5]
+    velocity_smoothing_window: 1
     debug_params:
       publish_debug_route: false
       publish_debug_map: false

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -118,6 +118,7 @@ struct DiffusionPlannerParams
   bool use_route_handler;
   int batch_size;
   std::vector<double> temperature_list;
+  int64_t velocity_smoothing_window;
 };
 struct DiffusionPlannerDebugParams
 {

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/dimensions.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/dimensions.hpp
@@ -26,6 +26,7 @@ namespace autoware::diffusion_planner
 inline constexpr int64_t NUM_SEGMENTS_IN_LANE = 70;
 inline constexpr int64_t NUM_SEGMENTS_IN_ROUTE = 25;
 inline constexpr int64_t MAX_NUM_NEIGHBORS = 32;
+inline constexpr int64_t MAX_NUM_AGENTS = MAX_NUM_NEIGHBORS + 1;  // Including ego
 inline constexpr int64_t POINTS_PER_SEGMENT = 20;  //!< Number of points in each lane segment.
 // Number of columns in a segment matrix
 // (X,Y,dX,dY,LeftBoundX,LeftBoundY,RightBoundX,RightBoundY,TrafficLightEncoding(Dim5),Speed Limit)
@@ -58,12 +59,11 @@ inline constexpr int64_t SEGMENT_POINT_DIM = LINE_TYPE_RIGHT_START + LINE_TYPE_N
 inline constexpr int64_t INPUT_T = 20;
 inline constexpr int64_t OUTPUT_T = 80;  // Output timestamp number
 inline constexpr int64_t POSE_DIM = 4;   // x, y, cos(yaw), sin(yaw)
-inline constexpr std::array<int64_t, 4> OUTPUT_SHAPE = {
-  1, MAX_NUM_NEIGHBORS + 1, OUTPUT_T, POSE_DIM};
+inline constexpr std::array<int64_t, 4> OUTPUT_SHAPE = {1, MAX_NUM_AGENTS, OUTPUT_T, POSE_DIM};
 inline constexpr std::array<int64_t, 2> TURN_INDICATOR_LOGIT_SHAPE = {1, 4};
 
 inline constexpr std::array<int64_t, 4> SAMPLED_TRAJECTORIES_SHAPE = {
-  1, MAX_NUM_NEIGHBORS + 1, OUTPUT_T + 1, POSE_DIM};
+  1, MAX_NUM_AGENTS, OUTPUT_T + 1, POSE_DIM};
 inline constexpr std::array<int64_t, 3> EGO_HISTORY_SHAPE = {1, INPUT_T + 1, POSE_DIM};
 inline constexpr std::array<int64_t, 2> EGO_CURRENT_STATE_SHAPE = {1, 10};
 inline constexpr std::array<int64_t, 4> NEIGHBOR_SHAPE = {1, MAX_NUM_NEIGHBORS, INPUT_T + 1, 11};

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
@@ -59,13 +59,12 @@ PredictedObjects create_predicted_objects(
  * @param prediction The tensor prediction output.
  * @param stamp The ROS time stamp for the message.
  * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
- * @param batch The batch index to extract.
- * @param agent The agent index to extract.
+ * @param batch_index The batch index to extract.
  * @return A Trajectory message for the specified batch and agent.
  */
-Trajectory create_trajectory(
+Trajectory create_ego_trajectory(
   const std::vector<float> & prediction, const rclcpp::Time & stamp,
-  const Eigen::Matrix4d & transform_ego_to_map, int64_t batch, int64_t agent);
+  const Eigen::Matrix4d & transform_ego_to_map, const int64_t batch_index);
 
 /**
  * @brief Converts a Trajectory message to a CandidateTrajectories message with generator info.

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
@@ -67,17 +67,6 @@ Trajectory create_ego_trajectory(
   const Eigen::Matrix4d & transform_ego_to_map, const int64_t batch_index);
 
 /**
- * @brief Converts a Trajectory message to a CandidateTrajectories message with generator info.
- *
- * @param trajectory The Trajectory message to convert.
- * @param generator_uuid The UUID of the trajectory generator.
- * @param generator_name The name of the trajectory generator.
- * @return A CandidateTrajectories message containing the input trajectory and generator info.
- */
-CandidateTrajectories to_candidate_trajectories_msg(
-  const Trajectory & trajectory, const UUID & generator_uuid, const std::string & generator_name);
-
-/**
  * @brief Converts turn indicator logit to TurnIndicatorsCommand message.
  *
  * @param turn_indicator_logit The turn indicator logit from the model output.

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
@@ -60,11 +60,13 @@ PredictedObjects create_predicted_objects(
  * @param stamp The ROS time stamp for the message.
  * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
  * @param batch_index The batch index to extract.
+ * @param velocity_smoothing_window The window size for velocity smoothing.
  * @return A Trajectory message for the specified batch and agent.
  */
 Trajectory create_ego_trajectory(
   const std::vector<float> & prediction, const rclcpp::Time & stamp,
-  const Eigen::Matrix4d & transform_ego_to_map, const int64_t batch_index);
+  const Eigen::Matrix4d & transform_ego_to_map, const int64_t batch_index,
+  const int64_t velocity_smoothing_window);
 
 /**
  * @brief Converts turn indicator logit to TurnIndicatorsCommand message.

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -83,6 +83,12 @@
           "default": [0.5],
           "description": "List of temperature for sampling trajectories. Its length must be the same as `batch_size`. Each value means the coefficient of the standard normal distribution which is used for each initial noise of corresponding batch index. val = N(0,1) * temperature"
         },
+        "velocity_smoothing_window": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 1,
+          "description": "Window size for velocity smoothing. Set to 1 to disable smoothing."
+        },
         "debug_params": {
           "type": "object",
           "properties": {

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -131,6 +131,8 @@ void DiffusionPlanner::set_up_params()
   params_.use_route_handler = this->declare_parameter<bool>("use_route_handler", true);
   params_.batch_size = this->declare_parameter<int>("batch_size", 1);
   params_.temperature_list = this->declare_parameter<std::vector<double>>("temperature", {0.5});
+  params_.velocity_smoothing_window =
+    this->declare_parameter<int64_t>("velocity_smoothing_window", 1);
 
   // debug params
   debug_params_.publish_debug_map =
@@ -161,6 +163,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<bool>(parameters, "use_route_handler", temp_params.use_route_handler);
     update_param<int>(parameters, "batch_size", temp_params.batch_size);
     update_param<std::vector<double>>(parameters, "temperature", temp_params.temperature_list);
+    update_param<int64_t>(
+      parameters, "velocity_smoothing_window", temp_params.velocity_smoothing_window);
     params_ = temp_params;
   }
 
@@ -563,8 +567,8 @@ void DiffusionPlanner::publish_predictions(const std::vector<float> & prediction
   CandidateTrajectories candidate_trajectories;
 
   for (int i = 0; i < params_.batch_size; i++) {
-    const Trajectory trajectory =
-      postprocess::create_ego_trajectory(predictions, this->now(), transforms_.first, i);
+    const Trajectory trajectory = postprocess::create_ego_trajectory(
+      predictions, this->now(), transforms_.first, i, params_.velocity_smoothing_window);
     if (i == 0) {
       pub_trajectory_->publish(trajectory);
     }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -559,10 +559,9 @@ void DiffusionPlanner::publish_debug_markers(InputDataMap & input_data_map) cons
 void DiffusionPlanner::publish_predictions(const std::vector<float> & predictions) const
 {
   constexpr int64_t batch_idx = 0;
-  constexpr int64_t ego_agent_idx = 0;
 
-  const Trajectory output_trajectory = postprocess::create_trajectory(
-    predictions, this->now(), transforms_.first, batch_idx, ego_agent_idx);
+  const Trajectory output_trajectory =
+    postprocess::create_ego_trajectory(predictions, this->now(), transforms_.first, batch_idx);
   pub_trajectory_->publish(output_trajectory);
 
   // Publish all batch results as candidate trajectories
@@ -576,7 +575,7 @@ void DiffusionPlanner::publish_predictions(const std::vector<float> & prediction
   // Add additional batch results as more candidates
   for (int i = 1; i < batch_size; i++) {
     const Trajectory trajectory =
-      postprocess::create_trajectory(predictions, this->now(), transforms_.first, i, ego_agent_idx);
+      postprocess::create_ego_trajectory(predictions, this->now(), transforms_.first, i);
 
     const CandidateTrajectories additional_candidate = postprocess::to_candidate_trajectories_msg(
       trajectory, generator_uuid_, "DiffusionPlanner_batch_" + std::to_string(i));

--- a/planning/autoware_diffusion_planner/src/postprocessing/postprocessing_utils.cpp
+++ b/planning/autoware_diffusion_planner/src/postprocessing/postprocessing_utils.cpp
@@ -171,13 +171,14 @@ PredictedObjects create_predicted_objects(
   return predicted_objects;
 }
 
-Trajectory create_trajectory(
+Trajectory create_ego_trajectory(
   const std::vector<float> & prediction, const rclcpp::Time & stamp,
-  const Eigen::Matrix4d & transform_ego_to_map, int64_t batch, int64_t agent)
+  const Eigen::Matrix4d & transform_ego_to_map, const int64_t batch_index)
 {
+  const int64_t agent = 0;
   // one batch of prediction
   Eigen::MatrixXd prediction_matrix =
-    get_prediction_matrix(prediction, transform_ego_to_map, batch, agent);
+    get_prediction_matrix(prediction, transform_ego_to_map, batch_index, agent);
   return get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp);
 }
 

--- a/planning/autoware_diffusion_planner/src/postprocessing/postprocessing_utils.cpp
+++ b/planning/autoware_diffusion_planner/src/postprocessing/postprocessing_utils.cpp
@@ -22,9 +22,6 @@
 #include <rclcpp/duration.hpp>
 #include <rclcpp/time.hpp>
 
-#include <autoware_internal_planning_msgs/msg/detail/candidate_trajectory__builder.hpp>
-#include <autoware_internal_planning_msgs/msg/detail/candidate_trajectory__struct.hpp>
-#include <autoware_internal_planning_msgs/msg/generator_info.hpp>
 #include <autoware_perception_msgs/msg/detail/predicted_objects__struct.hpp>
 
 #include <Eigen/src/Core/Matrix.h>
@@ -180,30 +177,6 @@ Trajectory create_ego_trajectory(
   Eigen::MatrixXd prediction_matrix =
     get_prediction_matrix(prediction, transform_ego_to_map, batch_index, agent);
   return get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp);
-}
-
-CandidateTrajectories to_candidate_trajectories_msg(
-  const Trajectory & trajectory, const UUID & generator_uuid, const std::string & generator_name)
-{
-  const auto candidate_trajectory = autoware_internal_planning_msgs::build<
-                                      autoware_internal_planning_msgs::msg::CandidateTrajectory>()
-                                      .header(trajectory.header)
-                                      .generator_id(generator_uuid)
-                                      .points(trajectory.points);
-
-  std_msgs::msg::String generator_name_msg;
-  generator_name_msg.data = generator_name;
-
-  const auto generator_info =
-    autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::GeneratorInfo>()
-      .generator_id(generator_uuid)
-      .generator_name(generator_name_msg);
-
-  const auto output = autoware_internal_planning_msgs::build<
-                        autoware_internal_planning_msgs::msg::CandidateTrajectories>()
-                        .candidate_trajectories({candidate_trajectory})
-                        .generator_info({generator_info});
-  return output;
 }
 
 TurnIndicatorsCommand create_turn_indicators_command(

--- a/planning/autoware_diffusion_planner/test/postprocessing_utils_edge_case_test.cpp
+++ b/planning/autoware_diffusion_planner/test/postprocessing_utils_edge_case_test.cpp
@@ -101,28 +101,4 @@ TEST_F(PostprocessingUtilsEdgeCaseTest, CreatePredictedObjects_MorePredictionsTh
   EXPECT_EQ(result.objects.size(), 2);
 }
 
-// Test edge case: UUID edge cases
-TEST_F(PostprocessingUtilsEdgeCaseTest, ToCandidateTrajectoriesMsg_UUIDEdgeCases)
-{
-  using UUID = unique_identifier_msgs::msg::UUID;
-  Trajectory traj;
-  traj.header.frame_id = "map";
-
-  // Test with all zeros UUID
-  UUID zero_uuid;
-  std::fill(zero_uuid.uuid.begin(), zero_uuid.uuid.end(), 0);
-
-  auto msg1 = postprocess::to_candidate_trajectories_msg(traj, zero_uuid, "");
-  EXPECT_EQ(msg1.generator_info[0].generator_name.data, "");
-
-  // Test with all max values UUID
-  UUID max_uuid;
-  std::fill(max_uuid.uuid.begin(), max_uuid.uuid.end(), 255);
-
-  // Test with very long generator name
-  std::string long_name(1000, 'a');
-  auto msg2 = postprocess::to_candidate_trajectories_msg(traj, max_uuid, long_name);
-  EXPECT_EQ(msg2.generator_info[0].generator_name.data, long_name);
-}
-
 }  // namespace autoware::diffusion_planner::test

--- a/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
@@ -44,8 +44,9 @@ TEST(PostprocessingUtilsTest, CreateTrajectoryAndMultipleTrajectories)
   rclcpp::Time stamp(123, 0);
 
   auto expected_points = prediction_shape[2];
-
-  auto traj = postprocess::create_ego_trajectory(data, stamp, transform, 0);
+  const int64_t velocity_smoothing_window = 1;
+  auto traj =
+    postprocess::create_ego_trajectory(data, stamp, transform, 0, velocity_smoothing_window);
   ASSERT_EQ(traj.points.size(), expected_points);
 }
 

--- a/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
@@ -49,20 +49,4 @@ TEST(PostprocessingUtilsTest, CreateTrajectoryAndMultipleTrajectories)
   ASSERT_EQ(traj.points.size(), expected_points);
 }
 
-TEST(PostprocessingUtilsTest, ToCandidateTrajectoriesMsgPopulatesFields)
-{
-  using UUID = unique_identifier_msgs::msg::UUID;
-  Trajectory traj;
-  traj.header.frame_id = "map";
-  traj.points.resize(2);
-  UUID uuid;
-  std::fill(uuid.uuid.begin(), uuid.uuid.end(), 42);
-
-  auto msg = postprocess::to_candidate_trajectories_msg(traj, uuid, "test_generator");
-  ASSERT_EQ(msg.candidate_trajectories.size(), 1);
-  ASSERT_EQ(msg.generator_info.size(), 1);
-  EXPECT_EQ(msg.candidate_trajectories[0].header.frame_id, "map");
-  EXPECT_EQ(msg.generator_info[0].generator_name.data, "test_generator");
-}
-
 }  // namespace autoware::diffusion_planner::test

--- a/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
@@ -45,7 +45,7 @@ TEST(PostprocessingUtilsTest, CreateTrajectoryAndMultipleTrajectories)
 
   auto expected_points = prediction_shape[2];
 
-  auto traj = postprocess::create_trajectory(data, stamp, transform, 0, 0);
+  auto traj = postprocess::create_ego_trajectory(data, stamp, transform, 0);
   ASSERT_EQ(traj.points.size(), expected_points);
 }
 


### PR DESCRIPTION
## Description

In the planning simulator, the vehicle can stop at red traffic lights without velocity_smoothing of `autoware_trajectory_optiimzer` after tuning some parameters.

- diffusion_planner
    - velocity_smoothing_window: 8
- pid_controller
    - delay_compensation_time: 0.4
    - kp: 0.4

https://github.com/user-attachments/assets/c1005e01-8ba6-4042-b61f-418944d753d1


## How was this PR tested?

planning simulator

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `velocity_smoothing_window`   | `int64_t` | `1`         | Window size for velocity smoothing. Set to 1 to disable smoothing. |

## Effects on system behavior

None.
