### PR TITLE
fix(crosswalk, traffic_light): correct distance calculation by swapping src and dst

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -1546,7 +1546,7 @@ void CrosswalkModule::planStop(
   const bool suppress_restart = checkRestartSuppression(ego_path, stop_factor);
   if (suppress_restart) {
     const auto & ego_pos = planner_data_->current_odometry->pose.position;
-    const double dist = calcSignedArcLength(ego_path.points, ego_pos, 0L);
+    const double dist = calcSignedArcLength(ego_path.points, 0L, ego_pos);
     const auto pose_opt = calcLongitudinalOffsetPose(ego_path.points, 0L, dist);
     if (pose_opt.has_value()) stop_factor->stop_pose = pose_opt.value();
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -150,7 +150,7 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
         RCLCPP_DEBUG(logger_, "Suppressing restart due to proximity to stop line.");
         const auto & ego_pos = planner_data_->current_odometry->pose.position;
         const double dist =
-          autoware::motion_utils::calcSignedArcLength(input_path.points, ego_pos, 0L);
+          autoware::motion_utils::calcSignedArcLength(input_path.points, 0L, ego_pos);
         const auto pose_opt =
           autoware::motion_utils::calcLongitudinalOffsetPose(input_path.points, 0L, dist);
         if (pose_opt.has_value()) {


### PR DESCRIPTION
## Description

This PR fixes an issue in the CrosswalkModule and TrafficLightModule where the arguments for calcSignedArcLength were passed in reverse order. Previously, the ego position was provided as the source and the stop line index as the destination, which caused incorrect computation of the signed arc length when determining the offset pose. The argument order has been corrected to ensure proper distance calculation and consistent behavior when suppressing restarts near stop lines.

AFTER THIS PR



## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/11165
- https://github.com/autowarefoundation/autoware_universe/pull/11166

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
