### PR TITLE
fix(autoware_lidar_apollo_instance_segmentation): remove invalid key and change variable int to double

### DIFF
--- a/perception/autoware_lidar_apollo_instance_segmentation/config/hdl-64.param.yaml
+++ b/perception/autoware_lidar_apollo_instance_segmentation/config/hdl-64.param.yaml
@@ -1,11 +1,10 @@
 /**:
   ros__parameters:
-    lidar_instance_segmentation:
-      score_threshold: 0.1
-      range: 70
-      width: 672
-      height: 672
-      use_intensity_feature: true
-      use_constant_feature: false
-      z_offset: -2.0
-      onnx_file: "hdl-64.onnx"
+    score_threshold: 0.1
+    range: 70.0
+    width: 672
+    height: 672
+    use_intensity_feature: true
+    use_constant_feature: false
+    z_offset: -2.0
+    onnx_file: "hdl-64.onnx"

--- a/perception/autoware_lidar_apollo_instance_segmentation/config/vlp-16.param.yaml
+++ b/perception/autoware_lidar_apollo_instance_segmentation/config/vlp-16.param.yaml
@@ -1,11 +1,10 @@
 /**:
   ros__parameters:
-    lidar_instance_segmentation:
-      score_threshold: 0.1
-      range: 70
-      width: 672
-      height: 672
-      use_intensity_feature: true
-      use_constant_feature: false
-      z_offset: -2.0
-      onnx_file: "vlp-16.onnx"
+    score_threshold: 0.1
+    range: 70.0
+    width: 672
+    height: 672
+    use_intensity_feature: true
+    use_constant_feature: false
+    z_offset: -2.0
+    onnx_file: "vlp-16.onnx"

--- a/perception/autoware_lidar_apollo_instance_segmentation/config/vls-128.param.yaml
+++ b/perception/autoware_lidar_apollo_instance_segmentation/config/vls-128.param.yaml
@@ -1,11 +1,10 @@
 /**:
   ros__parameters:
-    lidar_instance_segmentation:
-      score_threshold: 0.1
-      range: 90
-      width: 864
-      height: 864
-      use_intensity_feature: false
-      use_constant_feature: false
-      z_offset: -2.0
-      onnx_file: "vls-128.onnx"
+    score_threshold: 0.1
+    range: 90.0
+    width: 864
+    height: 864
+    use_intensity_feature: false
+    use_constant_feature: false
+    z_offset: -2.0
+    onnx_file: "vls-128.onnx"

--- a/perception/autoware_lidar_apollo_instance_segmentation/src/detector.cpp
+++ b/perception/autoware_lidar_apollo_instance_segmentation/src/detector.cpp
@@ -38,15 +38,15 @@ LidarApolloInstanceSegmentation::LidarApolloInstanceSegmentation(rclcpp::Node * 
   int range, width, height;
   bool use_intensity_feature, use_constant_feature;
   std::string onnx_file;
-  score_threshold_ = node_->declare_parameter("score_threshold", 0.8);
-  range = node_->declare_parameter("range", 60);
-  width = node_->declare_parameter("width", 640);
-  height = node_->declare_parameter("height", 640);
+  score_threshold_ = node_->declare_parameter<double>("score_threshold");
+  range = node_->declare_parameter<double>("range");
+  width = node_->declare_parameter<int>("width");
+  height = node_->declare_parameter<int>("height");
   onnx_file = node_->declare_parameter("onnx_file", "vls-128.onnx");
-  use_intensity_feature = node_->declare_parameter("use_intensity_feature", true);
-  use_constant_feature = node_->declare_parameter("use_constant_feature", true);
+  use_intensity_feature = node_->declare_parameter<bool>("use_intensity_feature");
+  use_constant_feature = node_->declare_parameter<bool>("use_constant_feature");
   target_frame_ = node_->declare_parameter("target_frame", "base_link");
-  z_offset_ = node_->declare_parameter<float>("z_offset", -2.0);
+  z_offset_ = node_->declare_parameter<float>("z_offset");
   const auto precision = node_->declare_parameter("precision", "fp32");
 
   trt_common_ = std::make_unique<autoware::tensorrt_common::TrtCommon>(


### PR DESCRIPTION
## Description

This PR fix the issue caused by https://github.com/autowarefoundation/autoware_universe/pull/10097 and https://github.com/autowarefoundation/autoware_universe/pull/11357.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
