### PR TITLE
fix(cuda_pointcloud_preprocessor): use uint64_t and nanoseconds to prevent potential precision loss

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -92,11 +92,11 @@ private:
   // Helper Functions
   [[nodiscard]] bool validatePointcloudLayout(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const;
-  std::pair<double, std::uint32_t> getFirstPointTimeInfo(
+  std::pair<std::uint64_t, std::uint32_t> getFirstPointTimeInfo(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
 
-  void updateTwistQueue(double first_point_stamp);
-  void updateImuQueue(double first_point_stamp);
+  void updateTwistQueue(std::uint64_t first_point_stamp);
+  void updateImuQueue(std::uint64_t first_point_stamp);
   std::optional<geometry_msgs::msg::TransformStamped> lookupTransformToBase(
     const std::string & source_frame);
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> processPointcloud(


### PR DESCRIPTION
## Description
This PR fixes an issue where distortion-corrected pointclouds appear in an unexpected region.

The root cause of the issue lies in precision loss on timestamp comparison if two timestamps are close on a micro- or nanosecond level. This PR resolves this issue by expressing timestamps in nanoseconds using `std::uint64_t` instead of expressing them in seconds using `double`.

## Related links

**Parent Issue:**

- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-39571)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Download rosbag:
  ```bash
  webauto data rosbag pull --project-id x2_dev \
     --environment-id 5fd46b47-f1a2-48e0-aeaa-75cd9c68197d \
     --rosbag-id 0e2e1965-317d-4c51-af0c-256e201e66a6 \
     --target-dir ${TARGET_DIR}
  ```

- Generate a rosbag that contains the topics required for  logging simulator
  - Nebula workspace needs to be `source`d for `nebula_packets` to be recognized
  - [ros2bag_extensions](https://github.com/tier4/ros2bag_extensions) is required for `ros2 bag filter`
  ```bash
  ros2 bag filter -i \
          "/sensing/.*" \
          "/vehicle/.*" \
          "/localization/.*" \
          "/tf" \
          -o ${TARGET_DIR}/filtered ${TARGET_DIR}
  ```

- play rosbag
  ```bash
  ros2 bag play ${TARGET_DIR}/filter --clock 100
  ```

- run logging simulator & monitor `/sensing/lidar/rear_upper/aw_points_ex` and `/sensing/lidar/rear_upper/pointcloud_before_sync` are displayed in reasonable area on RViz
  ```bash
  ros2 launch autoware_launch logging_simulator.launch.xml map_path:=<MAP_PATH> \
    vehicle_model:=j6_gen2 sensor_model:=aip_x2_gen2 vehicle_id:=j6_gen2_12 \
    localization:=false system:=false control:=false use_sim_time:=true rviz:=true \
    perception:=false planning:=false map:=false
  ```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
