### PR TITLE
chore(carla-interface): fix spell-check

### DIFF
--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -57,7 +57,7 @@ class carla_ros2_interface(object):
         return qos
 
     def _initialize_parameters(self):
-        """Initialize and declare ROS2 parameters."""
+        """Initialize and declare ROS 2 parameters."""
         self.parameters = {
             "host": rclpy.Parameter.Type.STRING,
             "port": rclpy.Parameter.Type.INTEGER,
@@ -106,7 +106,7 @@ class carla_ros2_interface(object):
         )
 
     def _initialize_subscriptions(self):
-        """Initialize all ROS2 subscriptions."""
+        """Initialize all ROS 2 subscriptions."""
         self.sub_control = self.ros2_node.create_subscription(
             ActuationCommandStamped, "/control/command/actuation_cmd", self.control_callback, 1
         )
@@ -148,7 +148,7 @@ class carla_ros2_interface(object):
         # Initialize instance variables
         self._initialize_instance_variables()
 
-        # Initialize ROS2 node
+        # Initialize ROS 2 node
         rclpy.init(args=None)
         self.ros2_node = rclpy.create_node("carla_ros2_interface")
 
@@ -164,7 +164,7 @@ class carla_ros2_interface(object):
         self._initialize_status_publishers()
         self._create_sensor_publishers()
 
-        # Start ROS2 spin thread
+        # Start ROS 2 spin thread
         self.spin_thread = threading.Thread(target=rclpy.spin, args=(self.ros2_node,))
         self.spin_thread.start()
 


### PR DESCRIPTION
## Description

This PR fixes spell-check CI error by replacing `ROS2` to `ROS 2`.

<img width="951" height="304" alt="Screenshot from 2025-09-26 14-35-16" src="https://github.com/user-attachments/assets/f92b5294-26c5-42d6-8621-1fa7db22cf97" />

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
