### PR TITLE
fix(planning_validator): update QoS settings for operational mode state subscriber

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
@@ -91,7 +91,7 @@ private:
   autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> sub_acceleration_{
     this, "~/input/acceleration"};
   autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_operational_state_{
-    this, "~/input/operational_mode_state"};
+    this, "~/input/operational_mode_state", rclcpp::QoS{1}.transient_local()};
   autoware_utils::InterProcessPollingSubscriber<TrafficLightGroupArray> sub_traffic_signals_{
     this, "~/input/traffic_signals"};
 

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker_diag.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker_diag.cpp
@@ -73,7 +73,7 @@ public:
       "/planning_validator_node/input/acceleration", 1);
     pointcloud_pub_ = create_publisher<PointCloud2>("/planning_validator_node/input/pointcloud", 1);
     operational_mode_pub_ = create_publisher<OperationModeState>(
-      "/planning_validator_node/input/operational_mode_state", 1);
+      "/planning_validator_node/input/operational_mode_state", rclcpp::QoS(1).transient_local());
     diag_sub_ = create_subscription<DiagnosticArray>(
       "/diagnostics", 1,
       [this](const DiagnosticArray::ConstSharedPtr msg) { received_diags_.push_back(msg); });


### PR DESCRIPTION
## Description

This PR updates the QoS settings for the operational mode state subscriber in the autoware planning validator. 
This change is necessary because the publisher side is configured with `transient_local` QoS settings, requiring the subscriber to use matching QoS configuration for proper communication.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] build succeeded
- [x] run psim and check the planning_validator is working without errors

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
