### PR TITLE
fix(crosswalk): limit start_distance of cooperate status to positive

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -1505,7 +1505,8 @@ void CrosswalkModule::setDistanceToStop(
   // Set distance
   if (stop_pos) {
     const auto & ego_pos = planner_data_->current_odometry->pose.position;
-    const double dist_ego2stop = calcSignedArcLength(ego_path.points, ego_pos, *stop_pos);
+    const double dist_ego2stop =
+      std::max(calcSignedArcLength(ego_path.points, ego_pos, *stop_pos), 0.0);
     setDistance(dist_ego2stop);
   } else {
     setDistance(std::numeric_limits<double>::lowest());


### PR DESCRIPTION
## Description
This PR limits the ```start_distance``` field in the CooperateStatus, which is published by the crosswalk module, to a positive value. This change enables the MOT to approve and allow passage when a vehicle stops on a crosswalk.

<img width="3252" height="2057" alt="image" src="https://github.com/user-attachments/assets/368847fb-0a89-419c-b387-b1d1fe3f3e75" />


## Related links

## How was this PR tested?
- [CommonScenario_Basic](https://evaluation.tier4.jp/evaluation/reports/a00fd6a2-a898-5867-a493-910ddca9df47?project_id=prd_jt)
- [ControlDLRCommon_Basic](https://evaluation.tier4.jp/evaluation/reports/78131831-6f4c-5f91-a082-801409904e7f?project_id=prd_jt)
- [FuncVerificationScenario_Basic](https://evaluation.tier4.jp/evaluation/reports/452c7e71-78ee-5ff4-8f96-a3f1a367e11f?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
