### PR TITLE
fix(out_of_lane): ignore collisions inside the trajectory lanelets

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/lanelets_selection.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/lanelets_selection.cpp
@@ -128,8 +128,9 @@ void calculate_out_lanelet_rtree(
   const auto pose_beyond = autoware_utils::calc_offset_pose(
     ego_data.trajectory_points.back().pose, params.front_offset, 0.0, 0.0, 0.0);
   trajectory_ls.emplace_back(pose_beyond.position.x, pose_beyond.position.y);
-  const auto trajectory_lanelets = calculate_trajectory_lanelets(trajectory_ls, route_handler);
-  const auto ignored_lanelets = calculate_ignored_lanelets(trajectory_lanelets, route_handler);
+  ego_data.trajectory_lanelets = calculate_trajectory_lanelets(trajectory_ls, route_handler);
+  const auto ignored_lanelets =
+    calculate_ignored_lanelets(ego_data.trajectory_lanelets, route_handler);
 
   const auto max_ego_footprint_offset = std::max({
     params.front_offset + params.extra_front_offset,
@@ -149,8 +150,8 @@ void calculate_out_lanelet_rtree(
     end_strategy, circle_strategy);
 
   ego_data.out_lanelets = calculate_out_lanelets(
-    route_handler.getLaneletMapPtr()->laneletLayer, trajectory_footprints, trajectory_lanelets,
-    ignored_lanelets);
+    route_handler.getLaneletMapPtr()->laneletLayer, trajectory_footprints,
+    ego_data.trajectory_lanelets, ignored_lanelets);
   ego_data.out_lanelets_rtree = calculate_out_lanelet_rtree(ego_data.out_lanelets);
 }
 }  // namespace autoware::motion_velocity_planner::out_of_lane

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_collisions.cpp
@@ -20,12 +20,15 @@
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
 #include <rclcpp/duration.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 
+#include <boost/geometry/algorithms/detail/disjoint/interface.hpp>
 #include <boost/geometry/algorithms/detail/intersects/interface.hpp>
 #include <boost/geometry/algorithms/disjoint.hpp>
+#include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/index/predicates.hpp>
 
 #include <lanelet2_core/Forward.h>
@@ -298,15 +301,31 @@ OutOfLanePoint calculate_out_of_lane_point(
   }
   return p;
 }
+
 std::vector<OutOfLanePoint> calculate_out_of_lane_points(const EgoData & ego_data)
 {
+  autoware_utils_geometry::MultiPolygon2d trajectory_lanelets_polygons;
+  for (const auto & lanelet : ego_data.trajectory_lanelets) {
+    autoware_utils_geometry::Polygon2d poly;
+    boost::geometry::convert(lanelet.polygon2d().basicPolygon(), poly);
+    autoware_utils_geometry::MultiPolygon2d tmp_result;
+    boost::geometry::union_(trajectory_lanelets_polygons, poly, tmp_result);
+    trajectory_lanelets_polygons = tmp_result;
+  }
   std::vector<OutOfLanePoint> out_of_lane_points;
   for (auto i = 0UL; i < ego_data.trajectory_footprints.size(); ++i) {
     const auto & footprint = ego_data.trajectory_footprints[i];
     OutOfLanePoint p =
       calculate_out_of_lane_point(footprint, ego_data.out_lanelets, ego_data.out_lanelets_rtree);
     p.trajectory_index = i;
-    if (!p.overlapped_lanelets.empty()) {
+    p.out_overlaps.erase(
+      std::remove_if(
+        p.out_overlaps.begin(), p.out_overlaps.end(),
+        [&](const autoware_utils_geometry::Polygon2d & area) {
+          return boost::geometry::within(area, trajectory_lanelets_polygons);
+        }),
+      p.out_overlaps.end());
+    if (!p.overlapped_lanelets.empty() && !p.out_overlaps.empty()) {
       out_of_lane_points.push_back(p);
     }
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/types.hpp
@@ -116,6 +116,8 @@ struct EgoData
   double min_stop_arc_length{};  // [m] minimum arc length along the filtered trajectory where ego
                                  // can stop
 
+  lanelet::ConstLanelets trajectory_lanelets;  // lanelets where ego is driving and where the module
+                                               // can ignore collisions
   lanelet::ConstLanelets out_lanelets;  // lanelets where ego would be considered "out of lane"
   OutLaneletRtree out_lanelets_rtree;
 


### PR DESCRIPTION
## Description

By definition the `out_of_lane` module should only care about collisions happening outside the ego lane.
There is a bug in the current implementation where areas inside a lanelet followed by the ego trajectory can be incorrectly checked for collisions. This happens when another lanelet overlap the trajectory lanelet.
This PR fixes the issue by making sure that the areas checked for collisions are not completely inside a trajectory lanelet.

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-39409)

## How was this PR tested?

Psim + reproducer.
Evaluator: TODO

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
