### PR TITLE
feat(run_out): support specifying polygon subtypes for map filtering

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/README.md
@@ -44,6 +44,8 @@ we prepare the following sets of geometries based on the parameters defined for 
 - segments to strictly cut predicted paths (`cut_predicted_paths.strict_polygon_types`, `cut_predicted_paths.strict_linestring_types`, and `cut_predicted_paths.strict_lanelet_subtypes`).
   - strict cutting means that the cut is always applied, regardless of any preserved distance or duration.
 
+Polygon subtypes can also be considered if the parameter value is in the format `"type.subtype"`.
+
 The following figure shows an example where the polygons to ignore objects are shown in blue, to ignore collisions in green, and to cut predicted paths in red.
 
 ![map_filtering_data](./docs/map_filtering_data.png)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/schema/run_out.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/schema/run_out.schema.json
@@ -303,7 +303,7 @@
             },
             "polygon_types": {
               "type": "array",
-              "description": "types of polygons in the vector map used to ignore objects",
+              "description": "types of polygons in the vector map used to ignore objects. Subtypes can also be represented using format 'type.subtype'.",
               "items": {
                 "type": "string"
               },


### PR DESCRIPTION
## Description

The `run_out` module uses parameters to define map geometries (linestring, polygon, lanelets) that can be used to filter the predicted paths or collisions used by the module.
Previously, polygons could only be selected based on their `type`. This PR adds a way to also define their `subtype`.

## Related links
**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-39491)

## How was this PR tested?

Psim after adding an item in the `polygon_types` parameter in the format `type.subtype` (e.g., `area.vegetation`).

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
