### PR TITLE
feat(autoware_freespace_planner): utilize all 3 components of velocity

### DIFF
--- a/planning/autoware_freespace_planner/src/autoware_freespace_planner/utils.cpp
+++ b/planning/autoware_freespace_planner/src/autoware_freespace_planner/utils.cpp
@@ -168,8 +168,11 @@ Trajectory create_stop_trajectory(const Trajectory & trajectory)
 bool is_stopped(
   const std::deque<Odometry::ConstSharedPtr> & odom_buffer, const double th_stopped_velocity_mps)
 {
+  const double th_stopped_velocity_sq = th_stopped_velocity_mps * th_stopped_velocity_mps;
   for (const auto & odom : odom_buffer) {
-    if (std::abs(odom->twist.twist.linear.x) > th_stopped_velocity_mps) {
+    const auto & lin = odom->twist.twist.linear;
+    const double velocity_sq = lin.x * lin.x + lin.y * lin.y + lin.z * lin.z;
+    if (velocity_sq > th_stopped_velocity_sq) {
       return false;
     }
   }


### PR DESCRIPTION
## Description
This is a recreation of https://github.com/autowarefoundation/autoware_universe/pull/7859.
I have made some updates to avoid repeating calculation of `th_stopped_velocity_mps * th_stopped_velocity_mps` compared  to the original PR.

## Related links
https://github.com/autowarefoundation/autoware_universe/issues/7834

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
