### PR TITLE
feat(intersection): revert stop position calculation as before temporarily

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/include/autoware/behavior_velocity_intersection_module/decision_result.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/include/autoware/behavior_velocity_intersection_module/decision_result.hpp
@@ -15,8 +15,6 @@
 #ifndef AUTOWARE__BEHAVIOR_VELOCITY_INTERSECTION_MODULE__DECISION_RESULT_HPP_
 #define AUTOWARE__BEHAVIOR_VELOCITY_INTERSECTION_MODULE__DECISION_RESULT_HPP_
 
-#include <geometry_msgs/msg/pose.hpp>
-
 #include <optional>
 #include <string>
 #include <variant>
@@ -70,7 +68,6 @@ struct NonOccludedCollisionStop
   size_t collision_stopline_idx{0};
   size_t occlusion_stopline_idx{0};
   std::string occlusion_report;
-  geometry_msgs::msg::Pose collision_stop_pose;
 };
 
 /**
@@ -101,7 +98,6 @@ struct PeekingTowardOcclusion
   //! intersection_occlusion(x.y)
   std::optional<double> static_occlusion_timeout{std::nullopt};
   std::string occlusion_report;
-  geometry_msgs::msg::Pose collision_stop_pose;
 };
 
 /**
@@ -117,7 +113,6 @@ struct OccludedCollisionStop
   //! contains the remaining time to release the static occlusion stuck
   std::optional<double> static_occlusion_timeout{std::nullopt};
   std::string occlusion_report;
-  geometry_msgs::msg::Pose collision_stop_pose;
 };
 
 /**
@@ -143,7 +138,6 @@ struct Safe
   size_t collision_stopline_idx{0};
   size_t occlusion_stopline_idx{0};
   std::string occlusion_report;
-  geometry_msgs::msg::Pose collision_stop_pose;
 };
 
 /**
@@ -156,7 +150,6 @@ struct FullyPrioritized
   size_t collision_stopline_idx{0};
   size_t occlusion_stopline_idx{0};
   std::string safety_report;
-  geometry_msgs::msg::Pose collision_stop_pose;
 };
 
 using DecisionResult = std::variant<

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/include/autoware/behavior_velocity_intersection_module/intersection_stoplines.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/include/autoware/behavior_velocity_intersection_module/intersection_stoplines.hpp
@@ -38,11 +38,6 @@ struct IntersectionStopLines
   std::optional<size_t> default_stopline{std::nullopt};
 
   /**
-   * collision_stopline is ahead of closest_idx by the braking distance
-   */
-  size_t collision_stopline{0};
-
-  /**
    * first_attention_stopline is null if ego footprint along the path does not intersect with
    * attention area. if path[0] satisfies the condition, it is 0
    */

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/include/autoware/behavior_velocity_intersection_module/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/include/autoware/behavior_velocity_intersection_module/scene_intersection.hpp
@@ -807,8 +807,7 @@ private:
    * intersection_stoplines.occlusion_peeking_stopline
    */
   std::optional<NonOccludedCollisionStop> isGreenPseudoCollisionStatus(
-    const autoware_internal_planning_msgs::msg::PathWithLaneId & path, const size_t closest_idx,
-    const size_t collision_stopline_idx,
+    const size_t closest_idx, const size_t collision_stopline_idx,
     const IntersectionStopLines & intersection_stoplines) const;
 
   /**
@@ -863,11 +862,6 @@ private:
     ego_ttc_pub_;
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64MultiArrayStamped>::SharedPtr
     object_ttc_pub_;
-
-  template <class T>
-  std::pair<size_t, geometry_msgs::msg::Pose> holdStopPoseIfNecessary(
-    const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
-    const size_t current_collision_stopline_idx) const;
 };
 
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -358,8 +358,7 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
 
   const bool is_over_default_stopline = util::isOverTargetIndex(
     *path, closest_idx, planner_data_->current_odometry->pose, default_stopline_idx);
-  const auto collision_stopline_idx =
-    is_over_default_stopline ? intersection_stoplines.collision_stopline : default_stopline_idx;
+  const auto collision_stopline_idx = is_over_default_stopline ? closest_idx : default_stopline_idx;
 
   // ==========================================================================================
   // pseudo collision detection on green light

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -327,9 +327,8 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
         // NOTE(soblin): intersection_stoplines.maximum_footprint_overshoot_line.value() is not used
         // as stop line. in this case, ego tries to stop at current position
         const auto stop_line_idx = closest_idx;
-        const auto collision_stop_pose = path->points.at(stop_line_idx).point.pose;
         return NonOccludedCollisionStop{
-          closest_idx, stop_line_idx, occlusion_stopline_idx, occlusion_diag, collision_stop_pose};
+          closest_idx, stop_line_idx, occlusion_stopline_idx, occlusion_diag};
       }
     }
     if (has_collision) {
@@ -365,8 +364,8 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
   // ==========================================================================================
   // pseudo collision detection on green light
   // ==========================================================================================
-  const auto is_green_pseudo_collision_status = isGreenPseudoCollisionStatus(
-    *path, closest_idx, collision_stopline_idx, intersection_stoplines);
+  const auto is_green_pseudo_collision_status =
+    isGreenPseudoCollisionStatus(closest_idx, collision_stopline_idx, intersection_stoplines);
   if (is_green_pseudo_collision_status) {
     return is_green_pseudo_collision_status.value();
   }
@@ -383,27 +382,19 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
   }
 
   if (is_prioritized) {
-    const auto [held_collision_stopline_idx, collision_stop_pose] =
-      holdStopPoseIfNecessary<NonOccludedCollisionStop>(*path, collision_stopline_idx);
-    return FullyPrioritized{has_collision_with_margin, closest_idx,   held_collision_stopline_idx,
-                            occlusion_stopline_idx,    safety_report, collision_stop_pose};
+    return FullyPrioritized{
+      has_collision_with_margin, closest_idx, collision_stopline_idx, occlusion_stopline_idx,
+      safety_report};
   }
 
   // Safe
   if (!is_occlusion_state && !has_collision_with_margin) {
-    const auto [held_collision_stopline_idx, collision_stop_pose] =
-      holdStopPoseIfNecessary<NonOccludedCollisionStop>(*path, collision_stopline_idx);
-    return Safe{
-      closest_idx, held_collision_stopline_idx, occlusion_stopline_idx, occlusion_diag,
-      collision_stop_pose};
+    return Safe{closest_idx, collision_stopline_idx, occlusion_stopline_idx, occlusion_diag};
   }
   // Only collision
   if (!is_occlusion_state && has_collision_with_margin) {
-    const auto [held_collision_stopline_idx, collision_stop_pose] =
-      holdStopPoseIfNecessary<NonOccludedCollisionStop>(*path, collision_stopline_idx);
     return NonOccludedCollisionStop{
-      closest_idx, held_collision_stopline_idx, occlusion_stopline_idx, occlusion_diag,
-      collision_stop_pose};
+      closest_idx, collision_stopline_idx, occlusion_stopline_idx, occlusion_diag};
   }
   // Occluded
   // utility functions
@@ -490,11 +481,7 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
     const bool release_static_occlusion_stuck =
       (static_occlusion_timeout_state_machine_.getState() == StateMachine::State::GO);
     if (!has_collision_with_margin && release_static_occlusion_stuck) {
-      const auto [held_collision_stopline_idx, collision_stop_pose] =
-        holdStopPoseIfNecessary<NonOccludedCollisionStop>(*path, collision_stopline_idx);
-      return Safe{
-        closest_idx, held_collision_stopline_idx, occlusion_stopline_idx, occlusion_diag,
-        collision_stop_pose};
+      return Safe{closest_idx, collision_stopline_idx, occlusion_stopline_idx, occlusion_diag};
     }
     // occlusion_status is either STATICALLY_OCCLUDED or DYNAMICALLY_OCCLUDED
     const double max_timeout =
@@ -507,27 +494,13 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
             occlusion_stop_state_machine_.getDuration())
         : (is_static_occlusion ? std::make_optional<double>(max_timeout) : std::nullopt);
     if (has_collision_with_margin) {
-      const auto [held_collision_stopline_idx, collision_stop_pose] =
-        holdStopPoseIfNecessary<PeekingTowardOcclusion>(*path, collision_stopline_idx);
-      return OccludedCollisionStop{
-        is_occlusion_cleared_with_margin,
-        closest_idx,
-        held_collision_stopline_idx,
-        occlusion_stopline_idx,
-        static_occlusion_timeout,
-        occlusion_diag,
-        collision_stop_pose};
+      return OccludedCollisionStop{is_occlusion_cleared_with_margin, closest_idx,
+                                   collision_stopline_idx,           occlusion_stopline_idx,
+                                   static_occlusion_timeout,         occlusion_diag};
     } else {
-      const auto [held_collision_stopline_idx, collision_stop_pose] =
-        holdStopPoseIfNecessary<PeekingTowardOcclusion>(*path, collision_stopline_idx);
-      return PeekingTowardOcclusion{
-        is_occlusion_cleared_with_margin,
-        closest_idx,
-        held_collision_stopline_idx,
-        occlusion_stopline_idx,
-        static_occlusion_timeout,
-        occlusion_diag,
-        collision_stop_pose};
+      return PeekingTowardOcclusion{is_occlusion_cleared_with_margin, closest_idx,
+                                    collision_stopline_idx,           occlusion_stopline_idx,
+                                    static_occlusion_timeout,         occlusion_diag};
     }
   } else {
     return FirstWaitBeforeOcclusion{
@@ -1506,44 +1479,5 @@ IntersectionModule::PassJudgeStatus IntersectionModule::isOverPassJudgeLinesStat
     is_over_1st_pass_judge_line, is_over_2nd_pass_judge_line,
     safely_passed_1st_judge_line_first_time, safely_passed_2nd_judge_line_first_time};
 }
-
-template <class T>
-std::pair<size_t, geometry_msgs::msg::Pose> IntersectionModule::holdStopPoseIfNecessary(
-  const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
-  const size_t current_collision_stopline_idx) const
-{
-  // check if previous decision was same type and inherit stop pose
-  if (std::holds_alternative<T>(prev_decision_result_)) {
-    const auto & prev_decision = std::get<T>(prev_decision_result_);
-    const auto collision_stop_line_idx = autoware::motion_utils::findNearestIndex(
-      path.points, prev_decision.collision_stop_pose.position);
-
-    return {collision_stop_line_idx, prev_decision.collision_stop_pose};
-  }
-
-  const auto current_collision_stop_pose =
-    path.points.at(current_collision_stopline_idx).point.pose;
-  return {current_collision_stopline_idx, current_collision_stop_pose};
-}
-
-template std::pair<size_t, geometry_msgs::msg::Pose>
-IntersectionModule::holdStopPoseIfNecessary<NonOccludedCollisionStop>(
-  const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
-  const size_t current_collision_stopline_idx) const;
-
-template std::pair<size_t, geometry_msgs::msg::Pose>
-IntersectionModule::holdStopPoseIfNecessary<PeekingTowardOcclusion>(
-  const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
-  const size_t current_collision_stopline_idx) const;
-
-template std::pair<size_t, geometry_msgs::msg::Pose>
-IntersectionModule::holdStopPoseIfNecessary<OccludedCollisionStop>(
-  const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
-  const size_t current_collision_stopline_idx) const;
-
-template std::pair<size_t, geometry_msgs::msg::Pose>
-IntersectionModule::holdStopPoseIfNecessary<Safe>(
-  const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
-  const size_t current_collision_stopline_idx) const;
 
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
@@ -469,8 +469,8 @@ void IntersectionModule::cutPredictPathWithinDuration(
 }
 
 std::optional<NonOccludedCollisionStop> IntersectionModule::isGreenPseudoCollisionStatus(
-  const autoware_internal_planning_msgs::msg::PathWithLaneId & path, const size_t closest_idx,
-  const size_t collision_stopline_idx, const IntersectionStopLines & intersection_stoplines) const
+  const size_t closest_idx, const size_t collision_stopline_idx,
+  const IntersectionStopLines & intersection_stoplines) const
 {
   // ==========================================================================================
   // if there are any vehicles on the attention area when ego entered the intersection on green
@@ -492,11 +492,8 @@ std::optional<NonOccludedCollisionStop> IntersectionModule::isGreenPseudoCollisi
       });
     if (exist_close_vehicles) {
       const auto occlusion_stopline_idx = intersection_stoplines.occlusion_peeking_stopline.value();
-      const auto [held_collision_stopline_idx, collision_stop_pose] =
-        holdStopPoseIfNecessary<NonOccludedCollisionStop>(path, collision_stopline_idx);
       return NonOccludedCollisionStop{
-        closest_idx, held_collision_stopline_idx, occlusion_stopline_idx, std::string(""),
-        collision_stop_pose};
+        closest_idx, collision_stopline_idx, occlusion_stopline_idx, std::string("")};
     }
   }
   return std::nullopt;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
@@ -303,16 +303,6 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
     path_ip.points, current_pose, planner_data_->ego_nearest_dist_threshold,
     planner_data_->ego_nearest_yaw_threshold);
 
-  const double velocity = planner_data_->current_velocity->twist.linear.x;
-  const double acceleration = planner_data_->current_acceleration->accel.accel.linear.x;
-  const double braking_dist = planning_utils::calcJudgeLineDistWithJerkLimit(
-    velocity, acceleration, max_accel, max_jerk, delay_response_time);
-
-  // collision_stopline
-  const size_t collision_stopline_ip = std::clamp<size_t>(
-    closest_idx_ip + std::ceil(braking_dist / ds), 0,
-    static_cast<size_t>(path_ip.points.size()) - 1);
-
   // (3) occlusion peeking stop line position on interpolated path
   int occlusion_peeking_line_ip_int = static_cast<int>(default_stopline_ip);
   bool occlusion_peeking_line_valid = true;
@@ -338,6 +328,10 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
   const bool first_attention_stopline_valid = true;
 
   // (5) 1st pass judge line position on interpolated path
+  const double velocity = planner_data_->current_velocity->twist.linear.x;
+  const double acceleration = planner_data_->current_acceleration->accel.accel.linear.x;
+  const double braking_dist = planning_utils::calcJudgeLineDistWithJerkLimit(
+    velocity, acceleration, max_accel, max_jerk, delay_response_time);
   int first_pass_judge_ip_int =
     static_cast<int>(first_footprint_inside_1st_attention_ip) - std::ceil(braking_dist / ds);
   const auto first_pass_judge_line_ip = static_cast<size_t>(
@@ -420,7 +414,6 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
     size_t closest_idx{0};
     size_t stuck_stopline{0};
     size_t default_stopline{0};
-    size_t collision_stopline{0};
     size_t first_attention_stopline{0};
     size_t second_attention_stopline{0};
     size_t occlusion_peeking_stopline{0};
@@ -435,7 +428,6 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
     {&closest_idx_ip, &intersection_stoplines_temp.closest_idx},
     {&stuck_stopline_ip, &intersection_stoplines_temp.stuck_stopline},
     {&default_stopline_ip, &intersection_stoplines_temp.default_stopline},
-    {&collision_stopline_ip, &intersection_stoplines_temp.collision_stopline},
     {&first_attention_stopline_ip, &intersection_stoplines_temp.first_attention_stopline},
     {&second_attention_stopline_ip, &intersection_stoplines_temp.second_attention_stopline},
     {&occlusion_peeking_line_ip, &intersection_stoplines_temp.occlusion_peeking_stopline},
@@ -466,7 +458,6 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
 
   IntersectionStopLines intersection_stoplines;
   intersection_stoplines.closest_idx = intersection_stoplines_temp.closest_idx;
-  intersection_stoplines.collision_stopline = intersection_stoplines_temp.collision_stopline;
   if (stuck_stopline_valid) {
     intersection_stoplines.stuck_stopline = intersection_stoplines_temp.stuck_stopline;
   }


### PR DESCRIPTION
## Description

In order to avoid "will_overrun" diagnosis, the planner needs to memorize stop position and keep inserting the position.

Following PRs

- https://github.com/autowarefoundation/autoware_universe/pull/10900
- https://github.com/autowarefoundation/autoware_universe/pull/11247

are problematic because

- if stopline moves dynamically according to current barking_distance, the controller's tracking to expected stopline degrades
- even if previous stopline is hold, actual stop position is inserted at the point closeset to it, causing some error for the desired stop position and making that stop line position moves a bit depending on the interpolation result in each cycle.

In the future subsequent PR,

- once stop position is commanded, it is memorized.
- when generating IntersectionStopLine, previous stopline position is considered

## Related links

- https://tier4.atlassian.net/browse/RT0-38849
- https://tier4.atlassian.net/browse/RT0-38746
- https://tier4.atlassian.net/browse/RT0-36571

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/0e1a275a-9c08-5f8a-a396-137b652dd18d?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/236222b9-70f0-5e25-919a-1bc06aa1aaff?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/e870ed3f-f00b-5daf-92ad-a80f20f630c5?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
