### PR TITLE
fix(tensorrt_common): resolve error message of clang

### DIFF
--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
@@ -27,6 +27,7 @@ namespace fs = ::std::experimental::filesystem;
 #endif
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
## Description

This pull request introduces a minor update to the `utils.hpp` header by adding the `<array>` header to the list of included libraries. This change ensures that the functionality provided by `std::array` is available in files that include `utils.hpp`.

By including `<array>`, the following error message disappeared:

<img width="1627" height="379" alt="Screenshot from 2025-10-03 05-14-13" src="https://github.com/user-attachments/assets/6d961fdd-1033-4c1c-8ea3-8eca3a453741" />

* Added `#include <array>` to `perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp` to support usage of `std::array`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
