### PR TITLE
fix(out_of_lane): ensure the calculated stop pose is feasible

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.cpp
@@ -317,7 +317,10 @@ void OutOfLaneModule::update_slowdown_pose_buffer(
 
   slowdown_pose_buffer_ = valid_poses;
 
-  if (!slowdown_pose) return;
+  if (
+    !slowdown_pose ||
+    (ego_data.velocity > 0.1 && slowdown_pose_arc_length < ego_data.min_stop_arc_length))
+    return;
 
   static constexpr double eps = 1e-3;
   if (slowdown_pose_buffer_.empty()) {


### PR DESCRIPTION
## Description

This PR adds a check to make sure the `out_of_lane` module does not output an unfeasible stop point.
When it is too late to avoid the `out_of_lane` collision, ego will keep driving instead of generating an unfeasible stop.

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-39670)

## How was this PR tested?

Psim + Reproducer

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
