### PR TITLE
feat(dummy_perception_publisher): Add conversion to PointXYZIRC for output clouds

### DIFF
--- a/simulator/autoware_dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/autoware_dummy_perception_publisher/CMakeLists.txt
@@ -4,11 +4,14 @@ project(autoware_dummy_perception_publisher)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(autoware_point_types REQUIRED)
+
 # See ndt_omp package for documentation on why PCL is special
 find_package(PCL REQUIRED COMPONENTS common filters)
 
 set(${PROJECT_NAME}_DEPENDENCIES
   autoware_perception_msgs
+  autoware_point_types
   tier4_perception_msgs
   pcl_conversions
   rclcpp

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/node.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/node.hpp
@@ -19,6 +19,7 @@
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware/point_types/types.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 #include <tier4_simulation_msgs/msg/dummy_object.hpp>
@@ -125,6 +126,9 @@ private:
 
   void timerCallback();
   void objectCallback(const DummyObject::ConstSharedPtr msg);
+
+  pcl::PointCloud<autoware::point_types::PointXYZIRC> convertPointCloudXYZtoXYZIRC(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud) const;
 
 public:
   DummyPerceptionPublisherNode();

--- a/simulator/autoware_dummy_perception_publisher/package.xml
+++ b/simulator/autoware_dummy_perception_publisher/package.xml
@@ -23,6 +23,7 @@
 
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_trajectory</depend>
+  <depend>autoware_point_types</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_utils_uuid</depend>

--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware/dummy_perception_publisher/predicted_object_movement_plugin.hpp"
 #include "autoware/dummy_perception_publisher/straight_line_object_movement_plugin.hpp"
+#include "autoware/point_types/types.hpp"
 #include "autoware_utils_geometry/geometry.hpp"
 
 #include <autoware_utils_uuid/uuid_helper.hpp>
@@ -117,6 +118,27 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   movement_plugins_.push_back(std::make_shared<pluginlib::PredictedObjectMovementPlugin>(this));
 }
 
+pcl::PointCloud<autoware::point_types::PointXYZIRC>
+DummyPerceptionPublisherNode::convertPointCloudXYZtoXYZIRC(
+  const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud) const
+{
+  pcl::PointCloud<autoware::point_types::PointXYZIRC> cloud_xyzirc;
+  cloud_xyzirc.reserve(input_cloud->size());
+
+  for (const auto & pt_xyz : input_cloud->points) {
+    autoware::point_types::PointXYZIRC p_xyzirc;
+    p_xyzirc.x = pt_xyz.x;
+    p_xyzirc.y = pt_xyz.y;
+    p_xyzirc.z = pt_xyz.z;
+    p_xyzirc.intensity = 0;
+    p_xyzirc.return_type = 0;
+    p_xyzirc.channel = 0;
+    cloud_xyzirc.push_back(p_xyzirc);
+  }
+
+  return cloud_xyzirc;
+}
+
 void DummyPerceptionPublisherNode::timerCallback()
 {
   // output msgs
@@ -190,11 +212,13 @@ void DummyPerceptionPublisherNode::timerCallback()
     new pcl::PointCloud<pcl::PointXYZ>);
 
   if (all_objects.empty()) {
-    pcl::toROSMsg(*merged_pointcloud_ptr, output_pointcloud_msg);
+    const auto pointcloud_xyzirc = convertPointCloudXYZtoXYZIRC(merged_pointcloud_ptr);
+    pcl::toROSMsg(pointcloud_xyzirc, output_pointcloud_msg);
   } else {
     pointcloud_creator_->create_pointclouds(
       obj_infos, tf_base_link2map, random_generator_, merged_pointcloud_ptr);
-    pcl::toROSMsg(*merged_pointcloud_ptr, output_pointcloud_msg);
+    const auto pointcloud_xyzirc = convertPointCloudXYZtoXYZIRC(merged_pointcloud_ptr);
+    pcl::toROSMsg(pointcloud_xyzirc, output_pointcloud_msg);
   }
   if (!selected_indices.empty()) {
     std::vector<ObjectInfo> detected_obj_infos;
@@ -240,7 +264,8 @@ void DummyPerceptionPublisherNode::timerCallback()
         tf_base_link2noised_moved_object,
         feature_object.object.kinematics.pose_with_covariance.pose);
       feature_object.object.shape = object.shape;
-      pcl::toROSMsg(*pointcloud, feature_object.feature.cluster);
+      const auto pointcloud_xyzirc = convertPointCloudXYZtoXYZIRC(pointcloud);
+      pcl::toROSMsg(pointcloud_xyzirc, feature_object.feature.cluster);
       output_dynamic_object_msg.feature_objects.push_back(feature_object);
 
       // check delete idx

--- a/simulator/autoware_dummy_perception_publisher/src/pointcloud_creator.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/pointcloud_creator.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/dummy_perception_publisher/node.hpp"
 #include "autoware/dummy_perception_publisher/signed_distance_function.hpp"
+#include "autoware/point_types/types.hpp"
 
 #include <pcl/impl/point_types.hpp>
 


### PR DESCRIPTION
## Description
The dummy_perception_publisher node was creating point clouds with a pcl::PointXYZ structure. This caused downstream nodes that expect a PointXYZIRC structure (such as voxel_grid_downsample_filter) to crash due to a data format mismatch.

This change introduces a conversion step after the internal point cloud generation is complete. Since the dummy publisher does not generate real intensity, return type, or channel data, these corresponding fields are filled with default zero values to ensure format compatibility.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Launched the planning simulator with perception enabled.

- Confirmed that the runtime error in voxel_grid_downsample_filter no longer occurs.

- Confirmed that the output format of the topic is correct using ros2 topic echo. The fields now match the PointXYZIRC structure as intended.

`ros2 topic echo /perception/obstacle_segmentation/pointcloud --field fields
`
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
