### PR TITLE
fix(goal_planner): fix node crash due to freespace planner multithreading

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -95,6 +95,8 @@ public:
     initializeOccupancyGridMap(planner_data, parameters_);
   };
 
+  FreespaceParkingRequest(const FreespaceParkingRequest & other);
+
   const ModuleStatus & getCurrentStatus() const { return current_status_; }
   void update(
     const PlannerData & planner_data, const ModuleStatus & current_status,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -19,6 +19,27 @@
 namespace autoware::behavior_path_planner
 {
 
+FreespaceParkingRequest::FreespaceParkingRequest(const FreespaceParkingRequest & other)
+: parameters_(other.parameters_),
+  vehicle_footprint_(other.vehicle_footprint_),
+  goal_candidates_(other.goal_candidates_),
+  planner_data_(
+    other.planner_data_ ? std::make_shared<PlannerData>(*other.planner_data_) : nullptr),
+  current_status_(other.current_status_),
+  occupancy_grid_map_(
+    other.occupancy_grid_map_
+      ? std::make_shared<OccupancyGridBasedCollisionDetector>(*other.occupancy_grid_map_)
+      : nullptr),
+  pull_over_path_(other.pull_over_path_),
+  last_path_update_time_(other.last_path_update_time_),
+  is_stopped_(other.is_stopped_)
+{
+  if (planner_data_ && other.planner_data_ && other.planner_data_->route_handler) {
+    planner_data_->route_handler =
+      std::make_shared<RouteHandler>(*other.planner_data_->route_handler);
+  }
+}
+
 void LaneParkingRequest::update(
   const PlannerData & planner_data, const ModuleStatus & current_status,
   const BehaviorModuleOutput & upstream_module_output,


### PR DESCRIPTION
## Description

### Cause
Fix node crash.
```
[openscenario_interpreter_node-3] [component_container_mt-25] malloc(): invalid next size (unsorted)
[openscenario_interpreter_node-3] [component_container_mt-25] *** Aborted at 1759080823 (unix time) try "date -d @1759080823" if you are using GNU date ***
[openscenario_interpreter_node-3] [component_container_mt-25] PC: @                0x0 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25] *** SIGABRT (@0x3e800000989) received by PID 2441 (TID 0x7efcecf71640) from PID 2441; stack trace: ***
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf52dc4d6 google::(anonymous namespace)::FailureSignalHandler()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4b90520 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4be49fc pthread_kill
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4b90476 raise
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4b767f3 abort
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4bd7677 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4beecfc (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4bf20ec (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4bf3139 malloc
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4e4598c operator new()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4b17050 rcl_wait_set_resize
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf515c16d rclcpp::Executor::wait_for_work()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf515c6d3 rclcpp::Executor::get_next_executable()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf516040a rclcpp::executors::MultiThreadedExecutor::run()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4e73253 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4be2ac3 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7efcf4c73a74 clone
[openscenario_interpreter_node-3] [ERROR] [component_container_mt-25]: process has died [pid 2441, exit code -6, cmd '/home/autoware/pilot-auto/install/lib/rclcpp_components/component_container_mt --ros-args -r __node:=behavior_planning_container -r __ns:=/planning/scenario_planning/lane_driving/behavior_planning -p use_sim_time:=False -p wheel_radius:=0.383 -p wheel_width:=0.235 -p wheel_base:=2.79 -p wheel_tread:=1.64 -p front_overhang:=1.0 -p rear_overhang:=1.1 -p left_overhang:=0.128 -p right_overhang:=0.128 -p vehicle_height:=2.5 -p max_steer_angle:=0.7 -p use_sim_time:=False -p wheel_radius:=0.383 -p wheel_width:=0.235 -p wheel_base:=2.79 -p wheel_tread:=1.64 -p front_overhang:=1.0 -p rear_overhang:=1.1 -p left_overhang:=0.128 -p right_overhang:=0.128 -p vehicle_height:=2.5 -p max_steer_angle:=0.7'].
[openscenario_interpreter_node-3] [component_container_mt-37] [WARN] [1759080823.938042213] [autoware_api.external.vehicle_status]: The hazard_lights_ topic is not subscribed
[openscenario_interpreter_node-3] [component_container-7] [WARN] [1759080824.197532696] [system.topic_state_monitor_scenario_planning_trajectory]: /planning/trajectory topic is timeout. Set ERROR in diagnostics.
[openscenario_interpreter_node-3] [logging_node-15] [WARN] [1759080824.270930278] [logging_diag_graph]: The target mode is not available for the following reasons:
[openscenario_interpreter_node-3] [logging_node-15] - /autoware/modes/autonomous ERROR
[openscenario_interpreter_node-3] [logging_node-15]     - /planning/autonomous_available ERROR
[openscenario_interpreter_node-3] [logging_node-15]         - /planning/emergency_stop ERROR
[openscenario_interpreter_node-3] [logging_node-15]             - /planning/001-topic_status/trajectory-error ERROR
[openscenario_interpreter_node-3] [logging_node-15] 
```

The issue stemmed from a race condition in the occupancy grid map management.

Whenever `GoalPlannerModule::syncWithThreads()` was called, it executed `freespace_parking_request_->update()`. This, in turn, called `setMap()` on the shared `OccupancyGridBasedCollisionDetector`, which rebuilt the internal costmap array.

Simultaneously, a separate thread (the freespace parking timer) would call `planFreespacePath()` → `goal_searcher.update()` without holding a lock. Inside this call, it executed `detectCollision()` and `getMap()` on the exact same collision detector instance.
```
std::make_shared<OccupancyGridBasedCollisionDetector>(*other.occupancy_grid_map_)
```

This meant both threads were simultaneously writing to and reading from the same object, corrupting its internal buffers and leading to heap corruption (e.g. `malloc(): invalid next size`).

### Solution
We explicitly defined the copy constructor for `FreespaceParkingRequest` to perform a deep copy of `occupancy_grid_map_`.

Now, when the timer thread creates and processes a local_request, it references an independent collision detector instance. This prevents collisions with the main thread's `setMap()` call, allowing `detectCollision()` to be called safely and independently.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

https://tier4.atlassian.net/browse/T4DEV-31190

## How was this PR tested?

I confirmed that no issues occurred with zero retries.

[test_1](https://evaluation.tier4.jp/evaluation/reports/ad961f79-e4c6-5eba-8f7b-7d2b7506120d/tests/8caa0de2-99be-5031-994f-eba1d1207237?project_id=prd_jt)

[test_2](https://evaluation.tier4.jp/evaluation/reports/fb26522d-349c-5af1-8850-0c30a102e788/tests/8445015c-1938-5805-ada4-9b4950f36c45?project_id=prd_jt)

[test_3](https://evaluation.tier4.jp/evaluation/reports/ec56d6d0-795b-5e34-9dd9-dc21c894281b/tests/a7533691-bf24-5b83-8c6e-7e9d28a068b8?project_id=prd_jt)

[test_4](https://evaluation.tier4.jp/evaluation/reports/5bb7a6ea-fe4c-5d14-bc85-41f789ea0eb5/tests/c590a14d-9ef4-5c73-82c5-f5c716261062?project_id=prd_jt)

[test_5](https://evaluation.tier4.jp/evaluation/reports/2fb4b830-94f0-5d11-a5b5-2c33143c79c8/tests/0e48322c-cee6-5f59-aeaa-e2fddb525233?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
