### PR TITLE
chore: relieve pose_estimator_lateral_tolerance to 0.5

### DIFF
--- a/localization/autoware_pose_instability_detector/config/pose_instability_detector.param.yaml
+++ b/localization/autoware_pose_instability_detector/config/pose_instability_detector.param.yaml
@@ -11,7 +11,7 @@
 
     pose_estimator_longitudinal_tolerance: 0.11   # [m]
     pose_estimator_lateral_tolerance: 0.11        # [m]
-    pose_estimator_vertical_tolerance: 0.50       # [m]
+    pose_estimator_vertical_tolerance: 0.5        # [m]
     pose_estimator_angular_tolerance: 0.0175      # [rad]
 
     enable_validation:

--- a/localization/autoware_pose_instability_detector/config/pose_instability_detector.param.yaml
+++ b/localization/autoware_pose_instability_detector/config/pose_instability_detector.param.yaml
@@ -11,7 +11,7 @@
 
     pose_estimator_longitudinal_tolerance: 0.11   # [m]
     pose_estimator_lateral_tolerance: 0.11        # [m]
-    pose_estimator_vertical_tolerance: 0.11       # [m]
+    pose_estimator_vertical_tolerance: 0.50       # [m]
     pose_estimator_angular_tolerance: 0.0175      # [rad]
 
     enable_validation:

--- a/localization/autoware_pose_instability_detector/schema/pose_instability_detector.schema.json
+++ b/localization/autoware_pose_instability_detector/schema/pose_instability_detector.schema.json
@@ -56,7 +56,7 @@
         },
         "pose_estimator_vertical_tolerance": {
           "type": "number",
-          "default": 0.11,
+          "default": 0.5,
           "minimum": 0.0,
           "description": "The tolerance of vertical position of pose estimator (m)."
         },


### PR DESCRIPTION
## Description

The pose_instability_detector detects position jump of vehicles and its threshold is calculated based on the parameters.

The parameter `pose_estimator_vertical_tolerance` manages the jump of the z coordinates but the current default value `0.11` is too small when we consider bumpy roads. This PR relieves it to `0.5` meters.

## Related links

Autoware will read the parameters in the autoware_launch. The PR below is the corresponding one to this PR.

https://github.com/autowarefoundation/autoware_launch/pull/1667

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `pose_estimator_vertical_tolerance` | `double` | **`0.11`**         | Tolerance of pose difference in the z coordinates |
| New     | `pose_estimator_vertical_tolerance` | `double` | **`0.5`**         | Tolerance of pose difference in the z coordinates |

## Effects on system behavior

The pose_instability_detector diagnostics will be more tolerant to shaky vehicle positions in the z coordinate.