### PR TITLE
fix(stop_mode_operator): fix stop condition

### DIFF
--- a/control/autoware_stop_mode_operator/src/continuous_condition.cpp
+++ b/control/autoware_stop_mode_operator/src/continuous_condition.cpp
@@ -20,16 +20,19 @@ namespace autoware::stop_mode_operator
 void ContinuousCondition::update(const rclcpp::Time & stamp, bool condition)
 {
   if (!condition) {
+    last_stamp_ = std::nullopt;
     start_stamp_ = std::nullopt;
-  } else if (!start_stamp_) {
-    start_stamp_ = stamp;
+  } else {
+    last_stamp_ = stamp;
+    start_stamp_ = start_stamp_.value_or(stamp);
   }
 }
 
 void ContinuousCondition::update(const rclcpp::Time & stamp, double timeout)
 {
-  if (start_stamp_) {
-    if (timeout <= (stamp - *start_stamp_).seconds()) {
+  if (last_stamp_) {
+    if (timeout <= (stamp - *last_stamp_).seconds()) {
+      last_stamp_ = std::nullopt;
       start_stamp_ = std::nullopt;
     }
   }

--- a/control/autoware_stop_mode_operator/src/continuous_condition.hpp
+++ b/control/autoware_stop_mode_operator/src/continuous_condition.hpp
@@ -30,6 +30,7 @@ public:
   bool check(const rclcpp::Time & stamp, double duration) const;
 
 private:
+  std::optional<rclcpp::Time> last_stamp_;
   std::optional<rclcpp::Time> start_stamp_;
 };
 

--- a/control/autoware_stop_mode_operator/src/stop_mode_operator.cpp
+++ b/control/autoware_stop_mode_operator/src/stop_mode_operator.cpp
@@ -82,13 +82,10 @@ void StopModeOperator::publish_gear_command()
     parking = parking_route_state && parking_vehicle_stop;
   }
 
-  if (last_parking_ != parking) {
-    GearCommand gear;
-    gear.stamp = now();
-    gear.command = parking ? GearCommand::PARK : GearCommand::NONE;
-    pub_gear_->publish(gear);
-  }
-  last_parking_ = parking;
+  GearCommand gear;
+  gear.stamp = now();
+  gear.command = parking ? GearCommand::PARK : GearCommand::NONE;
+  pub_gear_->publish(gear);
 }
 
 void StopModeOperator::publish_turn_indicators_command()

--- a/control/autoware_stop_mode_operator/src/stop_mode_operator.hpp
+++ b/control/autoware_stop_mode_operator/src/stop_mode_operator.hpp
@@ -27,8 +27,6 @@
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 
-#include <optional>
-
 namespace autoware::stop_mode_operator
 {
 
@@ -64,7 +62,6 @@ private:
   SteeringReport current_steering_;
   RouteState current_route_state_;
   ContinuousCondition vehicle_stop_check_;
-  std::optional<bool> last_parking_;
 
   double stop_hold_acceleration_;
   bool enable_auto_parking_;


### PR DESCRIPTION
## Description

Fix that the stop_mode_operator stop condition is not worked correctly.

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-38870?atlOrigin=eyJpIjoiNmQ1YmM2Mjk0OGE4NDE3YTk2NzZiNjZjMjVkNjk0YzEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## How was this PR tested?

Launch planning simulation with `use_control_command_gate:=true` option.
Drive in autonomous mode.
Check the gear is parking when the vehicle arrived goal.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
