### PR TITLE
fix(autoware_cuda_pointcloud_preprocessor): add conditional include for CUDA 13.0 and above

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -48,6 +48,10 @@ include_directories(
     ${CUDA_INCLUDE_DIRS}
 )
 
+if(NOT CUDA_VERSION VERSION_LESS "13.0")
+  include_directories(SYSTEM ${CUDA_INCLUDE_DIRS}/cccl)
+endif()
+
 # cSpell: ignore expt
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 20012")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")

--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -48,7 +48,7 @@ include_directories(
     ${CUDA_INCLUDE_DIRS}
 )
 
-if(NOT CUDA_VERSION VERSION_LESS "13.0")
+if(CUDA_VERSION VERSION_GREATER_EQUAL "13.0")
   include_directories(SYSTEM ${CUDA_INCLUDE_DIRS}/cccl)
 endif()
 


### PR DESCRIPTION
## Description

The thrust inclusion path has changed in CUDA 13.0.

https://developer.nvidia.com/blog/whats-new-and-important-in-cuda-toolkit-13-0/#cccl_headers_have_moved_in_cuda_130

This PR has been adjusted to reflect this change.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
