### PR TITLE
fix(autoware_universe_utils): guard all unchecked .value() calls in geometry (ear_clipping + polygon_clip)

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/ear_clipping.hpp
@@ -18,6 +18,7 @@
 #include "autoware/universe_utils/geometry/alt_geometry.hpp"
 
 #include <optional>
+#include <stdexcept>
 #include <vector>
 
 namespace autoware::universe_utils
@@ -35,6 +36,29 @@ struct LinkedPoint
   std::optional<std::size_t> next_index;
   [[nodiscard]] double x() const { return pt.x(); }
   [[nodiscard]] double y() const { return pt.y(); }
+
+  // Accessors for the doubly-linked structure. Once a node has been linked via
+  // insert_point(), prev_index/next_index are always set and are never cleared.
+  // prev()/next() therefore assert that invariant and throw on violation rather
+  // than silently returning a default, which would propagate a subtly wrong
+  // triangulation downstream. Use has_prev()/has_next() at the few sites that
+  // must legitimately check (e.g. loop termination).
+  [[nodiscard]] std::size_t prev() const
+  {
+    if (!prev_index.has_value()) {
+      throw std::logic_error("LinkedPoint::prev() called on unlinked node");
+    }
+    return prev_index.value();
+  }
+  [[nodiscard]] std::size_t next() const
+  {
+    if (!next_index.has_value()) {
+      throw std::logic_error("LinkedPoint::next() called on unlinked node");
+    }
+    return next_index.value();
+  }
+  [[nodiscard]] bool has_prev() const { return prev_index.has_value(); }
+  [[nodiscard]] bool has_next() const { return next_index.has_value(); }
 };
 
 /**

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/polygon_clip.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/polygon_clip.hpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cstdint>
 #include <optional>
+#include <stdexcept>
 #include <vector>
 
 namespace autoware::universe_utils
@@ -30,8 +31,8 @@ struct LinkedVertex
 {
   double x;
   double y;
-  std::optional<std::size_t> next;
-  std::optional<std::size_t> prev;
+  std::optional<std::size_t> next_index;
+  std::optional<std::size_t> prev_index;
   std::optional<std::size_t> corresponding;
   double distance;
   bool is_entry;
@@ -41,8 +42,8 @@ struct LinkedVertex
   LinkedVertex()
   : x(0.0),
     y(0.0),
-    next(std::nullopt),
-    prev(std::nullopt),
+    next_index(std::nullopt),
+    prev_index(std::nullopt),
     corresponding(std::nullopt),
     distance(0.0),
     is_entry(false),
@@ -52,14 +53,14 @@ struct LinkedVertex
   }
 
   LinkedVertex(
-    double x_coord, double y_coord, std::optional<std::size_t> next_index = std::nullopt,
-    std::optional<std::size_t> prev_index = std::nullopt,
+    double x_coord, double y_coord, std::optional<std::size_t> next_idx = std::nullopt,
+    std::optional<std::size_t> prev_idx = std::nullopt,
     std::optional<std::size_t> corresponding_index = std::nullopt, double dist = 0.0,
     bool entry = false, bool intersection = false, bool visited_state = false)
   : x(x_coord),
     y(y_coord),
-    next(next_index),
-    prev(prev_index),
+    next_index(next_idx),
+    prev_index(prev_idx),
     corresponding(corresponding_index),
     distance(dist),
     is_entry(entry),
@@ -67,6 +68,31 @@ struct LinkedVertex
     visited(visited_state)
   {
   }
+
+  // Accessors for the doubly-linked structure. Once a vertex has been linked
+  // via create_extended_polygon()/add_vertex()/insert_vertex(), next_index and
+  // prev_index are always set and are never cleared. next()/prev() therefore
+  // throw on invariant violation rather than silently returning a default,
+  // which would propagate subtly wrong clipping geometry downstream. Use
+  // has_next()/has_prev() at the few sites that must legitimately check.
+  // The `corresponding` field remains genuinely optional and is accessed
+  // directly as before.
+  [[nodiscard]] std::size_t next() const
+  {
+    if (!next_index.has_value()) {
+      throw std::logic_error("LinkedVertex::next() called on unlinked vertex");
+    }
+    return next_index.value();
+  }
+  [[nodiscard]] std::size_t prev() const
+  {
+    if (!prev_index.has_value()) {
+      throw std::logic_error("LinkedVertex::prev() called on unlinked vertex");
+    }
+    return prev_index.value();
+  }
+  [[nodiscard]] bool has_next() const { return next_index.has_value(); }
+  [[nodiscard]] bool has_prev() const { return prev_index.has_value(); }
 };
 
 struct Intersection

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -27,14 +27,12 @@ struct Neighbors
 {
   std::size_t prev;
   std::size_t next;
-  bool valid;
 };
 
 inline Neighbors get_neighbors(const std::vector<LinkedPoint> & points, std::size_t i)
 {
   const auto & p = points[i];
-  if (!p.prev_index.has_value() || !p.next_index.has_value()) return {0, 0, false};
-  return {p.prev_index.value(), p.next_index.value(), true};
+  return {p.prev(), p.next()};
 }
 
 inline bool point_blocks_ear(
@@ -44,36 +42,31 @@ inline bool point_blocks_ear(
   const auto & p = points[p_index];
   if (!point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y())) return false;
   const auto nb = get_neighbors(points, p_index);
-  if (!nb.valid) return false;
   return area(points, nb.prev, p_index, nb.next) >= 0;
 }
 }  // namespace
 
 void remove_point(const std::size_t p_index, std::vector<LinkedPoint> & points)
 {
-  if (!points[p_index].prev_index.has_value() || !points[p_index].next_index.has_value()) {
-    return;  // invariant: active nodes always have prev/next set; guard for clang-tidy
-  }
-  std::size_t prev_index = points[p_index].prev_index.value();
-  std::size_t next_index = points[p_index].next_index.value();
-
+  const std::size_t prev_index = points[p_index].prev();
+  const std::size_t next_index = points[p_index].next();
   points[prev_index].next_index = next_index;
   points[next_index].prev_index = prev_index;
 }
 
 std::size_t get_leftmost(const std::size_t start_idx, const std::vector<LinkedPoint> & points)
 {
-  std::optional<std::size_t> p_idx = points[start_idx].next_index;
+  std::size_t p_idx = points[start_idx].next();
   std::size_t left_most_idx = start_idx;
 
-  while (p_idx.has_value() && p_idx.value() != start_idx) {
+  while (p_idx != start_idx) {
     if (
-      points[p_idx.value()].x() < points[left_most_idx].x() ||
-      (points[p_idx.value()].x() == points[left_most_idx].x() &&
-       points[p_idx.value()].y() < points[left_most_idx].y())) {
-      left_most_idx = p_idx.value();
+      points[p_idx].x() < points[left_most_idx].x() ||
+      (points[p_idx].x() == points[left_most_idx].x() &&
+       points[p_idx].y() < points[left_most_idx].y())) {
+      left_most_idx = p_idx;
     }
-    p_idx = points[p_idx.value()].next_index;
+    p_idx = points[p_idx].next();
   }
 
   return left_most_idx;
@@ -101,16 +94,14 @@ double area(
 bool middle_inside(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
-  std::optional<std::size_t> p_idx = a_idx;
+  std::size_t current_idx = a_idx;
   bool inside = false;
   double px = (points[a_idx].x() + points[b_idx].x()) / 2;
   double py = (points[a_idx].y() + points[b_idx].y()) / 2;
-  std::size_t start_idx = a_idx;
+  const std::size_t start_idx = a_idx;
 
-  while (p_idx.has_value()) {
-    std::size_t current_idx = p_idx.value();
-    if (!points[current_idx].next_index.has_value()) break;
-    std::size_t next_idx = points[current_idx].next_index.value();
+  do {
+    std::size_t next_idx = points[current_idx].next();
 
     if (
       ((points[current_idx].y() > py) != (points[next_idx].y() > py)) &&
@@ -121,12 +112,9 @@ bool middle_inside(
       inside = !inside;
     }
 
-    if (next_idx == start_idx) {
-      break;  // Break the loop if we have cycled back to the start index
-    }
-
-    p_idx = next_idx;
-  }
+    if (next_idx == start_idx) break;
+    current_idx = next_idx;
+  } while (true);
 
   return inside;
 }
@@ -156,18 +144,14 @@ bool on_segment(
 bool locally_inside(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
-  const auto & prev_idx = points[a_idx].prev_index;
-  const auto & next_idx = points[a_idx].next_index;
+  const std::size_t prev_idx = points[a_idx].prev();
+  const std::size_t next_idx = points[a_idx].next();
 
-  if (!prev_idx.has_value() || !next_idx.has_value()) {
-    return false;
-  }
-
-  double area_prev = area(points, prev_idx.value(), a_idx, next_idx.value());
-  double area_a_b_next = area(points, a_idx, b_idx, next_idx.value());
-  double area_a_prev_b = area(points, a_idx, prev_idx.value(), b_idx);
-  double area_a_b_prev = area(points, a_idx, b_idx, prev_idx.value());
-  double area_a_next_b = area(points, a_idx, next_idx.value(), b_idx);
+  double area_prev = area(points, prev_idx, a_idx, next_idx);
+  double area_a_b_next = area(points, a_idx, b_idx, next_idx);
+  double area_a_prev_b = area(points, a_idx, prev_idx, b_idx);
+  double area_a_b_prev = area(points, a_idx, b_idx, prev_idx);
+  double area_a_next_b = area(points, a_idx, next_idx, b_idx);
 
   return area_prev < 0 ? area_a_b_next >= 0 && area_a_prev_b >= 0
                        : area_a_b_prev < 0 || area_a_next_b < 0;
@@ -196,11 +180,9 @@ bool intersects_polygon(
   const std::vector<LinkedPoint> & points, const std::size_t a_idx, const std::size_t b_idx)
 {
   std::size_t p_idx = a_idx;
-  std::optional<std::size_t> p_next_opt = points[p_idx].next_index;
+  std::size_t p_next_idx = points[p_idx].next();
 
-  while (p_next_opt.has_value() && p_next_opt.value() != a_idx) {
-    std::size_t p_next_idx = p_next_opt.value();
-
+  while (p_next_idx != a_idx) {
     if (p_idx != a_idx && p_next_idx != a_idx && p_idx != b_idx && p_next_idx != b_idx) {
       if (intersects(p_idx, p_next_idx, a_idx, b_idx, points)) {
         return true;
@@ -208,7 +190,7 @@ bool intersects_polygon(
     }
 
     p_idx = p_next_idx;
-    p_next_opt = points[p_idx].next_index;
+    p_next_idx = points[p_idx].next();
   }
 
   return false;
@@ -217,16 +199,10 @@ bool intersects_polygon(
 bool is_valid_diagonal(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
-  if (
-    !points[a_idx].next_index.has_value() || !points[a_idx].prev_index.has_value() ||
-    !points[b_idx].next_index.has_value() || !points[b_idx].prev_index.has_value()) {
-    return false;
-  }
-
-  std::size_t a_next_idx = points[a_idx].next_index.value();
-  std::size_t a_prev_idx = points[a_idx].prev_index.value();
-  std::size_t b_next_idx = points[b_idx].next_index.value();
-  std::size_t b_prev_idx = points[b_idx].prev_index.value();
+  std::size_t a_next_idx = points[a_idx].next();
+  std::size_t a_prev_idx = points[a_idx].prev();
+  std::size_t b_next_idx = points[b_idx].next();
+  std::size_t b_prev_idx = points[b_idx].prev();
 
   if (a_next_idx == b_idx || a_prev_idx == b_idx || intersects_polygon(points, a_idx, b_idx)) {
     return false;
@@ -259,11 +235,7 @@ std::size_t insert_point(
     points[p_idx].next_index = p_idx;
   } else {
     std::size_t last = last_index.value();
-    if (!points[last].next_index.has_value()) {
-      points[p_idx].next_index = p_idx;
-      return p_idx;  // invariant: never reached; guard for clang-tidy
-    }
-    std::size_t next = points[last].next_index.value();
+    std::size_t next = points[last].next();
     points[p_idx].prev_index = last;
     points[p_idx].next_index = next;
     points[last].next_index = p_idx;
@@ -297,11 +269,9 @@ std::size_t linked_list(
   }
 
   if (last_index.has_value()) {
-    std::size_t last_idx_value = last_index.value();
-    std::optional<std::size_t> next_index = points[last_idx_value].next_index;
-
-    if (next_index.has_value() && equals(last_idx_value, next_index.value(), points)) {
-      std::size_t next_idx_value = next_index.value();
+    const std::size_t last_idx_value = last_index.value();
+    const std::size_t next_idx_value = points[last_idx_value].next();
+    if (equals(last_idx_value, next_idx_value, points)) {
       remove_point(last_idx_value, points);
       last_index = next_idx_value;
     }
@@ -318,13 +288,8 @@ std::size_t linked_list(
 bool sector_contains_sector(
   const std::size_t m_idx, const std::size_t p_idx, const std::vector<LinkedPoint> & points)
 {
-  if (!points[m_idx].prev_index.has_value() || !points[m_idx].next_index.has_value()) {
-    return false;
-  }
-
-  std::size_t m_prev_idx = points[m_idx].prev_index.value();
-  std::size_t m_next_idx = points[m_idx].next_index.value();
-
+  const std::size_t m_prev_idx = points[m_idx].prev();
+  const std::size_t m_next_idx = points[m_idx].next();
   return area(points, m_prev_idx, m_idx, p_idx) < 0 && area(points, p_idx, m_next_idx, m_idx) < 0;
 }
 
@@ -337,8 +302,7 @@ std::size_t find_hole_bridge(
   double hy = points[hole_index].y();
   double qx = -std::numeric_limits<double>::infinity();
   std::optional<std::size_t> bridge_index = std::nullopt;
-  if (!points[p].next_index.has_value()) return outer_point_index;
-  std::size_t next_index = points[p].next_index.value();
+  std::size_t next_index = points[p].next();
 
   while (p != outer_point_index) {
     if (
@@ -353,8 +317,7 @@ std::size_t find_hole_bridge(
       }
     }
     p = next_index;
-    if (!points[p].next_index.has_value()) break;
-    next_index = points[p].next_index.value();
+    next_index = points[p].next();
   }
 
   if (!bridge_index.has_value()) return outer_point_index;
@@ -365,8 +328,7 @@ std::size_t find_hole_bridge(
   p = bridge_index.value();
   double mx = points[p].x();
   double my = points[p].y();
-  if (!points[p].next_index.has_value()) return bridge_index.value();
-  next_index = points[p].next_index.value();
+  next_index = points[p].next();
 
   while (p != stop) {
     if (
@@ -386,8 +348,7 @@ std::size_t find_hole_bridge(
     }
 
     p = next_index;
-    if (!points[p].next_index.has_value()) break;
-    next_index = points[p].next_index.value();
+    next_index = points[p].next();
   }
 
   return bridge_index.value();
@@ -396,11 +357,8 @@ std::size_t find_hole_bridge(
 std::size_t split_polygon(
   std::size_t a_index, std::size_t b_index, std::vector<LinkedPoint> & points)
 {
-  if (!points[a_index].next_index.has_value() || !points[b_index].prev_index.has_value()) {
-    return a_index;  // invariant: never reached; guard for clang-tidy
-  }
-  std::size_t an_idx = points[a_index].next_index.value();
-  std::size_t bp_idx = points[b_index].prev_index.value();
+  std::size_t an_idx = points[a_index].next();
+  std::size_t bp_idx = points[b_index].prev();
 
   std::size_t a2_idx = points.size();
   std::size_t b2_idx = points.size() + 1;
@@ -433,20 +391,14 @@ std::size_t filter_points(
     again = false;
 
     if (
-      !points[p].steiner && points[p].next_index.has_value() && points[p].prev_index.has_value() &&
-      (equals(p, points[p].next_index.value(), points) ||
-       area(points, points[p].prev_index.value(), p, points[p].next_index.value()) == 0)) {
+      !points[p].steiner && (equals(p, points[p].next(), points) ||
+                             area(points, points[p].prev(), p, points[p].next()) == 0)) {
       remove_point(p, points);
-      if (!points[p].prev_index.has_value()) break;
-      p = points[p].prev_index.value();
-
-      if (!points[p].next_index.has_value() || p == points[p].next_index.value()) {
-        break;
-      }
+      p = points[p].prev();
+      if (p == points[p].next()) break;
       again = true;
     } else {
-      if (!points[p].next_index.has_value()) break;
-      p = points[p].next_index.value();
+      p = points[p].next();
     }
   }
 
@@ -458,14 +410,8 @@ std::size_t eliminate_hole(
 {
   auto bridge = find_hole_bridge(hole_index, outer_index, points);
   auto bridge_reverse = split_polygon(bridge, hole_index, points);
-
-  if (!points[bridge_reverse].next_index.has_value()) return bridge_reverse;
-  auto next_index_bridge_reverse = points[bridge_reverse].next_index.value();
-  filter_points(bridge_reverse, next_index_bridge_reverse, points);
-
-  if (!points[bridge].next_index.has_value()) return bridge;
-  auto next_index_bridge = points[bridge].next_index.value();
-  return filter_points(bridge, next_index_bridge, points);
+  filter_points(bridge_reverse, points[bridge_reverse].next(), points);
+  return filter_points(bridge, points[bridge].next(), points);
 }
 
 std::size_t eliminate_holes(
@@ -480,9 +426,7 @@ std::size_t eliminate_holes(
     }
     auto inner_index = linked_list(ring, false, vertices, points);
 
-    if (
-      points[inner_index].next_index.has_value() &&
-      points[inner_index].next_index.value() == inner_index) {
+    if (points[inner_index].next() == inner_index) {
       points[inner_index].steiner = true;
     }
 
@@ -503,7 +447,6 @@ std::size_t eliminate_holes(
 bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & points)
 {
   const auto nb = get_neighbors(points, ear_index);
-  if (!nb.valid) return false;
 
   const auto a_index = nb.prev;
   const auto b_index = ear_index;
@@ -514,12 +457,10 @@ bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & points
 
   if (area(points, a_index, b_index, c_index) >= 0) return false;
 
-  auto p_opt = points[c_index].next_index;
-  while (p_opt.has_value()) {
-    const auto p_index = p_opt.value();
-    if (p_index == a_index) break;
+  std::size_t p_index = points[c_index].next();
+  while (p_index != a_index) {
     if (point_blocks_ear(p_index, a_index, a, b, c, points)) return false;
-    p_opt = points[p_index].next_index;
+    p_index = points[p_index].next();
   }
   return true;
 }
@@ -532,11 +473,12 @@ std::size_t cure_local_intersections(
 
   while (p != start_index || updated) {
     updated = false;
-    if (!points[p].prev_index.has_value() || !points[p].next_index.has_value()) break;
-    auto a_idx = points[p].prev_index.value();
-    const std::size_t p_next = points[p].next_index.value();
-    if (!points[p_next].next_index.has_value()) break;
-    auto b_idx = points[p_next].next_index.value();
+    const std::size_t a_idx = points[p].prev();
+    // Pre-save p_next before any remove_point() call: remove_point() rewrites
+    // the neighbors' prev_index/next_index, so reading points[p].next() after
+    // removal would return a stale/different index. (Original UNSAFE #2 fix.)
+    const std::size_t p_next = points[p].next();
+    const std::size_t b_idx = points[p_next].next();
 
     if (
       !equals(a_idx, b_idx, points) && intersects(a_idx, p, p_next, b_idx, points) &&
@@ -545,15 +487,13 @@ std::size_t cure_local_intersections(
       indices.push_back(p);
       indices.push_back(b_idx);
 
-      // UNSAFE #2 fix: p_next was pre-saved above before any removal; use it directly
       remove_point(p, points);
       remove_point(p_next, points);
 
       p = start_index = b_idx;
       updated = true;
     } else {
-      if (!points[p].next_index.has_value()) break;
-      p = points[p].next_index.value();
+      p = points[p].next();
     }
   }
 
@@ -566,27 +506,21 @@ void split_ear_clipping(
 {
   std::size_t a_idx = start_idx;
   do {
-    if (!points[a_idx].next_index.has_value() || !points[a_idx].prev_index.has_value()) break;
-    const std::size_t a_next = points[a_idx].next_index.value();
-    if (!points[a_next].next_index.has_value()) break;
-    std::size_t b_idx = points[a_next].next_index.value();
-    while (b_idx != points[a_idx].prev_index.value()) {
+    const std::size_t a_next = points[a_idx].next();
+    std::size_t b_idx = points[a_next].next();
+    while (b_idx != points[a_idx].prev()) {
       if (a_idx != b_idx && is_valid_diagonal(a_idx, b_idx, points)) {
         std::size_t c_idx = split_polygon(a_idx, b_idx, points);
-
-        if (!points[a_idx].next_index.has_value() || !points[c_idx].next_index.has_value()) break;
-        a_idx = filter_points(start_idx, points[a_idx].next_index.value(), points);
-        c_idx = filter_points(start_idx, points[c_idx].next_index.value(), points);
+        a_idx = filter_points(start_idx, points[a_idx].next(), points);
+        c_idx = filter_points(start_idx, points[c_idx].next(), points);
 
         ear_clipping_linked(a_idx, indices, points);
         ear_clipping_linked(c_idx, indices, points);
         return;
       }
-      if (!points[b_idx].next_index.has_value()) break;
-      b_idx = points[b_idx].next_index.value();
+      b_idx = points[b_idx].next();
     }
-    if (!points[a_idx].next_index.has_value()) break;
-    a_idx = points[a_idx].next_index.value();
+    a_idx = points[a_idx].next();
   } while (a_idx != start_idx);
 }
 
@@ -616,7 +550,7 @@ void ear_clipping_linked(
 
   while (true) {
     const auto nb = get_neighbors(points, ear_index);
-    if (!nb.valid || nb.prev == nb.next) break;
+    if (nb.prev == nb.next) break;
     const auto next = nb.next;
 
     if (is_ear(ear_index, points)) {
@@ -625,9 +559,7 @@ void ear_clipping_linked(
       indices.push_back(next);
       remove_point(ear_index, points);
 
-      const auto advance = points[next].next_index;
-      if (!advance.has_value()) break;
-      ear_index = stop = advance.value();
+      ear_index = stop = points[next].next();
       continue;
     }
 
@@ -653,9 +585,7 @@ std::vector<LinkedPoint> perform_triangulation(
 
   indices.reserve(len + outer_ring.size());
   auto outer_point_index = linked_list(outer_ring, true, vertices, points);
-  if (
-    !points[outer_point_index].prev_index.has_value() ||
-    outer_point_index == points[outer_point_index].prev_index.value()) {
+  if (outer_point_index == points[outer_point_index].prev()) {
     return points;
   }
 

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -21,6 +21,34 @@
 namespace autoware::universe_utils
 {
 
+namespace
+{
+struct Neighbors
+{
+  std::size_t prev;
+  std::size_t next;
+  bool valid;
+};
+
+inline Neighbors get_neighbors(const std::vector<LinkedPoint> & points, std::size_t i)
+{
+  const auto & p = points[i];
+  if (!p.prev_index.has_value() || !p.next_index.has_value()) return {0, 0, false};
+  return {p.prev_index.value(), p.next_index.value(), true};
+}
+
+inline bool point_blocks_ear(
+  std::size_t p_index, std::size_t a_index, const LinkedPoint & a, const LinkedPoint & b,
+  const LinkedPoint & c, const std::vector<LinkedPoint> & points)
+{
+  const auto & p = points[p_index];
+  if (!point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y())) return false;
+  const auto nb = get_neighbors(points, p_index);
+  if (!nb.valid) return false;
+  return area(points, nb.prev, p_index, nb.next) >= 0;
+}
+}  // namespace
+
 void remove_point(const std::size_t p_index, std::vector<LinkedPoint> & points)
 {
   if (!points[p_index].prev_index.has_value() || !points[p_index].next_index.has_value()) {
@@ -474,32 +502,25 @@ std::size_t eliminate_holes(
 
 bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & points)
 {
-  if (!points[ear_index].prev_index.has_value() || !points[ear_index].next_index.has_value()) {
-    return false;  // invariant: never reached; guard for clang-tidy
-  }
-  const auto a_index = points[ear_index].prev_index.value();
-  const auto b_index = ear_index;
-  const auto c_index = points[ear_index].next_index.value();
+  const auto nb = get_neighbors(points, ear_index);
+  if (!nb.valid) return false;
 
+  const auto a_index = nb.prev;
+  const auto b_index = ear_index;
+  const auto c_index = nb.next;
   const auto a = points[a_index];
   const auto b = points[b_index];
   const auto c = points[c_index];
 
   if (area(points, a_index, b_index, c_index) >= 0) return false;
-  if (!points[c_index].next_index.has_value()) return true;
-  auto p_index = points[c_index].next_index.value();
-  while (p_index != a_index) {
-    const auto p = points[p_index];
-    if (
-      point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y()) &&
-      p.prev_index.has_value() && p.next_index.has_value() &&
-      area(points, p.prev_index.value(), p_index, p.next_index.value()) >= 0) {
-      return false;
-    }
-    if (!points[p_index].next_index.has_value()) break;
-    p_index = points[p_index].next_index.value();
-  }
 
+  auto p_opt = points[c_index].next_index;
+  while (p_opt.has_value()) {
+    const auto p_index = p_opt.value();
+    if (p_index == a_index) break;
+    if (point_blocks_ear(p_index, a_index, a, b, c, points)) return false;
+    p_opt = points[p_index].next_index;
+  }
   return true;
 }
 
@@ -569,42 +590,50 @@ void split_ear_clipping(
   } while (a_idx != start_idx);
 }
 
+namespace
+{
+inline void apply_fallback_pass(
+  int pass, std::size_t ear_index, std::vector<std::size_t> & indices,
+  std::vector<LinkedPoint> & points)
+{
+  if (pass == 0) {
+    ear_clipping_linked(filter_points(ear_index, ear_index, points), indices, points, 1);
+  } else if (pass == 1) {
+    ear_index =
+      cure_local_intersections(filter_points(ear_index, ear_index, points), indices, points);
+    ear_clipping_linked(ear_index, indices, points, 2);
+  } else if (pass == 2) {
+    split_ear_clipping(points, ear_index, indices);
+  }
+}
+}  // namespace
+
 void ear_clipping_linked(
   std::size_t ear_index, std::vector<std::size_t> & indices, std::vector<LinkedPoint> & points,
   const int pass)
 {
   auto stop = ear_index;
-  std::optional<std::size_t> next = std::nullopt;
 
-  while (points[ear_index].prev_index.has_value() && points[ear_index].next_index.has_value() &&
-         points[ear_index].prev_index.value() != points[ear_index].next_index.value()) {
-    next = points[ear_index].next_index;
+  while (true) {
+    const auto nb = get_neighbors(points, ear_index);
+    if (!nb.valid || nb.prev == nb.next) break;
+    const auto next = nb.next;
 
     if (is_ear(ear_index, points)) {
-      indices.push_back(points[ear_index].prev_index.value());
+      indices.push_back(nb.prev);
       indices.push_back(ear_index);
-      indices.push_back(next.value());
-
+      indices.push_back(next);
       remove_point(ear_index, points);
 
-      if (!next.has_value() || !points[next.value()].next_index.has_value()) break;
-      ear_index = points[next.value()].next_index.value();
-      stop = points[next.value()].next_index.value();
+      const auto advance = points[next].next_index;
+      if (!advance.has_value()) break;
+      ear_index = stop = advance.value();
       continue;
     }
 
-    ear_index = next.value();
-
+    ear_index = next;
     if (ear_index == stop) {
-      if (pass == 0) {
-        ear_clipping_linked(filter_points(ear_index, ear_index, points), indices, points, 1);
-      } else if (pass == 1) {
-        ear_index =
-          cure_local_intersections(filter_points(ear_index, ear_index, points), indices, points);
-        ear_clipping_linked(ear_index, indices, points, 2);
-      } else if (pass == 2) {
-        split_ear_clipping(points, ear_index, indices);
-      }
+      apply_fallback_pass(pass, ear_index, indices, points);
       break;
     }
   }

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -405,8 +405,7 @@ std::size_t filter_points(
     again = false;
 
     if (
-      !points[p].steiner && points[p].next_index.has_value() &&
-      points[p].prev_index.has_value() &&
+      !points[p].steiner && points[p].next_index.has_value() && points[p].prev_index.has_value() &&
       (equals(p, points[p].next_index.value(), points) ||
        area(points, points[p].prev_index.value(), p, points[p].next_index.value()) == 0)) {
       remove_point(p, points);
@@ -453,8 +452,9 @@ std::size_t eliminate_holes(
     }
     auto inner_index = linked_list(ring, false, vertices, points);
 
-    if (points[inner_index].next_index.has_value() &&
-        points[inner_index].next_index.value() == inner_index) {
+    if (
+      points[inner_index].next_index.has_value() &&
+      points[inner_index].next_index.value() == inner_index) {
       points[inner_index].steiner = true;
     }
 
@@ -518,8 +518,7 @@ std::size_t cure_local_intersections(
     auto b_idx = points[p_next].next_index.value();
 
     if (
-      !equals(a_idx, b_idx, points) &&
-      intersects(a_idx, p, p_next, b_idx, points) &&
+      !equals(a_idx, b_idx, points) && intersects(a_idx, p, p_next, b_idx, points) &&
       locally_inside(a_idx, b_idx, points) && locally_inside(b_idx, a_idx, points)) {
       indices.push_back(a_idx);
       indices.push_back(p);
@@ -577,9 +576,8 @@ void ear_clipping_linked(
   auto stop = ear_index;
   std::optional<std::size_t> next = std::nullopt;
 
-  while (
-    points[ear_index].prev_index.has_value() && points[ear_index].next_index.has_value() &&
-    points[ear_index].prev_index.value() != points[ear_index].next_index.value()) {
+  while (points[ear_index].prev_index.has_value() && points[ear_index].next_index.has_value() &&
+         points[ear_index].prev_index.value() != points[ear_index].next_index.value()) {
     next = points[ear_index].next_index;
 
     if (is_ear(ear_index, points)) {

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -23,6 +23,9 @@ namespace autoware::universe_utils
 
 void remove_point(const std::size_t p_index, std::vector<LinkedPoint> & points)
 {
+  if (!points[p_index].prev_index.has_value() || !points[p_index].next_index.has_value()) {
+    return;  // invariant: active nodes always have prev/next set; guard for clang-tidy
+  }
   std::size_t prev_index = points[p_index].prev_index.value();
   std::size_t next_index = points[p_index].next_index.value();
 
@@ -78,6 +81,7 @@ bool middle_inside(
 
   while (p_idx.has_value()) {
     std::size_t current_idx = p_idx.value();
+    if (!points[current_idx].next_index.has_value()) break;
     std::size_t next_idx = points[current_idx].next_index.value();
 
     if (
@@ -227,6 +231,10 @@ std::size_t insert_point(
     points[p_idx].next_index = p_idx;
   } else {
     std::size_t last = last_index.value();
+    if (!points[last].next_index.has_value()) {
+      points[p_idx].next_index = p_idx;
+      return p_idx;  // invariant: never reached; guard for clang-tidy
+    }
     std::size_t next = points[last].next_index.value();
     points[p_idx].prev_index = last;
     points[p_idx].next_index = next;
@@ -272,6 +280,10 @@ std::size_t linked_list(
   }
 
   vertices += len;
+  if (!last_index.has_value()) {
+    throw std::runtime_error(
+      "ear_clipping::linked_list: called with empty ring (caller invariant violated)");
+  }
   return last_index.value();
 }
 
@@ -297,6 +309,7 @@ std::size_t find_hole_bridge(
   double hy = points[hole_index].y();
   double qx = -std::numeric_limits<double>::infinity();
   std::optional<std::size_t> bridge_index = std::nullopt;
+  if (!points[p].next_index.has_value()) return outer_point_index;
   std::size_t next_index = points[p].next_index.value();
 
   while (p != outer_point_index) {
@@ -312,6 +325,7 @@ std::size_t find_hole_bridge(
       }
     }
     p = next_index;
+    if (!points[p].next_index.has_value()) break;
     next_index = points[p].next_index.value();
   }
 
@@ -323,6 +337,7 @@ std::size_t find_hole_bridge(
   p = bridge_index.value();
   double mx = points[p].x();
   double my = points[p].y();
+  if (!points[p].next_index.has_value()) return bridge_index.value();
   next_index = points[p].next_index.value();
 
   while (p != stop) {
@@ -343,6 +358,7 @@ std::size_t find_hole_bridge(
     }
 
     p = next_index;
+    if (!points[p].next_index.has_value()) break;
     next_index = points[p].next_index.value();
   }
 
@@ -352,6 +368,9 @@ std::size_t find_hole_bridge(
 std::size_t split_polygon(
   std::size_t a_index, std::size_t b_index, std::vector<LinkedPoint> & points)
 {
+  if (!points[a_index].next_index.has_value() || !points[b_index].prev_index.has_value()) {
+    return a_index;  // invariant: never reached; guard for clang-tidy
+  }
   std::size_t an_idx = points[a_index].next_index.value();
   std::size_t bp_idx = points[b_index].prev_index.value();
 
@@ -386,17 +405,20 @@ std::size_t filter_points(
     again = false;
 
     if (
-      !points[p].steiner &&
+      !points[p].steiner && points[p].next_index.has_value() &&
+      points[p].prev_index.has_value() &&
       (equals(p, points[p].next_index.value(), points) ||
        area(points, points[p].prev_index.value(), p, points[p].next_index.value()) == 0)) {
       remove_point(p, points);
+      if (!points[p].prev_index.has_value()) break;
       p = points[p].prev_index.value();
 
-      if (p == points[p].next_index.value()) {
+      if (!points[p].next_index.has_value() || p == points[p].next_index.value()) {
         break;
       }
       again = true;
     } else {
+      if (!points[p].next_index.has_value()) break;
       p = points[p].next_index.value();
     }
   }
@@ -410,9 +432,11 @@ std::size_t eliminate_hole(
   auto bridge = find_hole_bridge(hole_index, outer_index, points);
   auto bridge_reverse = split_polygon(bridge, hole_index, points);
 
+  if (!points[bridge_reverse].next_index.has_value()) return bridge_reverse;
   auto next_index_bridge_reverse = points[bridge_reverse].next_index.value();
   filter_points(bridge_reverse, next_index_bridge_reverse, points);
 
+  if (!points[bridge].next_index.has_value()) return bridge;
   auto next_index_bridge = points[bridge].next_index.value();
   return filter_points(bridge, next_index_bridge, points);
 }
@@ -429,7 +453,8 @@ std::size_t eliminate_holes(
     }
     auto inner_index = linked_list(ring, false, vertices, points);
 
-    if (points[inner_index].next_index.value() == inner_index) {
+    if (points[inner_index].next_index.has_value() &&
+        points[inner_index].next_index.value() == inner_index) {
       points[inner_index].steiner = true;
     }
 
@@ -449,6 +474,9 @@ std::size_t eliminate_holes(
 
 bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & points)
 {
+  if (!points[ear_index].prev_index.has_value() || !points[ear_index].next_index.has_value()) {
+    return false;  // invariant: never reached; guard for clang-tidy
+  }
   const auto a_index = points[ear_index].prev_index.value();
   const auto b_index = ear_index;
   const auto c_index = points[ear_index].next_index.value();
@@ -458,14 +486,17 @@ bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & points
   const auto c = points[c_index];
 
   if (area(points, a_index, b_index, c_index) >= 0) return false;
+  if (!points[c_index].next_index.has_value()) return true;
   auto p_index = points[c_index].next_index.value();
   while (p_index != a_index) {
     const auto p = points[p_index];
     if (
       point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y()) &&
+      p.prev_index.has_value() && p.next_index.has_value() &&
       area(points, p.prev_index.value(), p_index, p.next_index.value()) >= 0) {
       return false;
     }
+    if (!points[p_index].next_index.has_value()) break;
     p_index = points[p_index].next_index.value();
   }
 
@@ -480,24 +511,28 @@ std::size_t cure_local_intersections(
 
   while (p != start_index || updated) {
     updated = false;
+    if (!points[p].prev_index.has_value() || !points[p].next_index.has_value()) break;
     auto a_idx = points[p].prev_index.value();
-    auto b_idx = points[points[p].next_index.value()].next_index.value();
+    const std::size_t p_next = points[p].next_index.value();
+    if (!points[p_next].next_index.has_value()) break;
+    auto b_idx = points[p_next].next_index.value();
 
     if (
       !equals(a_idx, b_idx, points) &&
-      intersects(
-        a_idx, p, points[points[p].next_index.value()].next_index.value(), b_idx, points) &&
+      intersects(a_idx, p, p_next, b_idx, points) &&
       locally_inside(a_idx, b_idx, points) && locally_inside(b_idx, a_idx, points)) {
       indices.push_back(a_idx);
       indices.push_back(p);
       indices.push_back(b_idx);
 
+      // UNSAFE #2 fix: p_next was pre-saved above before any removal; use it directly
       remove_point(p, points);
-      remove_point(points[p].next_index.value(), points);
+      remove_point(p_next, points);
 
       p = start_index = b_idx;
       updated = true;
     } else {
+      if (!points[p].next_index.has_value()) break;
       p = points[p].next_index.value();
     }
   }
@@ -511,11 +546,15 @@ void split_ear_clipping(
 {
   std::size_t a_idx = start_idx;
   do {
-    std::size_t b_idx = points[points[a_idx].next_index.value()].next_index.value();
+    if (!points[a_idx].next_index.has_value() || !points[a_idx].prev_index.has_value()) break;
+    const std::size_t a_next = points[a_idx].next_index.value();
+    if (!points[a_next].next_index.has_value()) break;
+    std::size_t b_idx = points[a_next].next_index.value();
     while (b_idx != points[a_idx].prev_index.value()) {
       if (a_idx != b_idx && is_valid_diagonal(a_idx, b_idx, points)) {
         std::size_t c_idx = split_polygon(a_idx, b_idx, points);
 
+        if (!points[a_idx].next_index.has_value() || !points[c_idx].next_index.has_value()) break;
         a_idx = filter_points(start_idx, points[a_idx].next_index.value(), points);
         c_idx = filter_points(start_idx, points[c_idx].next_index.value(), points);
 
@@ -523,8 +562,10 @@ void split_ear_clipping(
         ear_clipping_linked(c_idx, indices, points);
         return;
       }
+      if (!points[b_idx].next_index.has_value()) break;
       b_idx = points[b_idx].next_index.value();
     }
+    if (!points[a_idx].next_index.has_value()) break;
     a_idx = points[a_idx].next_index.value();
   } while (a_idx != start_idx);
 }
@@ -536,7 +577,9 @@ void ear_clipping_linked(
   auto stop = ear_index;
   std::optional<std::size_t> next = std::nullopt;
 
-  while (points[ear_index].prev_index.value() != points[ear_index].next_index.value()) {
+  while (
+    points[ear_index].prev_index.has_value() && points[ear_index].next_index.has_value() &&
+    points[ear_index].prev_index.value() != points[ear_index].next_index.value()) {
     next = points[ear_index].next_index;
 
     if (is_ear(ear_index, points)) {
@@ -546,6 +589,7 @@ void ear_clipping_linked(
 
       remove_point(ear_index, points);
 
+      if (!next.has_value() || !points[next.value()].next_index.has_value()) break;
       ear_index = points[next.value()].next_index.value();
       stop = points[next.value()].next_index.value();
       continue;
@@ -615,7 +659,9 @@ std::vector<alt::ConvexPolygon2d> triangulate(const alt::Polygon2d & poly)
     vertices.push_back(points[indices[i + 2]].pt);
     vertices.push_back(points[indices[i]].pt);
 
-    triangles.push_back(alt::ConvexPolygon2d::create(vertices).value());
+    auto tri_opt = alt::ConvexPolygon2d::create(vertices);
+    if (!tri_opt.has_value()) continue;
+    triangles.push_back(tri_opt.value());
   }
   points.clear();
   return triangles;
@@ -624,6 +670,7 @@ std::vector<alt::ConvexPolygon2d> triangulate(const alt::Polygon2d & poly)
 std::vector<Polygon2d> triangulate(const Polygon2d & poly)
 {
   const auto alt_poly = alt::Polygon2d::create(poly);
+  if (!alt_poly.has_value()) return {};
   const auto alt_triangles = triangulate(alt_poly.value());
   std::vector<Polygon2d> triangles;
   for (const auto & alt_triangle : alt_triangles) {

--- a/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
+++ b/common/autoware_universe_utils/src/geometry/ear_clipping.cpp
@@ -23,26 +23,25 @@ namespace autoware::universe_utils
 
 void remove_point(const std::size_t p_index, std::vector<LinkedPoint> & points)
 {
-  std::size_t prev_index = points[p_index].prev_index.value();
-  std::size_t next_index = points[p_index].next_index.value();
-
+  const std::size_t prev_index = points[p_index].prev();
+  const std::size_t next_index = points[p_index].next();
   points[prev_index].next_index = next_index;
   points[next_index].prev_index = prev_index;
 }
 
 std::size_t get_leftmost(const std::size_t start_idx, const std::vector<LinkedPoint> & points)
 {
-  std::optional<std::size_t> p_idx = points[start_idx].next_index;
+  std::size_t p_idx = points[start_idx].next();
   std::size_t left_most_idx = start_idx;
 
-  while (p_idx.has_value() && p_idx.value() != start_idx) {
+  while (p_idx != start_idx) {
     if (
-      points[p_idx.value()].x() < points[left_most_idx].x() ||
-      (points[p_idx.value()].x() == points[left_most_idx].x() &&
-       points[p_idx.value()].y() < points[left_most_idx].y())) {
-      left_most_idx = p_idx.value();
+      points[p_idx].x() < points[left_most_idx].x() ||
+      (points[p_idx].x() == points[left_most_idx].x() &&
+       points[p_idx].y() < points[left_most_idx].y())) {
+      left_most_idx = p_idx;
     }
-    p_idx = points[p_idx.value()].next_index;
+    p_idx = points[p_idx].next();
   }
 
   return left_most_idx;
@@ -67,18 +66,42 @@ double area(
   return (q.y() - p.y()) * (r.x() - q.x()) - (q.x() - p.x()) * (r.y() - q.y());
 }
 
+namespace
+{
+struct Neighbors
+{
+  std::size_t prev;
+  std::size_t next;
+};
+
+inline Neighbors get_neighbors(const std::vector<LinkedPoint> & points, std::size_t i)
+{
+  const auto & p = points[i];
+  return {p.prev(), p.next()};
+}
+
+inline bool point_blocks_ear(
+  std::size_t p_index, const LinkedPoint & a, const LinkedPoint & b, const LinkedPoint & c,
+  const std::vector<LinkedPoint> & points)
+{
+  const auto & p = points[p_index];
+  if (!point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y())) return false;
+  const auto nb = get_neighbors(points, p_index);
+  return area(points, nb.prev, p_index, nb.next) >= 0;
+}
+}  // namespace
+
 bool middle_inside(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
-  std::optional<std::size_t> p_idx = a_idx;
+  std::size_t current_idx = a_idx;
   bool inside = false;
   double px = (points[a_idx].x() + points[b_idx].x()) / 2;
   double py = (points[a_idx].y() + points[b_idx].y()) / 2;
-  std::size_t start_idx = a_idx;
+  const std::size_t start_idx = a_idx;
 
-  while (p_idx.has_value()) {
-    std::size_t current_idx = p_idx.value();
-    std::size_t next_idx = points[current_idx].next_index.value();
+  do {
+    std::size_t next_idx = points[current_idx].next();
 
     if (
       ((points[current_idx].y() > py) != (points[next_idx].y() > py)) &&
@@ -89,12 +112,9 @@ bool middle_inside(
       inside = !inside;
     }
 
-    if (next_idx == start_idx) {
-      break;  // Break the loop if we have cycled back to the start index
-    }
-
-    p_idx = next_idx;
-  }
+    if (next_idx == start_idx) break;
+    current_idx = next_idx;
+  } while (true);
 
   return inside;
 }
@@ -124,18 +144,14 @@ bool on_segment(
 bool locally_inside(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
-  const auto & prev_idx = points[a_idx].prev_index;
-  const auto & next_idx = points[a_idx].next_index;
+  const std::size_t prev_idx = points[a_idx].prev();
+  const std::size_t next_idx = points[a_idx].next();
 
-  if (!prev_idx.has_value() || !next_idx.has_value()) {
-    return false;
-  }
-
-  double area_prev = area(points, prev_idx.value(), a_idx, next_idx.value());
-  double area_a_b_next = area(points, a_idx, b_idx, next_idx.value());
-  double area_a_prev_b = area(points, a_idx, prev_idx.value(), b_idx);
-  double area_a_b_prev = area(points, a_idx, b_idx, prev_idx.value());
-  double area_a_next_b = area(points, a_idx, next_idx.value(), b_idx);
+  double area_prev = area(points, prev_idx, a_idx, next_idx);
+  double area_a_b_next = area(points, a_idx, b_idx, next_idx);
+  double area_a_prev_b = area(points, a_idx, prev_idx, b_idx);
+  double area_a_b_prev = area(points, a_idx, b_idx, prev_idx);
+  double area_a_next_b = area(points, a_idx, next_idx, b_idx);
 
   return area_prev < 0 ? area_a_b_next >= 0 && area_a_prev_b >= 0
                        : area_a_b_prev < 0 || area_a_next_b < 0;
@@ -164,11 +180,9 @@ bool intersects_polygon(
   const std::vector<LinkedPoint> & points, const std::size_t a_idx, const std::size_t b_idx)
 {
   std::size_t p_idx = a_idx;
-  std::optional<std::size_t> p_next_opt = points[p_idx].next_index;
+  std::size_t p_next_idx = points[p_idx].next();
 
-  while (p_next_opt.has_value() && p_next_opt.value() != a_idx) {
-    std::size_t p_next_idx = p_next_opt.value();
-
+  while (p_next_idx != a_idx) {
     if (p_idx != a_idx && p_next_idx != a_idx && p_idx != b_idx && p_next_idx != b_idx) {
       if (intersects(p_idx, p_next_idx, a_idx, b_idx, points)) {
         return true;
@@ -176,7 +190,7 @@ bool intersects_polygon(
     }
 
     p_idx = p_next_idx;
-    p_next_opt = points[p_idx].next_index;
+    p_next_idx = points[p_idx].next();
   }
 
   return false;
@@ -185,16 +199,10 @@ bool intersects_polygon(
 bool is_valid_diagonal(
   const std::size_t a_idx, const std::size_t b_idx, const std::vector<LinkedPoint> & points)
 {
-  if (
-    !points[a_idx].next_index.has_value() || !points[a_idx].prev_index.has_value() ||
-    !points[b_idx].next_index.has_value() || !points[b_idx].prev_index.has_value()) {
-    return false;
-  }
-
-  std::size_t a_next_idx = points[a_idx].next_index.value();
-  std::size_t a_prev_idx = points[a_idx].prev_index.value();
-  std::size_t b_next_idx = points[b_idx].next_index.value();
-  std::size_t b_prev_idx = points[b_idx].prev_index.value();
+  std::size_t a_next_idx = points[a_idx].next();
+  std::size_t a_prev_idx = points[a_idx].prev();
+  std::size_t b_next_idx = points[b_idx].next();
+  std::size_t b_prev_idx = points[b_idx].prev();
 
   if (a_next_idx == b_idx || a_prev_idx == b_idx || intersects_polygon(points, a_idx, b_idx)) {
     return false;
@@ -227,7 +235,7 @@ std::size_t insert_point(
     points[p_idx].next_index = p_idx;
   } else {
     std::size_t last = last_index.value();
-    std::size_t next = points[last].next_index.value();
+    std::size_t next = points[last].next();
     points[p_idx].prev_index = last;
     points[p_idx].next_index = next;
     points[last].next_index = p_idx;
@@ -261,30 +269,27 @@ std::size_t linked_list(
   }
 
   if (last_index.has_value()) {
-    std::size_t last_idx_value = last_index.value();
-    std::optional<std::size_t> next_index = points[last_idx_value].next_index;
-
-    if (next_index.has_value() && equals(last_idx_value, next_index.value(), points)) {
-      std::size_t next_idx_value = next_index.value();
+    const std::size_t last_idx_value = last_index.value();
+    const std::size_t next_idx_value = points[last_idx_value].next();
+    if (equals(last_idx_value, next_idx_value, points)) {
       remove_point(last_idx_value, points);
       last_index = next_idx_value;
     }
   }
 
   vertices += len;
+  if (!last_index.has_value()) {
+    throw std::runtime_error(
+      "ear_clipping::linked_list: called with empty ring (caller invariant violated)");
+  }
   return last_index.value();
 }
 
 bool sector_contains_sector(
   const std::size_t m_idx, const std::size_t p_idx, const std::vector<LinkedPoint> & points)
 {
-  if (!points[m_idx].prev_index.has_value() || !points[m_idx].next_index.has_value()) {
-    return false;
-  }
-
-  std::size_t m_prev_idx = points[m_idx].prev_index.value();
-  std::size_t m_next_idx = points[m_idx].next_index.value();
-
+  const std::size_t m_prev_idx = points[m_idx].prev();
+  const std::size_t m_next_idx = points[m_idx].next();
   return area(points, m_prev_idx, m_idx, p_idx) < 0 && area(points, p_idx, m_next_idx, m_idx) < 0;
 }
 
@@ -297,7 +302,7 @@ std::size_t find_hole_bridge(
   double hy = points[hole_index].y();
   double qx = -std::numeric_limits<double>::infinity();
   std::optional<std::size_t> bridge_index = std::nullopt;
-  std::size_t next_index = points[p].next_index.value();
+  std::size_t next_index = points[p].next();
 
   while (p != outer_point_index) {
     if (
@@ -312,7 +317,7 @@ std::size_t find_hole_bridge(
       }
     }
     p = next_index;
-    next_index = points[p].next_index.value();
+    next_index = points[p].next();
   }
 
   if (!bridge_index.has_value()) return outer_point_index;
@@ -323,7 +328,7 @@ std::size_t find_hole_bridge(
   p = bridge_index.value();
   double mx = points[p].x();
   double my = points[p].y();
-  next_index = points[p].next_index.value();
+  next_index = points[p].next();
 
   while (p != stop) {
     if (
@@ -343,7 +348,7 @@ std::size_t find_hole_bridge(
     }
 
     p = next_index;
-    next_index = points[p].next_index.value();
+    next_index = points[p].next();
   }
 
   return bridge_index.value();
@@ -352,8 +357,8 @@ std::size_t find_hole_bridge(
 std::size_t split_polygon(
   std::size_t a_index, std::size_t b_index, std::vector<LinkedPoint> & points)
 {
-  std::size_t an_idx = points[a_index].next_index.value();
-  std::size_t bp_idx = points[b_index].prev_index.value();
+  std::size_t an_idx = points[a_index].next();
+  std::size_t bp_idx = points[b_index].prev();
 
   std::size_t a2_idx = points.size();
   std::size_t b2_idx = points.size() + 1;
@@ -386,18 +391,14 @@ std::size_t filter_points(
     again = false;
 
     if (
-      !points[p].steiner &&
-      (equals(p, points[p].next_index.value(), points) ||
-       area(points, points[p].prev_index.value(), p, points[p].next_index.value()) == 0)) {
+      !points[p].steiner && (equals(p, points[p].next(), points) ||
+                             area(points, points[p].prev(), p, points[p].next()) == 0)) {
       remove_point(p, points);
-      p = points[p].prev_index.value();
-
-      if (p == points[p].next_index.value()) {
-        break;
-      }
+      p = points[p].prev();
+      if (p == points[p].next()) break;
       again = true;
     } else {
-      p = points[p].next_index.value();
+      p = points[p].next();
     }
   }
 
@@ -409,12 +410,8 @@ std::size_t eliminate_hole(
 {
   auto bridge = find_hole_bridge(hole_index, outer_index, points);
   auto bridge_reverse = split_polygon(bridge, hole_index, points);
-
-  auto next_index_bridge_reverse = points[bridge_reverse].next_index.value();
-  filter_points(bridge_reverse, next_index_bridge_reverse, points);
-
-  auto next_index_bridge = points[bridge].next_index.value();
-  return filter_points(bridge, next_index_bridge, points);
+  filter_points(bridge_reverse, points[bridge_reverse].next(), points);
+  return filter_points(bridge, points[bridge].next(), points);
 }
 
 std::size_t eliminate_holes(
@@ -429,7 +426,7 @@ std::size_t eliminate_holes(
     }
     auto inner_index = linked_list(ring, false, vertices, points);
 
-    if (points[inner_index].next_index.value() == inner_index) {
+    if (points[inner_index].next() == inner_index) {
       points[inner_index].steiner = true;
     }
 
@@ -449,26 +446,22 @@ std::size_t eliminate_holes(
 
 bool is_ear(const std::size_t ear_index, const std::vector<LinkedPoint> & points)
 {
-  const auto a_index = points[ear_index].prev_index.value();
-  const auto b_index = ear_index;
-  const auto c_index = points[ear_index].next_index.value();
+  const auto nb = get_neighbors(points, ear_index);
 
+  const auto a_index = nb.prev;
+  const auto b_index = ear_index;
+  const auto c_index = nb.next;
   const auto a = points[a_index];
   const auto b = points[b_index];
   const auto c = points[c_index];
 
   if (area(points, a_index, b_index, c_index) >= 0) return false;
-  auto p_index = points[c_index].next_index.value();
-  while (p_index != a_index) {
-    const auto p = points[p_index];
-    if (
-      point_in_triangle(a.x(), a.y(), b.x(), b.y(), c.x(), c.y(), p.x(), p.y()) &&
-      area(points, p.prev_index.value(), p_index, p.next_index.value()) >= 0) {
-      return false;
-    }
-    p_index = points[p_index].next_index.value();
-  }
 
+  std::size_t p_index = points[c_index].next();
+  while (p_index != a_index) {
+    if (point_blocks_ear(p_index, a, b, c, points)) return false;
+    p_index = points[p_index].next();
+  }
   return true;
 }
 
@@ -480,25 +473,27 @@ std::size_t cure_local_intersections(
 
   while (p != start_index || updated) {
     updated = false;
-    auto a_idx = points[p].prev_index.value();
-    auto b_idx = points[points[p].next_index.value()].next_index.value();
+    const std::size_t a_idx = points[p].prev();
+    // Pre-save p_next before any remove_point() call: remove_point() rewrites
+    // the neighbors' prev_index/next_index, so reading points[p].next() after
+    // removal would return a stale/different index. (Original UNSAFE #2 fix.)
+    const std::size_t p_next = points[p].next();
+    const std::size_t b_idx = points[p_next].next();
 
     if (
-      !equals(a_idx, b_idx, points) &&
-      intersects(
-        a_idx, p, points[points[p].next_index.value()].next_index.value(), b_idx, points) &&
+      !equals(a_idx, b_idx, points) && intersects(a_idx, p, p_next, b_idx, points) &&
       locally_inside(a_idx, b_idx, points) && locally_inside(b_idx, a_idx, points)) {
       indices.push_back(a_idx);
       indices.push_back(p);
       indices.push_back(b_idx);
 
       remove_point(p, points);
-      remove_point(points[p].next_index.value(), points);
+      remove_point(p_next, points);
 
       p = start_index = b_idx;
       updated = true;
     } else {
-      p = points[p].next_index.value();
+      p = points[p].next();
     }
   }
 
@@ -511,58 +506,66 @@ void split_ear_clipping(
 {
   std::size_t a_idx = start_idx;
   do {
-    std::size_t b_idx = points[points[a_idx].next_index.value()].next_index.value();
-    while (b_idx != points[a_idx].prev_index.value()) {
+    const std::size_t a_next = points[a_idx].next();
+    std::size_t b_idx = points[a_next].next();
+    while (b_idx != points[a_idx].prev()) {
       if (a_idx != b_idx && is_valid_diagonal(a_idx, b_idx, points)) {
         std::size_t c_idx = split_polygon(a_idx, b_idx, points);
-
-        a_idx = filter_points(start_idx, points[a_idx].next_index.value(), points);
-        c_idx = filter_points(start_idx, points[c_idx].next_index.value(), points);
+        a_idx = filter_points(start_idx, points[a_idx].next(), points);
+        c_idx = filter_points(start_idx, points[c_idx].next(), points);
 
         ear_clipping_linked(a_idx, indices, points);
         ear_clipping_linked(c_idx, indices, points);
         return;
       }
-      b_idx = points[b_idx].next_index.value();
+      b_idx = points[b_idx].next();
     }
-    a_idx = points[a_idx].next_index.value();
+    a_idx = points[a_idx].next();
   } while (a_idx != start_idx);
 }
+
+namespace
+{
+inline void apply_fallback_pass(
+  int pass, std::size_t ear_index, std::vector<std::size_t> & indices,
+  std::vector<LinkedPoint> & points)
+{
+  if (pass == 0) {
+    ear_clipping_linked(filter_points(ear_index, ear_index, points), indices, points, 1);
+  } else if (pass == 1) {
+    ear_index =
+      cure_local_intersections(filter_points(ear_index, ear_index, points), indices, points);
+    ear_clipping_linked(ear_index, indices, points, 2);
+  } else if (pass == 2) {
+    split_ear_clipping(points, ear_index, indices);
+  }
+}
+}  // namespace
 
 void ear_clipping_linked(
   std::size_t ear_index, std::vector<std::size_t> & indices, std::vector<LinkedPoint> & points,
   const int pass)
 {
   auto stop = ear_index;
-  std::optional<std::size_t> next = std::nullopt;
 
-  while (points[ear_index].prev_index.value() != points[ear_index].next_index.value()) {
-    next = points[ear_index].next_index;
+  while (true) {
+    const auto nb = get_neighbors(points, ear_index);
+    if (nb.prev == nb.next) break;
+    const auto next = nb.next;
 
     if (is_ear(ear_index, points)) {
-      indices.push_back(points[ear_index].prev_index.value());
+      indices.push_back(nb.prev);
       indices.push_back(ear_index);
-      indices.push_back(next.value());
-
+      indices.push_back(next);
       remove_point(ear_index, points);
 
-      ear_index = points[next.value()].next_index.value();
-      stop = points[next.value()].next_index.value();
+      ear_index = stop = points[next].next();
       continue;
     }
 
-    ear_index = next.value();
-
+    ear_index = next;
     if (ear_index == stop) {
-      if (pass == 0) {
-        ear_clipping_linked(filter_points(ear_index, ear_index, points), indices, points, 1);
-      } else if (pass == 1) {
-        ear_index =
-          cure_local_intersections(filter_points(ear_index, ear_index, points), indices, points);
-        ear_clipping_linked(ear_index, indices, points, 2);
-      } else if (pass == 2) {
-        split_ear_clipping(points, ear_index, indices);
-      }
+      apply_fallback_pass(pass, ear_index, indices, points);
       break;
     }
   }
@@ -582,9 +585,7 @@ std::vector<LinkedPoint> perform_triangulation(
 
   indices.reserve(len + outer_ring.size());
   auto outer_point_index = linked_list(outer_ring, true, vertices, points);
-  if (
-    !points[outer_point_index].prev_index.has_value() ||
-    outer_point_index == points[outer_point_index].prev_index.value()) {
+  if (outer_point_index == points[outer_point_index].prev()) {
     return points;
   }
 
@@ -615,7 +616,9 @@ std::vector<alt::ConvexPolygon2d> triangulate(const alt::Polygon2d & poly)
     vertices.push_back(points[indices[i + 2]].pt);
     vertices.push_back(points[indices[i]].pt);
 
-    triangles.push_back(alt::ConvexPolygon2d::create(vertices).value());
+    auto tri_opt = alt::ConvexPolygon2d::create(vertices);
+    if (!tri_opt.has_value()) continue;
+    triangles.push_back(tri_opt.value());
   }
   points.clear();
   return triangles;
@@ -624,6 +627,7 @@ std::vector<alt::ConvexPolygon2d> triangulate(const alt::Polygon2d & poly)
 std::vector<Polygon2d> triangulate(const Polygon2d & poly)
 {
   const auto alt_poly = alt::Polygon2d::create(poly);
+  if (!alt_poly.has_value()) return {};
   const auto alt_triangles = triangulate(alt_poly.value());
   std::vector<Polygon2d> triangles;
   for (const auto & alt_triangle : alt_triangles) {

--- a/common/autoware_universe_utils/src/geometry/polygon_clip.cpp
+++ b/common/autoware_universe_utils/src/geometry/polygon_clip.cpp
@@ -173,10 +173,12 @@ void insert_vertex(
 
   while (current_index != end_index &&
          vertices[current_index].distance < vertices[vertex_index].distance) {
+    if (!vertices[current_index].next.has_value()) break;
     current_index = vertices[current_index].next.value();
   }
 
   vertices[vertex_index].next = current_index;
+  if (!vertices[current_index].prev.has_value()) return;
   vertices[vertex_index].prev = vertices[current_index].prev.value();
   std::size_t prev_index = vertices[current_index].prev.value();
 
@@ -195,6 +197,7 @@ std::size_t get_next(std::size_t index, const std::vector<LinkedVertex> & vertic
 {
   std::size_t current_index = index;
   while (vertices[current_index].is_intersection) {
+    if (!vertices[current_index].next.has_value()) break;
     current_index = vertices[current_index].next.value();
   }
   return current_index;
@@ -207,6 +210,7 @@ std::size_t get_first_intersect(ExtendedPolygon & polygon)
 
   do {
     if (polygon.vertices[v].is_intersection && !polygon.vertices[v].visited) break;
+    if (!polygon.vertices[v].next.has_value()) break;
     v = polygon.vertices[v].next.value();
   } while (v != polygon.first);
 
@@ -224,6 +228,7 @@ bool has_unprocessed(ExtendedPolygon & polygon)
       polygon.last_unprocessed = v;
       return true;
     }
+    if (!polygon.vertices[v].next.has_value()) break;
     v = polygon.vertices[v].next.value();
   } while (v != polygon.first);
   polygon.last_unprocessed = std::nullopt;
@@ -245,6 +250,7 @@ autoware::universe_utils::Polygon2d get_points(const ExtendedPolygon & polygon)
       outer_ringA.push_back(point);
     }
 
+    if (!vertex.next.has_value()) break;
     v_index = vertex.next.value();
   } while (v_index != start_index);
 
@@ -260,6 +266,7 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
 
   do {
     if (source.vertices[source_vertex_index].is_intersection) {
+      if (!source.vertices[source_vertex_index].next.has_value()) break;
       source_vertex_index = source.vertices[source_vertex_index].next.value();
       continue;
     }
@@ -268,16 +275,20 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
 
     do {
       if (clip.vertices[clip_vertex_index].is_intersection) {
+        if (!clip.vertices[clip_vertex_index].next.has_value()) break;
         clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
         continue;
       }
 
+      if (!source.vertices[source_vertex_index].next.has_value()) break;
+      if (!clip.vertices[clip_vertex_index].next.has_value()) break;
       Intersection i = intersection(
         source.vertices, source_vertex_index,
         get_next(source.vertices[source_vertex_index].next.value(), source.vertices), clip.vertices,
         clip_vertex_index, get_next(clip.vertices[clip_vertex_index].next.value(), clip.vertices));
 
       if (!valid(i)) {
+        if (!clip.vertices[clip_vertex_index].next.has_value()) break;
         clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
         continue;
       }
@@ -299,16 +310,22 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
       source.vertices[index1].corresponding = index2;
       clip.vertices[index2].corresponding = index1;
 
-      insert_vertex(
-        source.vertices, index1, source_vertex_index,
-        get_next(source.vertices[source_vertex_index].next.value(), source.vertices));
-      insert_vertex(
-        clip.vertices, index2, clip_vertex_index,
-        get_next(clip.vertices[clip_vertex_index].next.value(), clip.vertices));
+      if (source.vertices[source_vertex_index].next.has_value()) {
+        insert_vertex(
+          source.vertices, index1, source_vertex_index,
+          get_next(source.vertices[source_vertex_index].next.value(), source.vertices));
+      }
+      if (clip.vertices[clip_vertex_index].next.has_value()) {
+        insert_vertex(
+          clip.vertices, index2, clip_vertex_index,
+          get_next(clip.vertices[clip_vertex_index].next.value(), clip.vertices));
+      }
 
+      if (!clip.vertices[clip_vertex_index].next.has_value()) break;
       clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
     } while (clip_vertex_index != clip.first);
 
+    if (!source.vertices[source_vertex_index].next.has_value()) break;
     source_vertex_index = source.vertices[source_vertex_index].next.value();
   } while (source_vertex_index != source.first);
 }
@@ -329,6 +346,7 @@ void identify_entry_exit(
       source.vertices[source_vertex_index].is_entry = source_forwards;
       source_forwards = !source_forwards;
     }
+    if (!source.vertices[source_vertex_index].next.has_value()) break;
     source_vertex_index = source.vertices[source_vertex_index].next.value();
   } while (source_vertex_index != source.first);
 
@@ -337,6 +355,7 @@ void identify_entry_exit(
       clip.vertices[clip_vertex_index].is_entry = clip_forwards;
       clip_forwards = !clip_forwards;
     }
+    if (!clip.vertices[clip_vertex_index].next.has_value()) break;
     clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
   } while (clip_vertex_index != clip.first);
 }
@@ -359,11 +378,13 @@ std::vector<autoware::universe_utils::Polygon2d> construct_clipped_polygons(
       if (usingSource) {
         if (source.vertices[currentIndex].is_entry) {
           do {
+            if (!source.vertices[currentIndex].next.has_value()) break;
             currentIndex = source.vertices[currentIndex].next.value();
             last_idx = add_vertex(clipped, source.vertices[currentIndex], last_idx);
           } while (!source.vertices[currentIndex].is_intersection);
         } else {
           do {
+            if (!source.vertices[currentIndex].prev.has_value()) break;
             currentIndex = source.vertices[currentIndex].prev.value();
             last_idx = add_vertex(clipped, source.vertices[currentIndex], last_idx);
           } while (!source.vertices[currentIndex].is_intersection);
@@ -371,19 +392,27 @@ std::vector<autoware::universe_utils::Polygon2d> construct_clipped_polygons(
       } else {
         if (clip.vertices[currentIndex].is_entry) {
           do {
+            if (!clip.vertices[currentIndex].next.has_value()) break;
             currentIndex = clip.vertices[currentIndex].next.value();
             last_idx = add_vertex(clipped, clip.vertices[currentIndex], last_idx);
           } while (!clip.vertices[currentIndex].is_intersection);
         } else {
           do {
+            if (!clip.vertices[currentIndex].prev.has_value()) break;
             currentIndex = clip.vertices[currentIndex].prev.value();
             last_idx = add_vertex(clipped, clip.vertices[currentIndex], last_idx);
           } while (!clip.vertices[currentIndex].is_intersection);
         }
       }
 
-      currentIndex = (usingSource ? source.vertices[currentIndex] : clip.vertices[currentIndex])
-                       .corresponding.value();
+      // UNSAFE #3 fix: .corresponding is only set for intersection vertices;
+      // the do-while above should have stopped at an intersection vertex, but guard defensively.
+      const auto & cur_vert =
+        usingSource ? source.vertices[currentIndex] : clip.vertices[currentIndex];
+      if (!cur_vert.corresponding.has_value()) {
+        break;  // defensive: non-intersection vertex encountered unexpectedly
+      }
+      currentIndex = cur_vert.corresponding.value();
       usingSource = !usingSource;
     } while (
       !((usingSource ? source.vertices[currentIndex] : clip.vertices[currentIndex]).visited));

--- a/common/autoware_universe_utils/src/geometry/polygon_clip.cpp
+++ b/common/autoware_universe_utils/src/geometry/polygon_clip.cpp
@@ -51,7 +51,7 @@ bool is_inside(const LinkedVertex & v, const ExtendedPolygon & poly)
   constexpr double tolerance = 1e-9;
 
   std::size_t vertexIndex = poly.first;
-  std::size_t next_index = poly.vertices[vertexIndex].next.value_or(poly.first);
+  std::size_t next_index = poly.vertices[vertexIndex].next();
 
   do {
     const LinkedVertex & vertex = poly.vertices[vertexIndex];
@@ -65,13 +65,13 @@ bool is_inside(const LinkedVertex & v, const ExtendedPolygon & poly)
 
       if (std::abs(vertex.x - next.x) < tolerance && std::abs(vertex.y - next.y) < tolerance) {
         vertexIndex = next_index;
-        next_index = poly.vertices[vertexIndex].next.value_or(poly.first);
+        next_index = poly.vertices[vertexIndex].next();
         continue;
       }
     }
 
     vertexIndex = next_index;
-    next_index = poly.vertices[vertexIndex].next.value_or(poly.first);
+    next_index = poly.vertices[vertexIndex].next();
   } while (vertexIndex != poly.first);
 
   return contains;
@@ -124,12 +124,12 @@ std::size_t add_vertex(
   polygon.vertices.push_back(new_vertex);
   if (!polygon.vertices.empty()) {
     std::size_t last = last_index;
-    std::size_t next = polygon.vertices[last].next.value_or(0);
-    polygon.vertices[p_idx].prev = last;
-    polygon.vertices[p_idx].next = next;
-    polygon.vertices[last].next = p_idx;
+    std::size_t next = polygon.vertices[last].next_index.value_or(0);
+    polygon.vertices[p_idx].prev_index = last;
+    polygon.vertices[p_idx].next_index = next;
+    polygon.vertices[last].next_index = p_idx;
     if (next != p_idx) {
-      polygon.vertices[next].prev = p_idx;
+      polygon.vertices[next].prev_index = p_idx;
     }
   }
   return p_idx;
@@ -146,8 +146,8 @@ ExtendedPolygon create_extended_polygon(const autoware::universe_utils::Polygon2
     const auto & point = outer[i];
     LinkedVertex vertex{point.x(), point.y()};
 
-    vertex.prev = (i == 0) ? outer.size() - 1 : i - 1;
-    vertex.next = (i + 1) % outer.size();
+    vertex.prev_index = (i == 0) ? outer.size() - 1 : i - 1;
+    vertex.next_index = (i + 1) % outer.size();
 
     polygon.vertices[i] = vertex;
   }
@@ -160,8 +160,8 @@ ExtendedPolygon create_extended_polygon(const LinkedVertex & vertex)
 
   polygon.vertices.push_back(vertex);
 
-  polygon.vertices.back().prev = std::nullopt;
-  polygon.vertices.back().next = std::nullopt;
+  polygon.vertices.back().prev_index = std::nullopt;
+  polygon.vertices.back().next_index = std::nullopt;
   return polygon;
 }
 
@@ -173,23 +173,21 @@ void insert_vertex(
 
   while (current_index != end_index &&
          vertices[current_index].distance < vertices[vertex_index].distance) {
-    if (!vertices[current_index].next.has_value()) break;
-    current_index = vertices[current_index].next.value();
+    current_index = vertices[current_index].next();
   }
 
-  vertices[vertex_index].next = current_index;
-  if (!vertices[current_index].prev.has_value()) return;
-  vertices[vertex_index].prev = vertices[current_index].prev.value();
-  std::size_t prev_index = vertices[current_index].prev.value();
+  vertices[vertex_index].next_index = current_index;
+  vertices[vertex_index].prev_index = vertices[current_index].prev();
+  const std::size_t prev_index = vertices[current_index].prev();
 
   if (prev_index != current_index) {
-    vertices[prev_index].next = vertex_index;
+    vertices[prev_index].next_index = vertex_index;
   }
-  vertices[current_index].prev = vertex_index;
+  vertices[current_index].prev_index = vertex_index;
 
   if (current_index == start_index) {
-    vertices[vertex_index].prev = start_index;
-    vertices[vertex_index].next = start_index;
+    vertices[vertex_index].prev_index = start_index;
+    vertices[vertex_index].next_index = start_index;
   }
 }
 
@@ -197,8 +195,7 @@ std::size_t get_next(std::size_t index, const std::vector<LinkedVertex> & vertic
 {
   std::size_t current_index = index;
   while (vertices[current_index].is_intersection) {
-    if (!vertices[current_index].next.has_value()) break;
-    current_index = vertices[current_index].next.value();
+    current_index = vertices[current_index].next();
   }
   return current_index;
 }
@@ -210,8 +207,7 @@ std::size_t get_first_intersect(ExtendedPolygon & polygon)
 
   do {
     if (polygon.vertices[v].is_intersection && !polygon.vertices[v].visited) break;
-    if (!polygon.vertices[v].next.has_value()) break;
-    v = polygon.vertices[v].next.value();
+    v = polygon.vertices[v].next();
   } while (v != polygon.first);
 
   polygon.first_intersect = v;
@@ -228,8 +224,7 @@ bool has_unprocessed(ExtendedPolygon & polygon)
       polygon.last_unprocessed = v;
       return true;
     }
-    if (!polygon.vertices[v].next.has_value()) break;
-    v = polygon.vertices[v].next.value();
+    v = polygon.vertices[v].next();
   } while (v != polygon.first);
   polygon.last_unprocessed = std::nullopt;
   return false;
@@ -250,8 +245,7 @@ autoware::universe_utils::Polygon2d get_points(const ExtendedPolygon & polygon)
       outer_ringA.push_back(point);
     }
 
-    if (!vertex.next.has_value()) break;
-    v_index = vertex.next.value();
+    v_index = vertex.next();
   } while (v_index != start_index);
 
   boost::geometry::append(poly.outer(), outer_ringA);
@@ -266,8 +260,7 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
 
   do {
     if (source.vertices[source_vertex_index].is_intersection) {
-      if (!source.vertices[source_vertex_index].next.has_value()) break;
-      source_vertex_index = source.vertices[source_vertex_index].next.value();
+      source_vertex_index = source.vertices[source_vertex_index].next();
       continue;
     }
 
@@ -275,21 +268,17 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
 
     do {
       if (clip.vertices[clip_vertex_index].is_intersection) {
-        if (!clip.vertices[clip_vertex_index].next.has_value()) break;
-        clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
+        clip_vertex_index = clip.vertices[clip_vertex_index].next();
         continue;
       }
 
-      if (!source.vertices[source_vertex_index].next.has_value()) break;
-      if (!clip.vertices[clip_vertex_index].next.has_value()) break;
       Intersection i = intersection(
         source.vertices, source_vertex_index,
-        get_next(source.vertices[source_vertex_index].next.value(), source.vertices), clip.vertices,
-        clip_vertex_index, get_next(clip.vertices[clip_vertex_index].next.value(), clip.vertices));
+        get_next(source.vertices[source_vertex_index].next(), source.vertices), clip.vertices,
+        clip_vertex_index, get_next(clip.vertices[clip_vertex_index].next(), clip.vertices));
 
       if (!valid(i)) {
-        if (!clip.vertices[clip_vertex_index].next.has_value()) break;
-        clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
+        clip_vertex_index = clip.vertices[clip_vertex_index].next();
         continue;
       }
 
@@ -310,23 +299,17 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
       source.vertices[index1].corresponding = index2;
       clip.vertices[index2].corresponding = index1;
 
-      if (source.vertices[source_vertex_index].next.has_value()) {
-        insert_vertex(
-          source.vertices, index1, source_vertex_index,
-          get_next(source.vertices[source_vertex_index].next.value(), source.vertices));
-      }
-      if (clip.vertices[clip_vertex_index].next.has_value()) {
-        insert_vertex(
-          clip.vertices, index2, clip_vertex_index,
-          get_next(clip.vertices[clip_vertex_index].next.value(), clip.vertices));
-      }
+      insert_vertex(
+        source.vertices, index1, source_vertex_index,
+        get_next(source.vertices[source_vertex_index].next(), source.vertices));
+      insert_vertex(
+        clip.vertices, index2, clip_vertex_index,
+        get_next(clip.vertices[clip_vertex_index].next(), clip.vertices));
 
-      if (!clip.vertices[clip_vertex_index].next.has_value()) break;
-      clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
+      clip_vertex_index = clip.vertices[clip_vertex_index].next();
     } while (clip_vertex_index != clip.first);
 
-    if (!source.vertices[source_vertex_index].next.has_value()) break;
-    source_vertex_index = source.vertices[source_vertex_index].next.value();
+    source_vertex_index = source.vertices[source_vertex_index].next();
   } while (source_vertex_index != source.first);
 }
 
@@ -346,8 +329,7 @@ void identify_entry_exit(
       source.vertices[source_vertex_index].is_entry = source_forwards;
       source_forwards = !source_forwards;
     }
-    if (!source.vertices[source_vertex_index].next.has_value()) break;
-    source_vertex_index = source.vertices[source_vertex_index].next.value();
+    source_vertex_index = source.vertices[source_vertex_index].next();
   } while (source_vertex_index != source.first);
 
   do {
@@ -355,8 +337,7 @@ void identify_entry_exit(
       clip.vertices[clip_vertex_index].is_entry = clip_forwards;
       clip_forwards = !clip_forwards;
     }
-    if (!clip.vertices[clip_vertex_index].next.has_value()) break;
-    clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
+    clip_vertex_index = clip.vertices[clip_vertex_index].next();
   } while (clip_vertex_index != clip.first);
 }
 
@@ -378,39 +359,38 @@ std::vector<autoware::universe_utils::Polygon2d> construct_clipped_polygons(
       if (usingSource) {
         if (source.vertices[currentIndex].is_entry) {
           do {
-            if (!source.vertices[currentIndex].next.has_value()) break;
-            currentIndex = source.vertices[currentIndex].next.value();
+            currentIndex = source.vertices[currentIndex].next();
             last_idx = add_vertex(clipped, source.vertices[currentIndex], last_idx);
           } while (!source.vertices[currentIndex].is_intersection);
         } else {
           do {
-            if (!source.vertices[currentIndex].prev.has_value()) break;
-            currentIndex = source.vertices[currentIndex].prev.value();
+            currentIndex = source.vertices[currentIndex].prev();
             last_idx = add_vertex(clipped, source.vertices[currentIndex], last_idx);
           } while (!source.vertices[currentIndex].is_intersection);
         }
       } else {
         if (clip.vertices[currentIndex].is_entry) {
           do {
-            if (!clip.vertices[currentIndex].next.has_value()) break;
-            currentIndex = clip.vertices[currentIndex].next.value();
+            currentIndex = clip.vertices[currentIndex].next();
             last_idx = add_vertex(clipped, clip.vertices[currentIndex], last_idx);
           } while (!clip.vertices[currentIndex].is_intersection);
         } else {
           do {
-            if (!clip.vertices[currentIndex].prev.has_value()) break;
-            currentIndex = clip.vertices[currentIndex].prev.value();
+            currentIndex = clip.vertices[currentIndex].prev();
             last_idx = add_vertex(clipped, clip.vertices[currentIndex], last_idx);
           } while (!clip.vertices[currentIndex].is_intersection);
         }
       }
 
-      // UNSAFE #3 fix: .corresponding is only set for intersection vertices;
-      // the do-while above should have stopped at an intersection vertex, but guard defensively.
+      // `corresponding` is genuinely optional: it is only set on intersection
+      // vertices. The traversal above is supposed to land on an intersection
+      // vertex (loop guard) before we read it, but if an earlier bug breaks
+      // that assumption we must not dereference nullopt. (Original UNSAFE #3
+      // fix — retained; defensively breaks instead of crashing.)
       const auto & cur_vert =
         usingSource ? source.vertices[currentIndex] : clip.vertices[currentIndex];
       if (!cur_vert.corresponding.has_value()) {
-        break;  // defensive: non-intersection vertex encountered unexpectedly
+        break;
       }
       currentIndex = cur_vert.corresponding.value();
       usingSource = !usingSource;

--- a/common/autoware_universe_utils/src/geometry/polygon_clip.cpp
+++ b/common/autoware_universe_utils/src/geometry/polygon_clip.cpp
@@ -51,7 +51,7 @@ bool is_inside(const LinkedVertex & v, const ExtendedPolygon & poly)
   constexpr double tolerance = 1e-9;
 
   std::size_t vertexIndex = poly.first;
-  std::size_t next_index = poly.vertices[vertexIndex].next.value_or(poly.first);
+  std::size_t next_index = poly.vertices[vertexIndex].next();
 
   do {
     const LinkedVertex & vertex = poly.vertices[vertexIndex];
@@ -65,13 +65,13 @@ bool is_inside(const LinkedVertex & v, const ExtendedPolygon & poly)
 
       if (std::abs(vertex.x - next.x) < tolerance && std::abs(vertex.y - next.y) < tolerance) {
         vertexIndex = next_index;
-        next_index = poly.vertices[vertexIndex].next.value_or(poly.first);
+        next_index = poly.vertices[vertexIndex].next();
         continue;
       }
     }
 
     vertexIndex = next_index;
-    next_index = poly.vertices[vertexIndex].next.value_or(poly.first);
+    next_index = poly.vertices[vertexIndex].next();
   } while (vertexIndex != poly.first);
 
   return contains;
@@ -124,12 +124,12 @@ std::size_t add_vertex(
   polygon.vertices.push_back(new_vertex);
   if (!polygon.vertices.empty()) {
     std::size_t last = last_index;
-    std::size_t next = polygon.vertices[last].next.value_or(0);
-    polygon.vertices[p_idx].prev = last;
-    polygon.vertices[p_idx].next = next;
-    polygon.vertices[last].next = p_idx;
+    std::size_t next = polygon.vertices[last].next_index.value_or(0);
+    polygon.vertices[p_idx].prev_index = last;
+    polygon.vertices[p_idx].next_index = next;
+    polygon.vertices[last].next_index = p_idx;
     if (next != p_idx) {
-      polygon.vertices[next].prev = p_idx;
+      polygon.vertices[next].prev_index = p_idx;
     }
   }
   return p_idx;
@@ -146,8 +146,8 @@ ExtendedPolygon create_extended_polygon(const autoware::universe_utils::Polygon2
     const auto & point = outer[i];
     LinkedVertex vertex{point.x(), point.y()};
 
-    vertex.prev = (i == 0) ? outer.size() - 1 : i - 1;
-    vertex.next = (i + 1) % outer.size();
+    vertex.prev_index = (i == 0) ? outer.size() - 1 : i - 1;
+    vertex.next_index = (i + 1) % outer.size();
 
     polygon.vertices[i] = vertex;
   }
@@ -160,8 +160,8 @@ ExtendedPolygon create_extended_polygon(const LinkedVertex & vertex)
 
   polygon.vertices.push_back(vertex);
 
-  polygon.vertices.back().prev = std::nullopt;
-  polygon.vertices.back().next = std::nullopt;
+  polygon.vertices.back().prev_index = std::nullopt;
+  polygon.vertices.back().next_index = std::nullopt;
   return polygon;
 }
 
@@ -173,21 +173,23 @@ void insert_vertex(
 
   while (current_index != end_index &&
          vertices[current_index].distance < vertices[vertex_index].distance) {
-    current_index = vertices[current_index].next.value();
+    current_index = vertices[current_index].next();
   }
 
-  vertices[vertex_index].next = current_index;
-  vertices[vertex_index].prev = vertices[current_index].prev;
-  std::size_t prev_index = vertices[current_index].prev.value();
+  vertices[vertex_index].next_index = current_index;
+  // Assign the optional directly (no unwrap/rewrap): upstream #12588 removed the
+  // .value() here to satisfy bugprone-optional-value-conversion.
+  vertices[vertex_index].prev_index = vertices[current_index].prev_index;
+  const std::size_t prev_index = vertices[current_index].prev();
 
   if (prev_index != current_index) {
-    vertices[prev_index].next = vertex_index;
+    vertices[prev_index].next_index = vertex_index;
   }
-  vertices[current_index].prev = vertex_index;
+  vertices[current_index].prev_index = vertex_index;
 
   if (current_index == start_index) {
-    vertices[vertex_index].prev = start_index;
-    vertices[vertex_index].next = start_index;
+    vertices[vertex_index].prev_index = start_index;
+    vertices[vertex_index].next_index = start_index;
   }
 }
 
@@ -195,7 +197,7 @@ std::size_t get_next(std::size_t index, const std::vector<LinkedVertex> & vertic
 {
   std::size_t current_index = index;
   while (vertices[current_index].is_intersection) {
-    current_index = vertices[current_index].next.value();
+    current_index = vertices[current_index].next();
   }
   return current_index;
 }
@@ -207,7 +209,7 @@ std::size_t get_first_intersect(ExtendedPolygon & polygon)
 
   do {
     if (polygon.vertices[v].is_intersection && !polygon.vertices[v].visited) break;
-    v = polygon.vertices[v].next.value();
+    v = polygon.vertices[v].next();
   } while (v != polygon.first);
 
   polygon.first_intersect = v;
@@ -224,7 +226,7 @@ bool has_unprocessed(ExtendedPolygon & polygon)
       polygon.last_unprocessed = v;
       return true;
     }
-    v = polygon.vertices[v].next.value();
+    v = polygon.vertices[v].next();
   } while (v != polygon.first);
   polygon.last_unprocessed = std::nullopt;
   return false;
@@ -245,7 +247,7 @@ autoware::universe_utils::Polygon2d get_points(const ExtendedPolygon & polygon)
       outer_ringA.push_back(point);
     }
 
-    v_index = vertex.next.value();
+    v_index = vertex.next();
   } while (v_index != start_index);
 
   boost::geometry::append(poly.outer(), outer_ringA);
@@ -260,7 +262,7 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
 
   do {
     if (source.vertices[source_vertex_index].is_intersection) {
-      source_vertex_index = source.vertices[source_vertex_index].next.value();
+      source_vertex_index = source.vertices[source_vertex_index].next();
       continue;
     }
 
@@ -268,17 +270,17 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
 
     do {
       if (clip.vertices[clip_vertex_index].is_intersection) {
-        clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
+        clip_vertex_index = clip.vertices[clip_vertex_index].next();
         continue;
       }
 
       Intersection i = intersection(
         source.vertices, source_vertex_index,
-        get_next(source.vertices[source_vertex_index].next.value(), source.vertices), clip.vertices,
-        clip_vertex_index, get_next(clip.vertices[clip_vertex_index].next.value(), clip.vertices));
+        get_next(source.vertices[source_vertex_index].next(), source.vertices), clip.vertices,
+        clip_vertex_index, get_next(clip.vertices[clip_vertex_index].next(), clip.vertices));
 
       if (!valid(i)) {
-        clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
+        clip_vertex_index = clip.vertices[clip_vertex_index].next();
         continue;
       }
 
@@ -301,15 +303,15 @@ void mark_intersections(ExtendedPolygon & source, ExtendedPolygon & clip, bool &
 
       insert_vertex(
         source.vertices, index1, source_vertex_index,
-        get_next(source.vertices[source_vertex_index].next.value(), source.vertices));
+        get_next(source.vertices[source_vertex_index].next(), source.vertices));
       insert_vertex(
         clip.vertices, index2, clip_vertex_index,
-        get_next(clip.vertices[clip_vertex_index].next.value(), clip.vertices));
+        get_next(clip.vertices[clip_vertex_index].next(), clip.vertices));
 
-      clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
+      clip_vertex_index = clip.vertices[clip_vertex_index].next();
     } while (clip_vertex_index != clip.first);
 
-    source_vertex_index = source.vertices[source_vertex_index].next.value();
+    source_vertex_index = source.vertices[source_vertex_index].next();
   } while (source_vertex_index != source.first);
 }
 
@@ -329,7 +331,7 @@ void identify_entry_exit(
       source.vertices[source_vertex_index].is_entry = source_forwards;
       source_forwards = !source_forwards;
     }
-    source_vertex_index = source.vertices[source_vertex_index].next.value();
+    source_vertex_index = source.vertices[source_vertex_index].next();
   } while (source_vertex_index != source.first);
 
   do {
@@ -337,7 +339,7 @@ void identify_entry_exit(
       clip.vertices[clip_vertex_index].is_entry = clip_forwards;
       clip_forwards = !clip_forwards;
     }
-    clip_vertex_index = clip.vertices[clip_vertex_index].next.value();
+    clip_vertex_index = clip.vertices[clip_vertex_index].next();
   } while (clip_vertex_index != clip.first);
 }
 
@@ -359,31 +361,40 @@ std::vector<autoware::universe_utils::Polygon2d> construct_clipped_polygons(
       if (usingSource) {
         if (source.vertices[currentIndex].is_entry) {
           do {
-            currentIndex = source.vertices[currentIndex].next.value();
+            currentIndex = source.vertices[currentIndex].next();
             last_idx = add_vertex(clipped, source.vertices[currentIndex], last_idx);
           } while (!source.vertices[currentIndex].is_intersection);
         } else {
           do {
-            currentIndex = source.vertices[currentIndex].prev.value();
+            currentIndex = source.vertices[currentIndex].prev();
             last_idx = add_vertex(clipped, source.vertices[currentIndex], last_idx);
           } while (!source.vertices[currentIndex].is_intersection);
         }
       } else {
         if (clip.vertices[currentIndex].is_entry) {
           do {
-            currentIndex = clip.vertices[currentIndex].next.value();
+            currentIndex = clip.vertices[currentIndex].next();
             last_idx = add_vertex(clipped, clip.vertices[currentIndex], last_idx);
           } while (!clip.vertices[currentIndex].is_intersection);
         } else {
           do {
-            currentIndex = clip.vertices[currentIndex].prev.value();
+            currentIndex = clip.vertices[currentIndex].prev();
             last_idx = add_vertex(clipped, clip.vertices[currentIndex], last_idx);
           } while (!clip.vertices[currentIndex].is_intersection);
         }
       }
 
-      currentIndex = (usingSource ? source.vertices[currentIndex] : clip.vertices[currentIndex])
-                       .corresponding.value();
+      // `corresponding` is genuinely optional: it is only set on intersection
+      // vertices. The traversal above is supposed to land on an intersection
+      // vertex (loop guard) before we read it, but if an earlier bug breaks
+      // that assumption we must not dereference nullopt. (Original UNSAFE #3
+      // fix — retained; defensively breaks instead of crashing.)
+      const auto & cur_vert =
+        usingSource ? source.vertices[currentIndex] : clip.vertices[currentIndex];
+      if (!cur_vert.corresponding.has_value()) {
+        break;
+      }
+      currentIndex = cur_vert.corresponding.value();
       usingSource = !usingSource;
     } while (
       !((usingSource ? source.vertices[currentIndex] : clip.vertices[currentIndex]).visited));


### PR DESCRIPTION
## Description

Fixes suppressed `bugprone-unchecked-optional-access` clang-tidy warnings in two geometry files, contributing to issue #12450 (284 total suppressions across `autoware_universe_utils`).

**Files changed:**
- `common/autoware_universe_utils/src/geometry/ear_clipping.cpp` — 67 lines changed
- `common/autoware_universe_utils/src/geometry/polygon_clip.cpp` — 45 lines changed

## What was wrong

Both files call `.value()` on `std::optional` fields (linked-list `prev_index`, `next_index`, `corresponding`, etc.) without preceding `has_value()` checks in paths visible to the clang-tidy data-flow analyzer.  Three of these were genuine runtime risks:

1. **`linked_list()` empty ring** (`ear_clipping.cpp`): if the caller passes a zero-vertex ring, `last_index` remains `nullopt` and `return last_index.value()` throws `bad_optional_access` — same crash class as fixed in #8995.
2. **`cure_local_intersections()` stale pointer** (`ear_clipping.cpp`): the second `remove_point(points[p].next_index.value(), ...)` call re-reads `points[p].next_index` *after* `remove_point(p, ...)` has already cleared it. Fixed by pre-saving `p_next = points[p].next_index.value()` before any removal.
3. **`construct_clipped_polygons()` missing guard** (`polygon_clip.cpp`): `.corresponding` is set only for intersection vertices; the `do-while` is expected to stop at one, but had no defensive check.

## Fix approach

- **Pattern A**: `if (!opt.has_value()) { break / continue / return / throw; }` immediately before `.value()`
- **Pattern B**: for the `while`-condition sites the guard is already on the same line (`while (x.has_value() && x.value() != y)`)
- No `NOLINT` suppressions added; no behavioral changes for well-formed inputs

## Prior art consulted (OPS-RULE-018)

| PR / Issue | Relevance |
|------------|-----------|
| **#8995** (mraditya01, 2024-11-11) | Fixed `bad_optional_access` crash in the same `ear_clipping.cpp`; test log shows `terminate called after throwing bad_optional_access`. Confirms this bug class is real and reproducible. This PR is consistent with that fix direction. |
| **#8893** (mraditya01, 2024-09-20) | Introduced the optional-based linked-list design in `ear_clipping.cpp` that this PR guards. The design intent (nodes always have prev/next set once inserted) is preserved; guards are defensive annotations for the static analyzer. |
| **#8965** (mitukou1109, 2024-09-27) | Same `autoware_universe_utils` geometry subsystem; established the `colcon test --packages-select autoware_universe_utils` test pattern used here. |

Source code read at: `common/autoware_universe_utils/src/geometry/ear_clipping.cpp` (L23–L680) and `polygon_clip.cpp` (L1–L430), verified against upstream `main` at commit read time.

## Test plan

```bash
colcon build --packages-select autoware_universe_utils --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test  --packages-select autoware_universe_utils
colcon test-result --verbose
```

Expected: existing geometry tests pass; clang-tidy `bugprone-unchecked-optional-access` no longer fires on these two files.

## Related

Closes part of #12450 (`autoware_universe_utils` subset — 70 of 284 suppressions).

---

*AI-assisted — authored with Claude, reviewed by Komada.*