### PR TITLE
fix(mpc_lateral_controller): fix mpc predicted trajectory deviation

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
+++ b/control/autoware_mpc_lateral_controller/src/vehicle_model/vehicle_model_bicycle_kinematics.cpp
@@ -79,11 +79,6 @@ MPCTrajectory KinematicsBicycleModel::calculatePredictedTrajectoryInWorldCoordin
   // Relative coordinate state = [lat_err, yaw_err, steer]
   // World coordinate state_w = [x, y, yaw]
 
-  // Note: Ideally, the first-order delay of the steering should be considered, as in the control
-  // model. However, significant accuracy degradation was observed when discretizing with a long dt,
-  // so it has been ignored here. If the accuracy of the discretization improves,an appropriate
-  // model should be considered.
-
   const auto & t = reference_trajectory;
 
   // create initial state in the world coordinate
@@ -97,16 +92,20 @@ MPCTrajectory KinematicsBicycleModel::calculatePredictedTrajectoryInWorldCoordin
     return state;
   }();
 
+  const auto dt_ratio = std::min(dt / m_steer_tau, 1.0);
+  auto current_steer = x0(2);
+
   // update state in the world coordinate
   const auto updateState = [&](
                              const Eigen::Vector3d & state_w, const double & input, const double dt,
                              const double velocity) {
     const auto yaw = state_w(2);
+    current_steer += (input - current_steer) * dt_ratio;  // first-order delay
 
     Eigen::Vector3d dstate = Eigen::Vector3d::Zero();
     dstate(0) = velocity * std::cos(yaw);
     dstate(1) = velocity * std::sin(yaw);
-    dstate(2) = velocity * std::tan(input) / m_wheelbase;
+    dstate(2) = velocity * std::tan(current_steer) / m_wheelbase;
 
     // Note: don't do "return state_w + dstate * dt", which does not work due to the lazy evaluation
     // in Eigen.


### PR DESCRIPTION
## Description

The function `calculatePredictedTrajectoryInWorldCoordinate` does not consider the first-order delay of the steering when calculating the states in the world coordinate, resulting in a significant deviation between the mpc frenet trajectory and the corresponding world coordinate trajectory.
This PR introduces the first-order delay to match the kinematics to the ones used in the mpc solver, and minimize the deviation

Before:
<img width="3840" height="2160" alt="Screenshot from 2026-04-22 15-09-48" src="https://github.com/user-attachments/assets/78873db6-4099-42e9-93af-cb301ae940a8" />

After:
<img width="3840" height="2160" alt="Screenshot from 2026-04-22 15-30-35" src="https://github.com/user-attachments/assets/a2b4eb2d-6de7-44ef-bbe6-03858946fa25" />

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
