### PR TITLE
fix(clang-tidy): re-enable bugprone-optional-value-conversion for obstacle slow down module

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -12,7 +12,6 @@ Checks: "
   -bugprone-macro-parentheses,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
-  -bugprone-optional-value-conversion,
   -bugprone-parent-virtual-call,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -709,7 +709,7 @@ std::vector<SlowdownInterval> ObstacleSlowDownModule::plan_slow_down(
         slow_down_traj_points.at(inserted_idx.value()).longitudinal_velocity_mps =
           slow_down_traj_points.at(inserted_idx.value() + 1).longitudinal_velocity_mps;
       }
-      return inserted_idx.value();
+      return inserted_idx;
     }
     return std::nullopt;
   };


### PR DESCRIPTION
Re-enables `bugprone-optional-value-conversion` by removing its suppression from `.clang-tidy-ci`.

This PR fixes the reported error in `planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module`.

Refs #12450

## Fixes

The lambda already returns `std::optional<size_t>`, but the code dereferenced an optional and returned the contained value, causing unnecessary optional unwrap and rewrap.

This PR changes:

```cpp
return inserted_idx.value();
```

to:

```cpp
return inserted_idx;
```

This keeps behavior unchanged and avoids the optional value conversion warning.

## Verification

```bash
pre-commit run clang-format --files \
  planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to autoware_motion_velocity_obstacle_slow_down_module \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 49 packages finished
```

```bash
run-clang-tidy -p build/ \
  -config="$(cat src/autoware_universe/.clang-tidy-ci)" \
  -export-fixes /tmp/clang-tidy-result/fixes.yaml \
  -j $(nproc) \
  autoware_motion_velocity_obstacle_slow_down_module \
  > /tmp/clang-tidy-result/report.log 2>&1

grep -n "bugprone-optional-value-conversion" /tmp/clang-tidy-result/report.log | grep "error:" || echo "0 optional-value-conversion errors"
```

Result:

```text
0 optional-value-conversion errors
```