### PR TITLE
chore(autoware_behavior_path_planner): remove comment referencing to outdated COMPILE_WITH_OLD_ARCHITECTURE

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/scene_module_manager.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/scene_module_manager.param.yaml
@@ -1,5 +1,3 @@
-# USE ONLY WHEN THE OPTION COMPILE_WITH_OLD_ARCHITECTURE IS SET TO FALSE.
-# https://github.com/autowarefoundation/autoware_universe/blob/main/planning/behavior_path_planner/CMakeLists.txt
 # NOTE: The smaller the priority number is, the higher the module priority is.
 /**:
   ros__parameters:


### PR DESCRIPTION
See also https://github.com/autowarefoundation/autoware_launch/pull/1845

## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
