### PR TITLE
feat(hdd_monitor): add support device mapper, e.g., dm-crypt disk

### DIFF
--- a/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
+++ b/system/autoware_system_monitor/src/hdd_monitor/hdd_monitor.cpp
@@ -55,6 +55,11 @@ bool is_non_scsi_device(const std::string & device_name)
   // clang-format on
 }
 
+bool is_mapper_device(const std::string & device_name)
+{
+  return (boost::starts_with(device_name, "/dev/dm-"));  // device mapper
+}
+
 }  // namespace
 
 namespace bp = boost::process;
@@ -621,7 +626,7 @@ std::string HddMonitor::getDeviceFromMountPoint(const std::string & mount_point)
   bp::ipstream is_err{std::move(err_pipe)};
 
   bp::child c(
-    "/bin/sh", "-c", fmt::format("findmnt -n -o SOURCE {}", mount_point.c_str()),
+    "/bin/sh", "-c", fmt::format("readlink -e $(findmnt -n -o SOURCE {})", mount_point.c_str()),
     bp::std_out > is_out, bp::std_err > is_err);
   c.wait();
 
@@ -874,6 +879,8 @@ void HddMonitor::updateHddConnections()
           const std::regex pattern("p\\d+$");
           hdd_param.second.disk_device_ =
             std::regex_replace(hdd_param.second.part_device_, pattern, "");
+        } else if (is_mapper_device(hdd_param.second.part_device_)) {
+          hdd_param.second.disk_device_ = hdd_param.second.part_device_;
         }
 
         const std::regex raw_pattern(".*/");


### PR DESCRIPTION
## Description
To support monitoring LUKS (Linux Unified Key Setup) encrypted disks, add ``readlink`` command to follow symbolic link if SOURCE of mount_point is a symbolic link under /dev/mapper/ that refers to /dev/dm-? mapper device.
Besides, add "/dev/dm-" as a storage device name base to correctly detect existence of mapper device.

## Related links

**Private Links:**
- [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1774409408790859?thread_ts=1772681222.733169&cid=CRUE57C30)

## How was this PR tested?

- Tested on Intel PC with Ubuntu 22.04 (NVMe SSDs are installed)
   - Statistics information can be retrieved as expected for both LUKS encrypted disks and normal (non-encrypted) disks
   - There are no other changes regarding the behavior of the "hdd_monitor" node

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
