### PR TITLE
feat(autoware_tensorrt_plugins): support fused bias/activation in ImplicitGemmPlugin

### DIFF
--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -121,15 +121,16 @@ private:
   static constexpr std::int32_t INOUT_PAIR_MASK_FWD_SPLITS_INDEX{3};
   static constexpr std::int32_t INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX{4};
   static constexpr std::int32_t INOUT_OPTIONAL_BIAS_INDEX{5};
-  static constexpr std::int32_t kNumPluginInputsNoBias{5};
-  static constexpr std::int32_t kNumPluginInputsBias{6};
+
+  static constexpr std::int32_t NUM_PLUGIN_INPUTS_NO_BIAS{5};
+  static constexpr std::int32_t NUM_PLUGIN_INPUTS_BIAS{6};
 
   void initFieldsToSerialize();
 
   std::string layer_name_;
   ImplicitGemmParameters params_;
   /// Set in ``configurePlugin`` / ``onShapeChange``.
-  std::int32_t num_plugin_inputs_{kNumPluginInputsNoBias};
+  std::int32_t num_plugin_inputs_{NUM_PLUGIN_INPUTS_NO_BIAS};
   std::tuple<int, int> arch_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -43,6 +43,10 @@ struct ImplicitGemmParameters
   std::int32_t is_train{0};
   float output_add_scale{1.0F};
   float output_scale{1.0F};
+
+  /// tv::gemm::Activation as integer:
+  /// kNone=0, kReLU=1, kSigmoid=2, kLeakyReLU=3.
+  std::int32_t act_type{static_cast<std::int32_t>(tv::gemm::Activation::kNone)};
 };
 
 class ImplicitGemmPlugin : public IPluginV3,
@@ -116,12 +120,16 @@ private:
   static constexpr std::int32_t INOUT_PAIR_FWD_INDEX{2};
   static constexpr std::int32_t INOUT_PAIR_MASK_FWD_SPLITS_INDEX{3};
   static constexpr std::int32_t INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX{4};
-  static constexpr std::int32_t INOUT_OUT_FEATURES_INDEX{5};
+  static constexpr std::int32_t INOUT_OPTIONAL_BIAS_INDEX{5};
+  static constexpr std::int32_t kNumPluginInputsNoBias{5};
+  static constexpr std::int32_t kNumPluginInputsBias{6};
 
   void initFieldsToSerialize();
 
   std::string layer_name_;
   ImplicitGemmParameters params_;
+  /// Set in ``configurePlugin`` / ``onShapeChange``.
+  std::int32_t num_plugin_inputs_{kNumPluginInputsNoBias};
   std::tuple<int, int> arch_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -37,11 +37,12 @@
 namespace
 {
 
-/** Wrap the bias device pointer into a tv::Tensor of the activation dtype (no copy).
+/** Validate the bias inputs, then wrap the bias device pointer into a tv::Tensor of the
+ * activation dtype (no copy).
  *
  * Spconv's fused bias-add needs the bias dtype to match the activation dtype; the ONNX export
  * already emits it that way, so we only assert the match and wrap the pointer. */
-void wrap_bias_tensor(
+void validate_and_wrap_bias_tensor(
   void const * bias_in, std::int64_t c_bias, tv::DType activation_dtype,
   nvinfer1::DataType bias_trt_type, int device, tv::Tensor * bias_out) noexcept
 {
@@ -352,7 +353,7 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   if (num_plugin_inputs_ == NUM_PLUGIN_INPUTS_BIAS) {
     auto const bias_type = input_desc[INOUT_OPTIONAL_BIAS_INDEX].type;
     std::int64_t const c_bias = input_desc[INOUT_OPTIONAL_BIAS_INDEX].dims.d[0];
-    wrap_bias_tensor(
+    validate_and_wrap_bias_tensor(
       inputs[INOUT_OPTIONAL_BIAS_INDEX], c_bias, dtype, bias_type, input_features.device(),
       &bias_tv);
   }

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -37,24 +37,21 @@
 namespace
 {
 
-/** Wrap the optional per-channel bias pointer into a tv::Tensor of the right dtype.
+/** Wrap the bias device pointer into a tv::Tensor of the activation dtype (no copy).
  *
- * Spconv fused bias/add requires the bias dtype to match the activation dtype (see InferenceOps
- * bias_add). This avoids per-enqueue D2H/H2D dtype conversion overhead. */
-void build_bias_tensor_matching_activation(
-  tv::Tensor const & input_features, void const * bias_input, std::int64_t c_bias,
-  tv::DType activation_dtype, nvinfer1::DataType bias_trt_type, tv::Tensor * out_bias) noexcept
+ * Spconv's fused bias-add needs the bias dtype to match the activation dtype; the ONNX export
+ * already emits it that way, so we only assert the match and wrap the pointer. */
+void wrap_bias_tensor(
+  void const * bias_in, std::int64_t c_bias, tv::DType activation_dtype,
+  nvinfer1::DataType bias_trt_type, int device, tv::Tensor * bias_out) noexcept
 {
-  PLUGIN_ASSERT(out_bias != nullptr);
+  PLUGIN_ASSERT(bias_out != nullptr);
+  PLUGIN_ASSERT(bias_in != nullptr);
   PLUGIN_ASSERT(activation_dtype == tv::float16 || activation_dtype == tv::float32);
-  int const dev = input_features.device();
-  if (activation_dtype == tv::float16) {
-    PLUGIN_ASSERT(bias_trt_type == nvinfer1::DataType::kHALF);
-    *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float16, dev);
-    return;
-  }
-  PLUGIN_ASSERT(bias_trt_type == nvinfer1::DataType::kFLOAT);
-  *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float32, dev);
+  PLUGIN_ASSERT(
+    bias_trt_type ==
+    (activation_dtype == tv::float16 ? nvinfer1::DataType::kHALF : nvinfer1::DataType::kFLOAT));
+  *bias_out = tv::from_blob(const_cast<void *>(bias_in), {c_bias}, activation_dtype, device);
 }
 
 tv::gemm::Activation activation_from_int(std::int32_t const v) noexcept
@@ -349,13 +346,15 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   // Wrap the optional per-channel bias (BN-folded, 6th ONNX input) into a tv::Tensor.
   // When present, spconv fuses it inside the GEMM kernel instead of a separate bias_add kernel.
-  // bias_tv stays empty (default-constructed) when there are only 5 inputs (no bias).
+  // bias_tv stays empty (default-constructed) when there are only 5 inputs (no bias), in which
+  // case implicit_gemm runs without a bias term.
   tv::Tensor bias_tv{};
   if (num_plugin_inputs_ == NUM_PLUGIN_INPUTS_BIAS) {
     auto const bias_type = input_desc[INOUT_OPTIONAL_BIAS_INDEX].type;
     std::int64_t const c_bias = input_desc[INOUT_OPTIONAL_BIAS_INDEX].dims.d[0];
-    build_bias_tensor_matching_activation(
-      input_features, inputs[INOUT_OPTIONAL_BIAS_INDEX], c_bias, dtype, bias_type, &bias_tv);
+    wrap_bias_tensor(
+      inputs[INOUT_OPTIONAL_BIAS_INDEX], c_bias, dtype, bias_type, input_features.device(),
+      &bias_tv);
   }
 
   std::vector<tv::Tensor> pair_mask_splits;

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -375,8 +375,9 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   [[maybe_unused]] auto const conv_run_status = ConvGemmOps::implicit_gemm(
     alloc2, *tuner_ptr, input_features, weights, pair_fwd, pair_mask_splits, mask_argsort_splits,
     num_act_out, mask_tensor_, arch_, false, params_.is_subm,  // cSpell:ignore subm
-    reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false), true, false, tv::Tensor(),
-    0.0, 0.0, tv::gemm::Activation::kNone, false, 1.0, tv::Tensor(), tv::Tensor(), 0.0, -1);
+    reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false), true, false, bias_tv,
+    params_.act_alpha, params_.act_beta, activation_from_int(params_.act_type), false, 1.0,
+    tv::Tensor(), tv::Tensor(), 0.0, -1);
 
   return 0;
 }

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -158,7 +158,7 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   // arguments
   PLUGIN_ASSERT(in != nullptr);
   PLUGIN_ASSERT(out != nullptr);
-  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
 
   num_plugin_inputs_ = num_inputs;
@@ -184,7 +184,7 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   PLUGIN_ASSERT(
     in[INOUT_PAIR_FWD_INDEX].desc.type == in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.type);
 
-  if (num_inputs == kNumPluginInputsBias) {
+  if (num_inputs == NUM_PLUGIN_INPUTS_BIAS) {
     PLUGIN_ASSERT(in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.nbDims == 1);
     PLUGIN_ASSERT(
       in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.d[0] == in[INOUT_FILTERS_INDEX].desc.dims.d[0]);
@@ -203,7 +203,7 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
   std::int32_t num_outputs) noexcept
 {
   PLUGIN_ASSERT(in_out != nullptr);
-  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
   // in_out is the combined [inputs..., outputs...] tensor array; n_slots = num_inputs +
   // num_outputs.
@@ -239,7 +239,7 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
       break;
     // Optional fused bias must match input features dtype; rejected when there are only 5 inputs.
     case INOUT_OPTIONAL_BIAS_INDEX:
-      if (num_inputs == kNumPluginInputsBias) {
+      if (num_inputs == NUM_PLUGIN_INPUTS_BIAS) {
         supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
       } else {
         supported = false;
@@ -259,7 +259,7 @@ std::int32_t ImplicitGemmPlugin::getOutputDataTypes(
 {
   PLUGIN_ASSERT(output_types != nullptr);
   PLUGIN_ASSERT(input_types != nullptr);
-  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
 
   output_types[0] = input_types[INOUT_IN_FEATURES_INDEX];
@@ -275,7 +275,7 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
 {
   PLUGIN_ASSERT(inputs != nullptr);
   PLUGIN_ASSERT(outputs != nullptr);
-  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
   PLUGIN_ASSERT(inputs[0].nbDims == 2);
 
@@ -295,7 +295,8 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
 
   PLUGIN_ASSERT(
-    num_plugin_inputs_ == kNumPluginInputsNoBias || num_plugin_inputs_ == kNumPluginInputsBias);
+    num_plugin_inputs_ == NUM_PLUGIN_INPUTS_NO_BIAS ||
+    num_plugin_inputs_ == NUM_PLUGIN_INPUTS_BIAS);
 
   std::int64_t num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
   std::int64_t num_in_features = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];
@@ -350,7 +351,7 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   // When present, spconv fuses it inside the GEMM kernel instead of a separate bias_add kernel.
   // bias_tv stays empty (default-constructed) when there are only 5 inputs (no bias).
   tv::Tensor bias_tv{};
-  if (num_plugin_inputs_ == kNumPluginInputsBias) {
+  if (num_plugin_inputs_ == NUM_PLUGIN_INPUTS_BIAS) {
     auto const bias_type = input_desc[INOUT_OPTIONAL_BIAS_INDEX].type;
     std::int64_t const c_bias = input_desc[INOUT_OPTIONAL_BIAS_INDEX].dims.d[0];
     build_bias_tensor_matching_activation(
@@ -384,7 +385,7 @@ std::int32_t ImplicitGemmPlugin::onShapeChange(
   [[maybe_unused]] PluginTensorDesc const * in, std::int32_t num_inputs,
   [[maybe_unused]] PluginTensorDesc const * out, [[maybe_unused]] std::int32_t num_outputs) noexcept
 {
-  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   num_plugin_inputs_ = num_inputs;
   return 0;
 }

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -34,6 +34,38 @@
 #include <unordered_map>
 #include <vector>
 
+namespace
+{
+
+/** Wrap the optional per-channel bias pointer into a tv::Tensor of the right dtype.
+ *
+ * Spconv fused bias/add requires the bias dtype to match the activation dtype (see InferenceOps
+ * bias_add). This avoids per-enqueue D2H/H2D dtype conversion overhead. */
+void build_bias_tensor_matching_activation(
+  tv::Tensor const & input_features, void const * bias_input, std::int64_t c_bias,
+  tv::DType activation_dtype, nvinfer1::DataType bias_trt_type, tv::Tensor * out_bias) noexcept
+{
+  PLUGIN_ASSERT(out_bias != nullptr);
+  PLUGIN_ASSERT(activation_dtype == tv::float16 || activation_dtype == tv::float32);
+  int const dev = input_features.device();
+  if (activation_dtype == tv::float16) {
+    PLUGIN_ASSERT(bias_trt_type == nvinfer1::DataType::kHALF);
+    *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float16, dev);
+    return;
+  }
+  PLUGIN_ASSERT(bias_trt_type == nvinfer1::DataType::kFLOAT);
+  *out_bias = tv::from_blob(const_cast<void *>(bias_input), {c_bias}, tv::float32, dev);
+}
+
+tv::gemm::Activation activation_from_int(std::int32_t const v) noexcept
+{
+  PLUGIN_ASSERT(
+    v >= static_cast<std::int32_t>(tv::gemm::Activation::kNone) &&
+    v <= static_cast<std::int32_t>(tv::gemm::Activation::kLeakyReLU));
+  return static_cast<tv::gemm::Activation>(v);
+}
+}  // namespace
+
 namespace nvinfer1::plugin
 {
 
@@ -86,7 +118,8 @@ IPluginCapability * ImplicitGemmPlugin::getCapabilityInterface(PluginCapabilityT
 IPluginV3 * ImplicitGemmPlugin::clone() noexcept
 {
   try {
-    IPluginV3 * const plugin{new ImplicitGemmPlugin{layer_name_, params_}};
+    ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{layer_name_, params_}};
+    plugin->num_plugin_inputs_ = num_plugin_inputs_;
     return plugin;
   } catch (std::exception const & e) {
     caughtError(e);
@@ -119,10 +152,17 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   std::int32_t num_outputs) noexcept
 {
   // Validate input arguments.
+  // 5 inputs: standard implicit GEMM path without fused bias.
+  // 6 inputs: implicit GEMM path with optional per-channel bias.
+  // TODO(vividf): should use PLUGIN_VALIDATE_AND_RETURN instead of PLUGIN_ASSERT for input
+  // arguments
   PLUGIN_ASSERT(in != nullptr);
   PLUGIN_ASSERT(out != nullptr);
-  PLUGIN_ASSERT(num_inputs == 5);
+  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
   PLUGIN_ASSERT(num_outputs == 1);
+
+  num_plugin_inputs_ = num_inputs;
+
   PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.dims.nbDims == 2);
   PLUGIN_ASSERT(in[INOUT_FILTERS_INDEX].desc.dims.nbDims == 5);
   PLUGIN_ASSERT(in[INOUT_PAIR_FWD_INDEX].desc.dims.nbDims == 2);
@@ -144,6 +184,17 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   PLUGIN_ASSERT(
     in[INOUT_PAIR_FWD_INDEX].desc.type == in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.type);
 
+  if (num_inputs == kNumPluginInputsBias) {
+    PLUGIN_ASSERT(in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.nbDims == 1);
+    PLUGIN_ASSERT(
+      in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.d[0] == in[INOUT_FILTERS_INDEX].desc.dims.d[0]);
+    DataType const bias_t = in[INOUT_OPTIONAL_BIAS_INDEX].desc.type;
+    PLUGIN_ASSERT(bias_t == in[INOUT_IN_FEATURES_INDEX].desc.type);
+  }
+  PLUGIN_ASSERT(
+    params_.act_type >= static_cast<std::int32_t>(tv::gemm::Activation::kNone) &&
+    params_.act_type <= static_cast<std::int32_t>(tv::gemm::Activation::kLeakyReLU));
+
   return 0;
 }
 
@@ -152,15 +203,19 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
   std::int32_t num_outputs) noexcept
 {
   PLUGIN_ASSERT(in_out != nullptr);
-  PLUGIN_ASSERT(num_inputs == 5);
+  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
   PLUGIN_ASSERT(num_outputs == 1);
-  PLUGIN_ASSERT(pos >= 0 && pos < num_inputs + num_outputs);
+  // in_out is the combined [inputs..., outputs...] tensor array; n_slots = num_inputs +
+  // num_outputs.
+  std::int32_t const n_slots = num_inputs + num_outputs;
+  PLUGIN_ASSERT(pos >= 0 && pos < n_slots);
 
   // spconv only supports contiguous (LINEAR) layout for all tensors.
   bool supported = in_out[pos].desc.format == nvinfer1::TensorFormat::kLINEAR;
 
   // Output features must match the input features dtype.
-  if (pos == INOUT_OUT_FEATURES_INDEX) {
+  std::int32_t const out_pos = num_inputs;
+  if (pos == out_pos) {
     supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
     return supported;
   }
@@ -182,6 +237,14 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
     case INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX:
       supported &= in_out[pos].desc.type == nvinfer1::DataType::kINT32;
       break;
+    // Optional fused bias must match input features dtype; rejected when there are only 5 inputs.
+    case INOUT_OPTIONAL_BIAS_INDEX:
+      if (num_inputs == kNumPluginInputsBias) {
+        supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
+      } else {
+        supported = false;
+      }
+      break;
     default:
       supported = false;
       break;
@@ -196,7 +259,7 @@ std::int32_t ImplicitGemmPlugin::getOutputDataTypes(
 {
   PLUGIN_ASSERT(output_types != nullptr);
   PLUGIN_ASSERT(input_types != nullptr);
-  PLUGIN_ASSERT(num_inputs == 5);
+  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
   PLUGIN_ASSERT(num_outputs == 1);
 
   output_types[0] = input_types[INOUT_IN_FEATURES_INDEX];
@@ -212,7 +275,7 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
 {
   PLUGIN_ASSERT(inputs != nullptr);
   PLUGIN_ASSERT(outputs != nullptr);
-  PLUGIN_ASSERT(num_inputs == 5);
+  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
   PLUGIN_ASSERT(num_outputs == 1);
   PLUGIN_ASSERT(inputs[0].nbDims == 2);
 
@@ -224,12 +287,15 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
 }
 
 std::int32_t ImplicitGemmPlugin::enqueue(
-  PluginTensorDesc const * input_desc, PluginTensorDesc const * output_desc,
+  PluginTensorDesc const * input_desc, [[maybe_unused]] PluginTensorDesc const * output_desc,
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
   using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
   using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
+
+  PLUGIN_ASSERT(
+    num_plugin_inputs_ == kNumPluginInputsNoBias || num_plugin_inputs_ == kNumPluginInputsBias);
 
   std::int64_t num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
   std::int64_t num_in_features = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];
@@ -280,6 +346,17 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   tv::Tensor out_features = tv::from_blob(outputs[0], {num_act_out, num_out_features}, dtype, 0);
 
+  // Wrap the optional per-channel bias (BN-folded, 6th ONNX input) into a tv::Tensor.
+  // When present, spconv fuses it inside the GEMM kernel instead of a separate bias_add kernel.
+  // bias_tv stays empty (default-constructed) when there are only 5 inputs (no bias).
+  tv::Tensor bias_tv{};
+  if (num_plugin_inputs_ == kNumPluginInputsBias) {
+    auto const bias_type = input_desc[INOUT_OPTIONAL_BIAS_INDEX].type;
+    std::int64_t const c_bias = input_desc[INOUT_OPTIONAL_BIAS_INDEX].dims.d[0];
+    build_bias_tensor_matching_activation(
+      input_features, inputs[INOUT_OPTIONAL_BIAS_INDEX], c_bias, dtype, bias_type, &bias_tv);
+  }
+
   std::vector<tv::Tensor> pair_mask_splits;
   std::vector<tv::Tensor> mask_argsort_splits;
 
@@ -304,9 +381,11 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 }
 
 std::int32_t ImplicitGemmPlugin::onShapeChange(
-  [[maybe_unused]] PluginTensorDesc const * in, [[maybe_unused]] std::int32_t num_inputs,
+  [[maybe_unused]] PluginTensorDesc const * in, std::int32_t num_inputs,
   [[maybe_unused]] PluginTensorDesc const * out, [[maybe_unused]] std::int32_t num_outputs) noexcept
 {
+  PLUGIN_ASSERT(num_inputs == kNumPluginInputsNoBias || num_inputs == kNumPluginInputsBias);
+  num_plugin_inputs_ = num_inputs;
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -41,6 +41,7 @@ ImplicitGemmPluginCreator::ImplicitGemmPluginCreator()
   plugin_attributes_.emplace_back("is_train", nullptr, PluginFieldType::kINT32, 1);
   plugin_attributes_.emplace_back("output_add_scale", nullptr, PluginFieldType::kFLOAT32, 1);
   plugin_attributes_.emplace_back("output_scale", nullptr, PluginFieldType::kFLOAT32, 1);
+  plugin_attributes_.emplace_back("act_type", nullptr, PluginFieldType::kINT32, 1);
 
   fc_.nbFields = plugin_attributes_.size();
   fc_.fields = plugin_attributes_.data();
@@ -58,7 +59,8 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
   auto parse_fields = [](
                         nvinfer1::PluginField const * fields, std::int32_t num_fields,
                         ImplicitGemmParameters & parameters) {
-    PLUGIN_VALIDATE(num_fields == 6);
+    // Accept 6 (legacy without act_type) or 7 (with act_type).
+    PLUGIN_VALIDATE(num_fields == 6 || num_fields == 7);
     for (std::int32_t i{0}; i < num_fields; ++i) {
       const std::string attr_name = fields[i].name;
       const nvinfer1::PluginFieldType type = fields[i].type;
@@ -81,6 +83,10 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
       } else if (attr_name == "output_scale") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
         parameters.output_scale = static_cast<float const *>(fields[i].data)[0];
+      } else if (attr_name == "act_type") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+        parameters.act_type = static_cast<std::int32_t const *>(fields[i].data)[0];
+        PLUGIN_VALIDATE(parameters.act_type >= 0 && parameters.act_type <= 3);
       }
     }
   };
@@ -101,7 +107,7 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
          << " act_alpha=" << parameters.act_alpha << " act_beta=" << parameters.act_beta
          << " is_subm=" << parameters.is_subm << " is_train=" << parameters.is_train
          << " output_add_scale=" << parameters.output_add_scale
-         << " output_scale=" << parameters.output_scale;
+         << " output_scale=" << parameters.output_scale << " act_type=" << parameters.act_type;
       logDebug(ss.str().c_str());
 
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), parameters}};


### PR DESCRIPTION
## Description

This PR extends `ImplicitGemmPlugin` to support fused bias and activation in the spconv implicit GEMM path, while also fixing the plugin lifecycle handling between TensorRT build-time and runtime phases.

The main motivation is to reduce extra TensorRT kernels generated after sparse convolution, especially for BN-folded bias/add and activation patterns. When the ONNX graph provides an optional per-channel bias as the 6th input, the plugin now forwards it directly to spconv’s `implicit_gemm()` implementation, allowing the bias and activation to be fused inside the GEMM kernel instead of being executed as separate operations.


## Notes for reviewers
* https://github.com/autowarefoundation/autoware_universe/pull/12631
* https://github.com/autowarefoundation/autoware_universe/pull/12734
## Changes

### Fused Bias Support

- Added support for an optional 6th plugin input representing a per-channel bias tensor.
  - **5 inputs**: standard implicit GEMM path without bias.
  - **6 inputs**: implicit GEMM path with fused bias.
- Added validation for:
  - bias tensor shape
  - bias channel count
  - bias dtype consistency with activation dtype

### Fused Activation Support

- Added `act_type` to `ImplicitGemmParameters`.

| Value | Activation |
|---------|------------|
| 0 | None |
| 1 | ReLU |
| 2 | Sigmoid |
| 3 | LeakyReLU |

- Added activation conversion helper from serialized integer values to `tv::gemm::Activation`.
- Forward activation parameters (`act_alpha`, `act_beta`, `act_type`) into `ConvGemmOps::implicit_gemm()`.

### Bias Tensor Integration

- Added helper logic to construct a `tv::Tensor` from the optional bias input.
- Ensures the bias tensor uses the same dtype as the activation tensor (`FP16` or `FP32`).
- Avoids unnecessary dtype conversion during inference.

### TensorRT Plugin Lifecycle Fix

- Separated `createPlugin()` handling for:
  - `TensorRTPhase::kBUILD`
  - `TensorRTPhase::kRUNTIME`
- `kBUILD`
  - Parses expanded plugin attributes from ONNX.
- `kRUNTIME`
  - Restores plugin parameters from the serialized plugin state.
- Prevents runtime deserialization from incorrectly expecting ONNX-style plugin fields.

### Serialization Improvements

- Replaced individual field serialization with a packed `ImplicitGemmParameters` blob.
- Added default initialization for all plugin parameters.
- Added serialization support for the new `act_type` field.

### Validation and Debugging Improvements

- Added:
  - `PLUGIN_ASSERT_MSG`
  - `PLUGIN_VALIDATE_MSG`
- Improved error reporting with detailed validation and assertion messages.
- Added a clearer deserialization error message when an incompatible or outdated TensorRT engine is loaded.

## Notes
- ONNX graphs containing BN-folded bias tensors can now leverage fused bias execution inside the sparse convolution GEMM kernel.
- The plugin now correctly follows TensorRT's expected build-time and runtime plugin lifecycle behavior.

## Related links
https://github.com/autowarefoundation/autoware_universe/pull/12631

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
https://drive.google.com/file/d/13-hAjYzrJuKgqYuocvVKMPj9SLCr45CH/view?usp=drive_link


### Validation: BEVFusion ONNX and TensorRT Engine Comparison
The following comparison verifies that the fused implementation produces identical outputs to the original implementation for both ONNX and TensorRT engines.

| Before Fusion | After Fusion |
|---------------|--------------|
| <img width="100%" alt="Before Fusion" src="https://github.com/user-attachments/assets/065020d9-693e-4594-8e46-e92228c47897" /> | <img width="100%" alt="After Fusion" src="https://github.com/user-attachments/assets/0db018be-5f8d-45f1-b7fb-cd9c6a8b6b18" /> |

### Latency Comparison

| Setting | Preprocess (ms) | Inference (ms) | Postprocess (ms) | Total (ms) | FPS |
|----------|----------:|----------:|----------:|----------:|----------:|
| bevfusion_2_7 | 4.71 | 23.70 | 1.89 | 31.57 | 31.67 |
| bevfusion_2_7_opt | 4.94 | 20.04 (**-15.4%**) | 1.63 | 27.80 | 40.23 |



---

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
