### PR TITLE
feat(low_intensity_cluster_filter): apply `agnocast_wrapper::Node`

### DIFF
--- a/perception/autoware_raindrop_cluster_filter/CMakeLists.txt
+++ b/perception/autoware_raindrop_cluster_filter/CMakeLists.txt
@@ -28,7 +28,7 @@ autoware_agnocast_wrapper_setup(low_intensity_cluster_filter)
 autoware_agnocast_wrapper_register_node(low_intensity_cluster_filter
   PLUGIN "autoware::low_intensity_cluster_filter::LowIntensityClusterFilter"
   EXECUTABLE low_intensity_cluster_filter_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 

--- a/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.cpp
+++ b/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.cpp
@@ -28,7 +28,7 @@
 namespace autoware::low_intensity_cluster_filter
 {
 LowIntensityClusterFilter::LowIntensityClusterFilter(const rclcpp::NodeOptions & node_options)
-: Node("low_intensity_cluster_filter_node", node_options),
+: autoware::agnocast_wrapper::Node("low_intensity_cluster_filter_node", node_options),
   tf_buffer_(this->get_clock()),
   tf_listener_(tf_buffer_)
 {
@@ -50,20 +50,18 @@ LowIntensityClusterFilter::LowIntensityClusterFilter(const rclcpp::NodeOptions &
 
   using std::placeholders::_1;
   // Set publisher/subscriber
-  // cppcheck-suppress unknownMacro
-  object_sub_ = AUTOWARE_CREATE_SUBSCRIPTION(
-    tier4_perception_msgs::msg::DetectedObjectsWithFeature, "input/objects", rclcpp::QoS{1},
-    std::bind(&LowIntensityClusterFilter::objectCallback, this, _1),
-    AUTOWARE_SUBSCRIPTION_OPTIONS{});
-  object_pub_ = AUTOWARE_CREATE_PUBLISHER2(
-    tier4_perception_msgs::msg::DetectedObjectsWithFeature, "output/objects", rclcpp::QoS{1});
+  object_sub_ = create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
+    "input/objects", rclcpp::QoS{1},
+    std::bind(&LowIntensityClusterFilter::objectCallback, this, _1));
+  object_pub_ = create_publisher<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
+    "output/objects", rclcpp::QoS{1});
   // initialize debug tool
   {
-    using autoware_utils::DebugPublisher;
     using autoware_utils::StopWatch;
     stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
     debug_publisher_ptr_ =
-      std::make_unique<DebugPublisher>(this, "low_intensity_cluster_filter_node");
+      std::make_unique<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+        this, "low_intensity_cluster_filter_node");
     stop_watch_ptr_->tic("cyclic_time");
     stop_watch_ptr_->tic("processing_time");
   }

--- a/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp
+++ b/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp
@@ -21,6 +21,8 @@
 
 #include <Eigen/Eigen>
 #include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "tier4_perception_msgs/msg/detected_objects_with_feature.hpp"
@@ -34,7 +36,7 @@
 namespace autoware::low_intensity_cluster_filter
 {
 
-class LowIntensityClusterFilter : public rclcpp::Node
+class LowIntensityClusterFilter : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit LowIntensityClusterFilter(const rclcpp::NodeOptions & node_options);
@@ -48,8 +50,8 @@ private:
   AUTOWARE_PUBLISHER_PTR(tier4_perception_msgs::msg::DetectedObjectsWithFeature) object_pub_;
   AUTOWARE_SUBSCRIPTION_PTR(tier4_perception_msgs::msg::DetectedObjectsWithFeature) object_sub_;
 
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  autoware::agnocast_wrapper::TransformListener tf_listener_;
   double intensity_threshold_;
   double existence_probability_threshold_;
   double max_x_;
@@ -64,7 +66,8 @@ private:
 
   // debugger
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{nullptr};
-  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_ptr_{nullptr};
+  std::unique_ptr<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    debug_publisher_ptr_{nullptr};
 };
 
 }  // namespace autoware::low_intensity_cluster_filter


### PR DESCRIPTION
## Description
Apply `autoware_agnocast_wrapper` to `autoware_low_intensity_cluster_filter` so the node.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR.

### Changes
  - Migrate `DetectedObjectFeatureRemover` to inherit `autoware::agnocast_wrapper::Node` and register it with `AgnocastOnlyCallbackIsolatedExecutor`.
  - Route the publisher/subscriber and `PublishedTimePublisher` through the wrapper node; output is published zero-copy via `ALLOCATE_OUTPUT_MESSAGE_UNIQUE`.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers

- I will later suppress cppcheck warning in `.github/workflows/cppcheck-differntial.yaml` to avoid each node do it every time. Will delete the suppress comment once it is merged.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.