### PR TITLE
feat(detection_by_tracker): apply `agnocast_wrapper::Node`

### DIFF
--- a/perception/autoware_detection_by_tracker/CMakeLists.txt
+++ b/perception/autoware_detection_by_tracker/CMakeLists.txt
@@ -47,7 +47,7 @@ autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::detection_by_tracker::DetectionByTracker"
   EXECUTABLE detection_by_tracker_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 ament_auto_package(INSTALL_TO_SHARE

--- a/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
@@ -18,6 +18,7 @@
 #include "autoware_utils/ros/debug_publisher.hpp"
 #include "autoware_utils/system/stop_watch.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Transform.hpp>
 #include <tf2/convert.hpp>
@@ -41,7 +42,7 @@ namespace autoware::detection_by_tracker
 class Debugger
 {
 public:
-  explicit Debugger(rclcpp::Node * node)
+  explicit Debugger(autoware::agnocast_wrapper::Node * node)
   {
     initial_objects_pub_ = node->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
       "debug/initial_objects", 1);
@@ -51,8 +52,9 @@ public:
       "debug/merged_objects", 1);
     divided_objects_pub_ = node->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
       "debug/divided_objects", 1);
-    processing_time_publisher_ =
-      std::make_unique<autoware_utils::DebugPublisher>(node, "detection_by_tracker");
+    processing_time_publisher_ = std::make_unique<
+      autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+      node, "detection_by_tracker");
     stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
     this->startStopWatch();
   }
@@ -89,13 +91,14 @@ public:
   }
 
 private:
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr initial_objects_pub_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr tracked_objects_pub_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr merged_objects_pub_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr divided_objects_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) initial_objects_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) tracked_objects_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) merged_objects_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) divided_objects_pub_;
   // debug publisher
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
-  std::unique_ptr<autoware_utils::DebugPublisher> processing_time_publisher_;
+  std::unique_ptr<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    processing_time_publisher_;
 
   static autoware_perception_msgs::msg::DetectedObjects removeFeature(
     const tier4_perception_msgs::msg::DetectedObjectsWithFeature & input)

--- a/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
@@ -55,18 +55,22 @@ public:
   }
 
   ~Debugger() {}
+  // cppcheck-suppress functionStatic
   void publishInitialObjects(const tier4_perception_msgs::msg::DetectedObjectsWithFeature & input)
   {
     initial_objects_pub_->publish(removeFeature(input));
   }
+  // cppcheck-suppress functionStatic
   void publishTrackedObjects(const autoware_perception_msgs::msg::DetectedObjects & input)
   {
     tracked_objects_pub_->publish(input);
   }
+  // cppcheck-suppress functionStatic
   void publishMergedObjects(const tier4_perception_msgs::msg::DetectedObjectsWithFeature & input)
   {
     merged_objects_pub_->publish(removeFeature(input));
   }
+  // cppcheck-suppress functionStatic
   void publishDividedObjects(const tier4_perception_msgs::msg::DetectedObjectsWithFeature & input)
   {
     divided_objects_pub_->publish(removeFeature(input));

--- a/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
@@ -29,9 +29,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <chrono>
-#include <deque>
 #include <memory>
-#include <vector>
 namespace autoware::detection_by_tracker
 {
 class Debugger

--- a/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
@@ -18,22 +18,17 @@
 #include "autoware_utils/ros/debug_publisher.hpp"
 #include "autoware_utils/system/stop_watch.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2/LinearMath/Transform.hpp>
-#include <tf2/convert.hpp>
-#include <tf2/transform_datatypes.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
 #include "tier4_perception_msgs/msg/detected_objects_with_feature.hpp"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
-
+#include <chrono>
 #include <deque>
 #include <memory>
 #include <vector>

--- a/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
@@ -52,9 +52,9 @@ public:
       "debug/merged_objects", 1);
     divided_objects_pub_ = node->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
       "debug/divided_objects", 1);
-    processing_time_publisher_ = std::make_unique<
-      autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
-      node, "detection_by_tracker");
+    processing_time_publisher_ =
+      std::make_unique<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+        node, "detection_by_tracker");
     stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
     this->startStopWatch();
   }

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
@@ -87,18 +87,19 @@ namespace autoware::detection_by_tracker
 {
 
 DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
-: rclcpp::Node("detection_by_tracker", node_options),
+: autoware::agnocast_wrapper::Node("detection_by_tracker", node_options),
   tf_buffer_(this->get_clock()),
   tf_listener_(tf_buffer_)
 {
   // Create publishers and subscribers
   trackers_sub_ = create_subscription<autoware_perception_msgs::msg::TrackedObjects>(
     "~/input/tracked_objects", rclcpp::QoS{1},
-    std::bind(&TrackerHandler::onTrackedObjects, &tracker_handler_, std::placeholders::_1));
+    [this](
+      const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
+      input_msg) { tracker_handler_.onTrackedObjects(input_msg); });
   AUTOWARE_SUBSCRIPTION_OPTIONS options;
-  initial_objects_sub_ = AUTOWARE_CREATE_SUBSCRIPTION(
-    tier4_perception_msgs::msg::DetectedObjectsWithFeature, "~/input/initial_objects",
-    rclcpp::QoS{1},
+  initial_objects_sub_ = create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
+    "~/input/initial_objects", rclcpp::QoS{1},
     [this](
       const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
         tier4_perception_msgs::msg::DetectedObjectsWithFeature) &
@@ -125,7 +126,8 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
     false, 10, 10000, 0.7, 0.3, 0, std::numeric_limits<int>::max(), std::numeric_limits<int>::max(),
     10000);
   debugger_ = std::make_shared<Debugger>(this);
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ = std::make_unique<
+    autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>(this);
 }
 
 void DetectionByTracker::setMaxSearchRange()
@@ -157,8 +159,8 @@ void DetectionByTracker::onObjects(
   input_msg)
 {
   debugger_->startMeasureProcessingTime();
-  autoware_perception_msgs::msg::DetectedObjects detected_objects;
-  detected_objects.header = input_msg->header;
+  auto detected_objects = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(objects_pub_);
+  detected_objects->header = input_msg->header;
 
   // get objects from tracking module
   autoware_perception_msgs::msg::DetectedObjects tracked_objects;
@@ -170,8 +172,9 @@ void DetectionByTracker::onObjects(
       !available_trackers ||
       !autoware::object_recognition_utils::transformObjects(
         objects, input_msg->header.frame_id, tf_buffer_, transformed_objects)) {
-      objects_pub_->publish(detected_objects);
-      published_time_publisher_->publish_if_subscribed(objects_pub_, detected_objects.header.stamp);
+      const auto stamp = detected_objects->header.stamp;
+      objects_pub_->publish(std::move(detected_objects));
+      published_time_publisher_->publish_if_subscribed(objects_pub_, stamp);
       return;
     }
     // to simplify post processes, convert tracked_objects to DetectedObjects message.
@@ -195,14 +198,15 @@ void DetectionByTracker::onObjects(
 
   // merge under/over segmented objects to build output objects
   for (const auto & merged_object : merged_objects.feature_objects) {
-    detected_objects.objects.push_back(merged_object.object);
+    detected_objects->objects.push_back(merged_object.object);
   }
   for (const auto & divided_object : divided_objects.feature_objects) {
-    detected_objects.objects.push_back(divided_object.object);
+    detected_objects->objects.push_back(divided_object.object);
   }
 
-  objects_pub_->publish(detected_objects);
-  published_time_publisher_->publish_if_subscribed(objects_pub_, detected_objects.header.stamp);
+  const auto stamp = detected_objects->header.stamp;
+  objects_pub_->publish(std::move(detected_objects));
+  published_time_publisher_->publish_if_subscribed(objects_pub_, stamp);
   debugger_->publishProcessingTime();
 }
 

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
@@ -98,13 +98,14 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
       const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
       input_msg) { tracker_handler_.onTrackedObjects(input_msg); });
   AUTOWARE_SUBSCRIPTION_OPTIONS options;
-  initial_objects_sub_ = create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
-    "~/input/initial_objects", rclcpp::QoS{1},
-    [this](
-      const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
-        tier4_perception_msgs::msg::DetectedObjectsWithFeature) &
-      input_msg) { onObjects(input_msg); },
-    options);
+  initial_objects_sub_ =
+    create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
+      "~/input/initial_objects", rclcpp::QoS{1},
+      [this](
+        const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
+          tier4_perception_msgs::msg::DetectedObjectsWithFeature) &
+        input_msg) { onObjects(input_msg); },
+      options);
   objects_pub_ =
     create_publisher<autoware_perception_msgs::msg::DetectedObjects>("~/output", rclcpp::QoS{1});
 
@@ -126,8 +127,9 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
     false, 10, 10000, 0.7, 0.3, 0, std::numeric_limits<int>::max(), std::numeric_limits<int>::max(),
     10000);
   debugger_ = std::make_shared<Debugger>(this);
-  published_time_publisher_ = std::make_unique<
-    autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>(this);
+  published_time_publisher_ =
+    std::make_unique<autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>(
+      this);
 }
 
 void DetectionByTracker::setMaxSearchRange()

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
@@ -95,10 +95,9 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
   // Create publishers and subscribers
   trackers_sub_ = create_subscription<autoware_perception_msgs::msg::TrackedObjects>(
     "~/input/tracked_objects", rclcpp::QoS{1},
-    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
-      autoware_perception_msgs::msg::TrackedObjects) & msg) {
-      tracker_handler_.onTrackedObjects(*msg);
-    });
+    [this](
+      const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
+      msg) { tracker_handler_.onTrackedObjects(*msg); });
   initial_objects_sub_ =
     create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
       "~/input/initial_objects", rclcpp::QoS{1},

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 using Label = autoware_perception_msgs::msg::ObjectClassification;
@@ -94,17 +95,17 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
   // Create publishers and subscribers
   trackers_sub_ = create_subscription<autoware_perception_msgs::msg::TrackedObjects>(
     "~/input/tracked_objects", rclcpp::QoS{1},
-    [this](
-      const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
-      input_msg) { tracker_handler_.onTrackedObjects(input_msg); });
-  AUTOWARE_SUBSCRIPTION_OPTIONS options;
-  initial_objects_sub_ = create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
-    "~/input/initial_objects", rclcpp::QoS{1},
-    [this](
-      const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
-        tier4_perception_msgs::msg::DetectedObjectsWithFeature) &
-      input_msg) { onObjects(input_msg); },
-    options);
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
+      autoware_perception_msgs::msg::TrackedObjects) & msg) {
+      tracker_handler_.onTrackedObjects(*msg);
+    });
+  initial_objects_sub_ =
+    create_subscription<tier4_perception_msgs::msg::DetectedObjectsWithFeature>(
+      "~/input/initial_objects", rclcpp::QoS{1},
+      [this](
+        const AUTOWARE_MESSAGE_CONST_SHARED_PTR(
+          tier4_perception_msgs::msg::DetectedObjectsWithFeature) &
+        input_msg) { onObjects(input_msg); });
   objects_pub_ =
     create_publisher<autoware_perception_msgs::msg::DetectedObjects>("~/output", rclcpp::QoS{1});
 

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.hpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.hpp
@@ -24,7 +24,9 @@
 #include "tracker/tracker_handler.hpp"
 #include "utils/utils.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Transform.hpp>
 #include <tf2/convert.hpp>
@@ -36,9 +38,6 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <deque>
 #include <map>
@@ -59,8 +58,8 @@ private:
   AUTOWARE_SUBSCRIPTION_PTR(tier4_perception_msgs::msg::DetectedObjectsWithFeature)
   initial_objects_sub_;
 
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  autoware::agnocast_wrapper::TransformListener tf_listener_;
 
   TrackerHandler tracker_handler_;
   std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator_;
@@ -71,7 +70,8 @@ private:
 
   detection_by_tracker::utils::TrackerIgnoreLabel tracker_ignore_;
 
-  std::unique_ptr<autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
+  std::unique_ptr<
+    autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
     published_time_publisher_;
 
   void setMaxSearchRange();

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.hpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.hpp
@@ -70,8 +70,7 @@ private:
 
   detection_by_tracker::utils::TrackerIgnoreLabel tracker_ignore_;
 
-  std::unique_ptr<
-    autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
+  std::unique_ptr<autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
     published_time_publisher_;
 
   void setMaxSearchRange();

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.hpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.hpp
@@ -24,7 +24,7 @@
 #include "tracker/tracker_handler.hpp"
 #include "utils/utils.hpp"
 
-#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Transform.hpp>
 #include <tf2/convert.hpp>
@@ -48,14 +48,14 @@
 namespace autoware::detection_by_tracker
 {
 
-class DetectionByTracker : public rclcpp::Node
+class DetectionByTracker : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit DetectionByTracker(const rclcpp::NodeOptions & node_options);
 
 private:
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr trackers_sub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) objects_pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_perception_msgs::msg::TrackedObjects) trackers_sub_;
   AUTOWARE_SUBSCRIPTION_PTR(tier4_perception_msgs::msg::DetectedObjectsWithFeature)
   initial_objects_sub_;
 
@@ -71,7 +71,8 @@ private:
 
   detection_by_tracker::utils::TrackerIgnoreLabel tracker_ignore_;
 
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
+    published_time_publisher_;
 
   void setMaxSearchRange();
 

--- a/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.cpp
+++ b/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.cpp
@@ -23,13 +23,12 @@ namespace autoware::detection_by_tracker
 {
 
 void TrackerHandler::onTrackedObjects(
-  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
-    input_objects_msg)
+  const autoware_perception_msgs::msg::TrackedObjects & input_objects)
 {
   constexpr size_t max_buffer_size = 10;
 
   // Add tracked objects to buffer
-  objects_buffer_.push_front(*input_objects_msg);
+  objects_buffer_.push_front(input_objects);
 
   // Remove old data
   while (max_buffer_size < objects_buffer_.size()) {

--- a/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.cpp
+++ b/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.cpp
@@ -23,7 +23,8 @@ namespace autoware::detection_by_tracker
 {
 
 void TrackerHandler::onTrackedObjects(
-  const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr input_objects_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
+    input_objects_msg)
 {
   constexpr size_t max_buffer_size = 10;
 

--- a/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.cpp
+++ b/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.cpp
@@ -24,7 +24,7 @@ namespace autoware::detection_by_tracker
 
 void TrackerHandler::onTrackedObjects(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
-    input_objects_msg)
+  input_objects_msg)
 {
   constexpr size_t max_buffer_size = 10;
 

--- a/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.hpp
+++ b/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.hpp
@@ -15,7 +15,6 @@
 #ifndef TRACKER__TRACKER_HANDLER_HPP_
 #define TRACKER__TRACKER_HANDLER_HPP_
 
-#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
@@ -32,9 +31,7 @@ private:
 
 public:
   TrackerHandler() = default;
-  void onTrackedObjects(
-    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
-      input_objects_msg);
+  void onTrackedObjects(const autoware_perception_msgs::msg::TrackedObjects & input_objects);
   bool estimateTrackedObjects(
     const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObjects & output);
 };

--- a/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.hpp
+++ b/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.hpp
@@ -15,6 +15,7 @@
 #ifndef TRACKER__TRACKER_HANDLER_HPP_
 #define TRACKER__TRACKER_HANDLER_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
@@ -32,7 +33,8 @@ private:
 public:
   TrackerHandler() = default;
   void onTrackedObjects(
-    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr input_objects_msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
+      input_objects_msg);
   bool estimateTrackedObjects(
     const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObjects & output);
 };

--- a/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.hpp
+++ b/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.hpp
@@ -34,7 +34,7 @@ public:
   TrackerHandler() = default;
   void onTrackedObjects(
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
-      input_objects_msg);
+    input_objects_msg);
   bool estimateTrackedObjects(
     const rclcpp::Time & time, autoware_perception_msgs::msg::TrackedObjects & output);
 };


### PR DESCRIPTION
## Description
Apply `autoware_agnocast_wrapper` to `autoware_detection_by_tracker` so the node.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR.

### Changes
  - Migrate `DetectionByTracker` to inherit `autoware::agnocast_wrapper::Node` and register it with `AgnocastOnlyCallbackIsolatedExecutor`.
  - Route publishers/subscribers, `PublishedTimePublisher` and `DebugPublisher` through the wrapper node; output is published zero-copy via `ALLOCATE_OUTPUT_MESSAGE_UNIQUE`.
  - Replace `tf2_ros::Buffer` / `TransformListener` with `agnocast_wrapper::Buffer` / `TransformListener`, since an AgnocastOnly executor does not spin a ROS 2 `TransformListener`.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Confirmed a non-converted consumer of `transformObjects` (`autoware_object_merger`) still builds after the util change in https://github.com/autowarefoundation/autoware_core/pull/1120.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers

- This PR will be merged after https://github.com/autowarefoundation/autoware_core/pull/1120 is merged.
- I will later suppress cppcheck warning in `.github/workflows/cppcheck-differntial.yaml` to avoid each node do it every time. Will delete the suppress comment once it is merged.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.