### PR TITLE
feat(obstacle_pointcloud_based_validator): apply agnocast publisher to `obstacle_pointcloud_based_validator_node`

### DIFF
--- a/perception/autoware_detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
+++ b/perception/autoware_detected_object_validation/launch/obstacle_pointcloud_based_validator.launch.xml
@@ -5,10 +5,13 @@
   <arg name="output/objects" default="/perception/object_recognition/detection/validation/obstacle_pointcloud_based/objects"/>
   <arg name="obstacle_pointcloud_based_validator_param_path" default="$(find-pkg-share autoware_detected_object_validation)/config/obstacle_pointcloud_based_validator.param.yaml"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_detected_object_validation" exec="obstacle_pointcloud_based_validator_node" name="obstacle_pointcloud_based_validator_node" output="screen">
     <remap from="~/input/detected_objects" to="$(var input/detected_objects)"/>
     <remap from="~/input/obstacle_pointcloud" to="$(var input/obstacle_pointcloud)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param from="$(var obstacle_pointcloud_based_validator_param_path)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
   </node>
 </launch>

--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
@@ -305,8 +305,8 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
     validator_ = std::make_unique<Validator3D>(points_num_threshold_param_);
   }
 
-  objects_pub_ = create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
-    "~/output/objects", rclcpp::QoS{1});
+  objects_pub_ = AUTOWARE_CREATE_PUBLISHER2(
+    autoware_perception_msgs::msg::DetectedObjects, "~/output/objects", rclcpp::QoS{1});
   debug_publisher_ =
     std::make_unique<autoware_utils::DebugPublisher>(this, "obstacle_pointcloud_based_validator");
 
@@ -319,8 +319,9 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_obstacle_pointcloud)
 {
   autoware_utils::StopWatch<std::chrono::milliseconds> stopwatch;
-  autoware_perception_msgs::msg::DetectedObjects output, removed_objects;
-  output.header = input_objects->header;
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(objects_pub_);
+  autoware_perception_msgs::msg::DetectedObjects removed_objects;
+  output->header = input_objects->header;
   removed_objects.header = input_objects->header;
 
   // Transform to pointcloud frame
@@ -350,7 +351,7 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
         transformed_object.kinematics.pose_with_covariance.pose.position.y;
     if (distance_sq > validate_max_distance_sq_) {
       // pass to output
-      output.objects.push_back(object);
+      output->objects.push_back(object);
       continue;
     }
 
@@ -361,14 +362,15 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
       debugger_->addPointcloudWithinPolygon(validator_->getDebugPointCloudWithinObject());
     }
     if (validated) {
-      output.objects.push_back(object);
+      output->objects.push_back(object);
     } else {
       removed_objects.objects.push_back(object);
     }
   }
 
-  objects_pub_->publish(output);
-  published_time_publisher_->publish_if_subscribed(objects_pub_, output.header.stamp);
+  const auto output_stamp = output->header.stamp;
+  objects_pub_->publish(std::move(output));
+  published_time_publisher_->publish_if_subscribed(objects_pub_, output_stamp);
   if (debugger_) {
     debugger_->publishRemovedObjects(removed_objects);
     debugger_->publishNeighborPointcloud(input_obstacle_pointcloud->header);
@@ -378,7 +380,7 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
   // Publish processing time info
   const double pipeline_latency =
     std::chrono::duration<double, std::milli>(
-      std::chrono::nanoseconds((this->get_clock()->now() - output.header.stamp).nanoseconds()))
+      std::chrono::nanoseconds((this->get_clock()->now() - output_stamp).nanoseconds()))
       .count();
   debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/pipeline_latency_ms", pipeline_latency);

--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
@@ -27,6 +27,7 @@
 
 #include <cmath>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace autoware::detected_object_validation

--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
@@ -22,6 +22,7 @@
 #include "autoware_utils/system/stop_watch.hpp"
 #include "debugger.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
@@ -140,7 +141,7 @@ public:
   explicit ObstaclePointCloudBasedValidator(const rclcpp::NodeOptions & node_options);
 
 private:
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) objects_pub_;
   message_filters::Subscriber<autoware_perception_msgs::msg::DetectedObjects> objects_sub_;
   message_filters::Subscriber<sensor_msgs::msg::PointCloud2> obstacle_pointcloud_sub_;
   std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_{nullptr};


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper` to the publisher of `obstacle_pointcloud_based_validator_node` to enable zero-copy publishing via Agnocast.

### Changes
  - **`obstacle_pointcloud_validator.hpp`**: Include `autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp`, and change the output publisher type from `rclcpp::Publisher<...>::SharedPtr` to `AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects)`.
  - **`obstacle_pointcloud_validator.cpp`**: Create the publisher with `AUTOWARE_CREATE_PUBLISHER2`, allocate the output message via `ALLOCATE_OUTPUT_MESSAGE_UNIQUE` and publish it with `std::move` (caching the stamp beforehand since the message is moved out).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- colcon build succeeds with both ENABLE_AGNOCAST=1 and ENABLE_AGNOCAST=0.
- Ran an Autoware-based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.