### PR TITLE
fix(mpc_lateral_controller): throttle log output in setTrajectory

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -389,12 +389,12 @@ void MpcLateralController::setTrajectory(
   m_current_trajectory = msg;
 
   if (msg.points.size() < 3) {
-    RCLCPP_DEBUG(logger_, "received path size is < 3, not enough.");
+    RCLCPP_DEBUG_THROTTLE(logger_, *clock_, 5000, "received path size is < 3, not enough.");
     return;
   }
 
   if (!isValidTrajectory(msg)) {
-    RCLCPP_ERROR(logger_, "Trajectory is invalid!! stop computing.");
+    RCLCPP_ERROR_THROTTLE(logger_, *clock_, 5000, "Trajectory is invalid!! stop computing.");
     return;
   }
 


### PR DESCRIPTION
## Summary
- Replace `RCLCPP_DEBUG` and `RCLCPP_ERROR` with `_THROTTLE` variants (5000ms interval) in `setTrajectory` to prevent log flooding when the trajectory is too short or invalid.
- File changed: `control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp`

## Test plan
- [ ] Not run — see CI

## Notes for reviewers
None.