### PR TITLE
feat(autoware_commnad_mode_switcher_plugins): add in lane stop plugins

### DIFF
--- a/system/autoware_command_mode_switcher_plugins/CMakeLists.txt
+++ b/system/autoware_command_mode_switcher_plugins/CMakeLists.txt
@@ -13,6 +13,10 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   "src/emergency_stop.cpp"
   "src/comfortable_stop.cpp"
   "src/pull_over.cpp"
+  "src/main_ecu_in_lane_emergency_stop.cpp"
+  "src/main_ecu_in_lane_moderate_stop.cpp"
+  "src/sub_ecu_in_lane_moderate_stop.cpp"
+  "src/sub_ecu_standby.cpp"
 )
 
 if(BUILD_TESTING)

--- a/system/autoware_command_mode_switcher_plugins/README.md
+++ b/system/autoware_command_mode_switcher_plugins/README.md
@@ -1,0 +1,180 @@
+# autoware_command_mode_switcher_plugins
+
+## Overview
+
+`autoware_command_mode_switcher_plugins` is a package that manages plugins used by `autoware_command_mode_switcher`.
+
+`autoware_command_mode_switcher` is a node that manages switching between multiple control sources during MRM (Minimal Risk Maneuver) execution. Each plugin is implemented by inheriting the `CommandPlugin` interface defined in `autoware_command_mode_switcher/command_plugin.hpp`.
+
+Each plugin implements the following methods:
+
+| Method | Description |
+|---|---|
+| `mode()` | Returns the command mode ID that this plugin corresponds to |
+| `source()` | Returns the control source ID that this plugin uses |
+| `autoware_control()` | Returns whether Autoware controls the vehicle |
+| `initialize()` | Initializes publishers, subscribers, and service clients |
+| `update_source_state(bool request)` | Manages source gate open/close based on the switcher selection state (`request`) and executes side effects (deceleration command, relay control) |
+| `update_mrm_state()` | Returns the MRM execution state (`Normal` / `Operating` / `Succeeded`) |
+
+---
+
+## Plugins
+
+### `StopSwitcher`
+
+**Class**: `autoware::command_mode_switcher::StopSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::stop`
+
+### `AutonomousSwitcher`
+
+**Class**: `autoware::command_mode_switcher::AutonomousSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::autonomous`
+
+### `LocalSwitcher`
+
+**Class**: `autoware::command_mode_switcher::LocalSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::local`
+
+### `RemoteSwitcher`
+
+**Class**: `autoware::command_mode_switcher::RemoteSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::remote`
+
+### `EmergencyStopSwitcher`
+
+**Class**: `autoware::command_mode_switcher::EmergencyStopSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::emergency_stop`
+
+### `ComfortableStopSwitcher`
+
+**Class**: `autoware::command_mode_switcher::ComfortableStopSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::comfortable_stop`
+
+### `PullOverSwitcher`
+
+**Class**: `autoware::command_mode_switcher::PullOverSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::pull_over`
+
+---
+
+## x2 Plugins
+
+The following plugins are designed for a redundant Main ECU / Sub ECU configuration used in the x2 product.
+
+### `MainEcuInLaneEmergencyStopSwitcher`
+
+**Class**: `autoware::command_mode_switcher::MainEcuInLaneEmergencyStopSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::main_ecu_in_lane_emergency_stop`  
+**Source**: `autoware::command_mode_types::sources::in_lane_stop`
+
+#### Overview
+
+A switcher plugin that triggers in_lane_emergency_stop on the Main ECU in a redundant Main ECU / Sub ECU configuration. Its purpose is to bring the vehicle to an emergency stop within the current driving lane when the normal autonomous driving function fails.
+
+#### Functionality
+
+This switcher is composed of the following three functions.
+
+**1. State Management (`update_source_state` / `update_mrm_state`)**
+
+Conforming to the `autoware_command_mode_switcher` framework, this function manages source gate open/close and MRM execution state based on the switcher selection state (`request`) and `mrm_state_`.
+
+The state transitions in `update_source_state(bool request)` are as follows:
+
+| request | mrm_state_ | Action | SourceState |
+|---|---|---|---|
+| `true` | `Operating` | No action (already operating) | `{true, false}` |
+| `true` | `Succeeded` | No action (already stopped) | `{true, false}` |
+| `false` | `Normal` | No action (already released) | `{false, true}` |
+| `true` | `Normal` | Trigger ON, relay OFF → transition to `Operating` | `{true, false}` |
+| `false` | `Operating` / `Succeeded` | Trigger OFF, relay ON → transition to `Normal` | `{false, true}` |
+
+`update_mrm_state()` monitors the odometry from `/localization/kinematic_state` while in the `Operating` state, and transitions to `Succeeded` when the vehicle speed falls below 0.001 m/s.
+
+**2. Deceleration Command (`publish_jerk_constant_deceleration_trigger`)**
+
+Publishes a trigger message to the `jerk_constant_deceleration_controller` node specifying the target deceleration and jerk values. An ON trigger is published when the switcher is selected, and an OFF trigger is published to cancel when the switcher is deselected.
+
+- Publisher: `/control/jerk_constant_deceleration_trigger`
+- The deceleration profile is specified via the `target_acceleration` and `target_jerk` parameters.
+- For emergency stop, values corresponding to hard braking are expected to be configured.
+
+**3. Topic Relay Stop Control (`request_topic_relay_control`)**
+
+During normal autonomous driving, in_lane_stop continuously captures `pose_with_covariance` and `trajectory`, and uses the most recent valid data at the time of failure to control the vehicle. However, if unreliable sensor data or path planning continues to flow in after a failure, there is a risk of incorporating untrustworthy data. To prevent this, the `topic_relay_controller` filters these topics while the switcher is active.
+
+- Service client: `/system/topic_relay_controller_trajectory/operate`
+- Service client: `/system/topic_relay_controller_pose_with_covariance/operate`
+- Relay is turned OFF (filtering starts) when the switcher is selected, and turned ON (filtering ends) when deselected.
+- Each relay can be individually enabled or disabled via the `enable_trajectory_relay` and `enable_pose_with_covariance_relay` parameters.
+
+#### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `target_acceleration` | `double` | Target deceleration commanded to jerk_constant_deceleration_controller [m/s²] |
+| `target_jerk` | `double` | Target jerk commanded to jerk_constant_deceleration_controller [m/s³] |
+| `enable_trajectory_relay` | `bool` | Enable/disable trajectory relay control |
+| `enable_pose_with_covariance_relay` | `bool` | Enable/disable pose_with_covariance relay control |
+| `service_timeout_ms` | `int64` | Timeout for service calls [ms] |
+
+---
+
+### `MainEcuInLaneModerateStopSwitcher`
+
+**Class**: `autoware::command_mode_switcher::MainEcuInLaneModerateStopSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::main_ecu_in_lane_moderate_stop`  
+**Source**: `autoware::command_mode_types::sources::in_lane_stop`
+
+#### Overview
+
+A switcher plugin that triggers in_lane_moderate_stop on the Main ECU in a redundant Main ECU / Sub ECU configuration.
+
+The implementation is identical to `MainEcuInLaneEmergencyStopSwitcher`, providing the same three functions: state management, deceleration trigger publishing, and topic relay control. See [`MainEcuInLaneEmergencyStopSwitcher`](#mainecuinlaneemergencystopswitcher) for details.
+
+The only difference from `MainEcuInLaneEmergencyStopSwitcher` is that the `target_acceleration` and `target_jerk` parameters are expected to be configured with a gentler deceleration profile. While the emergency stop plugin handles hard braking to stop the vehicle immediately upon anomaly detection, the moderate stop plugin handles a smoother deceleration that reduces discomfort to occupants.
+
+#### Parameters
+
+Same as `MainEcuInLaneEmergencyStopSwitcher`. See the [parameter table above](#parameters).
+
+---
+
+### `SubEcuInLaneModerateStopSwitcher`
+
+**Class**: `autoware::command_mode_switcher::SubEcuInLaneModerateStopSwitcher`  
+**Mode**: `autoware::command_mode_types::modes::sub_ecu_in_lane_moderate_stop`  
+**Source**: `autoware::command_mode_types::sources::in_lane_stop`
+
+#### Overview
+
+A switcher plugin that triggers in_lane_moderate_stop on the Sub ECU in a redundant Main ECU / Sub ECU configuration.
+
+The implementation and functionality are identical to `MainEcuInLaneModerateStopSwitcher`, providing state management, deceleration trigger publishing, and topic relay control. See [`MainEcuInLaneEmergencyStopSwitcher`](#mainecuinlaneemergencystopswitcher) for details.
+
+The reason this plugin is defined separately from `MainEcuInLaneModerateStopSwitcher` is that its mode ID is defined as `sub_ecu_in_lane_moderate_stop` for the Sub ECU. This allows `autoware_command_mode_switcher` to manage the Main ECU and Sub ECU switchers independently.
+
+#### Parameters
+
+Same as `MainEcuInLaneEmergencyStopSwitcher`. See the [parameter table above](#parameters).
+
+---
+
+### `SubEcuStandbySwitcher`
+
+**Class**: `autoware::command_mode_switcher::SubEcuStandbySwitcher`  
+**Mode**: `autoware::command_mode_types::modes::sub_ecu_standby`  
+**Source**: `autoware::command_mode_types::sources::in_lane_stop`
+
+#### Overview
+
+The switcher plugin selected on the Sub ECU while the Main ECU is in control during normal operation in a redundant Main ECU / Sub ECU configuration.
+
+`initialize()` is an empty implementation with no publishers, subscribers, or service clients. Since `update_source_state` and `update_mrm_state` are not overridden, the base class default implementations are used. In other words, the Sub ECU makes no intervention to the vehicle command while this switcher is selected.
+
+#### Design Intent
+
+In a redundant configuration, the Sub ECU doing nothing has a clear purpose. If the Sub ECU were to independently issue deceleration commands or relay control while the Main ECU is operating normally, it would risk interfering with the Main ECU's control commands. By keeping the Sub ECU in a deliberately inactive state with `SubEcuStandbySwitcher` selected, the same control commands as the Main ECU are passed through to the vehicle without modification.
+
+When the Main ECU fails and the Sub ECU takes over control, a different switcher such as `sub_ecu_in_lane_moderate_stop` is selected, which initiates active MRM control on the Sub ECU side.

--- a/system/autoware_command_mode_switcher_plugins/README.md
+++ b/system/autoware_command_mode_switcher_plugins/README.md
@@ -111,13 +111,13 @@ During normal autonomous driving, in_lane_stop continuously captures `pose_with_
 
 #### Parameters
 
-| Parameter | Type | Description |
-|---|---|---|
-| `target_acceleration` | `double` | Target deceleration commanded to constant_jerk_deceleration_controller [m/s²] |
-| `target_jerk` | `double` | Target jerk commanded to constant_jerk_deceleration_controller [m/s³] |
-| `enable_trajectory_relay` | `bool` | Enable/disable trajectory relay control |
-| `enable_pose_with_covariance_relay` | `bool` | Enable/disable pose_with_covariance relay control |
-| `service_timeout_ms` | `int64` | Timeout for service calls [ms] |
+| Parameter                           | Type     | Description                                                                   |
+| ----------------------------------- | -------- | ----------------------------------------------------------------------------- |
+| `target_acceleration`               | `double` | Target deceleration commanded to constant_jerk_deceleration_controller [m/s²] |
+| `target_jerk`                       | `double` | Target jerk commanded to constant_jerk_deceleration_controller [m/s³]         |
+| `enable_trajectory_relay`           | `bool`   | Enable/disable trajectory relay control                                       |
+| `enable_pose_with_covariance_relay` | `bool`   | Enable/disable pose_with_covariance relay control                             |
+| `service_timeout_ms`                | `int64`  | Timeout for service calls [ms]                                                |
 
 ---
 

--- a/system/autoware_command_mode_switcher_plugins/README.md
+++ b/system/autoware_command_mode_switcher_plugins/README.md
@@ -8,14 +8,14 @@
 
 Each plugin implements the following methods:
 
-| Method | Description |
-|---|---|
-| `mode()` | Returns the command mode ID that this plugin corresponds to |
-| `source()` | Returns the control source ID that this plugin uses |
-| `autoware_control()` | Returns whether Autoware controls the vehicle |
-| `initialize()` | Initializes publishers, subscribers, and service clients |
+| Method                              | Description                                                                                                                                      |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `mode()`                            | Returns the command mode ID that this plugin corresponds to                                                                                      |
+| `source()`                          | Returns the control source ID that this plugin uses                                                                                              |
+| `autoware_control()`                | Returns whether Autoware controls the vehicle                                                                                                    |
+| `initialize()`                      | Initializes publishers, subscribers, and service clients                                                                                         |
 | `update_source_state(bool request)` | Manages source gate open/close based on the switcher selection state (`request`) and executes side effects (deceleration command, relay control) |
-| `update_mrm_state()` | Returns the MRM execution state (`Normal` / `Operating` / `Succeeded`) |
+| `update_mrm_state()`                | Returns the MRM execution state (`Normal` / `Operating` / `Succeeded`)                                                                           |
 
 ---
 
@@ -82,13 +82,13 @@ Conforming to the `autoware_command_mode_switcher` framework, this function mana
 
 The state transitions in `update_source_state(bool request)` are as follows:
 
-| request | mrm_state_ | Action | SourceState |
-|---|---|---|---|
-| `true` | `Operating` | No action (already operating) | `{true, false}` |
-| `true` | `Succeeded` | No action (already stopped) | `{true, false}` |
-| `false` | `Normal` | No action (already released) | `{false, true}` |
-| `true` | `Normal` | Trigger ON, relay OFF → transition to `Operating` | `{true, false}` |
-| `false` | `Operating` / `Succeeded` | Trigger OFF, relay ON → transition to `Normal` | `{false, true}` |
+| request | mrm*state*                | Action                                            | SourceState     |
+| ------- | ------------------------- | ------------------------------------------------- | --------------- |
+| `true`  | `Operating`               | No action (already operating)                     | `{true, false}` |
+| `true`  | `Succeeded`               | No action (already stopped)                       | `{true, false}` |
+| `false` | `Normal`                  | No action (already released)                      | `{false, true}` |
+| `true`  | `Normal`                  | Trigger ON, relay OFF → transition to `Operating` | `{true, false}` |
+| `false` | `Operating` / `Succeeded` | Trigger OFF, relay ON → transition to `Normal`    | `{false, true}` |
 
 `update_mrm_state()` monitors the odometry from `/localization/kinematic_state` while in the `Operating` state, and transitions to `Succeeded` when the vehicle speed falls below 0.001 m/s.
 
@@ -111,13 +111,13 @@ During normal autonomous driving, in_lane_stop continuously captures `pose_with_
 
 #### Parameters
 
-| Parameter | Type | Description |
-|---|---|---|
-| `target_acceleration` | `double` | Target deceleration commanded to jerk_constant_deceleration_controller [m/s²] |
-| `target_jerk` | `double` | Target jerk commanded to jerk_constant_deceleration_controller [m/s³] |
-| `enable_trajectory_relay` | `bool` | Enable/disable trajectory relay control |
-| `enable_pose_with_covariance_relay` | `bool` | Enable/disable pose_with_covariance relay control |
-| `service_timeout_ms` | `int64` | Timeout for service calls [ms] |
+| Parameter                           | Type     | Description                                                                   |
+| ----------------------------------- | -------- | ----------------------------------------------------------------------------- |
+| `target_acceleration`               | `double` | Target deceleration commanded to jerk_constant_deceleration_controller [m/s²] |
+| `target_jerk`                       | `double` | Target jerk commanded to jerk_constant_deceleration_controller [m/s³]         |
+| `enable_trajectory_relay`           | `bool`   | Enable/disable trajectory relay control                                       |
+| `enable_pose_with_covariance_relay` | `bool`   | Enable/disable pose_with_covariance relay control                             |
+| `service_timeout_ms`                | `int64`  | Timeout for service calls [ms]                                                |
 
 ---
 

--- a/system/autoware_command_mode_switcher_plugins/README.md
+++ b/system/autoware_command_mode_switcher_plugins/README.md
@@ -92,11 +92,11 @@ The state transitions in `update_source_state(bool request)` are as follows:
 
 `update_mrm_state()` monitors the odometry from `/localization/kinematic_state` while in the `Operating` state, and transitions to `Succeeded` when the vehicle speed falls below 0.001 m/s.
 
-**2. Deceleration Command (`publish_jerk_constant_deceleration_trigger`)**
+**2. Deceleration Command (`publish_constant_jerk_deceleration_trigger`)**
 
-Publishes a trigger message to the `jerk_constant_deceleration_controller` node specifying the target deceleration and jerk values. An ON trigger is published when the switcher is selected, and an OFF trigger is published to cancel when the switcher is deselected.
+Publishes a trigger message to the `constant_jerk_deceleration_controller` node specifying the target deceleration and jerk values. An ON trigger is published when the switcher is selected, and an OFF trigger is published to cancel when the switcher is deselected.
 
-- Publisher: `/control/jerk_constant_deceleration_trigger`
+- Publisher: `/control/constant_jerk_deceleration_trigger`
 - The deceleration profile is specified via the `target_acceleration` and `target_jerk` parameters.
 - For emergency stop, values corresponding to hard braking are expected to be configured.
 
@@ -111,13 +111,13 @@ During normal autonomous driving, in_lane_stop continuously captures `pose_with_
 
 #### Parameters
 
-| Parameter                           | Type     | Description                                                                   |
-| ----------------------------------- | -------- | ----------------------------------------------------------------------------- |
-| `target_acceleration`               | `double` | Target deceleration commanded to jerk_constant_deceleration_controller [m/s²] |
-| `target_jerk`                       | `double` | Target jerk commanded to jerk_constant_deceleration_controller [m/s³]         |
-| `enable_trajectory_relay`           | `bool`   | Enable/disable trajectory relay control                                       |
-| `enable_pose_with_covariance_relay` | `bool`   | Enable/disable pose_with_covariance relay control                             |
-| `service_timeout_ms`                | `int64`  | Timeout for service calls [ms]                                                |
+| Parameter | Type | Description |
+|---|---|---|
+| `target_acceleration` | `double` | Target deceleration commanded to constant_jerk_deceleration_controller [m/s²] |
+| `target_jerk` | `double` | Target jerk commanded to constant_jerk_deceleration_controller [m/s³] |
+| `enable_trajectory_relay` | `bool` | Enable/disable trajectory relay control |
+| `enable_pose_with_covariance_relay` | `bool` | Enable/disable pose_with_covariance relay control |
+| `service_timeout_ms` | `int64` | Timeout for service calls [ms] |
 
 ---
 

--- a/system/autoware_command_mode_switcher_plugins/package.xml
+++ b/system/autoware_command_mode_switcher_plugins/package.xml
@@ -12,6 +12,8 @@
 
   <depend>autoware_command_mode_switcher</depend>
   <depend>autoware_command_mode_types</depend>
+  <depend>autoware_utils_rclcpp</depend>
+  <depend>tier4_control_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_msgs</depend>

--- a/system/autoware_command_mode_switcher_plugins/package.xml
+++ b/system/autoware_command_mode_switcher_plugins/package.xml
@@ -12,14 +12,14 @@
 
   <depend>autoware_command_mode_switcher</depend>
   <depend>autoware_command_mode_types</depend>
-  <depend>autoware_utils_rclcpp</depend>
-  <depend>tier4_control_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>tier4_control_msgs</depend>
   <depend>tier4_system_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/system/autoware_command_mode_switcher_plugins/plugins.xml
+++ b/system/autoware_command_mode_switcher_plugins/plugins.xml
@@ -6,4 +6,8 @@
   <class base_class_type="autoware::command_mode_switcher::CommandPlugin" type="autoware::command_mode_switcher::EmergencyStopSwitcher"/>
   <class base_class_type="autoware::command_mode_switcher::CommandPlugin" type="autoware::command_mode_switcher::ComfortableStopSwitcher"/>
   <class base_class_type="autoware::command_mode_switcher::CommandPlugin" type="autoware::command_mode_switcher::PullOverSwitcher"/>
+  <class base_class_type="autoware::command_mode_switcher::CommandPlugin" type="autoware::command_mode_switcher::MainEcuInLaneEmergencyStopSwitcher"/>
+  <class base_class_type="autoware::command_mode_switcher::CommandPlugin" type="autoware::command_mode_switcher::MainEcuInLaneModerateStopSwitcher"/>
+  <class base_class_type="autoware::command_mode_switcher::CommandPlugin" type="autoware::command_mode_switcher::SubEcuInLaneModerateStopSwitcher"/>
+  <class base_class_type="autoware::command_mode_switcher::CommandPlugin" type="autoware::command_mode_switcher::SubEcuStandbySwitcher"/>
 </library>

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.cpp
@@ -1,0 +1,151 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "main_ecu_in_lane_emergency_stop.hpp"
+
+namespace autoware::command_mode_switcher
+{
+
+void MainEcuInLaneEmergencyStopSwitcher::initialize()
+{
+  pub_trigger_ = node_->create_publisher<JerkConstantDecelerationTrigger>(
+    "/control/jerk_constant_deceleration_trigger", rclcpp::QoS{1});
+  sub_odom_ =
+    std::make_unique<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
+      node_, "/localization/kinematic_state");
+  client_relay_trajectory_group_ =
+    node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  client_relay_trajectory_ = node_->create_client<tier4_system_msgs::srv::ChangeTopicRelayControl>(
+    "/system/topic_relay_controller_trajectory/operate", rmw_qos_profile_services_default,
+    client_relay_trajectory_group_);
+  client_relay_pose_with_covariance_group_ =
+    node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  client_relay_pose_with_covariance_ =
+    node_->create_client<tier4_system_msgs::srv::ChangeTopicRelayControl>(
+      "/system/topic_relay_controller_pose_with_covariance/operate",
+      rmw_qos_profile_services_default, client_relay_pose_with_covariance_group_);
+
+  params_.target_acceleration =
+    node_->declare_parameter<double>(expand_param("target_acceleration"));
+  params_.target_jerk = node_->declare_parameter<double>(expand_param("target_jerk"));
+  params_.enable_trajectory_relay =
+    node_->declare_parameter<bool>(expand_param("enable_trajectory_relay"));
+  params_.enable_pose_with_covariance_relay =
+    node_->declare_parameter<bool>(expand_param("enable_pose_with_covariance_relay"));
+  params_.service_timeout_ms =
+    node_->declare_parameter<int64_t>(expand_param("service_timeout_ms"));
+  mrm_state_ = MrmState::Normal;
+}
+
+SourceState MainEcuInLaneEmergencyStopSwitcher::update_source_state(bool request)
+{
+  if (request && mrm_state_ == MrmState::Operating) return SourceState{true, false};
+  if (request && mrm_state_ == MrmState::Succeeded) return SourceState{true, false};
+  if (!request && mrm_state_ == MrmState::Normal) return SourceState{false, true};
+
+  if (request) {
+    publish_jerk_constant_deceleration_trigger(request);
+    // TODO(TetsuKawa): When request_topic_relay_control fails (timeout or service error), we
+    // currently still return {true, false} and proceed with in_lane_stop. We need to decide
+    // whether relay failure should block the state transition (i.e., return {false, false} or
+    // retry) and how that interacts with autoware_command_mode_switcher's rollback mechanism,
+    // which cancels the mode transition after transition_timeout_ if is_completed() stays false.
+    if (params_.enable_trajectory_relay)
+      request_topic_relay_control(false, client_relay_trajectory_, "trajectory");
+    if (params_.enable_pose_with_covariance_relay)
+      request_topic_relay_control(false, client_relay_pose_with_covariance_, "pose_with_covariance");
+    mrm_state_ = MrmState::Operating;
+    return SourceState{true, false};
+  } else {
+    publish_jerk_constant_deceleration_trigger(request);
+    if (params_.enable_trajectory_relay)
+      request_topic_relay_control(true, client_relay_trajectory_, "trajectory");
+    if (params_.enable_pose_with_covariance_relay)
+      request_topic_relay_control(true, client_relay_pose_with_covariance_, "pose_with_covariance");
+    mrm_state_ = MrmState::Normal;
+    return SourceState{false, true};
+  }
+}
+
+MrmState MainEcuInLaneEmergencyStopSwitcher::update_mrm_state()
+{
+  if (mrm_state_ != MrmState::Operating) {
+    return mrm_state_;
+  }
+
+  if (is_stopped()) mrm_state_ = MrmState::Succeeded;
+  return mrm_state_;
+}
+
+void MainEcuInLaneEmergencyStopSwitcher::publish_jerk_constant_deceleration_trigger(bool turn_on)
+{
+  auto trigger = JerkConstantDecelerationTrigger();
+  trigger.stamp = node_->now();
+  trigger.trigger = turn_on;
+  trigger.target_acceleration = params_.target_acceleration;
+  trigger.target_jerk = params_.target_jerk;
+
+  pub_trigger_->publish(trigger);
+}
+
+void MainEcuInLaneEmergencyStopSwitcher::request_topic_relay_control(
+  const bool relay_on,
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
+  const std::string & srv_name)
+{
+  if (!client->service_is_ready()) {
+    RCLCPP_WARN(
+      node_->get_logger(), "Service unavailable %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+    return;
+  }
+
+  auto request = std::make_shared<tier4_system_msgs::srv::ChangeTopicRelayControl::Request>();
+  request->relay_on = relay_on;
+
+  auto future = client->async_send_request(request);
+  if (future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
+      std::future_status::ready) {
+    RCLCPP_WARN(
+      node_->get_logger(), "Timeout waiting for %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+    return;
+  }
+
+  const auto & response = future.get();
+  if (response->status.success) {
+    RCLCPP_INFO(
+      node_->get_logger(), "Changed %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+  } else {
+    RCLCPP_WARN(
+      node_->get_logger(), "Failed to change %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+  }
+}
+
+bool MainEcuInLaneEmergencyStopSwitcher::is_stopped()
+{
+  auto odom = sub_odom_->take_data();
+  if (odom == nullptr) return false;
+  constexpr auto th_stopped_velocity = 0.001;
+  return (std::abs(odom->twist.twist.linear.x) < th_stopped_velocity);
+}
+
+}  // namespace autoware::command_mode_switcher
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::command_mode_switcher::MainEcuInLaneEmergencyStopSwitcher,
+  autoware::command_mode_switcher::CommandPlugin)

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.cpp
@@ -64,7 +64,8 @@ SourceState MainEcuInLaneEmergencyStopSwitcher::update_source_state(bool request
     if (params_.enable_trajectory_relay)
       request_topic_relay_control(false, client_relay_trajectory_, "trajectory");
     if (params_.enable_pose_with_covariance_relay)
-      request_topic_relay_control(false, client_relay_pose_with_covariance_, "pose_with_covariance");
+      request_topic_relay_control(
+        false, client_relay_pose_with_covariance_, "pose_with_covariance");
     mrm_state_ = MrmState::Operating;
     return SourceState{true, false};
   } else {
@@ -115,8 +116,9 @@ void MainEcuInLaneEmergencyStopSwitcher::request_topic_relay_control(
   request->relay_on = relay_on;
 
   auto future = client->async_send_request(request);
-  if (future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
-      std::future_status::ready) {
+  if (
+    future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
+    std::future_status::ready) {
     RCLCPP_WARN(
       node_->get_logger(), "Timeout waiting for %s relay control: %s", srv_name.c_str(),
       relay_on ? "ON" : "OFF");

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.cpp
@@ -19,8 +19,8 @@ namespace autoware::command_mode_switcher
 
 void MainEcuInLaneEmergencyStopSwitcher::initialize()
 {
-  pub_trigger_ = node_->create_publisher<JerkConstantDecelerationTrigger>(
-    "/control/jerk_constant_deceleration_trigger", rclcpp::QoS{1});
+  pub_trigger_ = node_->create_publisher<ConstantJerkDecelerationTrigger>(
+    "/control/constant_jerk_deceleration_trigger", rclcpp::QoS{1});
   sub_odom_ =
     std::make_unique<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
       node_, "/localization/kinematic_state");
@@ -55,7 +55,7 @@ SourceState MainEcuInLaneEmergencyStopSwitcher::update_source_state(bool request
   if (!request && mrm_state_ == MrmState::Normal) return SourceState{false, true};
 
   if (request) {
-    publish_jerk_constant_deceleration_trigger(request);
+    publish_constant_jerk_deceleration_trigger(request);
     // TODO(TetsuKawa): When request_topic_relay_control fails (timeout or service error), we
     // currently still return {true, false} and proceed with in_lane_stop. We need to decide
     // whether relay failure should block the state transition (i.e., return {false, false} or
@@ -69,7 +69,7 @@ SourceState MainEcuInLaneEmergencyStopSwitcher::update_source_state(bool request
     mrm_state_ = MrmState::Operating;
     return SourceState{true, false};
   } else {
-    publish_jerk_constant_deceleration_trigger(request);
+    publish_constant_jerk_deceleration_trigger(request);
     if (params_.enable_trajectory_relay)
       request_topic_relay_control(true, client_relay_trajectory_, "trajectory");
     if (params_.enable_pose_with_covariance_relay)
@@ -89,9 +89,9 @@ MrmState MainEcuInLaneEmergencyStopSwitcher::update_mrm_state()
   return mrm_state_;
 }
 
-void MainEcuInLaneEmergencyStopSwitcher::publish_jerk_constant_deceleration_trigger(bool turn_on)
+void MainEcuInLaneEmergencyStopSwitcher::publish_constant_jerk_deceleration_trigger(bool turn_on)
 {
-  auto trigger = JerkConstantDecelerationTrigger();
+  auto trigger = ConstantJerkDecelerationTrigger();
   trigger.stamp = node_->now();
   trigger.trigger = turn_on;
   trigger.target_acceleration = params_.target_acceleration;

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.hpp
@@ -21,14 +21,14 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher
 {
 
-using tier4_control_msgs::msg::JerkConstantDecelerationTrigger;
+using tier4_control_msgs::msg::ConstantJerkDecelerationTrigger;
 
 class MainEcuInLaneEmergencyStopSwitcher : public CommandPlugin
 {
@@ -45,9 +45,9 @@ public:
   MrmState update_mrm_state() override;
 
 private:
-  void publish_jerk_constant_deceleration_trigger(bool turn_on);
+  void publish_constant_jerk_deceleration_trigger(bool turn_on);
   void request_topic_relay_control(
-    bool turn_on, rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
+    bool relay_on, rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
     const std::string & srv_name);
   bool is_stopped();
 
@@ -60,7 +60,7 @@ private:
     int64_t service_timeout_ms;
   };
 
-  rclcpp::Publisher<JerkConstantDecelerationTrigger>::SharedPtr pub_trigger_;
+  rclcpp::Publisher<ConstantJerkDecelerationTrigger>::SharedPtr pub_trigger_;
   std::unique_ptr<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>
     sub_odom_;
   rclcpp::CallbackGroup::SharedPtr client_relay_trajectory_group_;

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.hpp
@@ -1,0 +1,79 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef MAIN_ECU_IN_LANE_EMERGENCY_STOP_HPP_
+#define MAIN_ECU_IN_LANE_EMERGENCY_STOP_HPP_
+
+#include <autoware_command_mode_switcher/command_plugin.hpp>
+#include <autoware_command_mode_types/modes.hpp>
+#include <autoware_command_mode_types/sources.hpp>
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
+
+namespace autoware::command_mode_switcher
+{
+
+using tier4_control_msgs::msg::JerkConstantDecelerationTrigger;
+
+class MainEcuInLaneEmergencyStopSwitcher : public CommandPlugin
+{
+public:
+  uint16_t mode() const override
+  {
+    return autoware::command_mode_types::modes::main_ecu_in_lane_emergency_stop;
+  }
+  uint16_t source() const override { return autoware::command_mode_types::sources::in_lane_stop; }
+  bool autoware_control() const override { return true; }
+  void initialize() override;
+
+  SourceState update_source_state(bool request) override;
+  MrmState update_mrm_state() override;
+
+private:
+  void publish_jerk_constant_deceleration_trigger(bool turn_on);
+  void request_topic_relay_control(
+    bool turn_on, rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
+    const std::string & srv_name);
+  bool is_stopped();
+
+  struct Params
+  {
+    double target_acceleration;
+    double target_jerk;
+    bool enable_trajectory_relay;
+    bool enable_pose_with_covariance_relay;
+    int64_t service_timeout_ms;
+  };
+
+  rclcpp::Publisher<JerkConstantDecelerationTrigger>::SharedPtr pub_trigger_;
+  std::unique_ptr<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>
+    sub_odom_;
+  rclcpp::CallbackGroup::SharedPtr client_relay_trajectory_group_;
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr
+    client_relay_trajectory_;
+  rclcpp::CallbackGroup::SharedPtr client_relay_pose_with_covariance_group_;
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr
+    client_relay_pose_with_covariance_;
+
+  MrmState mrm_state_;
+  Params params_;
+};
+
+}  // namespace autoware::command_mode_switcher
+
+#endif  // MAIN_ECU_IN_LANE_EMERGENCY_STOP_HPP_

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.hpp
@@ -21,8 +21,8 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_emergency_stop.hpp
@@ -21,8 +21,8 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher
@@ -47,7 +47,8 @@ public:
 private:
   void publish_constant_jerk_deceleration_trigger(bool turn_on);
   void request_topic_relay_control(
-    bool relay_on, rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
+    bool relay_on,
+    rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
     const std::string & srv_name);
   bool is_stopped();
 

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.cpp
@@ -64,7 +64,8 @@ SourceState MainEcuInLaneModerateStopSwitcher::update_source_state(bool request)
     if (params_.enable_trajectory_relay)
       request_topic_relay_control(false, client_relay_trajectory_, "trajectory");
     if (params_.enable_pose_with_covariance_relay)
-      request_topic_relay_control(false, client_relay_pose_with_covariance_, "pose_with_covariance");
+      request_topic_relay_control(
+        false, client_relay_pose_with_covariance_, "pose_with_covariance");
     mrm_state_ = MrmState::Operating;
     return SourceState{true, false};
   } else {
@@ -115,8 +116,9 @@ void MainEcuInLaneModerateStopSwitcher::request_topic_relay_control(
   request->relay_on = relay_on;
 
   auto future = client->async_send_request(request);
-  if (future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
-      std::future_status::ready) {
+  if (
+    future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
+    std::future_status::ready) {
     RCLCPP_WARN(
       node_->get_logger(), "Timeout waiting for %s relay control: %s", srv_name.c_str(),
       relay_on ? "ON" : "OFF");

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.cpp
@@ -1,0 +1,151 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "main_ecu_in_lane_moderate_stop.hpp"
+
+namespace autoware::command_mode_switcher
+{
+
+void MainEcuInLaneModerateStopSwitcher::initialize()
+{
+  pub_trigger_ = node_->create_publisher<JerkConstantDecelerationTrigger>(
+    "/control/jerk_constant_deceleration_trigger", rclcpp::QoS{1});
+  sub_odom_ =
+    std::make_unique<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
+      node_, "/localization/kinematic_state");
+  client_relay_trajectory_group_ =
+    node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  client_relay_trajectory_ = node_->create_client<tier4_system_msgs::srv::ChangeTopicRelayControl>(
+    "/system/topic_relay_controller_trajectory/operate", rmw_qos_profile_services_default,
+    client_relay_trajectory_group_);
+  client_relay_pose_with_covariance_group_ =
+    node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  client_relay_pose_with_covariance_ =
+    node_->create_client<tier4_system_msgs::srv::ChangeTopicRelayControl>(
+      "/system/topic_relay_controller_pose_with_covariance/operate",
+      rmw_qos_profile_services_default, client_relay_pose_with_covariance_group_);
+
+  params_.target_acceleration =
+    node_->declare_parameter<double>(expand_param("target_acceleration"));
+  params_.target_jerk = node_->declare_parameter<double>(expand_param("target_jerk"));
+  params_.enable_trajectory_relay =
+    node_->declare_parameter<bool>(expand_param("enable_trajectory_relay"));
+  params_.enable_pose_with_covariance_relay =
+    node_->declare_parameter<bool>(expand_param("enable_pose_with_covariance_relay"));
+  params_.service_timeout_ms =
+    node_->declare_parameter<int64_t>(expand_param("service_timeout_ms"));
+  mrm_state_ = MrmState::Normal;
+}
+
+SourceState MainEcuInLaneModerateStopSwitcher::update_source_state(bool request)
+{
+  if (request && mrm_state_ == MrmState::Operating) return SourceState{true, false};
+  if (request && mrm_state_ == MrmState::Succeeded) return SourceState{true, false};
+  if (!request && mrm_state_ == MrmState::Normal) return SourceState{false, true};
+
+  if (request) {
+    publish_jerk_constant_deceleration_trigger(request);
+    // TODO(TetsuKawa): When request_topic_relay_control fails (timeout or service error), we
+    // currently still return {true, false} and proceed with in_lane_stop. We need to decide
+    // whether relay failure should block the state transition (i.e., return {false, false} or
+    // retry) and how that interacts with autoware_command_mode_switcher's rollback mechanism,
+    // which cancels the mode transition after transition_timeout_ if is_completed() stays false.
+    if (params_.enable_trajectory_relay)
+      request_topic_relay_control(false, client_relay_trajectory_, "trajectory");
+    if (params_.enable_pose_with_covariance_relay)
+      request_topic_relay_control(false, client_relay_pose_with_covariance_, "pose_with_covariance");
+    mrm_state_ = MrmState::Operating;
+    return SourceState{true, false};
+  } else {
+    publish_jerk_constant_deceleration_trigger(request);
+    if (params_.enable_trajectory_relay)
+      request_topic_relay_control(true, client_relay_trajectory_, "trajectory");
+    if (params_.enable_pose_with_covariance_relay)
+      request_topic_relay_control(true, client_relay_pose_with_covariance_, "pose_with_covariance");
+    mrm_state_ = MrmState::Normal;
+    return SourceState{false, true};
+  }
+}
+
+MrmState MainEcuInLaneModerateStopSwitcher::update_mrm_state()
+{
+  if (mrm_state_ != MrmState::Operating) {
+    return mrm_state_;
+  }
+
+  if (is_stopped()) mrm_state_ = MrmState::Succeeded;
+  return mrm_state_;
+}
+
+void MainEcuInLaneModerateStopSwitcher::publish_jerk_constant_deceleration_trigger(bool turn_on)
+{
+  auto trigger = JerkConstantDecelerationTrigger();
+  trigger.stamp = node_->now();
+  trigger.trigger = turn_on;
+  trigger.target_acceleration = params_.target_acceleration;
+  trigger.target_jerk = params_.target_jerk;
+
+  pub_trigger_->publish(trigger);
+}
+
+void MainEcuInLaneModerateStopSwitcher::request_topic_relay_control(
+  const bool relay_on,
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
+  const std::string & srv_name)
+{
+  if (!client->service_is_ready()) {
+    RCLCPP_WARN(
+      node_->get_logger(), "Service unavailable %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+    return;
+  }
+
+  auto request = std::make_shared<tier4_system_msgs::srv::ChangeTopicRelayControl::Request>();
+  request->relay_on = relay_on;
+
+  auto future = client->async_send_request(request);
+  if (future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
+      std::future_status::ready) {
+    RCLCPP_WARN(
+      node_->get_logger(), "Timeout waiting for %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+    return;
+  }
+
+  const auto & response = future.get();
+  if (response->status.success) {
+    RCLCPP_INFO(
+      node_->get_logger(), "Changed %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+  } else {
+    RCLCPP_WARN(
+      node_->get_logger(), "Failed to change %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+  }
+}
+
+bool MainEcuInLaneModerateStopSwitcher::is_stopped()
+{
+  auto odom = sub_odom_->take_data();
+  if (odom == nullptr) return false;
+  constexpr auto th_stopped_velocity = 0.001;
+  return (std::abs(odom->twist.twist.linear.x) < th_stopped_velocity);
+}
+
+}  // namespace autoware::command_mode_switcher
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::command_mode_switcher::MainEcuInLaneModerateStopSwitcher,
+  autoware::command_mode_switcher::CommandPlugin)

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.cpp
@@ -19,8 +19,8 @@ namespace autoware::command_mode_switcher
 
 void MainEcuInLaneModerateStopSwitcher::initialize()
 {
-  pub_trigger_ = node_->create_publisher<JerkConstantDecelerationTrigger>(
-    "/control/jerk_constant_deceleration_trigger", rclcpp::QoS{1});
+  pub_trigger_ = node_->create_publisher<ConstantJerkDecelerationTrigger>(
+    "/control/constant_jerk_deceleration_trigger", rclcpp::QoS{1});
   sub_odom_ =
     std::make_unique<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
       node_, "/localization/kinematic_state");
@@ -55,7 +55,7 @@ SourceState MainEcuInLaneModerateStopSwitcher::update_source_state(bool request)
   if (!request && mrm_state_ == MrmState::Normal) return SourceState{false, true};
 
   if (request) {
-    publish_jerk_constant_deceleration_trigger(request);
+    publish_constant_jerk_deceleration_trigger(request);
     // TODO(TetsuKawa): When request_topic_relay_control fails (timeout or service error), we
     // currently still return {true, false} and proceed with in_lane_stop. We need to decide
     // whether relay failure should block the state transition (i.e., return {false, false} or
@@ -69,7 +69,7 @@ SourceState MainEcuInLaneModerateStopSwitcher::update_source_state(bool request)
     mrm_state_ = MrmState::Operating;
     return SourceState{true, false};
   } else {
-    publish_jerk_constant_deceleration_trigger(request);
+    publish_constant_jerk_deceleration_trigger(request);
     if (params_.enable_trajectory_relay)
       request_topic_relay_control(true, client_relay_trajectory_, "trajectory");
     if (params_.enable_pose_with_covariance_relay)
@@ -89,9 +89,9 @@ MrmState MainEcuInLaneModerateStopSwitcher::update_mrm_state()
   return mrm_state_;
 }
 
-void MainEcuInLaneModerateStopSwitcher::publish_jerk_constant_deceleration_trigger(bool turn_on)
+void MainEcuInLaneModerateStopSwitcher::publish_constant_jerk_deceleration_trigger(bool turn_on)
 {
-  auto trigger = JerkConstantDecelerationTrigger();
+  auto trigger = ConstantJerkDecelerationTrigger();
   trigger.stamp = node_->now();
   trigger.trigger = turn_on;
   trigger.target_acceleration = params_.target_acceleration;

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.hpp
@@ -21,8 +21,8 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.hpp
@@ -1,0 +1,79 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef MAIN_ECU_IN_LANE_MODERATE_STOP_HPP_
+#define MAIN_ECU_IN_LANE_MODERATE_STOP_HPP_
+
+#include <autoware_command_mode_switcher/command_plugin.hpp>
+#include <autoware_command_mode_types/modes.hpp>
+#include <autoware_command_mode_types/sources.hpp>
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
+
+namespace autoware::command_mode_switcher
+{
+
+using tier4_control_msgs::msg::JerkConstantDecelerationTrigger;
+
+class MainEcuInLaneModerateStopSwitcher : public CommandPlugin
+{
+public:
+  uint16_t mode() const override
+  {
+    return autoware::command_mode_types::modes::main_ecu_in_lane_moderate_stop;
+  }
+  uint16_t source() const override { return autoware::command_mode_types::sources::in_lane_stop; }
+  bool autoware_control() const override { return true; }
+  void initialize() override;
+
+  SourceState update_source_state(bool request) override;
+  MrmState update_mrm_state() override;
+
+private:
+  void publish_jerk_constant_deceleration_trigger(bool turn_on);
+  void request_topic_relay_control(
+    bool turn_on, rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
+    const std::string & srv_name);
+  bool is_stopped();
+
+  struct Params
+  {
+    double target_acceleration;
+    double target_jerk;
+    bool enable_trajectory_relay;
+    bool enable_pose_with_covariance_relay;
+    int64_t service_timeout_ms;
+  };
+
+  rclcpp::Publisher<JerkConstantDecelerationTrigger>::SharedPtr pub_trigger_;
+  std::unique_ptr<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>
+    sub_odom_;
+  rclcpp::CallbackGroup::SharedPtr client_relay_trajectory_group_;
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr
+    client_relay_trajectory_;
+  rclcpp::CallbackGroup::SharedPtr client_relay_pose_with_covariance_group_;
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr
+    client_relay_pose_with_covariance_;
+
+  MrmState mrm_state_;
+  Params params_;
+};
+
+}  // namespace autoware::command_mode_switcher
+
+#endif  // MAIN_ECU_IN_LANE_MODERATE_STOP_HPP_

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.hpp
@@ -21,14 +21,14 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher
 {
 
-using tier4_control_msgs::msg::JerkConstantDecelerationTrigger;
+using tier4_control_msgs::msg::ConstantJerkDecelerationTrigger;
 
 class MainEcuInLaneModerateStopSwitcher : public CommandPlugin
 {
@@ -45,7 +45,7 @@ public:
   MrmState update_mrm_state() override;
 
 private:
-  void publish_jerk_constant_deceleration_trigger(bool turn_on);
+  void publish_constant_jerk_deceleration_trigger(bool turn_on);
   void request_topic_relay_control(
     bool turn_on, rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
     const std::string & srv_name);
@@ -60,7 +60,7 @@ private:
     int64_t service_timeout_ms;
   };
 
-  rclcpp::Publisher<JerkConstantDecelerationTrigger>::SharedPtr pub_trigger_;
+  rclcpp::Publisher<ConstantJerkDecelerationTrigger>::SharedPtr pub_trigger_;
   std::unique_ptr<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>
     sub_odom_;
   rclcpp::CallbackGroup::SharedPtr client_relay_trajectory_group_;

--- a/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/main_ecu_in_lane_moderate_stop.hpp
@@ -21,8 +21,8 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.cpp
@@ -64,7 +64,8 @@ SourceState SubEcuInLaneModerateStopSwitcher::update_source_state(bool request)
     if (params_.enable_trajectory_relay)
       request_topic_relay_control(false, client_relay_trajectory_, "trajectory");
     if (params_.enable_pose_with_covariance_relay)
-      request_topic_relay_control(false, client_relay_pose_with_covariance_, "pose_with_covariance");
+      request_topic_relay_control(
+        false, client_relay_pose_with_covariance_, "pose_with_covariance");
     mrm_state_ = MrmState::Operating;
     return SourceState{true, false};
   } else {
@@ -115,8 +116,9 @@ void SubEcuInLaneModerateStopSwitcher::request_topic_relay_control(
   request->relay_on = relay_on;
 
   auto future = client->async_send_request(request);
-  if (future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
-      std::future_status::ready) {
+  if (
+    future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
+    std::future_status::ready) {
     RCLCPP_WARN(
       node_->get_logger(), "Timeout waiting for %s relay control: %s", srv_name.c_str(),
       relay_on ? "ON" : "OFF");

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.cpp
@@ -1,0 +1,151 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "sub_ecu_in_lane_moderate_stop.hpp"
+
+namespace autoware::command_mode_switcher
+{
+
+void SubEcuInLaneModerateStopSwitcher::initialize()
+{
+  pub_trigger_ = node_->create_publisher<JerkConstantDecelerationTrigger>(
+    "/control/jerk_constant_deceleration_trigger", rclcpp::QoS{1});
+  sub_odom_ =
+    std::make_unique<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
+      node_, "/localization/kinematic_state");
+  client_relay_trajectory_group_ =
+    node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  client_relay_trajectory_ = node_->create_client<tier4_system_msgs::srv::ChangeTopicRelayControl>(
+    "/system/topic_relay_controller_trajectory/operate", rmw_qos_profile_services_default,
+    client_relay_trajectory_group_);
+  client_relay_pose_with_covariance_group_ =
+    node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  client_relay_pose_with_covariance_ =
+    node_->create_client<tier4_system_msgs::srv::ChangeTopicRelayControl>(
+      "/system/topic_relay_controller_pose_with_covariance/operate",
+      rmw_qos_profile_services_default, client_relay_pose_with_covariance_group_);
+
+  params_.target_acceleration =
+    node_->declare_parameter<double>(expand_param("target_acceleration"));
+  params_.target_jerk = node_->declare_parameter<double>(expand_param("target_jerk"));
+  params_.enable_trajectory_relay =
+    node_->declare_parameter<bool>(expand_param("enable_trajectory_relay"));
+  params_.enable_pose_with_covariance_relay =
+    node_->declare_parameter<bool>(expand_param("enable_pose_with_covariance_relay"));
+  params_.service_timeout_ms =
+    node_->declare_parameter<int64_t>(expand_param("service_timeout_ms"));
+  mrm_state_ = MrmState::Normal;
+}
+
+SourceState SubEcuInLaneModerateStopSwitcher::update_source_state(bool request)
+{
+  if (request && mrm_state_ == MrmState::Operating) return SourceState{true, false};
+  if (request && mrm_state_ == MrmState::Succeeded) return SourceState{true, false};
+  if (!request && mrm_state_ == MrmState::Normal) return SourceState{false, true};
+
+  if (request) {
+    publish_jerk_constant_deceleration_trigger(request);
+    // TODO(TetsuKawa): When request_topic_relay_control fails (timeout or service error), we
+    // currently still return {true, false} and proceed with in_lane_stop. We need to decide
+    // whether relay failure should block the state transition (i.e., return {false, false} or
+    // retry) and how that interacts with autoware_command_mode_switcher's rollback mechanism,
+    // which cancels the mode transition after transition_timeout_ if is_completed() stays false.
+    if (params_.enable_trajectory_relay)
+      request_topic_relay_control(false, client_relay_trajectory_, "trajectory");
+    if (params_.enable_pose_with_covariance_relay)
+      request_topic_relay_control(false, client_relay_pose_with_covariance_, "pose_with_covariance");
+    mrm_state_ = MrmState::Operating;
+    return SourceState{true, false};
+  } else {
+    publish_jerk_constant_deceleration_trigger(request);
+    if (params_.enable_trajectory_relay)
+      request_topic_relay_control(true, client_relay_trajectory_, "trajectory");
+    if (params_.enable_pose_with_covariance_relay)
+      request_topic_relay_control(true, client_relay_pose_with_covariance_, "pose_with_covariance");
+    mrm_state_ = MrmState::Normal;
+    return SourceState{false, true};
+  }
+}
+
+MrmState SubEcuInLaneModerateStopSwitcher::update_mrm_state()
+{
+  if (mrm_state_ != MrmState::Operating) {
+    return mrm_state_;
+  }
+
+  if (is_stopped()) mrm_state_ = MrmState::Succeeded;
+  return mrm_state_;
+}
+
+void SubEcuInLaneModerateStopSwitcher::publish_jerk_constant_deceleration_trigger(bool turn_on)
+{
+  auto trigger = JerkConstantDecelerationTrigger();
+  trigger.stamp = node_->now();
+  trigger.trigger = turn_on;
+  trigger.target_acceleration = params_.target_acceleration;
+  trigger.target_jerk = params_.target_jerk;
+
+  pub_trigger_->publish(trigger);
+}
+
+void SubEcuInLaneModerateStopSwitcher::request_topic_relay_control(
+  const bool relay_on,
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
+  const std::string & srv_name)
+{
+  if (!client->service_is_ready()) {
+    RCLCPP_WARN(
+      node_->get_logger(), "Service unavailable %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+    return;
+  }
+
+  auto request = std::make_shared<tier4_system_msgs::srv::ChangeTopicRelayControl::Request>();
+  request->relay_on = relay_on;
+
+  auto future = client->async_send_request(request);
+  if (future.wait_for(std::chrono::milliseconds(params_.service_timeout_ms)) !=
+      std::future_status::ready) {
+    RCLCPP_WARN(
+      node_->get_logger(), "Timeout waiting for %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+    return;
+  }
+
+  const auto & response = future.get();
+  if (response->status.success) {
+    RCLCPP_INFO(
+      node_->get_logger(), "Changed %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+  } else {
+    RCLCPP_WARN(
+      node_->get_logger(), "Failed to change %s relay control: %s", srv_name.c_str(),
+      relay_on ? "ON" : "OFF");
+  }
+}
+
+bool SubEcuInLaneModerateStopSwitcher::is_stopped()
+{
+  auto odom = sub_odom_->take_data();
+  if (odom == nullptr) return false;
+  constexpr auto th_stopped_velocity = 0.001;
+  return (std::abs(odom->twist.twist.linear.x) < th_stopped_velocity);
+}
+
+}  // namespace autoware::command_mode_switcher
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::command_mode_switcher::SubEcuInLaneModerateStopSwitcher,
+  autoware::command_mode_switcher::CommandPlugin)

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.cpp
@@ -19,8 +19,8 @@ namespace autoware::command_mode_switcher
 
 void SubEcuInLaneModerateStopSwitcher::initialize()
 {
-  pub_trigger_ = node_->create_publisher<JerkConstantDecelerationTrigger>(
-    "/control/jerk_constant_deceleration_trigger", rclcpp::QoS{1});
+  pub_trigger_ = node_->create_publisher<ConstantJerkDecelerationTrigger>(
+    "/control/constant_jerk_deceleration_trigger", rclcpp::QoS{1});
   sub_odom_ =
     std::make_unique<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>(
       node_, "/localization/kinematic_state");
@@ -55,7 +55,7 @@ SourceState SubEcuInLaneModerateStopSwitcher::update_source_state(bool request)
   if (!request && mrm_state_ == MrmState::Normal) return SourceState{false, true};
 
   if (request) {
-    publish_jerk_constant_deceleration_trigger(request);
+    publish_constant_jerk_deceleration_trigger(request);
     // TODO(TetsuKawa): When request_topic_relay_control fails (timeout or service error), we
     // currently still return {true, false} and proceed with in_lane_stop. We need to decide
     // whether relay failure should block the state transition (i.e., return {false, false} or
@@ -69,7 +69,7 @@ SourceState SubEcuInLaneModerateStopSwitcher::update_source_state(bool request)
     mrm_state_ = MrmState::Operating;
     return SourceState{true, false};
   } else {
-    publish_jerk_constant_deceleration_trigger(request);
+    publish_constant_jerk_deceleration_trigger(request);
     if (params_.enable_trajectory_relay)
       request_topic_relay_control(true, client_relay_trajectory_, "trajectory");
     if (params_.enable_pose_with_covariance_relay)
@@ -89,9 +89,9 @@ MrmState SubEcuInLaneModerateStopSwitcher::update_mrm_state()
   return mrm_state_;
 }
 
-void SubEcuInLaneModerateStopSwitcher::publish_jerk_constant_deceleration_trigger(bool turn_on)
+void SubEcuInLaneModerateStopSwitcher::publish_constant_jerk_deceleration_trigger(bool turn_on)
 {
-  auto trigger = JerkConstantDecelerationTrigger();
+  auto trigger = ConstantJerkDecelerationTrigger();
   trigger.stamp = node_->now();
   trigger.trigger = turn_on;
   trigger.target_acceleration = params_.target_acceleration;

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.hpp
@@ -21,8 +21,8 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.hpp
@@ -21,8 +21,8 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.hpp
@@ -1,0 +1,79 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef SUB_ECU_IN_LANE_MODERATE_STOP_HPP_
+#define SUB_ECU_IN_LANE_MODERATE_STOP_HPP_
+
+#include <autoware_command_mode_switcher/command_plugin.hpp>
+#include <autoware_command_mode_types/modes.hpp>
+#include <autoware_command_mode_types/sources.hpp>
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
+
+namespace autoware::command_mode_switcher
+{
+
+using tier4_control_msgs::msg::JerkConstantDecelerationTrigger;
+
+class SubEcuInLaneModerateStopSwitcher : public CommandPlugin
+{
+public:
+  uint16_t mode() const override
+  {
+    return autoware::command_mode_types::modes::sub_ecu_in_lane_moderate_stop;
+  }
+  uint16_t source() const override { return autoware::command_mode_types::sources::in_lane_stop; }
+  bool autoware_control() const override { return true; }
+  void initialize() override;
+
+  SourceState update_source_state(bool request) override;
+  MrmState update_mrm_state() override;
+
+private:
+  void publish_jerk_constant_deceleration_trigger(bool turn_on);
+  void request_topic_relay_control(
+    bool turn_on, rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
+    const std::string & srv_name);
+  bool is_stopped();
+
+  struct Params
+  {
+    double target_acceleration;
+    double target_jerk;
+    bool enable_trajectory_relay;
+    bool enable_pose_with_covariance_relay;
+    int64_t service_timeout_ms;
+  };
+
+  rclcpp::Publisher<JerkConstantDecelerationTrigger>::SharedPtr pub_trigger_;
+  std::unique_ptr<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>
+    sub_odom_;
+  rclcpp::CallbackGroup::SharedPtr client_relay_trajectory_group_;
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr
+    client_relay_trajectory_;
+  rclcpp::CallbackGroup::SharedPtr client_relay_pose_with_covariance_group_;
+  rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr
+    client_relay_pose_with_covariance_;
+
+  MrmState mrm_state_;
+  Params params_;
+};
+
+}  // namespace autoware::command_mode_switcher
+
+#endif  // SUB_ECU_IN_LANE_MODERATE_STOP_HPP_

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_in_lane_moderate_stop.hpp
@@ -21,14 +21,14 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <tier4_control_msgs/msg/constant_jerk_deceleration_trigger.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <tier4_control_msgs/msg/jerk_constant_deceleration_trigger.hpp>
 #include <tier4_system_msgs/srv/change_topic_relay_control.hpp>
 
 namespace autoware::command_mode_switcher
 {
 
-using tier4_control_msgs::msg::JerkConstantDecelerationTrigger;
+using tier4_control_msgs::msg::ConstantJerkDecelerationTrigger;
 
 class SubEcuInLaneModerateStopSwitcher : public CommandPlugin
 {
@@ -45,7 +45,7 @@ public:
   MrmState update_mrm_state() override;
 
 private:
-  void publish_jerk_constant_deceleration_trigger(bool turn_on);
+  void publish_constant_jerk_deceleration_trigger(bool turn_on);
   void request_topic_relay_control(
     bool turn_on, rclcpp::Client<tier4_system_msgs::srv::ChangeTopicRelayControl>::SharedPtr client,
     const std::string & srv_name);
@@ -60,7 +60,7 @@ private:
     int64_t service_timeout_ms;
   };
 
-  rclcpp::Publisher<JerkConstantDecelerationTrigger>::SharedPtr pub_trigger_;
+  rclcpp::Publisher<ConstantJerkDecelerationTrigger>::SharedPtr pub_trigger_;
   std::unique_ptr<autoware_utils_rclcpp::InterProcessPollingSubscriber<nav_msgs::msg::Odometry>>
     sub_odom_;
   rclcpp::CallbackGroup::SharedPtr client_relay_trajectory_group_;

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_standby.cpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_standby.cpp
@@ -1,0 +1,29 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "sub_ecu_standby.hpp"
+
+namespace autoware::command_mode_switcher
+{
+
+void SubEcuStandbySwitcher::initialize()
+{
+}
+
+}  // namespace autoware::command_mode_switcher
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::command_mode_switcher::SubEcuStandbySwitcher,
+  autoware::command_mode_switcher::CommandPlugin)

--- a/system/autoware_command_mode_switcher_plugins/src/sub_ecu_standby.hpp
+++ b/system/autoware_command_mode_switcher_plugins/src/sub_ecu_standby.hpp
@@ -1,0 +1,36 @@
+//  Copyright 2025 The Autoware Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef SUB_ECU_STANDBY_HPP_
+#define SUB_ECU_STANDBY_HPP_
+
+#include <autoware_command_mode_switcher/command_plugin.hpp>
+#include <autoware_command_mode_types/modes.hpp>
+#include <autoware_command_mode_types/sources.hpp>
+
+namespace autoware::command_mode_switcher
+{
+
+class SubEcuStandbySwitcher : public CommandPlugin
+{
+public:
+  uint16_t mode() const override { return autoware::command_mode_types::modes::sub_ecu_standby; }
+  uint16_t source() const override { return autoware::command_mode_types::sources::in_lane_stop; }
+  bool autoware_control() const override { return true; }
+  void initialize() override;
+};
+
+}  // namespace autoware::command_mode_switcher
+
+#endif  // SUB_ECU_STANDBY_HPP_


### PR DESCRIPTION
## Description
Add a plugin to execute an in-lane stop (in_lane_stop) for each ECU within the Main and Sub ECU redundant system.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_universe/issues/12691



**Private Links:**

Differences of TIER IV Internal developments
- [TIER IV internal link](https://github.com/tier4/mrm_plugin.x2/pull/25/changes/8b4a5d61bd1f64f4b97a5136e308f130dfecdb95)


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
