### PR TITLE
feat(autoware_command_mode_switcher): replace topic type

### DIFF
--- a/system/autoware_command_mode_switcher/launch/switcher.launch.xml
+++ b/system/autoware_command_mode_switcher/launch/switcher.launch.xml
@@ -6,7 +6,7 @@
   <arg name="~/command_mode/transition/completed" default="/system/command_mode/transition/completed"/>
   <arg name="~/source/status" default="/control/control_command_gate/source/status"/>
   <arg name="~/source/select" default="/control/control_command_gate/source/select"/>
-  <arg name="~/election/status" default="/system/election/status"/>
+  <arg name="~/active_control_unit" default="/system/redundancy/active_control_unit"/>
   <arg name="~/control_mode/report" default="/vehicle/status/control_mode"/>
   <arg name="~/control_mode/request" default="/control/control_mode_request"/>
 
@@ -17,7 +17,7 @@
     <remap from="~/command_mode/transition/completed" to="$(var ~/command_mode/transition/completed)"/>
     <remap from="~/source/status" to="$(var ~/source/status)"/>
     <remap from="~/source/select" to="$(var ~/source/select)"/>
-    <remap from="~/election/status" to="$(var ~/election/status)"/>
+    <remap from="~/active_control_unit" to="$(var ~/active_control_unit)"/>
     <remap from="~/control_mode/report" to="$(var ~/control_mode/report)"/>
     <remap from="~/control_mode/request" to="$(var ~/control_mode/request)"/>
   </node>

--- a/system/autoware_command_mode_switcher/src/common/selector_interface.cpp
+++ b/system/autoware_command_mode_switcher/src/common/selector_interface.cpp
@@ -47,11 +47,11 @@ VehicleGateInterface::VehicleGateInterface(rclcpp::Node & node, Callback callbac
 NetworkGateInterface::NetworkGateInterface(rclcpp::Node & node, Callback callback)
 {
   notification_callback_ = callback;
-  ecu_ = std::nullopt;
+  units_ = std::vector<uint8_t>{};
 
-  sub_election_status_ = node.create_subscription<ElectionStatus>(
-    "~/election/status", rclcpp::QoS(1),
-    std::bind(&NetworkGateInterface::on_election_status, this, std::placeholders::_1));
+  sub_active_control_unit_ = node.create_subscription<ActiveControlUnit>(
+    "~/active_control_unit", rclcpp::QoS(1).transient_local(),
+    std::bind(&NetworkGateInterface::on_active_control_unit, this, std::placeholders::_1));
 }
 
 template <class T>
@@ -77,30 +77,10 @@ void VehicleGateInterface::on_control_mode(const ControlModeReport & msg)
   if (!equals) notification_callback_();
 }
 
-void NetworkGateInterface::on_election_status(const ElectionStatus & msg)
+void NetworkGateInterface::on_active_control_unit(const ActiveControlUnit & msg)
 {
-  const auto get_ecu = [](uint8_t node, uint8_t path) -> std::optional<uint8_t> {
-    switch (node) {
-      case ElectionStatus::ELECTION_UNCLOSED:
-      case ElectionStatus::PATH_NOT_FOUND:
-      case ElectionStatus::SELF_INTERRUPTION:
-        return std::nullopt;
-    }
-    switch (path) {
-      case ElectionStatus::MAIN_ECU_TO_MAIN_VCU:
-      case ElectionStatus::MAIN_ECU_TO_SUB_VCU:
-        return ElectionStatus::MAIN_ECU;
-      case ElectionStatus::SUB_ECU_TO_MAIN_VCU:
-      case ElectionStatus::SUB_ECU_TO_SUB_VCU:
-        return ElectionStatus::SUB_ECU;
-      default:
-        return std::nullopt;
-    }
-  };
-
-  const auto ecu = get_ecu(msg.node_state, msg.path_info);
-  if (ecu_ != ecu) {
-    ecu_ = ecu;
+  if (units_ != msg.ids) {
+    units_ = msg.ids;
     notification_callback_();
   }
 }
@@ -142,7 +122,12 @@ bool VehicleGateInterface::is_selected(const CommandPlugin & plugin) const
 
 bool NetworkGateInterface::is_selected(const std::optional<uint8_t> ecu) const
 {
-  return ecu_ == ecu;
+  if (!ecu.has_value()) {
+    return true; // No multiple ECUs or not specified, consider selected
+  }
+  const auto id = ecu.value();
+  const auto itr = std::find(units_.begin(), units_.end(), id);
+  return itr != units_.end();
 }
 
 bool ControlGateInterface::request(const CommandPlugin & plugin, bool transition)

--- a/system/autoware_command_mode_switcher/src/common/selector_interface.cpp
+++ b/system/autoware_command_mode_switcher/src/common/selector_interface.cpp
@@ -123,7 +123,7 @@ bool VehicleGateInterface::is_selected(const CommandPlugin & plugin) const
 bool NetworkGateInterface::is_selected(const std::optional<uint8_t> ecu) const
 {
   if (!ecu.has_value()) {
-    return true; // No multiple ECUs or not specified, consider selected
+    return true;  // No multiple ECUs or not specified, consider selected
   }
   const auto id = ecu.value();
   const auto itr = std::find(units_.begin(), units_.end(), id);

--- a/system/autoware_command_mode_switcher/src/common/selector_interface.hpp
+++ b/system/autoware_command_mode_switcher/src/common/selector_interface.hpp
@@ -21,7 +21,7 @@
 
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_vehicle_msgs/srv/control_mode_command.hpp>
-#include <tier4_external_api_msgs/msg/election_status.hpp>
+#include <tier4_system_msgs/msg/active_control_unit.hpp>
 #include <tier4_system_msgs/msg/command_source_status.hpp>
 #include <tier4_system_msgs/srv/select_command_source.hpp>
 
@@ -91,13 +91,13 @@ public:
   bool is_selected(const std::optional<uint8_t> ecu) const;
 
 private:
-  using ElectionStatus = tier4_external_api_msgs::msg::ElectionStatus;
-  void on_election_status(const ElectionStatus & msg);
+  using ActiveControlUnit = tier4_system_msgs::msg::ActiveControlUnit;
+  void on_active_control_unit(const ActiveControlUnit & msg);
 
-  rclcpp::Subscription<ElectionStatus>::SharedPtr sub_election_status_;
+  rclcpp::Subscription<ActiveControlUnit>::SharedPtr sub_active_control_unit_;
 
   Callback notification_callback_;
-  std::optional<uint8_t> ecu_;
+  std::vector<uint8_t> units_;
 };
 
 }  // namespace autoware::command_mode_switcher


### PR DESCRIPTION
## Description
- **Replace `ElectionStatus.msg` with `ActiveControlUnit.msg`.**
- **Update the `network_gate` processing within `command_mode_switcher` to adapt to this change.**

## Related links

**Parent Issue:**

https://github.com/autowarefoundation/autoware_universe/issues/12691

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
