### PR TITLE
fix(autoware_topic_relay_controller): fix keep publish feature

### DIFF
--- a/system/autoware_topic_relay_controller/src/topic_relay_controller_node.cpp
+++ b/system/autoware_topic_relay_controller/src/topic_relay_controller_node.cpp
@@ -113,8 +113,6 @@ TopicRelayController::TopicRelayController(const rclcpp::NodeOptions & options)
   if (node_param_.enable_keep_publishing) {
     const auto update_period_ns = rclcpp::Rate(node_param_.update_rate).period();
     timer_ = rclcpp::create_timer(this, get_clock(), update_period_ns, [this]() {
-      if (!is_relaying_) return;
-
       if (node_param_.is_transform) {
         if (last_tf_topic_) pub_transform_->publish(*last_tf_topic_);
       } else {


### PR DESCRIPTION
## Description
Previously, the system provided the following two features:
- **`enable_relay_control`**: Turns topic relaying ON/OFF via external service requests.
- **`enable_keep_publishing`**: Continues publishing the last received value even if the input stops.

### Problem / Previous Behavior
When both features were set to `true`, the previous specification caused the topic forwarding to stop due to the `enable_relay_control` logic.

### Description / Updated Behavior
This change modifies the behavior so that when both features are `true`, the system will continue to publish the topic message received just before the service request

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_universe/issues/12691

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
