### PR TITLE
feat(pose_covariance_modifier): apply agnocast_wrapper::Node to pose_covariance_modifier

### DIFF
--- a/localization/autoware_pose_covariance_modifier/CMakeLists.txt
+++ b/localization/autoware_pose_covariance_modifier/CMakeLists.txt
@@ -4,13 +4,23 @@ project(autoware_pose_covariance_modifier)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(autoware_agnocast_wrapper REQUIRED)
+
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/pose_covariance_modifier.cpp
 )
+ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
+if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+  find_package(agnocastlib REQUIRED)
+  ament_target_dependencies(${PROJECT_NAME} agnocastlib)
+endif()
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::pose_covariance_modifier::PoseCovarianceModifierNode"
   EXECUTABLE ${PROJECT_NAME}_node
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/localization/autoware_pose_covariance_modifier/launch/pose_covariance_modifier.launch.xml
+++ b/localization/autoware_pose_covariance_modifier/launch/pose_covariance_modifier.launch.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="autoware_pose_covariance_modifier/input_gnss_pose_with_cov_topic" default="/sensing/gnss/pose_with_covariance"/>
   <arg name="autoware_pose_covariance_modifier/input_ndt_pose_with_cov_topic" default="/localization/pose_estimator/ndt_scan_matcher/pose_with_covariance"/>
   <arg name="autoware_pose_covariance_modifier/output_pose_with_covariance_topic" default="/localization/pose_estimator/pose_with_covariance"/>
   <arg name="param_file" default="$(find-pkg-share autoware_pose_covariance_modifier)/config/pose_covariance_modifier.param.yaml"/>
 
   <node pkg="autoware_pose_covariance_modifier" exec="autoware_pose_covariance_modifier_node" name="pose_covariance_modifier_node" output="both">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="input_gnss_pose_with_cov_topic" to="$(var autoware_pose_covariance_modifier/input_gnss_pose_with_cov_topic)"/>
     <remap from="input_ndt_pose_with_cov_topic" to="$(var autoware_pose_covariance_modifier/input_ndt_pose_with_cov_topic)"/>
     <remap from="output_pose_with_covariance_topic" to="$(var autoware_pose_covariance_modifier/output_pose_with_covariance_topic)"/>

--- a/localization/autoware_pose_covariance_modifier/package.xml
+++ b/localization/autoware_pose_covariance_modifier/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_interpolation</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/localization/autoware_pose_covariance_modifier/src/include/pose_covariance_modifier.hpp
+++ b/localization/autoware_pose_covariance_modifier/src/include/pose_covariance_modifier.hpp
@@ -14,6 +14,7 @@
 #ifndef POSE_COVARIANCE_MODIFIER_HPP_
 #define POSE_COVARIANCE_MODIFIER_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
@@ -22,7 +23,7 @@
 
 namespace autoware::pose_covariance_modifier
 {
-class PoseCovarianceModifierNode : public rclcpp::Node
+class PoseCovarianceModifierNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit PoseCovarianceModifierNode(const rclcpp::NodeOptions & node_options);
@@ -51,24 +52,27 @@ private:
   bool debug_mode_;
 
   rclcpp::Time gnss_pose_received_time_last_;
-  geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr gnss_pose_with_cov_last_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped)
+  gnss_pose_with_cov_last_;
   PoseSource pose_source_;
 
-  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
-    sub_gnss_pose_with_cov_;
-  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
-    sub_ndt_pose_with_cov_;
-  rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
-    pub_pose_with_covariance_stamped_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_str_pose_source_;
-  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pub_double_ndt_position_stddev_;
-  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pub_double_gnss_position_stddev_;
+  AUTOWARE_SUBSCRIPTION_PTR(geometry_msgs::msg::PoseWithCovarianceStamped)
+  sub_gnss_pose_with_cov_;
+  AUTOWARE_SUBSCRIPTION_PTR(geometry_msgs::msg::PoseWithCovarianceStamped)
+  sub_ndt_pose_with_cov_;
+  AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::PoseWithCovarianceStamped)
+  pub_pose_with_covariance_stamped_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::String) pub_str_pose_source_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Float64) pub_double_ndt_position_stddev_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Float64) pub_double_gnss_position_stddev_;
 
   void callback_gnss_pose_with_cov(
-    const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr & msg_pose_with_cov_in);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) &
+      msg_pose_with_cov_in);
 
   void callback_ndt_pose_with_cov(
-    const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr & msg_pose_with_cov_in);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) &
+      msg_pose_with_cov_in);
 
   bool gnss_pose_has_timed_out(const rclcpp::Time & gnss_pose_received_time_last);
 

--- a/localization/autoware_pose_covariance_modifier/src/include/pose_covariance_modifier.hpp
+++ b/localization/autoware_pose_covariance_modifier/src/include/pose_covariance_modifier.hpp
@@ -68,11 +68,11 @@ private:
 
   void callback_gnss_pose_with_cov(
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) &
-      msg_pose_with_cov_in);
+    msg_pose_with_cov_in);
 
   void callback_ndt_pose_with_cov(
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) &
-      msg_pose_with_cov_in);
+    msg_pose_with_cov_in);
 
   bool gnss_pose_has_timed_out(const rclcpp::Time & gnss_pose_received_time_last);
 

--- a/localization/autoware_pose_covariance_modifier/src/pose_covariance_modifier.cpp
+++ b/localization/autoware_pose_covariance_modifier/src/pose_covariance_modifier.cpp
@@ -74,7 +74,7 @@ PoseCovarianceModifierNode::PoseCovarianceModifierNode(const rclcpp::NodeOptions
 
 void PoseCovarianceModifierNode::callback_gnss_pose_with_cov(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) &
-    msg_pose_with_cov_in)
+  msg_pose_with_cov_in)
 {
   // will be used to check if GNSS pose has timed out in the NDT pose callback
   gnss_pose_received_time_last_ = this->now();
@@ -115,7 +115,7 @@ void PoseCovarianceModifierNode::callback_gnss_pose_with_cov(
 
 void PoseCovarianceModifierNode::callback_ndt_pose_with_cov(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) &
-    msg_pose_with_cov_in)
+  msg_pose_with_cov_in)
 {
   if (pose_source_ == PoseSource::GNSS) {
     // if the pose source is only gnss, GNSS pose will be used in the GNSS pose callback

--- a/localization/autoware_pose_covariance_modifier/src/pose_covariance_modifier.cpp
+++ b/localization/autoware_pose_covariance_modifier/src/pose_covariance_modifier.cpp
@@ -28,7 +28,7 @@ namespace autoware::pose_covariance_modifier
 using PoseSource = PoseCovarianceModifierNode::PoseSource;
 
 PoseCovarianceModifierNode::PoseCovarianceModifierNode(const rclcpp::NodeOptions & node_options)
-: Node("PoseCovarianceModifierNode", node_options),
+: autoware::agnocast_wrapper::Node("PoseCovarianceModifierNode", node_options),
   gnss_pose_received_time_last_(this->now()),
   pose_source_(PoseSource::NDT)
 {
@@ -73,7 +73,8 @@ PoseCovarianceModifierNode::PoseCovarianceModifierNode(const rclcpp::NodeOptions
 }
 
 void PoseCovarianceModifierNode::callback_gnss_pose_with_cov(
-  const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr & msg_pose_with_cov_in)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) &
+    msg_pose_with_cov_in)
 {
   // will be used to check if GNSS pose has timed out in the NDT pose callback
   gnss_pose_received_time_last_ = this->now();
@@ -101,17 +102,20 @@ void PoseCovarianceModifierNode::callback_gnss_pose_with_cov(
     return;
   }
 
-  pub_pose_with_covariance_stamped_->publish(*msg_pose_with_cov_in);
+  auto pose_out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_pose_with_covariance_stamped_);
+  *pose_out = *msg_pose_with_cov_in;
+  pub_pose_with_covariance_stamped_->publish(std::move(pose_out));
 
   if (debug_mode_) {
-    std_msgs::msg::Float64 msg_double;
-    msg_double.data = gnss_pose_stddev_xy;
-    pub_double_gnss_position_stddev_->publish(msg_double);
+    auto msg_double = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_double_gnss_position_stddev_);
+    msg_double->data = gnss_pose_stddev_xy;
+    pub_double_gnss_position_stddev_->publish(std::move(msg_double));
   }
 }
 
 void PoseCovarianceModifierNode::callback_ndt_pose_with_cov(
-  const geometry_msgs::msg::PoseWithCovarianceStamped::ConstSharedPtr & msg_pose_with_cov_in)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) &
+    msg_pose_with_cov_in)
 {
   if (pose_source_ == PoseSource::GNSS) {
     // if the pose source is only gnss, GNSS pose will be used in the GNSS pose callback
@@ -129,14 +133,16 @@ void PoseCovarianceModifierNode::callback_ndt_pose_with_cov(
     msg_pose_with_cov_out = ndt_pose_with_cov_updated;
   }
 
-  pub_pose_with_covariance_stamped_->publish(msg_pose_with_cov_out);
+  auto pose_out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_pose_with_covariance_stamped_);
+  *pose_out = msg_pose_with_cov_out;
+  pub_pose_with_covariance_stamped_->publish(std::move(pose_out));
 
   if (debug_mode_) {
-    std_msgs::msg::Float64 msg_double;
-    msg_double.data = (std::sqrt(msg_pose_with_cov_out.pose.covariance[X_POS_IDX_]) +
-                       std::sqrt(msg_pose_with_cov_out.pose.covariance[Y_POS_IDX_])) /
-                      2.0;
-    pub_double_ndt_position_stddev_->publish(msg_double);
+    auto msg_double = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_double_ndt_position_stddev_);
+    msg_double->data = (std::sqrt(msg_pose_with_cov_out.pose.covariance[X_POS_IDX_]) +
+                        std::sqrt(msg_pose_with_cov_out.pose.covariance[Y_POS_IDX_])) /
+                       2.0;
+    pub_double_ndt_position_stddev_->publish(std::move(msg_double));
   }
 }
 
@@ -224,22 +230,22 @@ std::array<double, 36> PoseCovarianceModifierNode::update_ndt_covariances_from_g
 
 void PoseCovarianceModifierNode::publish_pose_type(const PoseSource & pose_source)
 {
-  std_msgs::msg::String selected_pose_type;
+  auto selected_pose_type = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_str_pose_source_);
   switch (pose_source) {
     case PoseSource::GNSS:
-      selected_pose_type.data = "GNSS";
+      selected_pose_type->data = "GNSS";
       break;
     case PoseSource::GNSS_NDT:
-      selected_pose_type.data = "GNSS_NDT";
+      selected_pose_type->data = "GNSS_NDT";
       break;
     case PoseSource::NDT:
-      selected_pose_type.data = "NDT";
+      selected_pose_type->data = "NDT";
       break;
     default:
-      selected_pose_type.data = "NOT_DEFINED";
+      selected_pose_type->data = "NOT_DEFINED";
       break;
   }
-  pub_str_pose_source_->publish(selected_pose_type);
+  pub_str_pose_source_->publish(std::move(selected_pose_type));
 }
 
 }  // namespace autoware::pose_covariance_modifier


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
