### PR TITLE
feat(bevfusion): apply agnocast publisher to bevfusion

### DIFF
--- a/perception/autoware_bevfusion/CMakeLists.txt
+++ b/perception/autoware_bevfusion/CMakeLists.txt
@@ -155,9 +155,14 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     ${PROJECT_NAME}_lib
   )
 
-  rclcpp_components_register_node(${PROJECT_NAME}_component
+  find_package(autoware_agnocast_wrapper REQUIRED)
+  autoware_agnocast_wrapper_setup(${PROJECT_NAME}_component)
+
+  autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_component
     PLUGIN "autoware::bevfusion::BEVFusionNode"
     EXECUTABLE ${PROJECT_NAME}_node
+    AGNOCAST_EXECUTOR SingleThreadedAgnocastExecutor
+    ROS2_EXECUTOR SingleThreadedExecutor
   )
 
   install(

--- a/perception/autoware_bevfusion/CMakeLists.txt
+++ b/perception/autoware_bevfusion/CMakeLists.txt
@@ -161,7 +161,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
   autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_component
     PLUGIN "autoware::bevfusion::BEVFusionNode"
     EXECUTABLE ${PROJECT_NAME}_node
-    AGNOCAST_EXECUTOR SingleThreadedAgnocastExecutor
+    AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
     ROS2_EXECUTOR SingleThreadedExecutor
   )
 

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_node.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_node.hpp
@@ -23,6 +23,7 @@
 #include "autoware/bevfusion/visibility_control.hpp"
 
 #include <Eigen/Core>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_diagnostics/diagnostics_interface.hpp>
@@ -78,7 +79,7 @@ private:
   void precomputeIntrinsicsExtrinsics();
   void computeCameraMasks(double lidar_stamp);
   void publishDetectionResults(
-    const autoware_perception_msgs::msg::DetectedObjects & output_msg,
+    AUTOWARE_MESSAGE_UNIQUE_PTR(autoware_perception_msgs::msg::DetectedObjects) output_msg,
     const std_msgs::msg::Header & header);
   void publishDebugInfo(
     const std::unordered_map<std::string, double> & proc_timing,
@@ -99,8 +100,7 @@ private:
     cloud_sub_;
   std::vector<image_transport::Subscriber> image_subs_;
   std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::ConstSharedPtr> camera_info_subs_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_{
-    nullptr};
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) objects_pub_{nullptr};
   // unique_ptr to avoid copying the actual camera data in memory since there's gpu buffer in the
   // camera data
   std::vector<std::unique_ptr<CameraData>> camera_data_ptrs_;

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_node.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_node.hpp
@@ -100,7 +100,7 @@ private:
     cloud_sub_;
   std::vector<image_transport::Subscriber> image_subs_;
   std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::ConstSharedPtr> camera_info_subs_;
-  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) objects_pub_{nullptr};
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) objects_pub_ { nullptr };
   // unique_ptr to avoid copying the actual camera data in memory since there's gpu buffer in the
   // camera data
   std::vector<std::unique_ptr<CameraData>> camera_data_ptrs_;

--- a/perception/autoware_bevfusion/launch/bevfusion.launch.xml
+++ b/perception/autoware_bevfusion/launch/bevfusion.launch.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <arg name="input/pointcloud" default="/sensing/lidar/concatenated/pointcloud"/>
   <arg name="output/objects" default="objects"/>
   <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
@@ -66,6 +68,7 @@
   <group unless="$(var use_pointcloud_container)">
     <!-- Crash when using image_transport and topic name is longer than remapping topic, https://github.com/ros-perception/image_transport_plugins/issues/155 -->
     <node pkg="autoware_bevfusion" exec="autoware_bevfusion_node" name="bevfusion" output="screen" args="--ros-args --log-level $(var log_level)" namespace="/perception/detection">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
       <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
       <remap from="~/input/pointcloud/cuda" to="$(var input/pointcloud)/cuda"/>
       <remap from="~/output/objects" to="$(var output/objects)"/>

--- a/perception/autoware_bevfusion/package.xml
+++ b/perception/autoware_bevfusion/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_cuda_dependency_meta</depend>
   <depend>autoware_cuda_utils</depend>
   <depend>autoware_object_recognition_utils</depend>

--- a/perception/autoware_bevfusion/src/bevfusion_node.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node.cpp
@@ -21,6 +21,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 // Contains implementations of constructor, destructor, topic callbacks for BEVFusionNode.
@@ -237,8 +238,8 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
       *this, "~/input/pointcloud",
       std::bind(&BEVFusionNode::cloudCallback, this, std::placeholders::_1));
 
-  objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
-    "~/output/objects", rclcpp::QoS(1));
+  objects_pub_ = AUTOWARE_CREATE_PUBLISHER2(
+    autoware_perception_msgs::msg::DetectedObjects, "~/output/objects", rclcpp::QoS(1));
 
   initializeSensorFusionSubscribers(config.num_cameras_, image_pre_processing_params);
 
@@ -313,14 +314,14 @@ void BEVFusionNode::cloudCallback(
     raw_objects.emplace_back(obj);
   }
 
-  autoware_perception_msgs::msg::DetectedObjects output_msg;
-  output_msg.header = pc_msg_ptr->header;
-  output_msg.objects = iou_bev_nms_.apply(raw_objects);
+  auto output_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(objects_pub_);
+  output_msg->header = pc_msg_ptr->header;
+  output_msg->objects = iou_bev_nms_.apply(raw_objects);
 
-  detection_class_remapper_.mapClasses(output_msg);
+  detection_class_remapper_.mapClasses(*output_msg);
 
-  publishDetectionResults(output_msg, pc_msg_ptr->header);
-  publishDebugInfo(proc_timing, output_msg.header);
+  publishDetectionResults(std::move(output_msg), pc_msg_ptr->header);
+  publishDebugInfo(proc_timing, pc_msg_ptr->header);
 }
 
 void BEVFusionNode::imageCallback(

--- a/perception/autoware_bevfusion/src/bevfusion_node_utils.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node_utils.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 // Contains implementations of functions other than constructor,destructor, topic callbacks for
@@ -149,15 +150,15 @@ void BEVFusionNode::computeCameraMasks(double lidar_stamp)
 }
 
 void BEVFusionNode::publishDetectionResults(
-  const autoware_perception_msgs::msg::DetectedObjects & output_msg,
+  AUTOWARE_MESSAGE_UNIQUE_PTR(autoware_perception_msgs::msg::DetectedObjects) output_msg,
   const std_msgs::msg::Header & header)
 {
   const auto objects_sub_count =
     objects_pub_->get_subscription_count() + objects_pub_->get_intra_process_subscription_count();
 
   if (objects_sub_count > 0) {
-    objects_pub_->publish(output_msg);
-    published_time_pub_->publish_if_subscribed(objects_pub_, output_msg.header.stamp);
+    published_time_pub_->publish_if_subscribed(objects_pub_, output_msg->header.stamp);
+    objects_pub_->publish(std::move(output_msg));
   }
 
   diagnostics_detector_trt_->publish(header.stamp);


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper` to the `objects` subscription of `autoware_bevfusion` to enable zero-copy message publishing via Agnocast.
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method1](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-1-macro--free-function-api) of two integrations methods.

### Changes
  - Publisher: convert the `DetectedObjects` publisher to the agnocast macros — `AUTOWARE_PUBLISHER_PTR` / `AUTOWARE_CREATE_PUBLISHER2`, and publish via `ALLOCATE_OUTPUT_MESSAGE_UNIQUE` + `std::move`.

## Related links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- colcon build succeeds with both ENABLE_AGNOCAST=1 and ENABLE_AGNOCAST=0.
- Ran an Autoware-based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.