### PR TITLE
chore(poincloud_preprocessor): align param file schema to contain all necessary params for a node (input_frame, output_frame)

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/config/approximate_downsample_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/approximate_downsample_filter_node.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    input_frame: ""
+    output_frame: ""
     voxel_size_x: 0.3
     voxel_size_y: 0.3
     voxel_size_z: 0.1

--- a/sensing/autoware_pointcloud_preprocessor/config/crop_box_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/crop_box_filter_node.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    input_frame: base_link
+    output_frame: base_link
     min_x: -1.0
     min_y: -1.0
     min_z: -1.0

--- a/sensing/autoware_pointcloud_preprocessor/config/dual_return_outlier_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/dual_return_outlier_filter_node.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    input_frame: ""
+    output_frame: ""
     x_max: 18.0
     x_min: -12.0
     y_max: 2.0

--- a/sensing/autoware_pointcloud_preprocessor/config/passthrough_filter_uint16_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/passthrough_filter_uint16_node.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    input_frame: base_link
+    output_frame: base_link
     filter_limit_min: 0
     filter_limit_max: 127
     filter_field_name: "channel"

--- a/sensing/autoware_pointcloud_preprocessor/config/pickup_based_voxel_grid_downsample_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/pickup_based_voxel_grid_downsample_filter_node.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    input_frame: ""
+    output_frame: ""
     voxel_size_x: 1.0
     voxel_size_y: 1.0
     voxel_size_z: 1.0

--- a/sensing/autoware_pointcloud_preprocessor/config/pointcloud_accumulator_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/pointcloud_accumulator_node.param.yaml
@@ -1,4 +1,6 @@
 /**:
   ros__parameters:
+    input_frame: base_link
+    output_frame: base_link
     accumulation_time_sec: 2.0
     pointcloud_buffer_size: 50

--- a/sensing/autoware_pointcloud_preprocessor/config/polar_voxel_noise_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/polar_voxel_noise_filter_node.param.yaml
@@ -1,5 +1,8 @@
 /**:
   ros__parameters:
+    input_frame: ""
+    output_frame: ""
+
     radial_resolution: 0.5
     azimuth_resolution: 0.08
     elevation_resolution: 0.05

--- a/sensing/autoware_pointcloud_preprocessor/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/polar_voxel_outlier_filter_node.param.yaml
@@ -1,5 +1,8 @@
 /**:
   ros__parameters:
+    input_frame: ""
+    output_frame: ""
+
     # Core filtering parameters
     radial_resolution_m: 0.5                     # Resolution in radial direction (meters)
     azimuth_resolution_rad: 0.0175               # Resolution in azimuth direction (radians)

--- a/sensing/autoware_pointcloud_preprocessor/config/radius_search_2d_outlier_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/radius_search_2d_outlier_filter_node.param.yaml
@@ -1,4 +1,7 @@
 /**:
   ros__parameters:
+    input_frame: base_link
+    output_frame: base_link
+
     min_neighbors: 5
     search_radius: 0.2

--- a/sensing/autoware_pointcloud_preprocessor/config/random_downsample_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/random_downsample_filter_node.param.yaml
@@ -1,3 +1,5 @@
 /**:
   ros__parameters:
+    input_frame: ""
+    output_frame: ""
     sample_num: 1500

--- a/sensing/autoware_pointcloud_preprocessor/config/ring_outlier_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/ring_outlier_filter_node.param.yaml
@@ -1,5 +1,8 @@
 /**:
   ros__parameters:
+    input_frame: ""
+    output_frame: ""
+
     distance_ratio: 1.03
     object_length_threshold: 0.05
     max_rings_num: 128

--- a/sensing/autoware_pointcloud_preprocessor/config/voxel_grid_downsample_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/voxel_grid_downsample_filter_node.param.yaml
@@ -1,5 +1,8 @@
 /**:
   ros__parameters:
+    input_frame: base_link
+    output_frame: base_link
+
     voxel_size_x: 0.3
     voxel_size_y: 0.3
     voxel_size_z: 0.1

--- a/sensing/autoware_pointcloud_preprocessor/config/voxel_grid_outlier_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/voxel_grid_outlier_filter_node.param.yaml
@@ -1,5 +1,8 @@
 /**:
   ros__parameters:
+    input_frame: ""
+    output_frame: ""
+
     voxel_size_x: 0.3
     voxel_size_y: 0.3
     voxel_size_z: 0.1

--- a/sensing/autoware_pointcloud_preprocessor/launch/approximate_downsample_filter.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/approximate_downsample_filter.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud_raw"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/approximate_downsample_filter/pointcloud"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default=""/>
   <arg name="approximate_downsample_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/approximate_downsample_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="approximate_downsample_filter_node" name="approximate_downsample_filter">
     <param from="$(var approximate_downsample_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/crop_box_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/crop_box_filter_node.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud_raw_ex"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/self_cropped/pointcloud_ex"/>
-  <arg name="input_frame" default="base_link"/>
-  <arg name="output_frame" default="base_link"/>
   <arg name="crop_box_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/crop_box_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="crop_box_filter_node" name="crop_box_filter_node">
     <param from="$(var crop_box_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/dual_return_outlier_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/dual_return_outlier_filter_node.launch.xml
@@ -1,15 +1,11 @@
 <launch>
   <arg name="input_topic_name" default="/pointcloud"/>
   <arg name="output_topic_name" default="/pointcloud_filtered"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default=""/>
   <arg name="dual_return_outlier_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/dual_return_outlier_filter_node.param.yaml"/>
 
   <node pkg="autoware_pointcloud_preprocessor" exec="dual_return_outlier_filter_node" name="dual_return_outlier_filter_node">
     <param from="$(var dual_return_outlier_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/pickup_based_voxel_grid_downsample_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/pickup_based_voxel_grid_downsample_filter_node.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud_raw"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/pickup_based_voxel_grid_downsample_filter/pointcloud"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default=""/>
   <arg name="pickup_based_voxel_grid_downsample_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/pickup_based_voxel_grid_downsample_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="pickup_based_voxel_grid_downsample_filter_node" name="pickup_based_voxel_grid_downsample_filter_node">
     <param from="$(var pickup_based_voxel_grid_downsample_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/pointcloud_accumulator_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/pointcloud_accumulator_node.launch.xml
@@ -1,14 +1,12 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/pointcloud_accumulated"/>
-  <arg name="input_frame" default="base_link"/>
-  <arg name="output_frame" default="base_link"/>
+  <arg name="input_frame" default=""/>
+  <arg name="output_frame" default=""/>
   <arg name="pointcloud_accumulator_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/pointcloud_accumulator_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="pointcloud_accumulator_node" name="pointcloud_accumulator_node">
-    <param from="$(var pointcloud_accumulator_param_file)"/>
+    <param from="$(var pointcloud_accumulator_param_file)" allow_substs="true"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/polar_voxel_noise_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/polar_voxel_noise_filter_node.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/pointcloud_raw"/>
   <arg name="output_topic_name" default="/pointcloud_filtered"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default=""/>
   <arg name="polar_voxel_noise_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/polar_voxel_noise_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="polar_voxel_noise_filter_node" name="polar_voxel_noise_filter_node">
     <param from="$(var polar_voxel_noise_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/polar_voxel_outlier_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/polar_voxel_outlier_filter_node.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/pointcloud_raw"/>
   <arg name="output_topic_name" default="/pointcloud_filtered"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default=""/>
   <arg name="polar_voxel_outlier_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/polar_voxel_outlier_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="polar_voxel_outlier_filter_node" name="polar_voxel_outlier_filter_node">
     <param from="$(var polar_voxel_outlier_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/radius_search_2d_outlier_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/radius_search_2d_outlier_filter_node.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud_raw_ex"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/pointcloud_filtered"/>
-  <arg name="input_frame" default="base_link"/>
-  <arg name="output_frame" default="base_link"/>
   <arg name="radius_search_2d_outlier_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/radius_search_2d_outlier_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="radius_search_2d_outlier_filter_node" name="radius_search_2d_outlier_filter_node">
     <param from="$(var radius_search_2d_outlier_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/random_downsample_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/random_downsample_filter_node.launch.xml
@@ -1,15 +1,11 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud_raw"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/random_downsample_filter/pointcloud"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default=""/>
   <arg name="random_downsample_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/random_downsample_filter_node.param.yaml"/>
 
   <node pkg="autoware_pointcloud_preprocessor" exec="random_downsample_filter_node" name="random_downsample_filter_node">
     <param from="$(var random_downsample_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/ring_outlier_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/ring_outlier_filter_node.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud_raw_ex"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/pointcloud_ring_filtered"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default=""/>
   <arg name="ring_outlier_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/ring_outlier_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="ring_outlier_filter_node" name="ring_outlier_filter_node">
     <param from="$(var ring_outlier_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/ring_passthrough_filter.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/ring_passthrough_filter.launch.xml
@@ -1,15 +1,11 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud_raw"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/ring_passthrough_filtered/pointcloud"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default="base_link"/>
   <arg name="passthrough_filter_uint16_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/passthrough_filter_uint16_node.param.yaml"/>
 
   <node pkg="autoware_pointcloud_preprocessor" exec="passthrough_filter_uint16_node" name="ring_passthrough_filter">
     <param from="$(var passthrough_filter_uint16_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/voxel_grid_downsample_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/voxel_grid_downsample_filter_node.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/sensing/lidar/top/pointcloud_raw"/>
   <arg name="output_topic_name" default="/sensing/lidar/top/voxel_grid_downsample_filter/pointcloud"/>
-  <arg name="input_frame" default="base_link"/>
-  <arg name="output_frame" default="base_link"/>
   <arg name="voxel_grid_downsample_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/voxel_grid_downsample_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="voxel_grid_downsample_filter_node" name="voxel_grid_downsample_filter_node">
     <param from="$(var voxel_grid_downsample_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/voxel_grid_outlier_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/voxel_grid_outlier_filter_node.launch.xml
@@ -1,14 +1,10 @@
 <launch>
   <arg name="input_topic_name" default="/pointcloud_raw"/>
   <arg name="output_topic_name" default="/pointcloud_filtered"/>
-  <arg name="input_frame" default=""/>
-  <arg name="output_frame" default=""/>
   <arg name="voxel_grid_outlier_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/voxel_grid_outlier_filter_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="voxel_grid_outlier_filter_node" name="voxel_grid_outlier_filter_node">
     <param from="$(var voxel_grid_outlier_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
-    <param name="input_frame" value="$(var input_frame)"/>
-    <param name="output_frame" value="$(var output_frame)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/schema/approximate_downsample_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/approximate_downsample_filter_node.schema.json
@@ -6,6 +6,16 @@
     "approximate_downsample_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": ""
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": ""
+        },
         "voxel_size_x": {
           "type": "number",
           "description": "voxel size along the x-axis [m]",

--- a/sensing/autoware_pointcloud_preprocessor/schema/crop_box_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/crop_box_filter_node.schema.json
@@ -6,6 +6,16 @@
     "crop_box_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": "base_link"
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": "base_link"
+        },
         "min_x": {
           "type": "number",
           "description": "minimum x-coordinate value for crop range in meters",

--- a/sensing/autoware_pointcloud_preprocessor/schema/dual_return_outlier_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/dual_return_outlier_filter_node.schema.json
@@ -6,6 +6,16 @@
     "dual_return_outlier_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": ""
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": ""
+        },
         "x_max": {
           "type": "number",
           "description": "Maximum of x in meters for `Fixed_xyz_ROI` mode",

--- a/sensing/autoware_pointcloud_preprocessor/schema/passthrough_filter_uint16_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/passthrough_filter_uint16_node.schema.json
@@ -6,6 +6,16 @@
     "passthrough_filter_uint16": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": "base_link"
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": "base_link"
+        },
         "filter_limit_min": {
           "type": "integer",
           "description": "minimum allowed field value",

--- a/sensing/autoware_pointcloud_preprocessor/schema/pickup_based_voxel_grid_downsample_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/pickup_based_voxel_grid_downsample_filter_node.schema.json
@@ -6,6 +6,16 @@
     "pickup_based_voxel_grid_downsample_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": ""
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": ""
+        },
         "voxel_size_x": {
           "type": "number",
           "description": "voxel size along the x-axis [m]",

--- a/sensing/autoware_pointcloud_preprocessor/schema/pointcloud_accumulator_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/pointcloud_accumulator_node.schema.json
@@ -6,6 +6,16 @@
     "pointcloud_accumulator": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": "base_link"
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": "base_link"
+        },
         "accumulation_time_sec": {
           "type": "number",
           "description": "accumulation period [s]",

--- a/sensing/autoware_pointcloud_preprocessor/schema/polar_voxel_noise_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/polar_voxel_noise_filter_node.schema.json
@@ -6,6 +6,16 @@
     "polar_voxel_noise_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": ""
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": ""
+        },
         "radial_resolution": {
           "type": "number",
           "description": "Resolution in radial direction [m].",

--- a/sensing/autoware_pointcloud_preprocessor/schema/polar_voxel_outlier_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/polar_voxel_outlier_filter_node.schema.json
@@ -6,6 +6,16 @@
     "polar_voxel_outlier_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": ""
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": ""
+        },
         "radial_resolution_m": {
           "type": "number",
           "description": "The resolution in radial direction [m].",

--- a/sensing/autoware_pointcloud_preprocessor/schema/radius_search_2d_outlier_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/radius_search_2d_outlier_filter_node.schema.json
@@ -6,6 +6,16 @@
     "radius_search_2d_outlier_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": "base_link"
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": "base_link"
+        },
         "min_neighbors": {
           "type": "integer",
           "description": "If points in the circle centered on reference point is less than min_neighbors, a reference point is judged as outlier",

--- a/sensing/autoware_pointcloud_preprocessor/schema/ring_outlier_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/ring_outlier_filter_node.schema.json
@@ -6,6 +6,16 @@
     "ring_outlier_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": ""
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": ""
+        },
         "distance_ratio": {
           "type": "number",
           "description": "distance_ratio",

--- a/sensing/autoware_pointcloud_preprocessor/schema/voxel_grid_downsample_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/voxel_grid_downsample_filter_node.schema.json
@@ -6,6 +6,16 @@
     "voxel_grid_downsample_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": "base_link"
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": "base_link"
+        },
         "voxel_size_x": {
           "type": "number",
           "description": "the voxel size along x-axis [m]",

--- a/sensing/autoware_pointcloud_preprocessor/schema/voxel_grid_outlier_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/voxel_grid_outlier_filter_node.schema.json
@@ -6,6 +6,16 @@
     "voxel_grid_outlier_filter": {
       "type": "object",
       "properties": {
+        "input_frame": {
+          "type": "string",
+          "description": "input frame id for point cloud data",
+          "default": ""
+        },
+        "output_frame": {
+          "type": "string",
+          "description": "output frame id for point cloud data",
+          "default": ""
+        },
         "voxel_size_x": {
           "type": "number",
           "description": "the voxel size along x-axis [m]",


### PR DESCRIPTION
## Description

Let the param file schema contain all necessary params for a node in pointcloud preprocessor nodes. This adds `input_frame` and `output_frame` for pointcloud preprocessor nodes param file examples.

## Related links

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

For the provided launch files in this directory, feeding `input_frame:=...` and `output_frame:=...` in `ros2 launch` CLI will have no effect. The user should explicitly update the param file for desired input and output frames.
This is a tradeoff between self-containedness of the param file and local experiment convenience.

No interface or implementation changes for the node itself.

## Effects on system behavior

None.
