### PR TITLE
feat(system_monitor): debounce GPU usage error with duration parameter

### DIFF
--- a/system/autoware_system_monitor/config/gpu_monitor.param.yaml
+++ b/system/autoware_system_monitor/config/gpu_monitor.param.yaml
@@ -4,5 +4,6 @@
     temp_error: 95.0
     gpu_usage_warn: 0.90
     gpu_usage_error: 1.00
+    gpu_usage_error_duration: 0
     memory_usage_warn: 0.95
     memory_usage_error: 0.99

--- a/system/autoware_system_monitor/docs/ros_parameters.md
+++ b/system/autoware_system_monitor/docs/ros_parameters.md
@@ -95,14 +95,15 @@ process_monitor:
 
 gpu_monitor:
 
-| Name               | Type  |  Unit   | Default | Notes                                                                        |
-| :----------------- | :---: | :-----: | :-----: | :--------------------------------------------------------------------------- |
-| temp_warn          | float |  DegC   |  90.0   | Generates warning when GPU temperature reaches a specified value or higher.  |
-| temp_error         | float |  DegC   |  95.0   | Generates error when GPU temperature reaches a specified value or higher.    |
-| gpu_usage_warn     | float | %(1e-2) |  0.90   | Generates warning when GPU usage reaches a specified value or higher.        |
-| gpu_usage_error    | float | %(1e-2) |  1.00   | Generates error when GPU usage reaches a specified value or higher.          |
-| memory_usage_warn  | float | %(1e-2) |  0.90   | Generates warning when GPU memory usage reaches a specified value or higher. |
-| memory_usage_error | float | %(1e-2) |  1.00   | Generates error when GPU memory usage reaches a specified value or higher.   |
+| Name                     | Type  |  Unit   | Default | Notes                                                                                                      |
+| :----------------------- | :---: | :-----: | :-----: | :--------------------------------------------------------------------------------------------------------- |
+| temp_warn                | float |  DegC   |  90.0   | Generates warning when GPU temperature reaches a specified value or higher.                                |
+| temp_error               | float |  DegC   |  95.0   | Generates error when GPU temperature reaches a specified value or higher.                                  |
+| gpu_usage_warn           | float | %(1e-2) |  0.90   | Generates warning when GPU usage reaches a specified value or higher.                                      |
+| gpu_usage_error          | float | %(1e-2) |  1.00   | Generates error when GPU usage reaches a specified value or higher.                                        |
+| gpu_usage_error_duration |  int  |   sec   |    0    | Generates error when GPU usage stays at gpu_usage_error or higher for a specified duration. 0 disables it. |
+| memory_usage_warn        | float | %(1e-2) |  0.90   | Generates warning when GPU memory usage reaches a specified value or higher.                               |
+| memory_usage_error       | float | %(1e-2) |  1.00   | Generates error when GPU memory usage reaches a specified value or higher.                                 |
 
 ## <u>Voltage Monitor</u>
 

--- a/system/autoware_system_monitor/include/system_monitor/gpu_monitor/gpu_monitor_base.hpp
+++ b/system/autoware_system_monitor/include/system_monitor/gpu_monitor/gpu_monitor_base.hpp
@@ -28,6 +28,7 @@
 
 #include <climits>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -133,6 +134,14 @@ protected:
    */
   void publishGPUStatus();
 
+  /**
+   * @brief Convert GPU usage to diagnostic level
+   * @param [in] index GPU index
+   * @param [in] usage GPU usage ratio (0.0-1.0)
+   * @return diagnostic level
+   */
+  int gpuUsageToLevel(size_t index, float usage);
+
   diagnostic_updater::Updater updater_;  //!< @brief Updater class which advertises to /diagnostics
 
   rclcpp::Publisher<tier4_external_api_msgs::msg::GpuStatus>::SharedPtr
@@ -142,12 +151,16 @@ protected:
 
   char hostname_[HOST_NAME_MAX + 1];  //!< @brief host name
 
-  float temp_warn_;           //!< @brief GPU temperature(DegC) to generate warning
-  float temp_error_;          //!< @brief GPU temperature(DegC) to generate error
-  float gpu_usage_warn_;      //!< @brief GPU usage(%) to generate warning
-  float gpu_usage_error_;     //!< @brief GPU usage(%) to generate error
-  float memory_usage_warn_;   //!< @brief GPU memory usage(%) to generate warning
-  float memory_usage_error_;  //!< @brief GPU memory usage(%) to generate error
+  float temp_warn_;               //!< @brief GPU temperature(DegC) to generate warning
+  float temp_error_;              //!< @brief GPU temperature(DegC) to generate error
+  float gpu_usage_warn_;          //!< @brief GPU usage(%) to generate warning
+  float gpu_usage_error_;         //!< @brief GPU usage(%) to generate error
+  int gpu_usage_error_duration_;  //!< @brief duration(sec) over gpu_usage_error_ to generate error
+  float memory_usage_warn_;       //!< @brief GPU memory usage(%) to generate warning
+  float memory_usage_error_;      //!< @brief GPU memory usage(%) to generate error
+
+  std::vector<std::optional<rclcpp::Time>>
+    gpu_usage_error_start_times_;  //!< @brief start time of high GPU usage per GPU
 
   /**
    * @brief GPU temperature status messages

--- a/system/autoware_system_monitor/src/gpu_monitor/gpu_monitor_base.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/gpu_monitor_base.cpp
@@ -21,6 +21,7 @@
 
 #include <unistd.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -32,6 +33,7 @@ GPUMonitorBase::GPUMonitorBase(const std::string & node_name, const rclcpp::Node
   temp_error_(declare_parameter<float>("temp_error", 95.0)),
   gpu_usage_warn_(declare_parameter<float>("gpu_usage_warn", 0.90)),
   gpu_usage_error_(declare_parameter<float>("gpu_usage_error", 1.00)),
+  gpu_usage_error_duration_(declare_parameter<int>("gpu_usage_error_duration", 0)),
   memory_usage_warn_(declare_parameter<float>("memory_usage_warn", 0.95)),
   memory_usage_error_(declare_parameter<float>("memory_usage_error", 0.99))
 {
@@ -105,6 +107,37 @@ std::vector<GPUMonitorBase::GpuStatus> GPUMonitorBase::getGPUStatus() const
 void GPUMonitorBase::onTimer()
 {
   publishGPUStatus();
+}
+
+int GPUMonitorBase::gpuUsageToLevel(size_t index, float usage)
+{
+  int level = DiagStatus::OK;
+
+  if (usage >= gpu_usage_warn_) {
+    level = std::max(level, static_cast<int>(DiagStatus::WARN));
+  }
+
+  if (usage >= gpu_usage_error_) {
+    if (gpu_usage_error_duration_ <= 0) {
+      level = std::max(level, static_cast<int>(DiagStatus::ERROR));
+    } else {
+      if (index >= gpu_usage_error_start_times_.size()) {
+        gpu_usage_error_start_times_.resize(index + 1);
+      }
+      auto & start_time = gpu_usage_error_start_times_[index];
+      if (!start_time.has_value()) {
+        start_time = this->now();
+      }
+      const double elapsed_sec = (this->now() - start_time.value()).seconds();
+      if (elapsed_sec >= static_cast<double>(gpu_usage_error_duration_)) {
+        level = std::max(level, static_cast<int>(DiagStatus::ERROR));
+      }
+    }
+  } else if (index < gpu_usage_error_start_times_.size()) {
+    gpu_usage_error_start_times_[index].reset();
+  }
+
+  return level;
 }
 
 void GPUMonitorBase::publishGPUStatus()

--- a/system/autoware_system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/nvml_gpu_monitor.cpp
@@ -158,13 +158,8 @@ void GPUMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
       return;
     }
 
-    int level = DiagStatus::OK;
-    float usage = static_cast<float>(itr->utilization.gpu) / 100.0;
-    if (usage >= gpu_usage_error_) {
-      level = std::max(level, static_cast<int>(DiagStatus::ERROR));
-    } else if (usage >= gpu_usage_warn_) {
-      level = std::max(level, static_cast<int>(DiagStatus::WARN));
-    }
+    const float usage = static_cast<float>(itr->utilization.gpu) / 100.0;
+    const int level = gpuUsageToLevel(static_cast<size_t>(index), usage);
 
     stat.add(fmt::format("GPU {}: status", index), load_dict_.at(level));
     stat.add(fmt::format("GPU {}: name", index), itr->name);

--- a/system/autoware_system_monitor/src/gpu_monitor/tegra_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/src/gpu_monitor/tegra_gpu_monitor.cpp
@@ -93,8 +93,9 @@ void GPUMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
     return;
   }
 
-  int level = DiagStatus::OK;
+  int whole_level = DiagStatus::OK;
   std::string error_str;
+  int index = 0;
 
   for (const auto & itr : loads_) {
     // Read load file
@@ -111,19 +112,16 @@ void GPUMonitor::checkUsage(diagnostic_updater::DiagnosticStatusWrapper & stat)
     ifs.close();
     stat.addf(itr.label_, "%.1f%%", load / 10);
 
-    level = DiagStatus::OK;
     load /= 1000;
-    if (load >= gpu_usage_error_) {
-      level = std::max(level, static_cast<int>(DiagStatus::ERROR));
-    } else if (load >= gpu_usage_warn_) {
-      level = std::max(level, static_cast<int>(DiagStatus::WARN));
-    }
+    const int level = gpuUsageToLevel(static_cast<size_t>(index), load);
+    whole_level = std::max(whole_level, level);
+    ++index;
   }
 
   if (!error_str.empty()) {
     stat.summary(DiagStatus::ERROR, error_str);
   } else {
-    stat.summary(level, load_dict_.at(level));
+    stat.summary(whole_level, load_dict_.at(whole_level));
   }
 }
 

--- a/system/autoware_system_monitor/test/src/gpu_monitor/test_nvml_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/test/src/gpu_monitor/test_nvml_gpu_monitor.cpp
@@ -20,8 +20,10 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 
 using DiagStatus = diagnostic_msgs::msg::DiagnosticStatus;
 
@@ -48,6 +50,10 @@ public:
 
   void changeGPUUsageWarn(float gpu_usage_warn) { gpu_usage_warn_ = gpu_usage_warn; }
   void changeGPUUsageError(float gpu_usage_error) { gpu_usage_error_ = gpu_usage_error; }
+  void changeGPUUsageErrorDuration(int gpu_usage_error_duration)
+  {
+    gpu_usage_error_duration_ = gpu_usage_error_duration;
+  }
 
   void changeMemoryUsageWarn(float memory_usage_warn) { memory_usage_warn_ = memory_usage_warn; }
   void changeMemoryUsageError(float memory_usage_error)
@@ -325,6 +331,53 @@ TEST_F(GPUMonitorTestSuite, gpuUsageErrorTest)
     rclcpp::spin_some(monitor_->get_node_base_interface());
 
     // Verify
+    DiagStatus status;
+    ASSERT_TRUE(monitor_->findDiagStatus("GPU Usage", status));
+    ASSERT_EQ(status.level, DiagStatus::OK);
+  }
+}
+
+TEST_F(GPUMonitorTestSuite, gpuUsageErrorDurationTest)
+{
+  // Verify high usage does not immediately trigger error when duration is set
+  {
+    monitor_->changeGPUUsageErrorDuration(2);
+    monitor_->changeGPUUsageError(0.0);
+
+    monitor_->update();
+
+    rclcpp::WallRate(2).sleep();
+    rclcpp::spin_some(monitor_->get_node_base_interface());
+
+    DiagStatus status;
+    ASSERT_TRUE(monitor_->findDiagStatus("GPU Usage", status));
+    ASSERT_EQ(status.level, DiagStatus::WARN);
+  }
+
+  // Verify error after duration elapses
+  {
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    monitor_->update();
+
+    rclcpp::WallRate(2).sleep();
+    rclcpp::spin_some(monitor_->get_node_base_interface());
+
+    DiagStatus status;
+    ASSERT_TRUE(monitor_->findDiagStatus("GPU Usage", status));
+    ASSERT_EQ(status.level, DiagStatus::ERROR);
+  }
+
+  // Verify normal behavior after reset
+  {
+    monitor_->changeGPUUsageError(1.00);
+    monitor_->changeGPUUsageErrorDuration(0);
+
+    monitor_->update();
+
+    rclcpp::WallRate(2).sleep();
+    rclcpp::spin_some(monitor_->get_node_base_interface());
+
     DiagStatus status;
     ASSERT_TRUE(monitor_->findDiagStatus("GPU Usage", status));
     ASSERT_EQ(status.level, DiagStatus::OK);

--- a/system/autoware_system_monitor/test/src/gpu_monitor/test_tegra_gpu_monitor.cpp
+++ b/system/autoware_system_monitor/test/src/gpu_monitor/test_tegra_gpu_monitor.cpp
@@ -21,8 +21,11 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <fstream>
 #include <memory>
 #include <string>
+#include <thread>
 
 static constexpr const char * TEST_FILE = "test";
 
@@ -52,6 +55,12 @@ public:
 
   void addFreqName(const std::string & path) { freqs_.emplace_back(path, path); }
   void clearFreqNames() { freqs_.clear(); }
+
+  void changeGPUUsageError(float gpu_usage_error) { gpu_usage_error_ = gpu_usage_error; }
+  void changeGPUUsageErrorDuration(int gpu_usage_error_duration)
+  {
+    gpu_usage_error_duration_ = gpu_usage_error_duration;
+  }
 
   void update() { updater_.force_update(); }
 
@@ -387,6 +396,61 @@ TEST_F(GPUMonitorTestSuite, usageErrorTest)
     rclcpp::spin_some(monitor_->get_node_base_interface());
 
     // Verify
+    DiagStatus status;
+    ASSERT_TRUE(monitor_->findDiagStatus("GPU Usage", status));
+    ASSERT_EQ(status.level, DiagStatus::OK);
+  }
+}
+
+TEST_F(GPUMonitorTestSuite, usageErrorDurationTest)
+{
+  monitor_->addLoadName(TEST_FILE);
+
+  // Verify high usage does not immediately trigger error when duration is set
+  {
+    monitor_->changeGPUUsageErrorDuration(2);
+    monitor_->changeGPUUsageError(0.0);
+
+    std::ofstream ofs(TEST_FILE);
+    ofs << 1000 << std::endl;
+
+    monitor_->update();
+
+    rclcpp::WallRate(2).sleep();
+    rclcpp::spin_some(monitor_->get_node_base_interface());
+
+    DiagStatus status;
+    ASSERT_TRUE(monitor_->findDiagStatus("GPU Usage", status));
+    ASSERT_EQ(status.level, DiagStatus::WARN);
+  }
+
+  // Verify error after duration elapses
+  {
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    monitor_->update();
+
+    rclcpp::WallRate(2).sleep();
+    rclcpp::spin_some(monitor_->get_node_base_interface());
+
+    DiagStatus status;
+    ASSERT_TRUE(monitor_->findDiagStatus("GPU Usage", status));
+    ASSERT_EQ(status.level, DiagStatus::ERROR);
+  }
+
+  // Verify normal behavior after reset
+  {
+    monitor_->changeGPUUsageError(1.00);
+    monitor_->changeGPUUsageErrorDuration(0);
+
+    std::ofstream ofs(TEST_FILE);
+    ofs << 890 << std::endl;
+
+    monitor_->update();
+
+    rclcpp::WallRate(2).sleep();
+    rclcpp::spin_some(monitor_->get_node_base_interface());
+
     DiagStatus status;
     ASSERT_TRUE(monitor_->findDiagStatus("GPU Usage", status));
     ASSERT_EQ(status.level, DiagStatus::OK);


### PR DESCRIPTION
## Summary
- Add `gpu_usage_error_duration` parameter to `gpu_monitor` so usage ERROR is reported only after high GPU usage persists for the configured number of seconds
- Introduce shared `gpuUsageToLevel()` helper in `GPUMonitorBase` and apply it to both NVML and Tegra GPU monitors
- Default duration is `0` (backward compatible: immediate ERROR when usage exceeds threshold)

## Test plan
- [x] Built `autoware_system_monitor` with `colcon build --packages-select autoware_system_monitor`
- [x] Added duration-based unit tests for NVML and Tegra GPU monitors
- [ ] CI

## Notes for reviewers
- While duration has not elapsed, usage above the error threshold reports WARN (if above warn threshold) rather than ERROR
- Timer resets when usage drops below `gpu_usage_error`


Made with [Cursor](https://cursor.com)