### PR TITLE
perf(cuda_unique_ptr): add stream-ordered variant

### DIFF
--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
@@ -28,25 +28,73 @@
 
 namespace autoware::cuda_utils
 {
+namespace detail
+{
+inline bool is_default_stream(cudaStream_t stream)
+{
+  return stream == nullptr || stream == cudaStreamLegacy;
+}
+}  // namespace detail
+
 struct CudaDeleter
 {
-  void operator()(void * p) const { CHECK_CUDA_ERROR(::cudaFree(p)); }
+  void operator()(void * p) const
+  {
+    if (!p) {
+      return;
+    }
+    if (stream_ != nullptr) {
+      CHECK_CUDA_ERROR(::cudaFreeAsync(p, stream_));
+    } else {
+      CHECK_CUDA_ERROR(::cudaFree(p));
+    }
+  }
+
+  cudaStream_t stream_{nullptr};
 };
 template <typename T>
 using CudaUniquePtr = std::unique_ptr<T, CudaDeleter>;
 
 template <typename T>
 typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtr<T>> make_unique(
+  const std::size_t n, cudaStream_t stream)
+{
+  if (detail::is_default_stream(stream)) {
+    throw std::invalid_argument("Stream cannot be null or legacy.");
+  }
+
+  using U = typename std::remove_extent_t<T>;
+  U * p{nullptr};
+  CHECK_CUDA_ERROR(::cudaMallocAsync(reinterpret_cast<void **>(&p), sizeof(U) * n, stream));
+  return CudaUniquePtr<T>{p, CudaDeleter{stream}};
+}
+
+template <typename T>
+CudaUniquePtr<T> make_unique(cudaStream_t stream)
+{
+  if (detail::is_default_stream(stream)) {
+    throw std::invalid_argument("Stream cannot be null or legacy.");
+  }
+  
+  T * p{nullptr};
+  CHECK_CUDA_ERROR(::cudaMallocAsync(reinterpret_cast<void **>(&p), sizeof(T), stream));
+  return CudaUniquePtr<T>{p, CudaDeleter{stream}};
+}
+
+template <typename T>
+[[deprecated("Use make_unique<T[]>(n, cudaStream_t) for stream-ordered allocation")]]
+typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtr<T>> make_unique(
   const std::size_t n)
 {
   using U = typename std::remove_extent_t<T>;
-  U * p;
+  U * p{nullptr};
   CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&p), sizeof(U) * n));
   return CudaUniquePtr<T>{p};
 }
 
 template <typename T>
-CudaUniquePtr<T> make_unique()
+[[deprecated("Use make_unique<T>(cudaStream_t) for stream-ordered allocation")]] CudaUniquePtr<T>
+make_unique()
 {
   T * p;
   CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&p), sizeof(T)));

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
@@ -36,21 +36,25 @@ inline bool is_default_stream(cudaStream_t stream)
 }
 }  // namespace detail
 
-struct CudaDeleter
+class CudaDeleter
 {
+public:
+  explicit CudaDeleter(cudaStream_t stream = nullptr) : stream_(stream) {}
+
   void operator()(void * p) const
   {
     if (!p) {
       return;
     }
-    if (stream_ != nullptr) {
+    if (!detail::is_default_stream(stream_)) {
       CHECK_CUDA_ERROR(::cudaFreeAsync(p, stream_));
     } else {
       CHECK_CUDA_ERROR(::cudaFree(p));
     }
   }
 
-  cudaStream_t stream_{nullptr};
+private:
+  cudaStream_t stream_;
 };
 template <typename T>
 using CudaUniquePtr = std::unique_ptr<T, CudaDeleter>;
@@ -96,7 +100,7 @@ template <typename T>
 [[deprecated("Use make_unique<T>(cudaStream_t) for stream-ordered allocation")]] CudaUniquePtr<T>
 make_unique()
 {
-  T * p;
+  T * p{nullptr};
   CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&p), sizeof(T)));
   return CudaUniquePtr<T>{p};
 }
@@ -108,7 +112,7 @@ template <typename T>
 CudaPooledUniquePtr<T> make_unique(const std::size_t n, cudaStream_t stream, cudaMemPool_t pool)
 {
   using U = typename std::remove_extent_t<T>;
-  T * ptr = nullptr;
+  T * ptr{nullptr};
 
   CHECK_CUDA_ERROR(
     cudaMallocFromPoolAsync(reinterpret_cast<void **>(&ptr), sizeof(U) * n, pool, stream));
@@ -144,7 +148,7 @@ typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtrHost<T>> make_un
   const std::size_t n, unsigned int flag)
 {
   using U = typename std::remove_extent_t<T>;
-  U * p;
+  U * p{nullptr};
   CHECK_CUDA_ERROR(::cudaHostAlloc(reinterpret_cast<void **>(&p), sizeof(U) * n, flag));
   return CudaUniquePtrHost<T>{p};
 }
@@ -152,7 +156,7 @@ typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtrHost<T>> make_un
 template <typename T>
 CudaUniquePtrHost<T> make_unique_host(unsigned int flag = cudaHostAllocDefault)
 {
-  T * p;
+  T * p{nullptr};
   CHECK_CUDA_ERROR(::cudaHostAlloc(reinterpret_cast<void **>(&p), sizeof(T), flag));
   return CudaUniquePtrHost<T>{p};
 }

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
@@ -75,7 +75,7 @@ CudaUniquePtr<T> make_unique(cudaStream_t stream)
   if (detail::is_default_stream(stream)) {
     throw std::invalid_argument("Stream cannot be null or legacy.");
   }
-  
+
   T * p{nullptr};
   CHECK_CUDA_ERROR(::cudaMallocAsync(reinterpret_cast<void **>(&p), sizeof(T), stream));
   return CudaUniquePtr<T>{p, CudaDeleter{stream}};

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
@@ -87,8 +87,7 @@ typename std::enable_if_t<!std::is_array_v<T>, CudaUniquePtr<T>> make_unique(cud
 
 template <typename T>
 [[deprecated("Use make_unique<T[]>(n, cudaStream_t) for stream-ordered allocation")]]
-typename std::enable_if_t<std::is_array_v<T>, CudaUniquePtr<T>> make_unique(
-  const std::size_t n)
+typename std::enable_if_t<std::is_array_v<T>, CudaUniquePtr<T>> make_unique(const std::size_t n)
 {
   using U = typename std::remove_extent_t<T>;
   U * p{nullptr};
@@ -154,7 +153,8 @@ typename std::enable_if_t<std::is_array_v<T>, CudaUniquePtrHost<T>> make_unique_
 }
 
 template <typename T>
-typename std::enable_if_t<!std::is_array_v<T>, CudaUniquePtrHost<T>> make_unique_host(unsigned int flag = cudaHostAllocDefault)
+typename std::enable_if_t<!std::is_array_v<T>, CudaUniquePtrHost<T>> make_unique_host(
+  unsigned int flag = cudaHostAllocDefault)
 {
   T * p{nullptr};
   CHECK_CUDA_ERROR(::cudaHostAlloc(reinterpret_cast<void **>(&p), sizeof(T), flag));

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
@@ -60,7 +60,7 @@ template <typename T>
 using CudaUniquePtr = std::unique_ptr<T, CudaDeleter>;
 
 template <typename T>
-typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtr<T>> make_unique(
+typename std::enable_if_t<std::is_array_v<T>, CudaUniquePtr<T>> make_unique(
   const std::size_t n, cudaStream_t stream)
 {
   if (detail::is_default_stream(stream)) {
@@ -74,7 +74,7 @@ typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtr<T>> make_unique
 }
 
 template <typename T>
-CudaUniquePtr<T> make_unique(cudaStream_t stream)
+typename std::enable_if_t<!std::is_array_v<T>, CudaUniquePtr<T>> make_unique(cudaStream_t stream)
 {
   if (detail::is_default_stream(stream)) {
     throw std::invalid_argument("Stream cannot be null or legacy.");
@@ -87,7 +87,7 @@ CudaUniquePtr<T> make_unique(cudaStream_t stream)
 
 template <typename T>
 [[deprecated("Use make_unique<T[]>(n, cudaStream_t) for stream-ordered allocation")]]
-typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtr<T>> make_unique(
+typename std::enable_if_t<std::is_array_v<T>, CudaUniquePtr<T>> make_unique(
   const std::size_t n)
 {
   using U = typename std::remove_extent_t<T>;
@@ -97,8 +97,8 @@ typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtr<T>> make_unique
 }
 
 template <typename T>
-[[deprecated("Use make_unique<T>(cudaStream_t) for stream-ordered allocation")]] CudaUniquePtr<T>
-make_unique()
+[[deprecated("Use make_unique<T>(cudaStream_t) for stream-ordered allocation")]]
+typename std::enable_if_t<!std::is_array_v<T>, CudaUniquePtr<T>> make_unique()
 {
   T * p{nullptr};
   CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&p), sizeof(T)));
@@ -144,7 +144,7 @@ template <typename T>
 using CudaUniquePtrHost = std::unique_ptr<T, CudaDeleterHost>;
 
 template <typename T>
-typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtrHost<T>> make_unique_host(
+typename std::enable_if_t<std::is_array_v<T>, CudaUniquePtrHost<T>> make_unique_host(
   const std::size_t n, unsigned int flag)
 {
   using U = typename std::remove_extent_t<T>;
@@ -154,7 +154,7 @@ typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtrHost<T>> make_un
 }
 
 template <typename T>
-CudaUniquePtrHost<T> make_unique_host(unsigned int flag = cudaHostAllocDefault)
+typename std::enable_if_t<!std::is_array_v<T>, CudaUniquePtrHost<T>> make_unique_host(unsigned int flag = cudaHostAllocDefault)
 {
   T * p{nullptr};
   CHECK_CUDA_ERROR(::cudaHostAlloc(reinterpret_cast<void **>(&p), sizeof(T), flag));

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_unique_ptr.hpp
@@ -85,8 +85,9 @@ typename std::enable_if_t<!std::is_array_v<T>, CudaUniquePtr<T>> make_unique(cud
   return CudaUniquePtr<T>{p, CudaDeleter{stream}};
 }
 
+// TODO(mojomex): Deprecate once https://github.com/orgs/autowarefoundation/discussions/7167 is
+// resolved
 template <typename T>
-[[deprecated("Use make_unique<T[]>(n, cudaStream_t) for stream-ordered allocation")]]
 typename std::enable_if_t<std::is_array_v<T>, CudaUniquePtr<T>> make_unique(const std::size_t n)
 {
   using U = typename std::remove_extent_t<T>;
@@ -95,8 +96,9 @@ typename std::enable_if_t<std::is_array_v<T>, CudaUniquePtr<T>> make_unique(cons
   return CudaUniquePtr<T>{p};
 }
 
+// TODO(mojomex): Deprecate once https://github.com/orgs/autowarefoundation/discussions/7167 is
+// resolved
 template <typename T>
-[[deprecated("Use make_unique<T>(cudaStream_t) for stream-ordered allocation")]]
 typename std::enable_if_t<!std::is_array_v<T>, CudaUniquePtr<T>> make_unique()
 {
   T * p{nullptr};

--- a/sensing/autoware_cuda_utils/test/test_cuda_unique_ptr.cu
+++ b/sensing/autoware_cuda_utils/test/test_cuda_unique_ptr.cu
@@ -26,20 +26,32 @@ class CudaUniquePtrTest : public autoware::cuda_utils::CudaTest
 TEST_F(CudaUniquePtrTest, MakeUniqueDeviceMemory)
 {
   // Test creating a single object on device
-  auto ptr = autoware::cuda_utils::make_unique<float>();
-  EXPECT_NE(ptr.get(), nullptr);
+  cudaStream_t stream{};
+  CHECK_CUDA_ERROR(cudaStreamCreate(&stream));
+  {
+    auto ptr = autoware::cuda_utils::make_unique<float>(stream);
+    EXPECT_NE(ptr.get(), nullptr);
+  }
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream));
+  CHECK_CUDA_ERROR(cudaStreamDestroy(stream));
 }
 
 TEST_F(CudaUniquePtrTest, MakeUniqueDeviceArray)
 {
   // Test creating an array on device
-  auto ptr = autoware::cuda_utils::make_unique<float[]>(100);
-  EXPECT_NE(ptr.get(), nullptr);
+  cudaStream_t stream{};
+  CHECK_CUDA_ERROR(cudaStreamCreate(&stream));
+  {
+    auto ptr = autoware::cuda_utils::make_unique<float[]>(100, stream);
+    EXPECT_NE(ptr.get(), nullptr);
 
-  cudaPointerAttributes attributes{};
-  CHECK_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr.get()));
-  EXPECT_EQ(attributes.type, cudaMemoryTypeDevice);
-  EXPECT_EQ(attributes.devicePointer, ptr.get());
+    cudaPointerAttributes attributes{};
+    CHECK_CUDA_ERROR(cudaPointerGetAttributes(&attributes, ptr.get()));
+    EXPECT_EQ(attributes.type, cudaMemoryTypeDevice);
+    EXPECT_EQ(attributes.devicePointer, ptr.get());
+  }
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream));
+  CHECK_CUDA_ERROR(cudaStreamDestroy(stream));
 }
 
 TEST_F(CudaUniquePtrTest, MakeUniqueHostMemory)
@@ -64,10 +76,14 @@ TEST_F(CudaUniquePtrTest, MakeUniqueHostArray)
 TEST_F(CudaUniquePtrTest, DeleterFunctionality)
 {
   // Test that CudaDeleter and CudaDeleterHost types exist and are usable
+  cudaStream_t stream{};
+  CHECK_CUDA_ERROR(cudaStreamCreate(&stream));
   {
-    auto ptr = autoware::cuda_utils::make_unique<int>();
+    auto ptr = autoware::cuda_utils::make_unique<int>(stream);
     // Deleter will be called automatically on scope exit
   }
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream));
+  CHECK_CUDA_ERROR(cudaStreamDestroy(stream));
 
   {
     auto ptr = autoware::cuda_utils::make_unique_host<int>();


### PR DESCRIPTION
## Description

`autoware::cuda_utils::unique_ptr` is used in performance-critical code but only supports synchronous `cudaAlloc` and `cudaFree`. To prevent interference when multiple GPU workloads run in one process, a stream ordered API is provided by this PR.

To signify that there is a performance penalty when using the non-stream legacy APIs, I deprecated those.

Refactored unit tests to use non-deprecated API.

* Compare to the similar implementation in autowarefoundation/cuda_blackboard#22

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

Added:
```c++
CudaUniquePtr<T> make_unique(const std::size_t n, cudaStream_t stream);
CudaUniquePtr<T> make_unique(cudaStream_t stream);
```

Deprecated:
```c++
CudaUniquePtr<T> make_unique(const std::size_t n);
CudaUniquePtr<T> make_unique();
```

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
