### PR TITLE
perf(ptv3): use uint32 serialized metadata

### DIFF
--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -30,14 +30,14 @@ namespace autoware::ptv3
 
 struct SerializedPoolingDeviceStageView
 {
-  std::int64_t * indices{};
-  std::int64_t * indptr{};
-  std::int64_t * head_indices{};
-  std::int64_t * cluster{};
+  std::uint32_t * indices{};
+  std::uint32_t * indptr{};
+  std::uint32_t * head_indices{};
+  std::uint32_t * cluster{};
   std::int32_t * grid_coord{};
-  std::int64_t * serialized_code{};
-  std::int64_t * serialized_order{};
-  std::int64_t * serialized_inverse{};
+  std::uint32_t * serialized_code{};
+  std::uint32_t * serialized_order{};
+  std::uint32_t * serialized_inverse{};
 };
 
 class PreprocessCuda
@@ -47,13 +47,14 @@ public:
 
   std::size_t generateFeatures(
     const void * input_data, CloudFormat input_format, unsigned int num_points,
-    float * voxel_features, std::int32_t * voxel_coords, std::int64_t * voxel_hashes,
+    float * voxel_features, std::int32_t * voxel_coords, std::uint32_t * voxel_hashes,
     void * compact_points, float * reconstruction_features, void * cropped_source_points,
     std::int64_t * inverse_map, std::size_t * num_cropped_points);
 
   void generateSerializedPoolingMetadata(
-    const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
-    const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts);
+    const std::int32_t * grid_coord, const std::uint32_t * serialized_code,
+    std::uint32_t num_voxels, const std::vector<SerializedPoolingDeviceStageView> & stages,
+    std::uint32_t * stage_counts);
 
   [[nodiscard]] const std::uint32_t * cropMask() const { return crop_mask_d_.get(); }
   [[nodiscard]] const std::uint32_t * cropIndices() const { return crop_indices_d_.get(); }
@@ -85,12 +86,12 @@ private:
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> sort_workspace_d_{nullptr};
   std::size_t sort_workspace_size_{0};
 
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_keys_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_keys_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_indices_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_indices_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_flags_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_ids_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_sorted_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_sorted_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_run_flags_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_run_ids_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> pooling_workspace_d_{nullptr};
   std::size_t pooling_workspace_size_{0};
 };

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -35,7 +35,7 @@ struct SerializedPoolingDeviceStageView
   std::uint32_t * head_indices{};
   std::uint32_t * cluster{};
   std::int32_t * grid_coord{};
-  std::uint32_t * serialized_code{};
+  std::int64_t * serialized_code{};
   std::uint32_t * serialized_order{};
   std::uint32_t * serialized_inverse{};
 };
@@ -47,14 +47,13 @@ public:
 
   std::size_t generateFeatures(
     const void * input_data, CloudFormat input_format, unsigned int num_points,
-    float * voxel_features, std::int32_t * voxel_coords, std::uint32_t * voxel_hashes,
+    float * voxel_features, std::int32_t * voxel_coords, std::int64_t * voxel_hashes,
     void * compact_points, float * reconstruction_features, void * cropped_source_points,
     std::int64_t * inverse_map, std::size_t * num_cropped_points);
 
   void generateSerializedPoolingMetadata(
-    const std::int32_t * grid_coord, const std::uint32_t * serialized_code,
-    std::uint32_t num_voxels, const std::vector<SerializedPoolingDeviceStageView> & stages,
-    std::uint32_t * stage_counts);
+    const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::uint32_t num_voxels,
+    const std::vector<SerializedPoolingDeviceStageView> & stages, std::uint32_t * stage_counts);
 
   [[nodiscard]] const std::uint32_t * cropMask() const { return crop_mask_d_.get(); }
   [[nodiscard]] const std::uint32_t * cropIndices() const { return crop_indices_d_.get(); }
@@ -86,8 +85,8 @@ private:
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> sort_workspace_d_{nullptr};
   std::size_t sort_workspace_size_{0};
 
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_keys_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_sorted_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> pooling_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> pooling_sorted_keys_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_indices_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_sorted_indices_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> pooling_run_flags_d_{nullptr};

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -90,9 +90,9 @@ public:
     auto max_grid_size = std::max({grid_x_size_, grid_y_size_, grid_z_size_});
     serialization_depth_ =
       static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_grid_size))));
-    if (serialization_depth_ > 10) {
+    if (serialization_depth_ > 21) {
       throw std::runtime_error(
-        "The current PTv3 preprocessing path supports voxel grids up to 1024 per axis.");
+        "The current PTv3 preprocessing path supports serialized codes up to 63 bits.");
     }
 
     use_64bit_hash_ = false;

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -59,6 +59,12 @@ public:
     if (voxels_num.size() == 3) {
       min_num_voxels_ = voxels_num[0];
       max_num_voxels_ = voxels_num[2];
+      if (
+        cloud_capacity_ > std::numeric_limits<std::uint32_t>::max() ||
+        max_num_voxels_ > std::numeric_limits<std::uint32_t>::max()) {
+        throw std::runtime_error(
+          "The current PTv3 preprocessing path supports at most uint32 max points and voxels.");
+      }
 
       voxels_num_[0] = voxels_num[0];
       voxels_num_[1] = voxels_num[1];
@@ -84,14 +90,12 @@ public:
     auto max_grid_size = std::max({grid_x_size_, grid_y_size_, grid_z_size_});
     serialization_depth_ =
       static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_grid_size))));
-    auto max_voxels_depth =
-      static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_num_voxels_))));
-    if (serialization_depth_ * 3 + max_voxels_depth >= 64) {
-      throw std::runtime_error("Serialization depth is too large");
+    if (serialization_depth_ > 10) {
+      throw std::runtime_error(
+        "The current PTv3 preprocessing path supports voxel grids up to 1024 per axis.");
     }
 
-    use_64bit_hash_ =
-      grid_x_size_ * grid_y_size_ * grid_z_size_ > std::numeric_limits<std::uint32_t>::max();
+    use_64bit_hash_ = false;
 
     class_names_ = class_names;
     serialization_orders_ = validate_serialization_orders(serialization_orders);

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
@@ -114,7 +114,7 @@ protected:
     CudaUniquePtr<std::uint32_t[]> head_indices{nullptr};
     CudaUniquePtr<std::uint32_t[]> cluster{nullptr};
     CudaUniquePtr<std::int32_t[]> grid_coord{nullptr};
-    CudaUniquePtr<std::uint32_t[]> serialized_code{nullptr};
+    CudaUniquePtr<std::int64_t[]> serialized_code{nullptr};
     CudaUniquePtr<std::uint32_t[]> serialized_order{nullptr};
     CudaUniquePtr<std::uint32_t[]> serialized_inverse{nullptr};
   };
@@ -138,7 +138,7 @@ protected:
   CudaUniquePtr<float[]> reconstructed_probs_d_{nullptr};           // only for partial and full
   CudaUniquePtr<std::int32_t[]> grid_coord_d_{nullptr};
   CudaUniquePtr<float[]> feat_d_{nullptr};
-  CudaUniquePtr<std::uint32_t[]> serialized_code_d_{nullptr};
+  CudaUniquePtr<std::int64_t[]> serialized_code_d_{nullptr};
 
   // Backbone outputs shared with the segmentation head.
   CudaUniquePtr<float[]> bb_point_feat_d_{nullptr};

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
@@ -109,19 +109,19 @@ protected:
 
   struct SerializedPoolingDeviceStage
   {
-    CudaUniquePtr<std::int64_t[]> indices{nullptr};
-    CudaUniquePtr<std::int64_t[]> indptr{nullptr};
-    CudaUniquePtr<std::int64_t[]> head_indices{nullptr};
-    CudaUniquePtr<std::int64_t[]> cluster{nullptr};
+    CudaUniquePtr<std::uint32_t[]> indices{nullptr};
+    CudaUniquePtr<std::uint32_t[]> indptr{nullptr};
+    CudaUniquePtr<std::uint32_t[]> head_indices{nullptr};
+    CudaUniquePtr<std::uint32_t[]> cluster{nullptr};
     CudaUniquePtr<std::int32_t[]> grid_coord{nullptr};
-    CudaUniquePtr<std::int64_t[]> serialized_code{nullptr};
-    CudaUniquePtr<std::int64_t[]> serialized_order{nullptr};
-    CudaUniquePtr<std::int64_t[]> serialized_inverse{nullptr};
+    CudaUniquePtr<std::uint32_t[]> serialized_code{nullptr};
+    CudaUniquePtr<std::uint32_t[]> serialized_order{nullptr};
+    CudaUniquePtr<std::uint32_t[]> serialized_inverse{nullptr};
   };
 
   std::vector<SerializedPoolingDeviceStage> serialized_pooling_stages_d_;
-  CudaUniquePtr<std::int64_t[]> serialized_pooling_num_voxels_d_{nullptr};
-  std::vector<std::int64_t> serialized_pooling_num_voxels_;
+  CudaUniquePtr<std::uint32_t[]> serialized_pooling_num_voxels_d_{nullptr};
+  std::vector<std::uint32_t> serialized_pooling_num_voxels_;
   std::vector<std::int64_t> serialized_pooling_depths_;
 
   // Preprocess outputs
@@ -138,7 +138,7 @@ protected:
   CudaUniquePtr<float[]> reconstructed_probs_d_{nullptr};           // only for partial and full
   CudaUniquePtr<std::int32_t[]> grid_coord_d_{nullptr};
   CudaUniquePtr<float[]> feat_d_{nullptr};
-  CudaUniquePtr<std::int64_t[]> serialized_code_d_{nullptr};
+  CudaUniquePtr<std::uint32_t[]> serialized_code_d_{nullptr};
 
   // Backbone outputs shared with the segmentation head.
   CudaUniquePtr<float[]> bb_point_feat_d_{nullptr};

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -465,18 +465,20 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
       static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
-      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-      pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-      capacity, 0, 64, stream_));
+    CHECK_CUDA_ERROR(
+      cub::DeviceRadixSort::SortPairs(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+        capacity, 0, 64, stream_));
 
     markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       pooling_sorted_keys_d_.get(), pooling_run_flags_d_.get(), capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(cub::DeviceScan::InclusiveSum(
-      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
-      pooling_run_ids_d_.get(), capacity, stream_));
+    CHECK_CUDA_ERROR(
+      cub::DeviceScan::InclusiveSum(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
+        pooling_run_ids_d_.get(), capacity, stream_));
 
     fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       current_grid_coord, current_serialized_code, pooling_sorted_keys_d_.get(),
@@ -492,10 +494,11 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
         static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-      CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-        capacity, 0, 64, stream_));
+      CHECK_CUDA_ERROR(
+        cub::DeviceRadixSort::SortPairs(
+          pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+          pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+          capacity, 0, 64, stream_));
 
       fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
         pooling_sorted_keys_d_.get(), pooling_sorted_indices_d_.get(), stage_counts,

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -86,23 +86,24 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   sort_workspace_d_ = autoware::cuda_utils::make_unique<std::uint8_t[]>(sort_workspace_size_);
 
-  pooling_keys_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  pooling_keys_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
   pooling_sorted_keys_d_ =
-    autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_indices_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
+  pooling_indices_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
   pooling_sorted_indices_d_ =
-    autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_run_flags_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_run_ids_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
+  pooling_run_flags_d_ =
+    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
+  pooling_run_ids_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
 
   std::size_t pooling_sort_workspace_size = 0;
   std::size_t pooling_scan_workspace_size = 0;
-  std::int64_t * int64_nullptr = nullptr;
+  std::uint32_t * uint32_nullptr = nullptr;
   cub::DeviceRadixSort::SortPairs(
-    nullptr, pooling_sort_workspace_size, int64_nullptr, int64_nullptr, int64_nullptr,
-    int64_nullptr, config_.max_num_voxels_, 0, 63, nullptr);
+    nullptr, pooling_sort_workspace_size, uint32_nullptr, uint32_nullptr, uint32_nullptr,
+    uint32_nullptr, config_.max_num_voxels_, 0, 32, nullptr);
   cub::DeviceScan::InclusiveSum(
-    nullptr, pooling_scan_workspace_size, int64_nullptr, int64_nullptr, config_.max_num_voxels_,
+    nullptr, pooling_scan_workspace_size, uint32_nullptr, uint32_nullptr, config_.max_num_voxels_,
     nullptr);
   pooling_workspace_size_ = std::max(pooling_sort_workspace_size, pooling_scan_workspace_size);
   pooling_workspace_d_ = autoware::cuda_utils::make_unique<std::uint8_t[]>(pooling_workspace_size_);
@@ -264,7 +265,7 @@ __global__ void voxelizationHash32Kernel(
 
 __global__ void computeGridCoordsAndSerializationKernel(
   const float4 * __restrict__ points, int3 * __restrict__ coords,
-  std::int64_t * __restrict__ hashes, int num_points, float voxel_size_x, float voxel_size_y,
+  std::uint32_t * __restrict__ hashes, int num_points, float voxel_size_x, float voxel_size_y,
   float voxel_size_z, std::int32_t min_x, std::int32_t min_y, std::int32_t min_z, int depth)
 {
   static_assert(sizeof(int3) == sizeof(std::int32_t) * 3, "int3 must be 12 bytes");
@@ -280,11 +281,11 @@ __global__ void computeGridCoordsAndSerializationKernel(
 
   coords[idx] = make_int3(x, y, z);
 
-  std::int64_t key1 = 0;
-  std::int64_t key2 = 0;
+  std::uint32_t key1 = 0;
+  std::uint32_t key2 = 0;
 
   for (int i = 0; i < depth; ++i) {
-    std::int64_t mask = 1 << i;
+    const auto mask = static_cast<std::uint32_t>(1U << i);
     key1 |= ((x & mask) << (2 * i + 2));
     key1 |= ((y & mask) << (2 * i + 1));
     key1 |= ((z & mask) << (2 * i + 0));
@@ -298,20 +299,21 @@ __global__ void computeGridCoordsAndSerializationKernel(
   hashes[idx + num_points] = key2;
 }
 
-constexpr std::int64_t kInvalidPoolingKey = std::numeric_limits<std::int64_t>::max();
+constexpr std::uint32_t kInvalidPoolingKey = std::numeric_limits<std::uint32_t>::max();
 
 __global__ void setInitialStageCountKernel(
-  std::int64_t * __restrict__ stage_counts, std::int64_t num_voxels)
+  std::uint32_t * __restrict__ stage_counts, std::uint32_t num_voxels)
 {
   *stage_counts = num_voxels;
 }
 
 __global__ void preparePoolingSortInputKernel(
-  const std::int64_t * __restrict__ serialized_code, const std::int64_t * __restrict__ stage_counts,
-  std::int64_t * __restrict__ keys, std::int64_t * __restrict__ indices, std::int32_t stage_index,
-  std::int32_t pooling_depth, std::int64_t capacity)
+  const std::uint32_t * __restrict__ serialized_code,
+  const std::uint32_t * __restrict__ stage_counts, std::uint32_t * __restrict__ keys,
+  std::uint32_t * __restrict__ indices, std::int32_t stage_index, std::int32_t pooling_depth,
+  std::uint32_t capacity)
 {
-  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const auto idx = static_cast<std::uint32_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
     return;
   }
@@ -322,10 +324,10 @@ __global__ void preparePoolingSortInputKernel(
 }
 
 __global__ void markPoolingRunsKernel(
-  const std::int64_t * __restrict__ sorted_keys, std::int64_t * __restrict__ run_flags,
-  std::int64_t capacity)
+  const std::uint32_t * __restrict__ sorted_keys, std::uint32_t * __restrict__ run_flags,
+  std::uint32_t capacity)
 {
-  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const auto idx = static_cast<std::uint32_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
     return;
   }
@@ -336,16 +338,16 @@ __global__ void markPoolingRunsKernel(
 
 __global__ void fillPoolingStageKernel(
   const std::int32_t * __restrict__ grid_coord_in,
-  const std::int64_t * __restrict__ serialized_code_in,
-  const std::int64_t * __restrict__ sorted_keys, const std::int64_t * __restrict__ sorted_indices,
-  const std::int64_t * __restrict__ run_flags, const std::int64_t * __restrict__ run_ids,
-  std::int64_t * __restrict__ indices_out, std::int64_t * __restrict__ indptr_out,
-  std::int64_t * __restrict__ head_indices_out, std::int64_t * __restrict__ cluster_out,
-  std::int32_t * __restrict__ grid_coord_out, std::int64_t * __restrict__ serialized_code_out,
-  std::int64_t * __restrict__ stage_counts, std::int32_t stage_index, std::int32_t pooling_depth,
-  std::int32_t num_orders, std::int64_t capacity)
+  const std::uint32_t * __restrict__ serialized_code_in,
+  const std::uint32_t * __restrict__ sorted_keys, const std::uint32_t * __restrict__ sorted_indices,
+  const std::uint32_t * __restrict__ run_flags, const std::uint32_t * __restrict__ run_ids,
+  std::uint32_t * __restrict__ indices_out, std::uint32_t * __restrict__ indptr_out,
+  std::uint32_t * __restrict__ head_indices_out, std::uint32_t * __restrict__ cluster_out,
+  std::int32_t * __restrict__ grid_coord_out, std::uint32_t * __restrict__ serialized_code_out,
+  std::uint32_t * __restrict__ stage_counts, std::int32_t stage_index, std::int32_t pooling_depth,
+  std::int32_t num_orders, std::uint32_t capacity)
 {
-  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const auto idx = static_cast<std::uint32_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
     return;
   }
@@ -388,11 +390,12 @@ __global__ void fillPoolingStageKernel(
 }
 
 __global__ void prepareOrderSortInputKernel(
-  const std::int64_t * __restrict__ serialized_code, const std::int64_t * __restrict__ stage_counts,
-  std::int64_t * __restrict__ keys, std::int64_t * __restrict__ indices, std::int32_t stage_index,
-  std::int32_t order_index, std::int64_t capacity)
+  const std::uint32_t * __restrict__ serialized_code,
+  const std::uint32_t * __restrict__ stage_counts, std::uint32_t * __restrict__ keys,
+  std::uint32_t * __restrict__ indices, std::int32_t stage_index, std::int32_t order_index,
+  std::uint32_t capacity)
 {
-  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const auto idx = static_cast<std::uint32_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
     return;
   }
@@ -405,13 +408,13 @@ __global__ void prepareOrderSortInputKernel(
 }
 
 __global__ void fillOrderAndInverseKernel(
-  const std::int64_t * __restrict__ sorted_keys, const std::int64_t * __restrict__ sorted_indices,
-  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ order_out,
-  std::int64_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
-  std::int64_t capacity)
+  const std::uint32_t * __restrict__ sorted_keys, const std::uint32_t * __restrict__ sorted_indices,
+  const std::uint32_t * __restrict__ stage_counts, std::uint32_t * __restrict__ order_out,
+  std::uint32_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
+  std::uint32_t capacity)
 {
   const auto count = stage_counts[stage_index];
-  const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const auto rank = static_cast<std::uint32_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (rank >= capacity || rank >= count || sorted_keys[rank] == kInvalidPoolingKey) {
     return;
   }
@@ -432,14 +435,14 @@ std::int32_t poolingDepth(const std::int64_t stride)
 }
 
 void PreprocessCuda::generateSerializedPoolingMetadata(
-  const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
-  const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts)
+  const std::int32_t * grid_coord, const std::uint32_t * serialized_code, std::uint32_t num_voxels,
+  const std::vector<SerializedPoolingDeviceStageView> & stages, std::uint32_t * stage_counts)
 {
   if (stages.size() != config_.pooling_strides_.size()) {
     throw std::runtime_error("Serialized pooling stage buffer count does not match config.");
   }
 
-  const auto capacity = config_.max_num_voxels_;
+  const auto capacity = static_cast<std::uint32_t>(config_.max_num_voxels_);
   const auto num_orders = static_cast<std::int32_t>(config_.serialization_orders_.size());
   const auto num_blocks = divup(static_cast<std::size_t>(capacity), config_.threads_per_block_);
 
@@ -447,7 +450,7 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
   CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
   const std::int32_t * current_grid_coord = grid_coord;
-  const std::int64_t * current_serialized_code = serialized_code;
+  const std::uint32_t * current_serialized_code = serialized_code;
 
   for (std::size_t stage_index = 0; stage_index < stages.size(); ++stage_index) {
     const auto & stage = stages[stage_index];
@@ -458,20 +461,18 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
       static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-        capacity, 0, 63, stream_));
+    CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
+      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+      pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+      capacity, 0, 32, stream_));
 
     markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       pooling_sorted_keys_d_.get(), pooling_run_flags_d_.get(), capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceScan::InclusiveSum(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
-        pooling_run_ids_d_.get(), capacity, stream_));
+    CHECK_CUDA_ERROR(cub::DeviceScan::InclusiveSum(
+      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
+      pooling_run_ids_d_.get(), capacity, stream_));
 
     fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       current_grid_coord, current_serialized_code, pooling_sorted_keys_d_.get(),
@@ -487,11 +488,10 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
         static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-      CHECK_CUDA_ERROR(
-        cub::DeviceRadixSort::SortPairs(
-          pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-          pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-          capacity, 0, 63, stream_));
+      CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+        capacity, 0, 32, stream_));
 
       fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
         pooling_sorted_keys_d_.get(), pooling_sorted_indices_d_.get(), stage_counts,
@@ -507,7 +507,7 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
 
 std::size_t PreprocessCuda::generateFeatures(
   const void * input_data, CloudFormat input_format, unsigned int num_points,
-  float * voxel_features, std::int32_t * voxel_coords, std::int64_t * voxel_hashes,
+  float * voxel_features, std::int32_t * voxel_coords, std::uint32_t * voxel_hashes,
   void * compact_points, float * reconstruction_features, void * cropped_source_points,
   std::int64_t * inverse_map, std::size_t * output_num_cropped_points)
 {

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -86,9 +86,9 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   sort_workspace_d_ = autoware::cuda_utils::make_unique<std::uint8_t[]>(sort_workspace_size_);
 
-  pooling_keys_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
+  pooling_keys_d_ = autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.max_num_voxels_);
   pooling_sorted_keys_d_ =
-    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
+    autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.max_num_voxels_);
   pooling_indices_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
   pooling_sorted_indices_d_ =
     autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_);
@@ -98,13 +98,14 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   std::size_t pooling_sort_workspace_size = 0;
   std::size_t pooling_scan_workspace_size = 0;
-  std::uint32_t * uint32_nullptr = nullptr;
+  std::uint64_t * uint64_key_nullptr = nullptr;
+  std::uint32_t * uint32_value_nullptr = nullptr;
   cub::DeviceRadixSort::SortPairs(
-    nullptr, pooling_sort_workspace_size, uint32_nullptr, uint32_nullptr, uint32_nullptr,
-    uint32_nullptr, config_.max_num_voxels_, 0, 32, nullptr);
+    nullptr, pooling_sort_workspace_size, uint64_key_nullptr, uint64_key_nullptr,
+    uint32_value_nullptr, uint32_value_nullptr, config_.max_num_voxels_, 0, 64, nullptr);
   cub::DeviceScan::InclusiveSum(
-    nullptr, pooling_scan_workspace_size, uint32_nullptr, uint32_nullptr, config_.max_num_voxels_,
-    nullptr);
+    nullptr, pooling_scan_workspace_size, uint32_value_nullptr, uint32_value_nullptr,
+    config_.max_num_voxels_, nullptr);
   pooling_workspace_size_ = std::max(pooling_sort_workspace_size, pooling_scan_workspace_size);
   pooling_workspace_d_ = autoware::cuda_utils::make_unique<std::uint8_t[]>(pooling_workspace_size_);
 
@@ -265,7 +266,7 @@ __global__ void voxelizationHash32Kernel(
 
 __global__ void computeGridCoordsAndSerializationKernel(
   const float4 * __restrict__ points, int3 * __restrict__ coords,
-  std::uint32_t * __restrict__ hashes, int num_points, float voxel_size_x, float voxel_size_y,
+  std::int64_t * __restrict__ hashes, int num_points, float voxel_size_x, float voxel_size_y,
   float voxel_size_z, std::int32_t min_x, std::int32_t min_y, std::int32_t min_z, int depth)
 {
   static_assert(sizeof(int3) == sizeof(std::int32_t) * 3, "int3 must be 12 bytes");
@@ -281,11 +282,11 @@ __global__ void computeGridCoordsAndSerializationKernel(
 
   coords[idx] = make_int3(x, y, z);
 
-  std::uint32_t key1 = 0;
-  std::uint32_t key2 = 0;
+  std::uint64_t key1 = 0;
+  std::uint64_t key2 = 0;
 
   for (int i = 0; i < depth; ++i) {
-    const auto mask = static_cast<std::uint32_t>(1U << i);
+    const auto mask = static_cast<std::uint64_t>(1ULL << i);
     key1 |= ((x & mask) << (2 * i + 2));
     key1 |= ((y & mask) << (2 * i + 1));
     key1 |= ((z & mask) << (2 * i + 0));
@@ -295,11 +296,11 @@ __global__ void computeGridCoordsAndSerializationKernel(
     key2 |= ((z & mask) << (2 * i + 0));
   }
 
-  hashes[idx] = key1;
-  hashes[idx + num_points] = key2;
+  hashes[idx] = static_cast<std::int64_t>(key1);
+  hashes[idx + num_points] = static_cast<std::int64_t>(key2);
 }
 
-constexpr std::uint32_t kInvalidPoolingKey = std::numeric_limits<std::uint32_t>::max();
+constexpr std::uint64_t kInvalidPoolingKey = std::numeric_limits<std::uint64_t>::max();
 
 __global__ void setInitialStageCountKernel(
   std::uint32_t * __restrict__ stage_counts, std::uint32_t num_voxels)
@@ -308,8 +309,8 @@ __global__ void setInitialStageCountKernel(
 }
 
 __global__ void preparePoolingSortInputKernel(
-  const std::uint32_t * __restrict__ serialized_code,
-  const std::uint32_t * __restrict__ stage_counts, std::uint32_t * __restrict__ keys,
+  const std::int64_t * __restrict__ serialized_code,
+  const std::uint32_t * __restrict__ stage_counts, std::uint64_t * __restrict__ keys,
   std::uint32_t * __restrict__ indices, std::int32_t stage_index, std::int32_t pooling_depth,
   std::uint32_t capacity)
 {
@@ -319,12 +320,14 @@ __global__ void preparePoolingSortInputKernel(
   }
 
   const auto input_count = stage_counts[stage_index];
-  keys[idx] = idx < input_count ? serialized_code[idx] >> (pooling_depth * 3) : kInvalidPoolingKey;
+  keys[idx] = idx < input_count
+                ? static_cast<std::uint64_t>(serialized_code[idx]) >> (pooling_depth * 3)
+                : kInvalidPoolingKey;
   indices[idx] = idx;
 }
 
 __global__ void markPoolingRunsKernel(
-  const std::uint32_t * __restrict__ sorted_keys, std::uint32_t * __restrict__ run_flags,
+  const std::uint64_t * __restrict__ sorted_keys, std::uint32_t * __restrict__ run_flags,
   std::uint32_t capacity)
 {
   const auto idx = static_cast<std::uint32_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -338,12 +341,12 @@ __global__ void markPoolingRunsKernel(
 
 __global__ void fillPoolingStageKernel(
   const std::int32_t * __restrict__ grid_coord_in,
-  const std::uint32_t * __restrict__ serialized_code_in,
-  const std::uint32_t * __restrict__ sorted_keys, const std::uint32_t * __restrict__ sorted_indices,
+  const std::int64_t * __restrict__ serialized_code_in,
+  const std::uint64_t * __restrict__ sorted_keys, const std::uint32_t * __restrict__ sorted_indices,
   const std::uint32_t * __restrict__ run_flags, const std::uint32_t * __restrict__ run_ids,
   std::uint32_t * __restrict__ indices_out, std::uint32_t * __restrict__ indptr_out,
   std::uint32_t * __restrict__ head_indices_out, std::uint32_t * __restrict__ cluster_out,
-  std::int32_t * __restrict__ grid_coord_out, std::uint32_t * __restrict__ serialized_code_out,
+  std::int32_t * __restrict__ grid_coord_out, std::int64_t * __restrict__ serialized_code_out,
   std::uint32_t * __restrict__ stage_counts, std::int32_t stage_index, std::int32_t pooling_depth,
   std::int32_t num_orders, std::uint32_t capacity)
 {
@@ -390,8 +393,8 @@ __global__ void fillPoolingStageKernel(
 }
 
 __global__ void prepareOrderSortInputKernel(
-  const std::uint32_t * __restrict__ serialized_code,
-  const std::uint32_t * __restrict__ stage_counts, std::uint32_t * __restrict__ keys,
+  const std::int64_t * __restrict__ serialized_code,
+  const std::uint32_t * __restrict__ stage_counts, std::uint64_t * __restrict__ keys,
   std::uint32_t * __restrict__ indices, std::int32_t stage_index, std::int32_t order_index,
   std::uint32_t capacity)
 {
@@ -402,13 +405,14 @@ __global__ void prepareOrderSortInputKernel(
 
   const auto input_count = stage_counts[stage_index];
   // serialized_code is stored densely as [num_orders, input_count] (see fillPoolingStageKernel).
-  keys[idx] =
-    idx < input_count ? serialized_code[order_index * input_count + idx] : kInvalidPoolingKey;
+  keys[idx] = idx < input_count
+                ? static_cast<std::uint64_t>(serialized_code[order_index * input_count + idx])
+                : kInvalidPoolingKey;
   indices[idx] = idx;
 }
 
 __global__ void fillOrderAndInverseKernel(
-  const std::uint32_t * __restrict__ sorted_keys, const std::uint32_t * __restrict__ sorted_indices,
+  const std::uint64_t * __restrict__ sorted_keys, const std::uint32_t * __restrict__ sorted_indices,
   const std::uint32_t * __restrict__ stage_counts, std::uint32_t * __restrict__ order_out,
   std::uint32_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
   std::uint32_t capacity)
@@ -435,7 +439,7 @@ std::int32_t poolingDepth(const std::int64_t stride)
 }
 
 void PreprocessCuda::generateSerializedPoolingMetadata(
-  const std::int32_t * grid_coord, const std::uint32_t * serialized_code, std::uint32_t num_voxels,
+  const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::uint32_t num_voxels,
   const std::vector<SerializedPoolingDeviceStageView> & stages, std::uint32_t * stage_counts)
 {
   if (stages.size() != config_.pooling_strides_.size()) {
@@ -450,7 +454,7 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
   CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
   const std::int32_t * current_grid_coord = grid_coord;
-  const std::uint32_t * current_serialized_code = serialized_code;
+  const std::int64_t * current_serialized_code = serialized_code;
 
   for (std::size_t stage_index = 0; stage_index < stages.size(); ++stage_index) {
     const auto & stage = stages[stage_index];
@@ -461,20 +465,18 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
       static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-        capacity, 0, 32, stream_));
+    CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
+      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+      pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+      capacity, 0, 64, stream_));
 
     markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       pooling_sorted_keys_d_.get(), pooling_run_flags_d_.get(), capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceScan::InclusiveSum(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
-        pooling_run_ids_d_.get(), capacity, stream_));
+    CHECK_CUDA_ERROR(cub::DeviceScan::InclusiveSum(
+      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
+      pooling_run_ids_d_.get(), capacity, stream_));
 
     fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       current_grid_coord, current_serialized_code, pooling_sorted_keys_d_.get(),
@@ -490,11 +492,10 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
         static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-      CHECK_CUDA_ERROR(
-        cub::DeviceRadixSort::SortPairs(
-          pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-          pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-          capacity, 0, 32, stream_));
+      CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+        capacity, 0, 64, stream_));
 
       fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
         pooling_sorted_keys_d_.get(), pooling_sorted_indices_d_.get(), stage_counts,
@@ -510,7 +511,7 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
 
 std::size_t PreprocessCuda::generateFeatures(
   const void * input_data, CloudFormat input_format, unsigned int num_points,
-  float * voxel_features, std::int32_t * voxel_coords, std::uint32_t * voxel_hashes,
+  float * voxel_features, std::int32_t * voxel_coords, std::int64_t * voxel_hashes,
   void * compact_points, float * reconstruction_features, void * cropped_source_points,
   std::int64_t * inverse_map, std::size_t * output_num_cropped_points)
 {

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -461,18 +461,20 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
       static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
-      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-      pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-      capacity, 0, 32, stream_));
+    CHECK_CUDA_ERROR(
+      cub::DeviceRadixSort::SortPairs(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+        capacity, 0, 32, stream_));
 
     markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       pooling_sorted_keys_d_.get(), pooling_run_flags_d_.get(), capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(cub::DeviceScan::InclusiveSum(
-      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
-      pooling_run_ids_d_.get(), capacity, stream_));
+    CHECK_CUDA_ERROR(
+      cub::DeviceScan::InclusiveSum(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
+        pooling_run_ids_d_.get(), capacity, stream_));
 
     fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       current_grid_coord, current_serialized_code, pooling_sorted_keys_d_.get(),
@@ -488,10 +490,11 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
         static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-      CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-        capacity, 0, 32, stream_));
+      CHECK_CUDA_ERROR(
+        cub::DeviceRadixSort::SortPairs(
+          pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+          pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+          capacity, 0, 32, stream_));
 
       fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
         pooling_sorted_keys_d_.get(), pooling_sorted_indices_d_.get(), stage_counts,

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -147,7 +147,7 @@ void PTv3TRT::initPtr()
   grid_coord_d_ = autoware::cuda_utils::make_unique<std::int32_t[]>(config_.max_num_voxels_ * 3);
   feat_d_ = autoware::cuda_utils::make_unique<float[]>(config_.max_num_voxels_ * 4);
   serialized_code_d_ =
-    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_ * 2);
+    autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_ * 2);
 
   // Backbone outputs shared with the segmentation head.
   bb_point_feat_d_ = autoware::cuda_utils::make_unique<float[]>(
@@ -197,7 +197,7 @@ void PTv3TRT::allocateSerializedPoolingBuffers()
     stage.cluster = autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels);
     stage.grid_coord = autoware::cuda_utils::make_unique<std::int32_t[]>(max_num_voxels * 3);
     stage.serialized_code =
-      autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels * num_orders);
+      autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels * num_orders);
     stage.serialized_order =
       autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels * num_orders);
     stage.serialized_inverse =
@@ -256,7 +256,7 @@ void PTv3TRT::initBackboneTrt(const tensorrt_common::TrtCommonConfig & trt_confi
   network_io.emplace_back("grid_coord", nvinfer1::Dims{2, {-1, 3}}, nvinfer1::DataType::kINT32);
   network_io.emplace_back("feat", nvinfer1::Dims{2, {-1, 4}}, nvinfer1::DataType::kFLOAT);
   network_io.emplace_back(
-    "serialized_code", nvinfer1::Dims{2, {2, -1}}, nvinfer1::DataType::kINT32);
+    "serialized_code", nvinfer1::Dims{2, {2, -1}}, nvinfer1::DataType::kINT64);
 
   // Outputs: point_feat [N, backbone_feat_dim], point_grid_coord [N, 3], point_offset [1]
   network_io.emplace_back(
@@ -414,11 +414,10 @@ void PTv3TRT::precomputeSerializedPoolingMetadata()
   std::vector<SerializedPoolingDeviceStageView> stage_views;
   stage_views.reserve(serialized_pooling_stages_d_.size());
   for (auto & stage : serialized_pooling_stages_d_) {
-    stage_views.push_back(
-      SerializedPoolingDeviceStageView{
-        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-        stage.serialized_inverse.get()});
+    stage_views.push_back(SerializedPoolingDeviceStageView{
+      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+      stage.serialized_inverse.get()});
   }
 
   pre_ptr_->generateSerializedPoolingMetadata(

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -147,7 +147,7 @@ void PTv3TRT::initPtr()
   grid_coord_d_ = autoware::cuda_utils::make_unique<std::int32_t[]>(config_.max_num_voxels_ * 3);
   feat_d_ = autoware::cuda_utils::make_unique<float[]>(config_.max_num_voxels_ * 4);
   serialized_code_d_ =
-    autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_ * 2);
+    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.max_num_voxels_ * 2);
 
   // Backbone outputs shared with the segmentation head.
   bb_point_feat_d_ = autoware::cuda_utils::make_unique<float[]>(
@@ -191,22 +191,22 @@ void PTv3TRT::allocateSerializedPoolingBuffers()
 
   for (std::size_t stage_index = 0; stage_index < config_.pooling_strides_.size(); ++stage_index) {
     SerializedPoolingDeviceStage stage;
-    stage.indices = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels);
-    stage.indptr = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels + 1);
-    stage.head_indices = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels);
-    stage.cluster = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels);
+    stage.indices = autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels);
+    stage.indptr = autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels + 1);
+    stage.head_indices = autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels);
+    stage.cluster = autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels);
     stage.grid_coord = autoware::cuda_utils::make_unique<std::int32_t[]>(max_num_voxels * 3);
     stage.serialized_code =
-      autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels * num_orders);
+      autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels * num_orders);
     stage.serialized_order =
-      autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels * num_orders);
+      autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels * num_orders);
     stage.serialized_inverse =
-      autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels * num_orders);
+      autoware::cuda_utils::make_unique<std::uint32_t[]>(max_num_voxels * num_orders);
     serialized_pooling_stages_d_.push_back(std::move(stage));
   }
 
   serialized_pooling_num_voxels_d_ =
-    autoware::cuda_utils::make_unique<std::int64_t[]>(config_.pooling_strides_.size() + 1);
+    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.pooling_strides_.size() + 1);
   serialized_pooling_num_voxels_.assign(config_.pooling_strides_.size() + 1, 0);
   serialized_pooling_depths_.resize(config_.pooling_strides_.size());
   for (std::size_t stage_index = 0; stage_index < config_.pooling_strides_.size(); ++stage_index) {
@@ -256,7 +256,7 @@ void PTv3TRT::initBackboneTrt(const tensorrt_common::TrtCommonConfig & trt_confi
   network_io.emplace_back("grid_coord", nvinfer1::Dims{2, {-1, 3}}, nvinfer1::DataType::kINT32);
   network_io.emplace_back("feat", nvinfer1::Dims{2, {-1, 4}}, nvinfer1::DataType::kFLOAT);
   network_io.emplace_back(
-    "serialized_code", nvinfer1::Dims{2, {2, -1}}, nvinfer1::DataType::kINT64);
+    "serialized_code", nvinfer1::Dims{2, {2, -1}}, nvinfer1::DataType::kINT32);
 
   // Outputs: point_feat [N, backbone_feat_dim], point_grid_coord [N, 3], point_offset [1]
   network_io.emplace_back(
@@ -306,17 +306,18 @@ void PTv3TRT::initBackboneTrt(const tensorrt_common::TrtCommonConfig & trt_confi
     const std::int64_t in_min = stage == 0 ? min_voxels : 1;
     add_pooling_io(
       prefix + "indices", nvinfer1::Dims{1, {-1}}, nvinfer1::Dims{1, {in_min}},
-      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}});
+      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}}, nvinfer1::DataType::kINT32);
     add_pooling_io(
       prefix + "cluster", nvinfer1::Dims{1, {-1}}, nvinfer1::Dims{1, {in_min}},
-      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}});
+      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}}, nvinfer1::DataType::kINT32);
     // Output-count-sized (pooled) tensors.
     add_pooling_io(
       prefix + "indptr", nvinfer1::Dims{1, {-1}}, nvinfer1::Dims{1, {2}},
-      nvinfer1::Dims{1, {opt_voxels + 1}}, nvinfer1::Dims{1, {max_voxels + 1}});
+      nvinfer1::Dims{1, {opt_voxels + 1}}, nvinfer1::Dims{1, {max_voxels + 1}},
+      nvinfer1::DataType::kINT32);
     add_pooling_io(
       prefix + "head_indices", nvinfer1::Dims{1, {-1}}, nvinfer1::Dims{1, {1}},
-      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}});
+      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}}, nvinfer1::DataType::kINT32);
     add_pooling_io(
       prefix + "grid_coord", nvinfer1::Dims{2, {-1, 3}}, nvinfer1::Dims{2, {1, 3}},
       nvinfer1::Dims{2, {opt_voxels, 3}}, nvinfer1::Dims{2, {max_voxels, 3}},
@@ -324,11 +325,11 @@ void PTv3TRT::initBackboneTrt(const tensorrt_common::TrtCommonConfig & trt_confi
     add_pooling_io(
       prefix + "serialized_order", nvinfer1::Dims{2, {num_orders, -1}},
       nvinfer1::Dims{2, {num_orders, 1}}, nvinfer1::Dims{2, {num_orders, opt_voxels}},
-      nvinfer1::Dims{2, {num_orders, max_voxels}});
+      nvinfer1::Dims{2, {num_orders, max_voxels}}, nvinfer1::DataType::kINT32);
     add_pooling_io(
       prefix + "serialized_inverse", nvinfer1::Dims{2, {num_orders, -1}},
       nvinfer1::Dims{2, {num_orders, 1}}, nvinfer1::Dims{2, {num_orders, opt_voxels}},
-      nvinfer1::Dims{2, {num_orders, max_voxels}});
+      nvinfer1::Dims{2, {num_orders, max_voxels}}, nvinfer1::DataType::kINT32);
   }
 
   backbone_trt_ptr_ = std::make_unique<autoware::tensorrt_common::TrtCommon>(
@@ -413,19 +414,19 @@ void PTv3TRT::precomputeSerializedPoolingMetadata()
   std::vector<SerializedPoolingDeviceStageView> stage_views;
   stage_views.reserve(serialized_pooling_stages_d_.size());
   for (auto & stage : serialized_pooling_stages_d_) {
-    stage_views.push_back(
-      SerializedPoolingDeviceStageView{
-        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-        stage.serialized_inverse.get()});
+    stage_views.push_back(SerializedPoolingDeviceStageView{
+      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+      stage.serialized_inverse.get()});
   }
 
   pre_ptr_->generateSerializedPoolingMetadata(
-    grid_coord_d_.get(), serialized_code_d_.get(), num_voxels_, stage_views,
-    serialized_pooling_num_voxels_d_.get());
+    grid_coord_d_.get(), serialized_code_d_.get(), static_cast<std::uint32_t>(num_voxels_),
+    stage_views, serialized_pooling_num_voxels_d_.get());
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     serialized_pooling_num_voxels_.data(), serialized_pooling_num_voxels_d_.get(),
-    serialized_pooling_num_voxels_.size() * sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream_));
+    serialized_pooling_num_voxels_.size() * sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
+    stream_));
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 }
 

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -414,10 +414,11 @@ void PTv3TRT::precomputeSerializedPoolingMetadata()
   std::vector<SerializedPoolingDeviceStageView> stage_views;
   stage_views.reserve(serialized_pooling_stages_d_.size());
   for (auto & stage : serialized_pooling_stages_d_) {
-    stage_views.push_back(SerializedPoolingDeviceStageView{
-      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-      stage.serialized_inverse.get()});
+    stage_views.push_back(
+      SerializedPoolingDeviceStageView{
+        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+        stage.serialized_inverse.get()});
   }
 
   pre_ptr_->generateSerializedPoolingMetadata(

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -139,26 +139,26 @@ struct DeviceStage
   {
   }
 
-  DeviceBuffer<std::int64_t> indices;
-  DeviceBuffer<std::int64_t> indptr;
-  DeviceBuffer<std::int64_t> head_indices;
-  DeviceBuffer<std::int64_t> cluster;
+  DeviceBuffer<std::uint32_t> indices;
+  DeviceBuffer<std::uint32_t> indptr;
+  DeviceBuffer<std::uint32_t> head_indices;
+  DeviceBuffer<std::uint32_t> cluster;
   DeviceBuffer<std::int32_t> grid_coord;
-  DeviceBuffer<std::int64_t> serialized_code;
-  DeviceBuffer<std::int64_t> serialized_order;
-  DeviceBuffer<std::int64_t> serialized_inverse;
+  DeviceBuffer<std::uint32_t> serialized_code;
+  DeviceBuffer<std::uint32_t> serialized_order;
+  DeviceBuffer<std::uint32_t> serialized_inverse;
 };
 
 struct CpuStage
 {
-  std::vector<std::int64_t> indices;
-  std::vector<std::int64_t> indptr;
-  std::vector<std::int64_t> head_indices;
-  std::vector<std::int64_t> cluster;
+  std::vector<std::uint32_t> indices;
+  std::vector<std::uint32_t> indptr;
+  std::vector<std::uint32_t> head_indices;
+  std::vector<std::uint32_t> cluster;
   std::vector<std::int32_t> grid_coord;
-  std::vector<std::int64_t> serialized_code;
-  std::vector<std::int64_t> serialized_order;
-  std::vector<std::int64_t> serialized_inverse;
+  std::vector<std::uint32_t> serialized_code;
+  std::vector<std::uint32_t> serialized_order;
+  std::vector<std::uint32_t> serialized_inverse;
 };
 
 std::int32_t pooling_depth(const std::int64_t stride)
@@ -170,13 +170,13 @@ std::int32_t pooling_depth(const std::int64_t stride)
   return depth;
 }
 
-std::int64_t serialize_coord(
-  const std::int64_t x, const std::int64_t y, const std::int64_t z, const std::int32_t depth,
+std::uint32_t serialize_coord(
+  const std::int32_t x, const std::int32_t y, const std::int32_t z, const std::int32_t depth,
   const bool transposed)
 {
-  std::int64_t code = 0;
+  std::uint32_t code = 0;
   for (std::int32_t bit = 0; bit < depth; ++bit) {
-    const std::int64_t mask = 1LL << bit;
+    const auto mask = static_cast<std::uint32_t>(1U << bit);
     if (transposed) {
       code |= ((y & mask) << (2 * bit + 2));
       code |= ((x & mask) << (2 * bit + 1));
@@ -189,11 +189,11 @@ std::int64_t serialize_coord(
   return code;
 }
 
-std::vector<std::int64_t> make_serialized_code(
+std::vector<std::uint32_t> make_serialized_code(
   const std::vector<std::int32_t> & grid_coord, const std::int32_t depth)
 {
   const auto count = grid_coord.size() / 3;
-  std::vector<std::int64_t> code(2 * count);
+  std::vector<std::uint32_t> code(2 * count);
   for (std::size_t index = 0; index < count; ++index) {
     const auto x = grid_coord[index * 3 + 0];
     const auto y = grid_coord[index * 3 + 1];
@@ -204,9 +204,9 @@ std::vector<std::int64_t> make_serialized_code(
   return code;
 }
 
-std::vector<std::int64_t> stable_argsort(const std::vector<std::int64_t> & values)
+std::vector<std::uint32_t> stable_argsort(const std::vector<std::uint32_t> & values)
 {
-  std::vector<std::int64_t> order(values.size());
+  std::vector<std::uint32_t> order(values.size());
   std::iota(order.begin(), order.end(), 0);
   std::stable_sort(order.begin(), order.end(), [&values](const auto lhs, const auto rhs) {
     return values[static_cast<std::size_t>(lhs)] < values[static_cast<std::size_t>(rhs)];
@@ -216,23 +216,23 @@ std::vector<std::int64_t> stable_argsort(const std::vector<std::int64_t> & value
 
 CpuStage make_stage_reference(
   const std::vector<std::int32_t> & grid_coord_in,
-  const std::vector<std::int64_t> & serialized_code_in, const std::size_t num_orders,
+  const std::vector<std::uint32_t> & serialized_code_in, const std::size_t num_orders,
   const std::int64_t stride)
 {
   const auto input_count = grid_coord_in.size() / 3;
   const auto depth = pooling_depth(stride);
-  std::vector<std::int64_t> pooled_keys(input_count);
+  std::vector<std::uint32_t> pooled_keys(input_count);
   for (std::size_t index = 0; index < input_count; ++index) {
     pooled_keys[index] = serialized_code_in[index] >> (depth * 3);
   }
 
-  std::vector<std::int64_t> unique_keys = pooled_keys;
+  std::vector<std::uint32_t> unique_keys = pooled_keys;
   std::sort(unique_keys.begin(), unique_keys.end());
   unique_keys.erase(std::unique(unique_keys.begin(), unique_keys.end()), unique_keys.end());
 
-  std::map<std::int64_t, std::int64_t> key_to_cluster;
+  std::map<std::uint32_t, std::uint32_t> key_to_cluster;
   for (std::size_t index = 0; index < unique_keys.size(); ++index) {
-    key_to_cluster.emplace(unique_keys[index], static_cast<std::int64_t>(index));
+    key_to_cluster.emplace(unique_keys[index], static_cast<std::uint32_t>(index));
   }
 
   CpuStage stage;
@@ -241,7 +241,7 @@ CpuStage make_stage_reference(
   for (std::size_t index = 0; index < input_count; ++index) {
     const auto cluster = key_to_cluster.at(pooled_keys[index]);
     stage.cluster[index] = cluster;
-    ++stage.indptr[static_cast<std::size_t>(cluster + 1)];
+    ++stage.indptr[static_cast<std::size_t>(cluster + 1U)];
   }
   for (std::size_t index = 1; index < stage.indptr.size(); ++index) {
     stage.indptr[index] += stage.indptr[index - 1];
@@ -269,7 +269,7 @@ CpuStage make_stage_reference(
   stage.serialized_order.resize(num_orders * unique_keys.size());
   stage.serialized_inverse.resize(num_orders * unique_keys.size());
   for (std::size_t order = 0; order < num_orders; ++order) {
-    std::vector<std::int64_t> order_codes(unique_keys.size());
+    std::vector<std::uint32_t> order_codes(unique_keys.size());
     for (std::size_t index = 0; index < unique_keys.size(); ++index) {
       order_codes[index] = stage.serialized_code[order * unique_keys.size() + index];
     }
@@ -278,7 +278,7 @@ CpuStage make_stage_reference(
       const auto input_index = sorted_order[rank];
       stage.serialized_order[order * unique_keys.size() + rank] = input_index;
       stage.serialized_inverse[order * unique_keys.size() + static_cast<std::size_t>(input_index)] =
-        static_cast<std::int64_t>(rank);
+        static_cast<std::uint32_t>(rank);
     }
   }
   return stage;
@@ -307,24 +307,23 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
   const std::vector<std::int32_t> grid_coord{5, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 3,  0, 1,
                                              4, 4, 0, 5, 4, 1, 8, 0, 0, 9, 0, 0, 10, 2, 0};
   const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
-  const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
+  const auto num_voxels = static_cast<std::uint32_t>(grid_coord.size() / 3);
 
   CudaStreamGuard stream;
   PreprocessCuda preprocess(config, stream.get());
   DeviceBuffer<std::int32_t> grid_coord_d(grid_coord.size());
-  DeviceBuffer<std::int64_t> serialized_code_d(serialized_code.size());
-  DeviceBuffer<std::int64_t> stage_counts_d(config.pooling_strides_.size() + 1);
+  DeviceBuffer<std::uint32_t> serialized_code_d(serialized_code.size());
+  DeviceBuffer<std::uint32_t> stage_counts_d(config.pooling_strides_.size() + 1);
   std::vector<DeviceStage> device_stages;
   std::vector<SerializedPoolingDeviceStageView> stage_views;
   for (std::size_t stage = 0; stage < config.pooling_strides_.size(); ++stage) {
     device_stages.emplace_back(config.max_num_voxels_, kNumOrders);
   }
   for (auto & stage : device_stages) {
-    stage_views.push_back(
-      SerializedPoolingDeviceStageView{
-        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-        stage.serialized_inverse.get()});
+    stage_views.push_back(SerializedPoolingDeviceStageView{
+      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+      stage.serialized_inverse.get()});
   }
 
   copy_to_device(grid_coord_d.get(), grid_coord);
@@ -343,8 +342,8 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
 
   const auto stage_counts = copy_to_host(stage_counts_d.get(), config.pooling_strides_.size() + 1);
   ASSERT_EQ(stage_counts[0], num_voxels);
-  ASSERT_EQ(stage_counts[1], static_cast<std::int64_t>(references[0].head_indices.size()));
-  ASSERT_EQ(stage_counts[2], static_cast<std::int64_t>(references[1].head_indices.size()));
+  ASSERT_EQ(stage_counts[1], static_cast<std::uint32_t>(references[0].head_indices.size()));
+  ASSERT_EQ(stage_counts[2], static_cast<std::uint32_t>(references[1].head_indices.size()));
 
   for (std::size_t stage_index = 0; stage_index < references.size(); ++stage_index) {
     const auto & expected = references[stage_index];

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -144,7 +144,7 @@ struct DeviceStage
   DeviceBuffer<std::uint32_t> head_indices;
   DeviceBuffer<std::uint32_t> cluster;
   DeviceBuffer<std::int32_t> grid_coord;
-  DeviceBuffer<std::uint32_t> serialized_code;
+  DeviceBuffer<std::int64_t> serialized_code;
   DeviceBuffer<std::uint32_t> serialized_order;
   DeviceBuffer<std::uint32_t> serialized_inverse;
 };
@@ -156,7 +156,7 @@ struct CpuStage
   std::vector<std::uint32_t> head_indices;
   std::vector<std::uint32_t> cluster;
   std::vector<std::int32_t> grid_coord;
-  std::vector<std::uint32_t> serialized_code;
+  std::vector<std::int64_t> serialized_code;
   std::vector<std::uint32_t> serialized_order;
   std::vector<std::uint32_t> serialized_inverse;
 };
@@ -170,13 +170,13 @@ std::int32_t pooling_depth(const std::int64_t stride)
   return depth;
 }
 
-std::uint32_t serialize_coord(
+std::int64_t serialize_coord(
   const std::int32_t x, const std::int32_t y, const std::int32_t z, const std::int32_t depth,
   const bool transposed)
 {
-  std::uint32_t code = 0;
+  std::uint64_t code = 0;
   for (std::int32_t bit = 0; bit < depth; ++bit) {
-    const auto mask = static_cast<std::uint32_t>(1U << bit);
+    const auto mask = static_cast<std::uint64_t>(1ULL << bit);
     if (transposed) {
       code |= ((y & mask) << (2 * bit + 2));
       code |= ((x & mask) << (2 * bit + 1));
@@ -186,14 +186,14 @@ std::uint32_t serialize_coord(
     }
     code |= ((z & mask) << (2 * bit));
   }
-  return code;
+  return static_cast<std::int64_t>(code);
 }
 
-std::vector<std::uint32_t> make_serialized_code(
+std::vector<std::int64_t> make_serialized_code(
   const std::vector<std::int32_t> & grid_coord, const std::int32_t depth)
 {
   const auto count = grid_coord.size() / 3;
-  std::vector<std::uint32_t> code(2 * count);
+  std::vector<std::int64_t> code(2 * count);
   for (std::size_t index = 0; index < count; ++index) {
     const auto x = grid_coord[index * 3 + 0];
     const auto y = grid_coord[index * 3 + 1];
@@ -204,7 +204,8 @@ std::vector<std::uint32_t> make_serialized_code(
   return code;
 }
 
-std::vector<std::uint32_t> stable_argsort(const std::vector<std::uint32_t> & values)
+template <typename T>
+std::vector<std::uint32_t> stable_argsort(const std::vector<T> & values)
 {
   std::vector<std::uint32_t> order(values.size());
   std::iota(order.begin(), order.end(), 0);
@@ -216,21 +217,21 @@ std::vector<std::uint32_t> stable_argsort(const std::vector<std::uint32_t> & val
 
 CpuStage make_stage_reference(
   const std::vector<std::int32_t> & grid_coord_in,
-  const std::vector<std::uint32_t> & serialized_code_in, const std::size_t num_orders,
+  const std::vector<std::int64_t> & serialized_code_in, const std::size_t num_orders,
   const std::int64_t stride)
 {
   const auto input_count = grid_coord_in.size() / 3;
   const auto depth = pooling_depth(stride);
-  std::vector<std::uint32_t> pooled_keys(input_count);
+  std::vector<std::int64_t> pooled_keys(input_count);
   for (std::size_t index = 0; index < input_count; ++index) {
     pooled_keys[index] = serialized_code_in[index] >> (depth * 3);
   }
 
-  std::vector<std::uint32_t> unique_keys = pooled_keys;
+  std::vector<std::int64_t> unique_keys = pooled_keys;
   std::sort(unique_keys.begin(), unique_keys.end());
   unique_keys.erase(std::unique(unique_keys.begin(), unique_keys.end()), unique_keys.end());
 
-  std::map<std::uint32_t, std::uint32_t> key_to_cluster;
+  std::map<std::int64_t, std::uint32_t> key_to_cluster;
   for (std::size_t index = 0; index < unique_keys.size(); ++index) {
     key_to_cluster.emplace(unique_keys[index], static_cast<std::uint32_t>(index));
   }
@@ -269,7 +270,7 @@ CpuStage make_stage_reference(
   stage.serialized_order.resize(num_orders * unique_keys.size());
   stage.serialized_inverse.resize(num_orders * unique_keys.size());
   for (std::size_t order = 0; order < num_orders; ++order) {
-    std::vector<std::uint32_t> order_codes(unique_keys.size());
+    std::vector<std::int64_t> order_codes(unique_keys.size());
     for (std::size_t index = 0; index < unique_keys.size(); ++index) {
       order_codes[index] = stage.serialized_code[order * unique_keys.size() + index];
     }
@@ -312,7 +313,7 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
   CudaStreamGuard stream;
   PreprocessCuda preprocess(config, stream.get());
   DeviceBuffer<std::int32_t> grid_coord_d(grid_coord.size());
-  DeviceBuffer<std::uint32_t> serialized_code_d(serialized_code.size());
+  DeviceBuffer<std::int64_t> serialized_code_d(serialized_code.size());
   DeviceBuffer<std::uint32_t> stage_counts_d(config.pooling_strides_.size() + 1);
   std::vector<DeviceStage> device_stages;
   std::vector<SerializedPoolingDeviceStageView> stage_views;
@@ -320,11 +321,10 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     device_stages.emplace_back(config.max_num_voxels_, kNumOrders);
   }
   for (auto & stage : device_stages) {
-    stage_views.push_back(
-      SerializedPoolingDeviceStageView{
-        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-        stage.serialized_inverse.get()});
+    stage_views.push_back(SerializedPoolingDeviceStageView{
+      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+      stage.serialized_inverse.get()});
   }
 
   copy_to_device(grid_coord_d.get(), grid_coord);

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -321,10 +321,11 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     device_stages.emplace_back(config.max_num_voxels_, kNumOrders);
   }
   for (auto & stage : device_stages) {
-    stage_views.push_back(SerializedPoolingDeviceStageView{
-      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-      stage.serialized_inverse.get()});
+    stage_views.push_back(
+      SerializedPoolingDeviceStageView{
+        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+        stage.serialized_inverse.get()});
   }
 
   copy_to_device(grid_coord_d.get(), grid_coord);

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -320,10 +320,11 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     device_stages.emplace_back(config.max_num_voxels_, kNumOrders);
   }
   for (auto & stage : device_stages) {
-    stage_views.push_back(SerializedPoolingDeviceStageView{
-      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-      stage.serialized_inverse.get()});
+    stage_views.push_back(
+      SerializedPoolingDeviceStageView{
+        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+        stage.serialized_inverse.get()});
   }
 
   copy_to_device(grid_coord_d.get(), grid_coord);


### PR DESCRIPTION
## Summary
- switch PTv3 serialized codes and serialized-pooling metadata buffers from int64 to uint32
- bind the ONNX-facing metadata/code tensors as TensorRT INT32
- reject voxel grids above 1024 cells per axis and oversized point/voxel capacities

## Validation
- source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-select autoware_ptv3
- source /opt/ros/humble/setup.bash && colcon test --packages-select autoware_ptv3 --event-handlers console_direct+ --return-code-on-test-failure

## Note
This requires a matching INT32 ONNX export for serialized_code and serialized_pooling_* metadata inputs.