### PR TITLE
fix: correct typos (wether->whether, overriden->overridden)

### DIFF
--- a/perception/autoware_tensorrt_bevdet/include/autoware/tensorrt_bevdet/bevdet_node.hpp
+++ b/perception/autoware_tensorrt_bevdet/include/autoware/tensorrt_bevdet/bevdet_node.hpp
@@ -84,7 +84,7 @@ private:
 
   uchar * imgs_dev_ = nullptr;  ///< Device pointer for storing the images
   float score_threshold_;       ///< Score threshold for object detection
-  bool has_twist_ = true;       /// wether set twist for objects
+  bool has_twist_ = true;       /// whether to set twist for objects
 
   rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr
     pub_boxes_;  ///< Publisher for publishing the detected objects

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.hpp
@@ -41,7 +41,7 @@ public:
    * specific criteria.
    *
    * @param path A pointer to the path containing points to be modified.
-   * @return [bool] wether the path velocity was modified or not.
+   * @return [bool] whether the path velocity was modified or not.
    */
   bool modifyPathVelocity(
     experimental::Trajectory & path, const std::vector<geometry_msgs::msg::Point> & left_bound,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/README.md
@@ -164,7 +164,7 @@ For example a value of `1` means all trajectory points will be evaluated while a
 | `obstacles.dynamic_obstacles_buffer`                | float       | buffer around dynamic obstacles used when masking an obstacle in order to prevent noise.                                                |
 | `obstacles.dynamic_obstacles_min_vel`               | float       | velocity above which to mask a dynamic obstacle.                                                                                        |
 | `obstacles.static_map_tags`                         | string list | linestring of the lanelet map with this tags are used as obstacles.                                                                     |
-| `obstacles.filter_envelope`                         | bool        | wether to use the safety envelope to filter the dynamic obstacles source.                                                               |
+| `obstacles.filter_envelope`                         | bool        | whether to use the safety envelope to filter the dynamic obstacles source.                                                               |
 
 ## Assumptions / Known limits
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/README.md
@@ -164,7 +164,7 @@ For example a value of `1` means all trajectory points will be evaluated while a
 | `obstacles.dynamic_obstacles_buffer`                | float       | buffer around dynamic obstacles used when masking an obstacle in order to prevent noise.                                                |
 | `obstacles.dynamic_obstacles_min_vel`               | float       | velocity above which to mask a dynamic obstacle.                                                                                        |
 | `obstacles.static_map_tags`                         | string list | linestring of the lanelet map with this tags are used as obstacles.                                                                     |
-| `obstacles.filter_envelope`                         | bool        | whether to use the safety envelope to filter the dynamic obstacles source.                                                               |
+| `obstacles.filter_envelope`                         | bool        | whether to use the safety envelope to filter the dynamic obstacles source.                                                              |
 
 ## Assumptions / Known limits
 

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -158,7 +158,7 @@ void TrajectoryChecker::set_diag_status(
   }
 
   if (override_all_error_diag_) {
-    const auto warn_msg = msg + " (error diag was overriden internally)";
+    const auto warn_msg = msg + " (error diag was overridden internally)";
     stat.summary(DiagnosticStatus::WARN, warn_msg);
     return;
   }

--- a/vehicle/autoware_external_cmd_converter/tests/test_external_cmd_converter.cpp
+++ b/vehicle/autoware_external_cmd_converter/tests/test_external_cmd_converter.cpp
@@ -65,10 +65,10 @@ public:
   /**
    * @brief Test the external command converter's check_remote_topic_rate method under
    * different circumstances:
-   * @param received_data wether to simulate if the emergency heartbeat and gate mode messages have
+   * @param received_data whether to simulate if the emergency heartbeat and gate mode messages have
    * been received or not
    * @param is_external set the gate mode to Auto or External
-   * @param time_has_passed wether to sleep for a certain time to make sure the timeout period of
+   * @param time_has_passed whether to sleep for a certain time to make sure the timeout period of
    * the function has expired or not.
    */
   bool test_check_remote_topic_rate(bool received_data, bool is_auto, bool time_has_passed)
@@ -94,10 +94,10 @@ public:
   /**
    * @brief Test the external command converter's check_emergency_stop_topic_timeout method under
    * different circumstances:
-   * @param received_data wether to simulate if the emergency heartbeat and gate mode messages have
+   * @param received_data whether to simulate if the emergency heartbeat and gate mode messages have
    * been received or not
    * @param is_auto set the gate mode to Auto or External
-   * @param time_has_passed wether to sleep for a certain time to make sure the timeout period of
+   * @param time_has_passed whether to sleep for a certain time to make sure the timeout period of
    * the function has expired or not.
    */
   bool test_check_emergency_stop_topic_timeout(


### PR DESCRIPTION
## Description
Corrects two recurring spelling typos found across comments and documentation:
- `wether` → `whether` (7 occurrences)
- `overriden` → `overridden` (1 occurrence)

Found using codespell. No functional changes — only comments, a doc table, and a log message string are affected.

## Files changed
- perception/autoware_tensorrt_bevdet/.../bevdet_node.hpp
- planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.hpp
- planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/README.md
- planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
- vehicle/autoware_external_cmd_converter/tests/test_external_cmd_converter.cpp

## Related links
None.

## How was this PR tested?
No functional changes — comments, a documentation table, and a log message string only. Existing behavior is unaffected.

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
