### PR TITLE
perf(autoware_cuda_pointcloud_preprocessor): back thrust temporaries with a pre-allocated workspace

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -21,6 +21,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <autoware/cuda_utils/thrust_utils.hpp>
+#include <autoware/cuda_utils/thrust_workspace_allocator.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -90,6 +91,10 @@ private:
   int max_blocks_per_grid_{};
   const int threads_per_block_{256};
   cudaMemPool_t device_memory_pool_{};
+
+  // Pre-allocated workspace backing thrust temporaries so the per-callback
+  // reductions/scans run without process-wide cudaMalloc/cudaFree barriers.
+  autoware::cuda_utils::ThrustWorkspace thrust_workspace_;
 
   ProcessingStats stats_;
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -119,6 +119,10 @@ private:
   thrust::device_vector<std::uint8_t> device_mismatch_mask_;
   thrust::device_vector<std::uint32_t> device_ring_outlier_mask_;
   thrust::device_vector<std::uint32_t> device_indices_;
+  // Diagnostic counters (crop-passed / NaN / mismatch). Written by CUB reductions
+  // on the node stream and read back together at a single synchronize, so the
+  // stats never trigger thrust::count's default-stream host-value sync.
+  thrust::device_vector<int> device_diag_counts_;
   thrust::device_vector<TwistStruct2D> device_twist_2d_structs_;
   thrust::device_vector<TwistStruct3D> device_twist_3d_structs_;
   thrust::device_vector<CropBoxParameters> device_crop_box_structs_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
@@ -24,6 +24,7 @@
 #include <cuda_runtime.h>
 #include <thrust/device_vector.h>
 
+#include <cstddef>
 #include <deque>
 
 namespace autoware::cuda_pointcloud_preprocessor
@@ -38,13 +39,15 @@ void undistort3DLaunch(
   std::uint8_t * output_mismatch_mask, int threads_per_block, int blocks_per_grid,
   cudaStream_t & stream);
 
-void setupTwist2DStructs(
+// Returns the number of twist structs uploaded (the valid prefix of
+// device_twist_2d_structs, whose size() may exceed it: the buffer only grows).
+std::size_t setupTwist2DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
   const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
   const std::uint64_t pointcloud_stamp_nsec, const std::uint32_t first_point_rel_stamp_nsec,
   thrust::device_vector<TwistStruct2D> & device_twist_2d_structs, cudaStream_t & stream);
 
-void setupTwist3DStructs(
+std::size_t setupTwist3DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
   const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
   const std::uint64_t pointcloud_stamp_nsec, const std::uint32_t first_point_rel_stamp_nsec,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -31,8 +31,8 @@
 
 #include <cuda_runtime.h>
 #include <tf2/utils.h>
-#include <thrust/count.h>
 #include <thrust/execution_policy.h>
+#include <thrust/iterator/transform_iterator.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 
@@ -42,6 +42,48 @@ namespace autoware::cuda_pointcloud_preprocessor
 {
 
 namespace thrust_stream = cuda_utils::thrust_stream;
+
+namespace
+{
+template <typename T>
+struct EqualsTo
+{
+  using result_type = int;
+  T value;
+  __device__ int operator()(const T & x) const { return x == value ? 1 : 0; }
+};
+
+// Count, on `stream`, how many of the first `n` elements of `mask` equal `value`,
+// leaving the result in the device scalar `out_dev`. Using CUB DeviceReduce keeps
+// the result on the device: thrust::count would instead copy its return value to
+// the host and synchronize the *default* stream on every call (a process-wide
+// barrier). CUB scratch is carved from the pre-allocated thrust workspace, so no
+// per-call cudaMalloc/cudaFree is incurred either.
+template <typename T>
+void cubCountEqual(
+  const T * mask, std::size_t n, T value, int * out_dev,
+  autoware::cuda_utils::ThrustWorkspace::Allocator alloc, cudaStream_t stream)
+{
+  thrust::transform_iterator<EqualsTo<T>, const T *> it(mask, EqualsTo<T>{value});
+  std::size_t temp_bytes = 0;
+  CHECK_CUDA_ERROR(cub::DeviceReduce::Sum(nullptr, temp_bytes, it, out_dev, n, stream));
+  char * temp = alloc.allocate(static_cast<std::ptrdiff_t>(temp_bytes));
+  CHECK_CUDA_ERROR(cub::DeviceReduce::Sum(temp, temp_bytes, it, out_dev, n, stream));
+  alloc.deallocate(temp, temp_bytes);
+}
+
+// Ensure a device_vector can hold at least n elements, growing monotonically with
+// 2x headroom. An enlarging thrust::device_vector::resize() value-initializes the
+// new region on the *default* stream and synchronizes -- a process-wide barrier --
+// so never shrink and over-allocate, making regrowth geometrically rare. The
+// vector's size() therefore becomes a high-water mark: callers must drive kernels
+// with the logical element count, not size().
+template <typename Vec>
+void grow_to(Vec & vec, std::size_t n)
+{
+  if (vec.size() < n) vec.resize(n * 2);
+}
+}  // namespace
 
 CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_stream())
 {
@@ -105,6 +147,7 @@ CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_st
   device_mismatch_mask_.resize(num_organized_points_);
   device_ring_outlier_mask_.resize(num_organized_points_);
   device_indices_.resize(num_organized_points_);
+  device_diag_counts_.resize(3);
 
   preallocateOutput();
 }
@@ -188,28 +231,38 @@ void CudaPointcloudPreprocessor::organizePointcloud()
     max_points_per_ring_ = std::max((max_points_per_ring + 511) / 512 * 512, 512);
     num_organized_points_ = num_rings_ * max_points_per_ring_;
 
-    device_ring_index_.resize(num_rings_);
-    thrust_stream::fill(device_ring_index_, 0, stream_);
-    device_indexes_tensor_.resize(num_organized_points_);
-    thrust_stream::fill<uint32_t>(device_indexes_tensor_, num_raw_points_, stream_);
-    device_sorted_indexes_tensor_.resize(num_organized_points_);
-    thrust_stream::fill<uint32_t>(device_sorted_indexes_tensor_, num_raw_points_, stream_);
-    device_segment_offsets_.resize(num_rings_ + 1);
-    device_organized_points_.resize(num_organized_points_);
-    thrust_stream::fill(device_organized_points_, InputPointType{}, stream_);
+    // Grow these buffers monotonically with headroom (grow_to) so the
+    // value-initializing resize -- which thrust runs on the default stream and
+    // synchronizes -- only fires while climbing to the high-water mark, not on
+    // every ring-geometry change. The fills below initialize the live region on
+    // the node stream; kernels are driven by num_organized_points_/num_rings_,
+    // never by size().
+    grow_to(device_ring_index_, num_rings_);
+    thrust_stream::fill_n(device_ring_index_, num_rings_, 0, stream_);
+    grow_to(device_indexes_tensor_, num_organized_points_);
+    thrust_stream::fill_n<uint32_t>(
+      device_indexes_tensor_, num_organized_points_, num_raw_points_, stream_);
+    grow_to(device_sorted_indexes_tensor_, num_organized_points_);
+    thrust_stream::fill_n<uint32_t>(
+      device_sorted_indexes_tensor_, num_organized_points_, num_raw_points_, stream_);
+    grow_to(device_segment_offsets_, num_rings_ + 1);
+    grow_to(device_organized_points_, num_organized_points_);
+    thrust_stream::fill_n(
+      device_organized_points_, num_organized_points_, InputPointType{}, stream_);
 
-    device_transformed_points_.resize(num_organized_points_);
-    thrust_stream::fill(device_transformed_points_, InputPointType{}, stream_);
-    device_crop_mask_.resize(num_organized_points_);
-    thrust_stream::fill(device_crop_mask_, 0U, stream_);
-    device_nan_mask_.resize(num_organized_points_);
-    thrust_stream::fill<uint8_t>(device_nan_mask_, 0, stream_);
-    device_mismatch_mask_.resize(num_organized_points_);
-    thrust_stream::fill<uint8_t>(device_mismatch_mask_, 0, stream_);
-    device_ring_outlier_mask_.resize(num_organized_points_);
-    thrust_stream::fill(device_ring_outlier_mask_, 0U, stream_);
-    device_indices_.resize(num_organized_points_);
-    thrust_stream::fill(device_indices_, 0U, stream_);
+    grow_to(device_transformed_points_, num_organized_points_);
+    thrust_stream::fill_n(
+      device_transformed_points_, num_organized_points_, InputPointType{}, stream_);
+    grow_to(device_crop_mask_, num_organized_points_);
+    thrust_stream::fill_n(device_crop_mask_, num_organized_points_, 0U, stream_);
+    grow_to(device_nan_mask_, num_organized_points_);
+    thrust_stream::fill_n<uint8_t>(device_nan_mask_, num_organized_points_, 0, stream_);
+    grow_to(device_mismatch_mask_, num_organized_points_);
+    thrust_stream::fill_n<uint8_t>(device_mismatch_mask_, num_organized_points_, 0, stream_);
+    grow_to(device_ring_outlier_mask_, num_organized_points_);
+    thrust_stream::fill_n(device_ring_outlier_mask_, num_organized_points_, 0U, stream_);
+    grow_to(device_indices_, num_organized_points_);
+    thrust_stream::fill_n(device_indices_, num_organized_points_, 0U, stream_);
 
     preallocateOutput();
 
@@ -233,7 +286,7 @@ void CudaPointcloudPreprocessor::organizePointcloud()
       num_organized_points_, num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
       thrust::raw_pointer_cast(device_indexes_tensor_.data()),
       thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
-    device_sort_workspace_.resize(sort_workspace_bytes_);
+    grow_to(device_sort_workspace_, sort_workspace_bytes_);
 
     organizeLaunch(
       thrust::raw_pointer_cast(device_input_points_.data()),
@@ -303,9 +356,11 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     device_input_points_.resize(new_capacity);
   }
 
-  // Reset all contents in the device vector
+  // Reset contents in the device vectors. device_organized_points_ may be
+  // over-allocated (grow_to), so reset only its live [0, num_organized_points_)
+  // region on the node stream.
   thrust_stream::fill(device_input_points_, InputPointType{}, stream_);
-  thrust_stream::fill(device_organized_points_, InputPointType{}, stream_);
+  thrust_stream::fill_n(device_organized_points_, num_organized_points_, InputPointType{}, stream_);
 
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     thrust::raw_pointer_cast(device_input_points_.data()), input_pointcloud_msg.data.data(),
@@ -347,12 +402,17 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     static_cast<std::uint64_t>(1'000'000'000) * input_pointcloud_msg.header.stamp.sec +
     input_pointcloud_msg.header.stamp.nanosec;
 
+  // Valid twist count for this callback. device_twist_*_structs_.size() is only a
+  // monotonic high-water mark (see setupTwist*Structs), so the kernels below must
+  // use these counts rather than .size().
+  std::size_t num_twist_2d_structs = 0;
+  std::size_t num_twist_3d_structs = 0;
   if (undistortion_type_ == UndistortionType::Undistortion3D) {
-    setupTwist3DStructs(
+    num_twist_3d_structs = setupTwist3DStructs(
       twist_queue, angular_velocity_queue, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
       device_twist_3d_structs_, stream_);
   } else if (undistortion_type_ == UndistortionType::Undistortion2D) {
-    setupTwist2DStructs(
+    num_twist_2d_structs = setupTwist2DStructs(
       twist_queue, angular_velocity_queue, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
       device_twist_2d_structs_, stream_);
   } else {
@@ -393,17 +453,15 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   }
 
   // Undistortion
-  if (
-    undistortion_type_ == UndistortionType::Undistortion3D && device_twist_3d_structs_.size() > 0) {
+  if (undistortion_type_ == UndistortionType::Undistortion3D && num_twist_3d_structs > 0) {
     undistort3DLaunch(
       device_transformed_points, num_organized_points_, device_twist_3d_structs,
-      static_cast<int>(device_twist_3d_structs_.size()), device_mismatch_mask, threads_per_block_,
+      static_cast<int>(num_twist_3d_structs), device_mismatch_mask, threads_per_block_,
       blocks_per_grid, stream_);
-  } else if (
-    undistortion_type_ == UndistortionType::Undistortion2D && device_twist_2d_structs_.size() > 0) {
+  } else if (undistortion_type_ == UndistortionType::Undistortion2D && num_twist_2d_structs > 0) {
     undistort2DLaunch(
       device_transformed_points, num_organized_points_, device_twist_2d_structs,
-      static_cast<int>(device_twist_2d_structs_.size()), device_mismatch_mask, threads_per_block_,
+      static_cast<int>(num_twist_2d_structs), device_mismatch_mask, threads_per_block_,
       blocks_per_grid, stream_);
   }
 
@@ -417,8 +475,8 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
       threads_per_block_, blocks_per_grid, stream_);
   } else {
     thrust::fill(
-      thrust::device, device_ring_outlier_mask, device_ring_outlier_mask + num_organized_points_,
-      1);
+      cuda_utils::thrust_on_stream(stream_), device_ring_outlier_mask,
+      device_ring_outlier_mask + num_organized_points_, 1);
   }
 
   combineMasksLaunch(
@@ -438,34 +496,47 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     workspace_policy, device_ring_outlier_mask, device_ring_outlier_mask + num_organized_points_,
     device_indices);
 
+  // Diagnostic counts: reduce on the node stream with CUB into device scalars
+  // instead of thrust::count, whose host-value return synchronizes the default
+  // stream on every call. The results are read back at the single synchronize
+  // below, alongside num_output_points.
+  // num_organized_points_ is the logical element count; the mask buffers may be
+  // over-allocated (grow_to), so count over [0, num_organized_points_), not size().
+  int * device_diag_counts = thrust::raw_pointer_cast(device_diag_counts_.data());
+  cubCountEqual(
+    device_crop_mask, num_organized_points_, static_cast<std::uint32_t>(1), device_diag_counts + 0,
+    thrust_workspace_.allocator(), stream_);
+  cubCountEqual(
+    device_nan_mask, num_organized_points_, static_cast<std::uint8_t>(1), device_diag_counts + 1,
+    thrust_workspace_.allocator(), stream_);
+  cubCountEqual(
+    device_mismatch_mask, num_organized_points_, static_cast<std::uint8_t>(1),
+    device_diag_counts + 2, thrust_workspace_.allocator(), stream_);
+
+  // The extract kernel writes only the points the scan selected, so launching it
+  // unconditionally is a no-op when nothing passed. Doing so removes the host's
+  // dependency on num_output_points before the launch, letting every
+  // device->host result be gathered at one synchronize after all GPU work is
+  // queued (rather than syncing mid-pipeline to read the count back first).
+  extractPointsLaunch(
+    device_transformed_points, device_ring_outlier_mask, device_indices, num_organized_points_,
+    reinterpret_cast<OutputPointType *>(output_pointcloud_ptr_->data.get()), threads_per_block_,
+    blocks_per_grid, stream_);
+
   int num_output_points{};
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     &num_output_points, device_indices + num_organized_points_ - 1, sizeof(int),
     cudaMemcpyDeviceToHost, stream_));
+  int diag_counts_host[3] = {0, 0, 0};
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    diag_counts_host, device_diag_counts, sizeof(diag_counts_host), cudaMemcpyDeviceToHost,
+    stream_));
 
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 
-  // Get information and extract points after filters
-  size_t num_crop_box_passed_points =
-    thrust::count(workspace_policy, device_crop_mask_.begin(), device_crop_mask_.end(), 1U);
-  size_t num_nan_points = thrust::count(
-    workspace_policy, device_nan_mask_.begin(), device_nan_mask_.end(), static_cast<uint8_t>(1));
-  size_t mismatch_count = thrust::count(
-    workspace_policy, device_mismatch_mask_.begin(), device_mismatch_mask_.end(),
-    static_cast<uint8_t>(1));
-
-  stats_.num_nan_points = static_cast<int>(num_nan_points);
-  stats_.num_crop_box_passed_points = static_cast<int>(num_crop_box_passed_points);
-  stats_.mismatch_count = static_cast<int>(mismatch_count);
-
-  if (num_output_points > 0) {
-    extractPointsLaunch(
-      device_transformed_points, device_ring_outlier_mask, device_indices, num_organized_points_,
-      reinterpret_cast<OutputPointType *>(output_pointcloud_ptr_->data.get()), threads_per_block_,
-      blocks_per_grid, stream_);
-  }
-
-  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+  stats_.num_crop_box_passed_points = diag_counts_host[0];
+  stats_.num_nan_points = diag_counts_host[1];
+  stats_.mismatch_count = diag_counts_host[2];
 
   // Copy the transformed points back
   output_pointcloud_ptr_->row_step = num_output_points * sizeof(OutputPointType);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -435,8 +435,8 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   const auto workspace_policy = thrust::cuda::par(thrust_workspace_.allocator()).on(stream_);
 
   thrust::inclusive_scan(
-    workspace_policy, device_ring_outlier_mask,
-    device_ring_outlier_mask + num_organized_points_, device_indices);
+    workspace_policy, device_ring_outlier_mask, device_ring_outlier_mask + num_organized_points_,
+    device_indices);
 
   int num_output_points{};
   CHECK_CUDA_ERROR(cudaMemcpyAsync(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -430,8 +430,12 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     device_is_valid_point, device_ring_outlier_mask, num_organized_points_,
     device_ring_outlier_mask, threads_per_block_, blocks_per_grid, stream_);
 
+  // Back thrust temporaries with the pre-allocated workspace (no per-call
+  // cudaMalloc/cudaFree) while keeping execution on the node's own stream.
+  const auto workspace_policy = thrust::cuda::par(thrust_workspace_.allocator()).on(stream_);
+
   thrust::inclusive_scan(
-    cuda_utils::thrust_on_stream(stream_), device_ring_outlier_mask,
+    workspace_policy, device_ring_outlier_mask,
     device_ring_outlier_mask + num_organized_points_, device_indices);
 
   int num_output_points{};
@@ -442,9 +446,13 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 
   // Get information and extract points after filters
-  size_t num_crop_box_passed_points = thrust_stream::count(device_crop_mask_, 1U, stream_);
-  size_t num_nan_points = thrust_stream::count<uint8_t>(device_nan_mask_, 1, stream_);
-  size_t mismatch_count = thrust_stream::count<uint8_t>(device_mismatch_mask_, 1, stream_);
+  size_t num_crop_box_passed_points =
+    thrust::count(workspace_policy, device_crop_mask_.begin(), device_crop_mask_.end(), 1U);
+  size_t num_nan_points = thrust::count(
+    workspace_policy, device_nan_mask_.begin(), device_nan_mask_.end(), static_cast<uint8_t>(1));
+  size_t mismatch_count = thrust::count(
+    workspace_policy, device_mismatch_mask_.begin(), device_mismatch_mask_.end(),
+    static_cast<uint8_t>(1));
 
   stats_.num_nan_points = static_cast<int>(num_nan_points);
   stats_.num_crop_box_passed_points = static_cast<int>(num_crop_box_passed_points);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/undistort_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/undistort_kernels.cu
@@ -165,7 +165,7 @@ void undistort3DLaunch(
   CHECK_CUDA_ERROR(cudaGetLastError());
 }
 
-void setupTwist2DStructs(
+std::size_t setupTwist2DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
   const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
   const std::uint64_t pointcloud_stamp_nsec, const std::uint32_t first_point_rel_stamp_nsec,
@@ -246,14 +246,25 @@ void setupTwist2DStructs(
     cum_y += d * sin(cum_theta);
   }
 
-  // Copy to device
-  device_twist_2d_structs.resize(host_twist_2d_structs.size());
+  // Copy to device. Grow the device buffer monotonically (never shrink), with 2x
+  // headroom: a thrust::device_vector::resize() that enlarges value-initializes
+  // the new region on the *default* stream and synchronizes -- a process-wide
+  // barrier -- right before we overwrite it. Only enlarging past the high-water
+  // mark keeps that off the steady-state path, and doubling makes regrowth
+  // geometrically rare (O(log) total grows). The copy itself runs on the node
+  // stream; size() is therefore a high-water mark, so callers use the returned
+  // count, not size().
+  const std::size_t num_twist_structs = host_twist_2d_structs.size();
+  if (device_twist_2d_structs.size() < num_twist_structs) {
+    device_twist_2d_structs.resize(num_twist_structs * 2);
+  }
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     thrust::raw_pointer_cast(device_twist_2d_structs.data()), host_twist_2d_structs.data(),
-    host_twist_2d_structs.size() * sizeof(TwistStruct2D), cudaMemcpyHostToDevice, stream));
+    num_twist_structs * sizeof(TwistStruct2D), cudaMemcpyHostToDevice, stream));
+  return num_twist_structs;
 }
 
-void setupTwist3DStructs(
+std::size_t setupTwist3DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
   const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
   const std::uint64_t pointcloud_stamp_nsec, const std::uint32_t first_point_rel_stamp_nsec,
@@ -339,11 +350,21 @@ void setupTwist3DStructs(
     cum_transform = cum_transform * delta_transform;
   }
 
-  // Copy to device
-  device_twist_3d_structs.resize(host_twist_3d_structs.size());
+  // Copy to device. Grow monotonically (never shrink), with 2x headroom: an
+  // enlarging thrust::device_vector::resize() value-initializes the new region on
+  // the *default* stream and synchronizes -- a process-wide barrier -- right
+  // before we overwrite it. Only enlarging past the high-water mark keeps that
+  // off the steady-state path, and doubling makes regrowth geometrically rare.
+  // The copy itself runs on the node stream; size() is therefore a high-water
+  // mark, so callers use the returned count, not size().
+  const std::size_t num_twist_structs = host_twist_3d_structs.size();
+  if (device_twist_3d_structs.size() < num_twist_structs) {
+    device_twist_3d_structs.resize(num_twist_structs * 2);
+  }
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     thrust::raw_pointer_cast(device_twist_3d_structs.data()), host_twist_3d_structs.data(),
-    host_twist_3d_structs.size() * sizeof(TwistStruct3D), cudaMemcpyHostToDevice, stream));
+    num_twist_structs * sizeof(TwistStruct3D), cudaMemcpyHostToDevice, stream));
+  return num_twist_structs;
 }
 
 }  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/thrust_workspace_allocator.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/thrust_workspace_allocator.hpp
@@ -1,0 +1,181 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_UTILS__THRUST_WORKSPACE_ALLOCATOR_HPP_
+#define AUTOWARE__CUDA_UTILS__THRUST_WORKSPACE_ALLOCATOR_HPP_
+
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace autoware::cuda_utils
+{
+
+/// \brief Pre-allocated device-memory workspace that backs Thrust temporary
+/// allocations, so Thrust algorithms incur no per-call device allocation.
+///
+/// Thrust algorithms (sort, reduce/count, scan, copy_if, ...) need scratch
+/// memory. With Thrust's default device allocator they obtain it via plain
+/// \c cudaMalloc / \c cudaFree, each of which is a *process-wide* device
+/// synchronization. In a process that hosts several GPU workloads (e.g. one ROS
+/// component container running multiple CUDA nodes) those barriers serialize
+/// otherwise-independent streams.
+///
+/// \c ThrustWorkspace hands out slices of a single device buffer with a bump
+/// pointer and resets once every outstanding allocation has been returned —
+/// which is always the case between Thrust algorithm invocations. In steady
+/// state it therefore performs no device allocation, letting Thrust run free of
+/// the process-wide barriers. Use it together with the node's own stream:
+///
+/// \code
+///   ThrustWorkspace ws{1 << 20};  // construct once (e.g. a node member)
+///   const auto policy = thrust::cuda::par(ws.allocator()).on(stream);
+///   thrust::sort(policy, first, last);
+///   const auto n = thrust::count_if(policy, first, last, pred);
+/// \endcode
+///
+/// The buffer grows (once) if an algorithm ever needs more than the current
+/// capacity, converging to a fixed footprint after the largest workload has
+/// been seen; pass a sufficient \p initial_capacity_bytes to avoid even that.
+///
+/// \note Not thread-safe. Use one workspace per stream/thread (the GPU work it
+/// backs runs serially on a single stream anyway).
+class ThrustWorkspace
+{
+public:
+  explicit ThrustWorkspace(std::size_t initial_capacity_bytes = 0)
+  {
+    if (initial_capacity_bytes > 0) {
+      grow(initial_capacity_bytes);
+    }
+  }
+
+  ~ThrustWorkspace()
+  {
+    if (buffer_ != nullptr) {
+      static_cast<void>(::cudaFree(buffer_));  // best-effort; never throw from dtor
+    }
+  }
+
+  ThrustWorkspace(const ThrustWorkspace &) = delete;
+  ThrustWorkspace & operator=(const ThrustWorkspace &) = delete;
+
+  /// \brief Lightweight, copyable handle that satisfies Thrust's allocator
+  /// requirements (value_type == char). Pass to \c thrust::cuda::par(...).
+  class Allocator
+  {
+  public:
+    using value_type = char;
+
+    explicit Allocator(ThrustWorkspace * workspace) : workspace_(workspace) {}
+
+    char * allocate(std::ptrdiff_t num_bytes)
+    {
+      return workspace_->allocate(static_cast<std::size_t>(num_bytes));
+    }
+
+    void deallocate(char * ptr, std::size_t /*num_bytes*/) { workspace_->deallocate(ptr); }
+
+  private:
+    ThrustWorkspace * workspace_;
+  };
+
+  [[nodiscard]] Allocator allocator() { return Allocator{this}; }
+
+  [[nodiscard]] std::size_t capacity_bytes() const { return capacity_; }
+  [[nodiscard]] std::size_t peak_bytes() const { return peak_; }
+  [[nodiscard]] std::size_t fallback_count() const { return fallback_count_; }
+
+private:
+  static constexpr std::size_t kAlignment = 256;
+
+  static std::size_t align_up(std::size_t value, std::size_t alignment)
+  {
+    return (value + alignment - 1) & ~(alignment - 1);
+  }
+
+  char * allocate(std::size_t num_bytes)
+  {
+    const std::size_t offset = align_up(offset_, kAlignment);
+    const std::size_t end = offset + num_bytes;
+
+    if (end <= capacity_) {  // fast path: carve a slice out of the buffer
+      char * ptr = buffer_ + offset;
+      offset_ = end;
+      peak_ = std::max(peak_, offset_);
+      ++live_;
+      return ptr;
+    }
+
+    if (live_ == 0) {  // nothing outstanding: safe to (re)allocate a larger buffer
+      grow(std::max(end, capacity_ * 2));
+      char * ptr = buffer_;  // offset_ was reset to 0 by grow()
+      offset_ = num_bytes;
+      peak_ = std::max(peak_, offset_);
+      ++live_;
+      return ptr;
+    }
+
+    // Mid-algorithm overflow (rare): satisfy this one block directly and grow on
+    // the next reset so steady state stops hitting this path.
+    pending_capacity_ = std::max(pending_capacity_, end);
+    char * ptr = nullptr;
+    CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&ptr), num_bytes));
+    ++live_;
+    ++fallback_count_;
+    return ptr;
+  }
+
+  void deallocate(char * ptr)
+  {
+    --live_;
+    const bool from_buffer = (ptr >= buffer_) && (ptr < buffer_ + capacity_);
+    if (!from_buffer) {
+      static_cast<void>(::cudaFree(ptr));  // a fallback block
+    }
+    if (live_ == 0) {
+      offset_ = 0;
+      if (pending_capacity_ > capacity_) {
+        grow(pending_capacity_);
+        pending_capacity_ = 0;
+      }
+    }
+  }
+
+  void grow(std::size_t bytes)
+  {
+    if (buffer_ != nullptr) {
+      static_cast<void>(::cudaFree(buffer_));
+    }
+    CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&buffer_), bytes));
+    capacity_ = bytes;
+    offset_ = 0;
+  }
+
+  char * buffer_{nullptr};
+  std::size_t capacity_{0};
+  std::size_t offset_{0};
+  std::size_t peak_{0};
+  std::size_t pending_capacity_{0};
+  std::int64_t live_{0};
+  std::size_t fallback_count_{0};
+};
+
+}  // namespace autoware::cuda_utils
+
+#endif  // AUTOWARE__CUDA_UTILS__THRUST_WORKSPACE_ALLOCATOR_HPP_


### PR DESCRIPTION
## Description

The CUDA pointcloud preprocessor runs several Thrust reductions/scans per pointcloud — an `inclusive_scan` over the ring-outlier mask and three `count` passes over the crop / NaN / mismatch masks. With Thrust's default device allocator each of those takes scratch memory via `cudaMalloc`/`cudaFree`, i.e. ~7 alloc/free pairs per callback. Each is a **process-wide** device barrier, which serializes the other GPU workloads sharing the container (`cuda_blackboard` co-locates them in one process).

This PR routes those temporaries through `autoware::cuda_utils::ThrustWorkspace` (a pre-allocated device buffer; see the stacked base PR) on the node's own stream, so in steady state the preprocessor performs no per-callback device allocation.

```cpp
const auto workspace_policy = thrust::cuda::par(thrust_workspace_.allocator()).on(stream_);
thrust::inclusive_scan(workspace_policy, ...);
thrust::count(workspace_policy, ...);
```

## How was this PR tested?

Full `logging_simulator` run traced with Nsight Systems; device-blocking CUDA calls attributed to the `pointcloud_preprocessor` NVTX subtree (measurement window, excludes warm-up):

| | before | after |
|---|--:|--:|
| `cudaMalloc` | 6524 | **29** |
| `cudaFree` | 6524 | **29** |

≈99.6% fewer process-wide allocation barriers. The remaining ~29 are the (untouched) twist `device_vector` resizes; the `cudaStreamSynchronize` count is unchanged (those are D2H count read-backs, addressed separately). No behavioral change — identical results, identical execution stream.

## Notes for reviewers

**Stacked on #12856**, which adds `ThrustWorkspace`. Until #12856 merges its header appears in this PR's diff; the change unique to this PR is the `autoware_cuda_pointcloud_preprocessor` edit (1 include, 1 member, the scan + 3 counts).

## Effects on system behavior

Less default-stream contention in the LiDAR preprocessing path; no functional change.
