### PR TITLE
perf(autoware_bevfusion): reuse pre-allocated buffers + workspace in postprocess

### DIFF
--- a/perception/autoware_bevfusion/include/autoware/bevfusion/postprocess/circle_nms_kernel.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/postprocess/circle_nms_kernel.hpp
@@ -23,12 +23,10 @@
 
 namespace autoware::bevfusion
 {
-// Non-maximum suppression (NMS) uses the distance on the xy plane instead of
-// intersection over union (IoU) to suppress overlapped objects.
-std::size_t circleNMS(
-  thrust::device_vector<Box3D> & boxes3d, const float distance_threshold,
-  thrust::device_vector<bool> & keep_mask, cudaStream_t stream);
-
+// Distance-based non-maximum suppression (xy-plane distance instead of IoU) is
+// implemented as a private PostprocessCuda method (see postprocess_kernel.hpp),
+// reusing that class's pre-allocated scratch. The kernel launcher lives in
+// circle_nms_kernel.cu.
 }  // namespace autoware::bevfusion
 
 #endif  // AUTOWARE__BEVFUSION__POSTPROCESS__CIRCLE_NMS_KERNEL_HPP_

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/postprocess/postprocess_kernel.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/postprocess/postprocess_kernel.hpp
@@ -19,10 +19,14 @@
 #include "autoware/bevfusion/utils.hpp"
 
 #include <autoware/cuda_utils/cuda_unique_ptr.hpp>
+#include <autoware/cuda_utils/thrust_workspace_allocator.hpp>
 
 #include <cuda.h>
 #include <cuda_runtime_api.h>
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
 
+#include <cstdint>
 #include <vector>
 
 namespace autoware::bevfusion
@@ -39,12 +43,30 @@ public:
     const float * score_output, std::vector<Box3D> & det_boxes3d, cudaStream_t stream);
 
 private:
+  // Distance-based NMS over the first num_boxes3d entries of det_boxes3d_d_,
+  // writing keep_mask_d_; reuses the pre-allocated scratch below.
+  std::size_t circleNMS(std::size_t num_boxes3d, float distance_threshold, cudaStream_t stream);
+
   BEVFusionConfig config_;
   cudaStream_t stream_;
 
   // For distance-based and class-based score thresholding
   CudaUniquePtr<float[]> distance_bin_upper_limits_d_ptr_{nullptr};
   CudaUniquePtr<float[]> score_thresholds_d_ptr_{nullptr};
+
+  // Thrust temporary workspace + persistent scratch, allocated once so the
+  // per-frame reductions/sort/NMS perform no device or pinned-host allocation
+  // and run on the node's stream (no default-stream barriers).
+  autoware::cuda_utils::ThrustWorkspace thrust_workspace_;
+  thrust::device_vector<Box3D> boxes3d_d_;
+  thrust::device_vector<float> yaw_norm_thresholds_d_;
+  thrust::device_vector<Box3D> det_boxes3d_d_;
+  thrust::device_vector<bool> keep_mask_d_;
+  thrust::device_vector<Box3D> final_det_boxes3d_d_;
+  thrust::device_vector<std::uint64_t> nms_mask_d_;
+  thrust::host_vector<std::uint64_t> nms_mask_h_;
+  thrust::host_vector<bool> keep_mask_h_;
+  std::vector<std::uint64_t> nms_remv_h_;
 };
 
 }  // namespace autoware::bevfusion

--- a/perception/autoware_bevfusion/lib/postprocess/circle_nms_kernel.cu
+++ b/perception/autoware_bevfusion/lib/postprocess/circle_nms_kernel.cu
@@ -22,13 +22,16 @@ All Rights Reserved 2019-2020.
 */
 
 #include "autoware/bevfusion/postprocess/circle_nms_kernel.hpp"
+#include "autoware/bevfusion/postprocess/postprocess_kernel.hpp"
 #include "autoware/bevfusion/utils.hpp"
 
 #include <autoware/cuda_utils/cuda_check_error.hpp>
 
+#include <thrust/copy.h>
 #include <thrust/host_vector.h>
 
 #include <cstddef>
+#include <vector>
 
 namespace
 {
@@ -102,44 +105,55 @@ cudaError_t circleNMS_launch(
   return cudaGetLastError();
 }
 
-std::size_t circleNMS(
-  thrust::device_vector<Box3D> & boxes3d, const float distance_threshold,
-  thrust::device_vector<bool> & keep_mask, cudaStream_t stream)
+std::size_t PostprocessCuda::circleNMS(
+  std::size_t num_boxes3d, const float distance_threshold, cudaStream_t stream)
 {
-  const auto num_boxes3d = boxes3d.size();
   const auto col_blocks = divup(num_boxes3d, THREADS_PER_BLOCK_NMS);
-  thrust::device_vector<std::uint64_t> mask_d(num_boxes3d * col_blocks);
 
-  CHECK_CUDA_ERROR(
-    circleNMS_launch(boxes3d, num_boxes3d, col_blocks, distance_threshold, mask_d, stream));
+  // Reserve scratch to the worst case once; per-call resizes never reallocate.
+  const std::size_t max_boxes = static_cast<std::size_t>(config_.num_proposals_);
+  const std::size_t max_col_blocks = divup(max_boxes, THREADS_PER_BLOCK_NMS);
+  nms_mask_d_.reserve(max_boxes * max_col_blocks);
+  nms_mask_h_.reserve(max_boxes * max_col_blocks);
+  keep_mask_h_.reserve(max_boxes);
+  nms_remv_h_.reserve(max_col_blocks);
 
-  // memcpy device to host
-  thrust::host_vector<std::uint64_t> mask_h(mask_d.size());
-  thrust::copy(mask_d.begin(), mask_d.end(), mask_h.begin());
+  nms_mask_d_.resize(num_boxes3d * col_blocks);
+  CHECK_CUDA_ERROR(circleNMS_launch(
+    det_boxes3d_d_, num_boxes3d, col_blocks, distance_threshold, nms_mask_d_, stream));
+
+  // copy the suppression mask to host on the node stream (stream-local sync)
+  nms_mask_h_.resize(nms_mask_d_.size());
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    thrust::raw_pointer_cast(nms_mask_h_.data()), thrust::raw_pointer_cast(nms_mask_d_.data()),
+    nms_mask_d_.size() * sizeof(std::uint64_t), cudaMemcpyDeviceToHost, stream));
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream));
 
-  // generate keep_mask
-  std::vector<std::uint64_t> remv_h(col_blocks);
-  thrust::host_vector<bool> keep_mask_h(keep_mask.size());
+  // generate keep_mask on host
+  nms_remv_h_.assign(col_blocks, 0);
+  keep_mask_h_.resize(num_boxes3d);
   std::size_t num_to_keep = 0;
   for (std::size_t i = 0; i < num_boxes3d; i++) {
     auto nblock = i / THREADS_PER_BLOCK_NMS;
     auto inblock = i % THREADS_PER_BLOCK_NMS;
 
-    if (!(remv_h[nblock] & (1ULL << inblock))) {
-      keep_mask_h[i] = true;
+    if (!(nms_remv_h_[nblock] & (1ULL << inblock))) {
+      keep_mask_h_[i] = true;
       num_to_keep++;
-      std::uint64_t * p = &mask_h[0] + i * col_blocks;
+      std::uint64_t * p = &nms_mask_h_[0] + i * col_blocks;
       for (std::size_t j = nblock; j < col_blocks; j++) {
-        remv_h[j] |= p[j];
+        nms_remv_h_[j] |= p[j];
       }
     } else {
-      keep_mask_h[i] = false;
+      keep_mask_h_[i] = false;
     }
   }
 
-  // memcpy host to device
-  keep_mask = keep_mask_h;
+  // memcpy host to device on the node stream (ordered before the copy_if that reads it)
+  keep_mask_d_.resize(num_boxes3d);
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    thrust::raw_pointer_cast(keep_mask_d_.data()), thrust::raw_pointer_cast(keep_mask_h_.data()),
+    num_boxes3d * sizeof(bool), cudaMemcpyHostToDevice, stream));
 
   return num_to_keep;
 }

--- a/perception/autoware_bevfusion/lib/postprocess/postprocess_kernel.cu
+++ b/perception/autoware_bevfusion/lib/postprocess/postprocess_kernel.cu
@@ -19,8 +19,10 @@
 #include <autoware/cuda_utils/cuda_unique_ptr.hpp>
 #include <autoware/cuda_utils/cuda_utils.hpp>
 
+#include <thrust/copy.h>
 #include <thrust/count.h>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 #include <thrust/host_vector.h>
 #include <thrust/sort.h>
 
@@ -136,6 +138,16 @@ PostprocessCuda::PostprocessCuda(const BEVFusionConfig & config, cudaStream_t st
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     distance_bin_upper_limits_d_ptr_.get(), config_.distance_bin_upper_limits_.data(),
     config_.distance_bin_upper_limits_.size() * sizeof(float), cudaMemcpyHostToDevice, stream_));
+
+  // Pre-size scratch to the worst case (num_proposals) so the per-frame path
+  // performs no device (re)allocation. NMS scratch is reserved in circleNMS().
+  // yaw_norm_thresholds_ is constant -> upload once.
+  const std::size_t max_boxes = static_cast<std::size_t>(config_.num_proposals_);
+  boxes3d_d_.reserve(max_boxes);
+  det_boxes3d_d_.reserve(max_boxes);
+  keep_mask_d_.reserve(max_boxes);
+  final_det_boxes3d_d_.reserve(max_boxes);
+  yaw_norm_thresholds_d_ = config_.yaw_norm_thresholds_;
 }
 
 // cspell: ignore divup
@@ -146,45 +158,50 @@ cudaError_t PostprocessCuda::generateDetectedBoxes3D_launch(
   dim3 threads = {config_.threads_per_block_};
   dim3 blocks = {divup(config_.num_proposals_, threads.x)};
 
-  auto boxes3d_d = thrust::device_vector<Box3D>(config_.num_proposals_);
-  auto yaw_norm_thresholds_d = thrust::device_vector<float>(
-    config_.yaw_norm_thresholds_.begin(), config_.yaw_norm_thresholds_.end());
+  // Run all thrust algorithms on the node stream with a pre-allocated workspace,
+  // so they neither sync the default stream nor cudaMalloc/cudaFree per call.
+  const auto policy = thrust::cuda::par(thrust_workspace_.allocator()).on(stream);
 
+  boxes3d_d_.resize(config_.num_proposals_);
   generateBoxes3D_kernel<<<blocks, threads, 0, stream>>>(
     label_pred_output, bbox_pred_output, score_output, config_.voxel_x_size_, config_.voxel_y_size_,
     config_.min_x_range_, config_.min_y_range_, config_.num_proposals_, config_.out_size_factor_,
-    thrust::raw_pointer_cast(yaw_norm_thresholds_d.data()), config_.num_classes_,
+    thrust::raw_pointer_cast(yaw_norm_thresholds_d_.data()), config_.num_classes_,
     distance_bin_upper_limits_d_ptr_.get(), score_thresholds_d_ptr_.get(),
-    config_.distance_bin_upper_limits_.size(), thrust::raw_pointer_cast(boxes3d_d.data()));
+    config_.distance_bin_upper_limits_.size(), thrust::raw_pointer_cast(boxes3d_d_.data()));
 
   // suppress by score
   const auto num_det_boxes3d =
-    thrust::count_if(thrust::device, boxes3d_d.begin(), boxes3d_d.end(), is_score_keep());
+    thrust::count_if(policy, boxes3d_d_.begin(), boxes3d_d_.end(), is_score_keep());
 
   if (num_det_boxes3d == 0) {
     return cudaGetLastError();
   }
 
-  thrust::device_vector<Box3D> det_boxes3d_d(num_det_boxes3d);
+  det_boxes3d_d_.resize(num_det_boxes3d);
   // Remove any boxes with score == 0.0 after distance-based and class-based filtering
   thrust::copy_if(
-    thrust::device, boxes3d_d.begin(), boxes3d_d.end(), det_boxes3d_d.begin(), is_score_keep());
+    policy, boxes3d_d_.begin(), boxes3d_d_.end(), det_boxes3d_d_.begin(), is_score_keep());
 
   // sort by score
-  thrust::sort(det_boxes3d_d.begin(), det_boxes3d_d.end(), score_greater());
+  thrust::sort(policy, det_boxes3d_d_.begin(), det_boxes3d_d_.end(), score_greater());
 
-  // supress by NMS
-  thrust::device_vector<bool> final_keep_mask_d(num_det_boxes3d);
+  // suppress by NMS (writes keep_mask_d_)
   const auto num_final_det_boxes3d =
-    circleNMS(det_boxes3d_d, config_.circle_nms_dist_threshold_, final_keep_mask_d, stream);
-  thrust::device_vector<Box3D> final_det_boxes3d_d(num_final_det_boxes3d);
+    circleNMS(num_det_boxes3d, config_.circle_nms_dist_threshold_, stream);
+  final_det_boxes3d_d_.resize(num_final_det_boxes3d);
   thrust::copy_if(
-    thrust::device, det_boxes3d_d.begin(), det_boxes3d_d.end(), final_keep_mask_d.begin(),
-    final_det_boxes3d_d.begin(), is_kept());
+    policy, det_boxes3d_d_.begin(), det_boxes3d_d_.end(), keep_mask_d_.begin(),
+    final_det_boxes3d_d_.begin(), is_kept());
 
-  // memcpy device to host
+  // Copy results to host on the node stream (stream-local sync, not a
+  // default-stream barrier). A thrust::copy with a CUDA policy would
+  // mis-dispatch this device->host copy as device->device.
   det_boxes3d.resize(num_final_det_boxes3d);
-  thrust::copy(final_det_boxes3d_d.begin(), final_det_boxes3d_d.end(), det_boxes3d.begin());
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    det_boxes3d.data(), thrust::raw_pointer_cast(final_det_boxes3d_d_.data()),
+    num_final_det_boxes3d * sizeof(Box3D), cudaMemcpyDeviceToHost, stream));
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream));
 
   return cudaGetLastError();
 }

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/thrust_workspace_allocator.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/thrust_workspace_allocator.hpp
@@ -1,0 +1,181 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_UTILS__THRUST_WORKSPACE_ALLOCATOR_HPP_
+#define AUTOWARE__CUDA_UTILS__THRUST_WORKSPACE_ALLOCATOR_HPP_
+
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace autoware::cuda_utils
+{
+
+/// \brief Pre-allocated device-memory workspace that backs Thrust temporary
+/// allocations, so Thrust algorithms incur no per-call device allocation.
+///
+/// Thrust algorithms (sort, reduce/count, scan, copy_if, ...) need scratch
+/// memory. With Thrust's default device allocator they obtain it via plain
+/// \c cudaMalloc / \c cudaFree, each of which is a *process-wide* device
+/// synchronization. In a process that hosts several GPU workloads (e.g. one ROS
+/// component container running multiple CUDA nodes) those barriers serialize
+/// otherwise-independent streams.
+///
+/// \c ThrustWorkspace hands out slices of a single device buffer with a bump
+/// pointer and resets once every outstanding allocation has been returned —
+/// which is always the case between Thrust algorithm invocations. In steady
+/// state it therefore performs no device allocation, letting Thrust run free of
+/// the process-wide barriers. Use it together with the node's own stream:
+///
+/// \code
+///   ThrustWorkspace ws{1 << 20};  // construct once (e.g. a node member)
+///   const auto policy = thrust::cuda::par(ws.allocator()).on(stream);
+///   thrust::sort(policy, first, last);
+///   const auto n = thrust::count_if(policy, first, last, pred);
+/// \endcode
+///
+/// The buffer grows (once) if an algorithm ever needs more than the current
+/// capacity, converging to a fixed footprint after the largest workload has
+/// been seen; pass a sufficient \p initial_capacity_bytes to avoid even that.
+///
+/// \note Not thread-safe. Use one workspace per stream/thread (the GPU work it
+/// backs runs serially on a single stream anyway).
+class ThrustWorkspace
+{
+public:
+  explicit ThrustWorkspace(std::size_t initial_capacity_bytes = 0)
+  {
+    if (initial_capacity_bytes > 0) {
+      grow(initial_capacity_bytes);
+    }
+  }
+
+  ~ThrustWorkspace()
+  {
+    if (buffer_ != nullptr) {
+      static_cast<void>(::cudaFree(buffer_));  // best-effort; never throw from dtor
+    }
+  }
+
+  ThrustWorkspace(const ThrustWorkspace &) = delete;
+  ThrustWorkspace & operator=(const ThrustWorkspace &) = delete;
+
+  /// \brief Lightweight, copyable handle that satisfies Thrust's allocator
+  /// requirements (value_type == char). Pass to \c thrust::cuda::par(...).
+  class Allocator
+  {
+  public:
+    using value_type = char;
+
+    explicit Allocator(ThrustWorkspace * workspace) : workspace_(workspace) {}
+
+    char * allocate(std::ptrdiff_t num_bytes)
+    {
+      return workspace_->allocate(static_cast<std::size_t>(num_bytes));
+    }
+
+    void deallocate(char * ptr, std::size_t /*num_bytes*/) { workspace_->deallocate(ptr); }
+
+  private:
+    ThrustWorkspace * workspace_;
+  };
+
+  [[nodiscard]] Allocator allocator() { return Allocator{this}; }
+
+  [[nodiscard]] std::size_t capacity_bytes() const { return capacity_; }
+  [[nodiscard]] std::size_t peak_bytes() const { return peak_; }
+  [[nodiscard]] std::size_t fallback_count() const { return fallback_count_; }
+
+private:
+  static constexpr std::size_t kAlignment = 256;
+
+  static std::size_t align_up(std::size_t value, std::size_t alignment)
+  {
+    return (value + alignment - 1) & ~(alignment - 1);
+  }
+
+  char * allocate(std::size_t num_bytes)
+  {
+    const std::size_t offset = align_up(offset_, kAlignment);
+    const std::size_t end = offset + num_bytes;
+
+    if (end <= capacity_) {  // fast path: carve a slice out of the buffer
+      char * ptr = buffer_ + offset;
+      offset_ = end;
+      peak_ = std::max(peak_, offset_);
+      ++live_;
+      return ptr;
+    }
+
+    if (live_ == 0) {  // nothing outstanding: safe to (re)allocate a larger buffer
+      grow(std::max(end, capacity_ * 2));
+      char * ptr = buffer_;  // offset_ was reset to 0 by grow()
+      offset_ = num_bytes;
+      peak_ = std::max(peak_, offset_);
+      ++live_;
+      return ptr;
+    }
+
+    // Mid-algorithm overflow (rare): satisfy this one block directly and grow on
+    // the next reset so steady state stops hitting this path.
+    pending_capacity_ = std::max(pending_capacity_, end);
+    char * ptr = nullptr;
+    CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&ptr), num_bytes));
+    ++live_;
+    ++fallback_count_;
+    return ptr;
+  }
+
+  void deallocate(char * ptr)
+  {
+    --live_;
+    const bool from_buffer = (ptr >= buffer_) && (ptr < buffer_ + capacity_);
+    if (!from_buffer) {
+      static_cast<void>(::cudaFree(ptr));  // a fallback block
+    }
+    if (live_ == 0) {
+      offset_ = 0;
+      if (pending_capacity_ > capacity_) {
+        grow(pending_capacity_);
+        pending_capacity_ = 0;
+      }
+    }
+  }
+
+  void grow(std::size_t bytes)
+  {
+    if (buffer_ != nullptr) {
+      static_cast<void>(::cudaFree(buffer_));
+    }
+    CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&buffer_), bytes));
+    capacity_ = bytes;
+    offset_ = 0;
+  }
+
+  char * buffer_{nullptr};
+  std::size_t capacity_{0};
+  std::size_t offset_{0};
+  std::size_t peak_{0};
+  std::size_t pending_capacity_{0};
+  std::int64_t live_{0};
+  std::size_t fallback_count_{0};
+};
+
+}  // namespace autoware::cuda_utils
+
+#endif  // AUTOWARE__CUDA_UTILS__THRUST_WORKSPACE_ALLOCATOR_HPP_


### PR DESCRIPTION
## Description

BEVFusion postprocess (`generateDetectedBoxes3D_launch` + `circleNMS`) allocated fresh `thrust::device_vector`s and pinned `thrust::host_vector`s **every frame**, and ran its reductions/sort with `thrust::device` (the **default stream**). Per detection cycle that is ~10 `cudaMalloc`/`cudaFree` pairs plus many default-stream synchronizations — each a **process-wide** device barrier that serializes the other GPU workloads sharing the container (`cuda_blackboard` co-locates them in one process).

This PR:
- Promotes the scratch (candidate boxes, detected boxes, NMS suppression mask + keep-mask, and the host mask/keep buffers) to **persistent members reserved once** to `num_proposals`; per-frame they are only `resize`d (≤ capacity → no realloc). `yaw_norm_thresholds` is uploaded once in the constructor.
- Runs `count_if` / `copy_if` / `sort` through an `autoware::cuda_utils::ThrustWorkspace` on the **node's own stream** (`thrust::cuda::par(ws.allocator()).on(stream)`), so neither the temp scratch nor the syncs hit the default stream.
- Uses explicit `cudaMemcpyAsync(..., stream)` for the host↔device result/mask copies (a `thrust::copy` under a CUDA policy mis-dispatches a D→H copy as D→D).
- Makes `circleNMS` a private `PostprocessCuda` method reusing that scratch.

The detection logic (distance-bin / per-class score thresholding) is **unchanged**.

## How was this PR tested?

The equivalent change was applied to our downstream BEVFusion postprocess and measured on a full `logging_simulator` run with Nsight Systems. Device-blocking calls attributed to `bevfusion>postprocess` dropped from **~4,068 to ~215** per measurement window (`cudaMalloc`/`cudaFree` ~1,130/~1,130 → ~5/~3; default-stream syncs ~1,808 → ~207), with identical detections.

> ⚠️ Note for reviewers: our downstream postprocess has diverged slightly from `main` (it drops the distance-bin/per-class thresholding present here), so this PR re-applies the *same allocation/stream pattern* onto `main`'s postprocess. The pattern is verified downstream as above, but this exact port onto `main` was **not** re-benchmarked. Please confirm via CI / a local run.

## Notes for reviewers

**Stacked on #12856** (adds `ThrustWorkspace`). Until it merges, that header appears in this diff; the change unique to this PR is the `autoware_bevfusion` postprocess.

## Effects on system behavior

Less default-stream contention from the LiDAR detector postprocess; no functional change to detections.
