### PR TITLE
feat(map_based_prediction): rear-axle center-anchored bicycle heading for vehicle path generation

### DIFF
--- a/perception/autoware_map_based_prediction/README.md
+++ b/perception/autoware_map_based_prediction/README.md
@@ -142,6 +142,32 @@ You can change these parameters in rosparam in the table below.
 | `max_lateral_accel`                      | `2.0` [m/s^2]  |
 | `min_acceleration_before_curve`          | `-2.0` [m/s^2] |
 
+#### Center-anchored bicycle heading for path integration (for vehicle obstacles)
+
+A vehicle pivots about its **rear axle**, not its body-box center, so its heading lags the path
+tangent on turns and lane changes (the body-box center traces the lane while the heading carries a
+slip angle). The body-box center is kept on the Frenet reference path — preserving lane-centering —
+while the **heading is integrated forward as a state** rather than read off the segment azimuth.
+
+For on-lane vehicles, `convertToPredictedPath` integrates the body heading `psi` along the predicted
+center path with a rear-axle relaxation law:
+
+```text
+gain = 1 - exp(-chord / lr)
+psi += gain * normalize_radian(theta_c - psi)
+```
+
+where `chord` is the inter-point center displacement, `theta_c` is the center velocity direction, and
+`lr = dimensions.x * wheel_pos_ratio_rear` is the rear lever arm. The heading relaxes toward the
+center velocity direction with a lag that is exactly the bicycle slip angle, so cornering produces the
+correct rear-tucking geometry. The formulation is unconditionally stable (`gain` in `(0, 1)` for all
+inputs), which replaces an earlier post-pass that recovered heading by finite-differencing positions
+and dividing by `lr` — a feedback loop that diverged at high speed / fine sampling.
+
+The per-class `wheel_pos_ratio_rear` values mirror `autoware_multi_object_tracker`'s
+`object_model.hpp` (`0.25` for car/bus/truck/trailer, `0.30` for motorcycle) and are kept in sync
+manually so this package keeps no build dependency on the tracker.
+
 ## Using Vehicle Acceleration for Path Prediction (for Vehicle Obstacles)
 
 By default, the `map_based_prediction` module uses the current obstacle's velocity to compute its predicted path length. However, it is possible to use the obstacle's current acceleration to calculate its predicted path's length.

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/path_generator/frenet.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/path_generator/frenet.hpp
@@ -37,7 +37,7 @@ using FrenetPath = std::vector<FrenetPoint>;
 FrenetPoint getFrenetPoint(
   const TrackedObject & object, const geometry_msgs::msg::Pose & ref_pose, const double duration,
   const double speed_limit, bool use_vehicle_acceleration,
-  double acceleration_exponential_half_life);
+  double acceleration_exponential_half_life, double rear_lever_arm = 0.0);
 
 FrenetPath generateFrenetPath(
   const FrenetPoint & current_point, const FrenetPoint & target_point, const double max_length,
@@ -48,7 +48,7 @@ PosePath interpolateReferencePath(
 
 PredictedPath convertToPredictedPath(
   const TrackedObject & object, const FrenetPath & frenet_predicted_path, const PosePath & ref_path,
-  const double sampling_time_interval);
+  const double sampling_time_interval, const double rear_lever_arm = 0.0);
 
 }  // namespace autoware::map_based_prediction
 

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/path_generator/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/path_generator/path_generator.hpp
@@ -75,8 +75,8 @@ public:
 
   PredictedPath generatePathForOnLaneVehicle(
     const TrackedObject & object, const PosePath & ref_path, const double duration,
-    const double lateral_duration, const double path_width = 0.0,
-    const double speed_limit = 0.0) const;
+    const double lateral_duration, const double path_width = 0.0, const double speed_limit = 0.0,
+    const double rear_lever_arm = 0.0) const;
 
   [[nodiscard]] PredictedPathWithArrivalIndex generatePathForCrosswalkUser(
     const TrackedObject & object, const CrosswalkEdgePoints & reachable_crosswalk,
@@ -110,7 +110,7 @@ private:
   PredictedPath generatePolynomialPath(
     const TrackedObject & object, const PosePath & ref_path, const double duration,
     const double lateral_duration, const double path_width, const double backlash_width,
-    const double speed_limit = 0.0) const;
+    const double speed_limit = 0.0, const double rear_lever_arm = 0.0) const;
 };
 }  // namespace autoware::map_based_prediction
 

--- a/perception/autoware_map_based_prediction/lib/path_generator/frenet.cpp
+++ b/perception/autoware_map_based_prediction/lib/path_generator/frenet.cpp
@@ -15,9 +15,11 @@
 #include "autoware/map_based_prediction/path_generator/frenet.hpp"
 
 #include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/normalization.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/utils.hpp>
 
+#include <cmath>
 #include <vector>
 
 namespace autoware::map_based_prediction
@@ -174,7 +176,7 @@ std::vector<tf2::Quaternion> interpolationLerp(
 FrenetPoint getFrenetPoint(
   const TrackedObject & object, const geometry_msgs::msg::Pose & ref_pose, const double duration,
   const double speed_limit, const bool use_vehicle_acceleration,
-  const double acceleration_exponential_half_life)
+  const double acceleration_exponential_half_life, const double rear_lever_arm)
 {
   FrenetPoint frenet_point;
 
@@ -190,7 +192,11 @@ FrenetPoint getFrenetPoint(
 
   // 2. Velocity (adjusted by acceleration)
   const float vx = static_cast<float>(object.kinematics.twist_with_covariance.twist.linear.x);
-  const float vy = static_cast<float>(object.kinematics.twist_with_covariance.twist.linear.y);
+  // set initial slip by yaw rate and rear lever arm
+  const float vy =
+    rear_lever_arm != 0.0
+      ? static_cast<float>(rear_lever_arm * object.kinematics.twist_with_covariance.twist.angular.z)
+      : static_cast<float>(object.kinematics.twist_with_covariance.twist.linear.y);
   const float ax =
     use_vehicle_acceleration
       ? static_cast<float>(object.kinematics.acceleration_with_covariance.accel.linear.x)
@@ -373,7 +379,7 @@ PosePath interpolateReferencePath(
 
 PredictedPath convertToPredictedPath(
   const TrackedObject & object, const FrenetPath & frenet_predicted_path, const PosePath & ref_path,
-  const double sampling_time_interval)
+  const double sampling_time_interval, const double rear_lever_arm)
 {
   // Object position
   const auto & object_pose = object.kinematics.pose_with_covariance.pose;
@@ -387,6 +393,15 @@ PredictedPath convertToPredictedPath(
   // Set the first point as the object's current position
   predicted_path.path.at(0) = object_pose;
 
+  // Center-anchored bicycle heading: the box center rides the Frenet path while the heading psi is
+  // integrated forward toward the center velocity direction theta_c, lagging by the rear-axle slip.
+  //   gain = 1 - exp(-chord / L)   // in (0, 1) -> stable
+  //   psi += gain * normalize_radian(theta_c - psi)
+  // L -> 0: gain -> 1 -> psi = theta_c (plain azimuth heading). chord -> 0: heading frozen (idle).
+  constexpr double min_chord = 1e-3;           // [m] below this the object is treated as idle
+  constexpr double min_rear_lever_arm = 1e-3;  // [m] below this fall back to azimuth heading
+  double psi = tf2::getYaw(object_pose.orientation);
+
   // Convert the rest of the points
   for (size_t i = 1; i < predicted_path.path.size(); ++i) {
     // Reference Point from interpolated reference path
@@ -396,12 +411,21 @@ PredictedPath convertToPredictedPath(
     const auto & frenet_point = frenet_predicted_path.at(i);
     double d_offset = frenet_point.d;
 
-    // Converted Pose
+    // Converted Pose: the center position rides the Frenet path
     auto predicted_pose = autoware_utils::calc_offset_pose(ref_pose, 0.0, d_offset, 0.0);
     predicted_pose.position.z += object_height;
-    const double yaw = autoware_utils::calc_azimuth_angle(
-      predicted_path.path.at(i - 1).position, predicted_pose.position);
-    predicted_pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
+
+    const auto & prev_position = predicted_path.path.at(i - 1).position;
+    const double chord = autoware_utils::calc_distance2d(prev_position, predicted_pose.position);
+    if (chord > min_chord) {
+      const double theta_c =
+        autoware_utils::calc_azimuth_angle(prev_position, predicted_pose.position);
+      const double heading_error = autoware_utils::normalize_radian(theta_c - psi);
+      const double relaxation_gain =
+        rear_lever_arm > min_rear_lever_arm ? 1.0 - std::exp(-chord / rear_lever_arm) : 1.0;
+      psi = autoware_utils::normalize_radian(psi + relaxation_gain * heading_error);
+    }
+    predicted_pose.orientation = autoware_utils::create_quaternion_from_yaw(psi);
 
     predicted_path.path.at(i) = predicted_pose;
   }

--- a/perception/autoware_map_based_prediction/lib/path_generator/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/lib/path_generator/path_generator.cpp
@@ -188,7 +188,8 @@ PredictedPath PathGenerator::generatePathForOffLaneVehicle(
 
 PredictedPath PathGenerator::generatePathForOnLaneVehicle(
   const TrackedObject & object, const PosePath & ref_path, const double duration,
-  const double lateral_duration, const double path_width, const double speed_limit) const
+  const double lateral_duration, const double path_width, const double speed_limit,
+  const double rear_lever_arm) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
@@ -217,7 +218,8 @@ PredictedPath PathGenerator::generatePathForOnLaneVehicle(
   backlash_width = std::max(backlash_width, 0.0);  // minimum is 0.0
 
   return generatePolynomialPath(
-    object, ref_path, duration, lateral_duration, path_width, backlash_width, speed_limit);
+    object, ref_path, duration, lateral_duration, path_width, backlash_width, speed_limit,
+    rear_lever_arm);
 }
 
 PredictedPath PathGenerator::generateStraightPath(
@@ -243,7 +245,7 @@ PredictedPath PathGenerator::generateStraightPath(
 PredictedPath PathGenerator::generatePolynomialPath(
   const TrackedObject & object, const PosePath & ref_path, const double duration,
   const double lateral_duration, const double path_width, const double backlash_width,
-  const double speed_limit) const
+  const double speed_limit, const double rear_lever_arm) const
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
@@ -252,7 +254,7 @@ PredictedPath PathGenerator::generatePolynomialPath(
   const double ref_path_len = autoware::motion_utils::calcArcLength(ref_path);
   const auto current_point = getFrenetPoint(
     object, ref_path.at(0), duration, speed_limit, use_vehicle_acceleration_,
-    acceleration_exponential_half_life_);
+    acceleration_exponential_half_life_, rear_lever_arm);
 
   // Step 1. Set Target Frenet Point
   // Note that we do not set position s,
@@ -317,7 +319,7 @@ PredictedPath PathGenerator::generatePolynomialPath(
 
   // Step 4. Convert predicted trajectory from Frenet to Cartesian coordinate
   return convertToPredictedPath(
-    object, frenet_predicted_path, interpolated_ref_path, sampling_time_interval_);
+    object, frenet_predicted_path, interpolated_ref_path, sampling_time_interval_, rear_lever_arm);
 }
 
 }  // namespace autoware::map_based_prediction

--- a/perception/autoware_map_based_prediction/lib/predictor_vehicle/path_processing.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vehicle/path_processing.cpp
@@ -158,7 +158,7 @@ double rearAxleRatioForLabel(const uint8_t label)
     case ObjectClassification::TRUCK:
     case ObjectClassification::TRAILER:
     default:
-      return 0.25;
+      return 0.16; // 1/3 of vehicle length, 1/6 from center to rear axle
   }
 }
 

--- a/perception/autoware_map_based_prediction/lib/predictor_vehicle/path_processing.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vehicle/path_processing.cpp
@@ -21,6 +21,7 @@
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/motion_utils/resample/resample.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/object_recognition_utils/object_recognition_utils.hpp>
 #include <autoware_utils/autoware_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/normalization.hpp>
@@ -139,6 +140,34 @@ void replaceObjectYawWithLaneletsYaw(
   tf2::Quaternion filtered_quaternion;
   filtered_quaternion.setRPY(roll, pitch, mean_yaw_angle);
   pose_with_cov.pose.orientation = tf2::toMsg(filtered_quaternion);
+}
+
+// Ratio of the body length (dimensions.x) between the rear axle and the body-box center.
+// Mirrored from autoware_multi_object_tracker object_model.hpp (BicycleModelState
+// wheel_pos_ratio_rear). Kept in sync manually so this package does not depend on the tracker:
+//   CAR / BUS / TRUCK / TRAILER (normal_vehicle, big_vehicle): 0.25
+//   MOTORCYCLE / BICYCLE        (bicycle):                      0.30
+double rearAxleRatioForLabel(const uint8_t label)
+{
+  switch (label) {
+    case ObjectClassification::MOTORCYCLE:
+    case ObjectClassification::BICYCLE:
+      return 0.30;
+    case ObjectClassification::CAR:
+    case ObjectClassification::BUS:
+    case ObjectClassification::TRUCK:
+    case ObjectClassification::TRAILER:
+    default:
+      return 0.25;
+  }
+}
+
+double rearAxleOffset(const TrackedObject & object)
+{
+  if (object.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) return 0.0;
+  const uint8_t label =
+    autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+  return object.shape.dimensions.x * rearAxleRatioForLabel(label);
 }
 }  // namespace
 
@@ -265,6 +294,9 @@ std::optional<PredictedObject> PathProcessor::predict(
     replaceObjectYawWithLaneletsYaw(current_lanelets, yaw_fixed_object);
   }
 
+  // Rear axle offset for bicycle motion model
+  const double rear_lever_arm = rearAxleOffset(yaw_fixed_object);
+
   std::vector<PredictedPath> predicted_paths;
   double min_avg_curvature = std::numeric_limits<double>::max();
   std::optional<PredictedPath> path_with_smallest_avg_curvature;
@@ -272,7 +304,7 @@ std::optional<PredictedObject> PathProcessor::predict(
   for (const auto & ref_path : ref_paths) {
     PredictedPath predicted_path = path_generator_->generatePathForOnLaneVehicle(
       yaw_fixed_object, ref_path.path, params_.prediction_time_horizon,
-      params_.lateral_control_time_horizon, ref_path.width, ref_path.speed_limit);
+      params_.lateral_control_time_horizon, ref_path.width, ref_path.speed_limit, rear_lever_arm);
     if (predicted_path.path.empty()) continue;
 
     if (!params_.check_lateral_acceleration_constraints) {

--- a/perception/autoware_map_based_prediction/lib/predictor_vehicle/path_processing.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vehicle/path_processing.cpp
@@ -158,7 +158,7 @@ double rearAxleRatioForLabel(const uint8_t label)
     case ObjectClassification::TRUCK:
     case ObjectClassification::TRAILER:
     default:
-      return 0.16; // 1/3 of vehicle length, 1/6 from center to rear axle
+      return 0.16;  // 1/3 of vehicle length, 1/6 from center to rear axle
   }
 }
 

--- a/perception/autoware_map_based_prediction/test/map_based_prediction/test_path_generator.cpp
+++ b/perception/autoware_map_based_prediction/test/map_based_prediction/test_path_generator.cpp
@@ -13,9 +13,18 @@
 // limitations under the License.
 
 #include "autoware/map_based_prediction/data_structure.hpp"
+#include "autoware/map_based_prediction/path_generator/frenet.hpp"
 #include "autoware/map_based_prediction/path_generator/path_generator.hpp"
 
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/normalization.hpp>
+#include <tf2/utils.hpp>
+
 #include <gtest/gtest.h>
+
+#include <cmath>
+#include <utility>
+#include <vector>
 
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
@@ -185,6 +194,18 @@ TEST(PathGenerator, test_generatePathForCrosswalkUser)
   EXPECT_EQ(predicted_path.path[0].position.z, 0.0);
 }
 
+namespace
+{
+geometry_msgs::msg::Pose make_pose(const double x, const double y, const double yaw)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
+  return pose;
+}
+}  // namespace
+
 TEST(PathGenerator, test_generatePathToTargetPoint)
 {
   // Generate Path generator
@@ -210,4 +231,174 @@ TEST(PathGenerator, test_generatePathToTargetPoint)
   EXPECT_EQ(predicted_path.path[0].position.x, 0.0);
   EXPECT_EQ(predicted_path.path[0].position.y, 0.0);
   EXPECT_EQ(predicted_path.path[0].position.z, 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// Center-anchored combined model: forward heading integration in
+// convertToPredictedPath. The center rides the Frenet path; the heading relaxes
+// toward the center velocity direction with a lag set by the rear lever arm.
+// These tests pin the behavior that replaced the old, divergent post-pass
+// (applyBicycleYawToCenterPath).
+// ---------------------------------------------------------------------------
+namespace
+{
+using autoware::map_based_prediction::convertToPredictedPath;
+using autoware::map_based_prediction::FrenetPath;
+using autoware::map_based_prediction::FrenetPoint;
+using autoware::map_based_prediction::PosePath;
+
+TrackedObject make_box_object_with_yaw(const double yaw, const double x = 0.0, const double y = 0.0)
+{
+  TrackedObject object = generate_static_object(ObjectClassification::CAR);
+  object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = 4.0;
+  object.shape.dimensions.y = 2.0;
+  object.shape.dimensions.z = 1.5;
+  object.kinematics.pose_with_covariance.pose = make_pose(x, y, yaw);
+  return object;
+}
+
+// Straight reference path of `count` poses spaced `step` apart along +x, all lateral offsets zero.
+std::pair<PosePath, FrenetPath> make_straight_inputs(const size_t count, const double step)
+{
+  PosePath ref_path;
+  FrenetPath frenet_path;
+  for (size_t i = 0; i < count; ++i) {
+    ref_path.push_back(make_pose(step * static_cast<double>(i), 0.0, 0.0));
+    frenet_path.push_back(FrenetPoint{});  // d = 0 -> center stays on the reference path
+  }
+  return {ref_path, frenet_path};
+}
+}  // namespace
+
+TEST(ConvertToPredictedPath, first_point_keeps_object_pose)
+{
+  TrackedObject object = make_box_object_with_yaw(0.9, 3.0, -2.0);
+  const auto [ref_path, frenet_path] = make_straight_inputs(5, 2.0);
+
+  const auto path = convertToPredictedPath(object, frenet_path, ref_path, 0.5, 1.0);
+
+  ASSERT_FALSE(path.path.empty());
+  EXPECT_DOUBLE_EQ(path.path[0].position.x, 3.0);
+  EXPECT_DOUBLE_EQ(path.path[0].position.y, -2.0);
+  EXPECT_NEAR(tf2::getYaw(path.path[0].orientation), 0.9, 1e-9);
+}
+
+TEST(ConvertToPredictedPath, high_speed_straight_heading_does_not_diverge)
+{
+  // The divergence repro: high speed (5 m chords ~ 10 m/s @ 0.5 s) + an initial heading error.
+  // The old inversion-based post-pass oscillated to +/- 100 deg here; the integrator must decay.
+  const double init_yaw = 0.2;
+  TrackedObject object = make_box_object_with_yaw(init_yaw);
+  const auto [ref_path, frenet_path] = make_straight_inputs(21, 5.0);
+  const double rear_lever_arm = 1.0;
+
+  const auto path = convertToPredictedPath(object, frenet_path, ref_path, 0.5, rear_lever_arm);
+
+  ASSERT_EQ(path.path.size(), ref_path.size());
+  EXPECT_NEAR(tf2::getYaw(path.path.front().orientation), init_yaw, 1e-9);
+  double prev_abs = std::abs(init_yaw);
+  for (size_t i = 1; i < path.path.size(); ++i) {
+    const double yaw = tf2::getYaw(path.path[i].orientation);
+    EXPECT_LE(std::abs(yaw), std::abs(init_yaw) + 1e-9);  // stays within the initial band
+    EXPECT_LE(std::abs(yaw), prev_abs + 1e-9);            // monotonic decay toward the tangent
+    prev_abs = std::abs(yaw);
+  }
+  EXPECT_NEAR(tf2::getYaw(path.path.back().orientation), 0.0, 1e-2);
+}
+
+TEST(ConvertToPredictedPath, zero_lever_arm_uses_azimuth_heading)
+{
+  // L -> 0 (non-bbox / tiny shapes): the relaxation gain saturates to 1, so the heading equals the
+  // segment azimuth exactly -- bit-for-bit parity with the pre-bicycle behavior.
+  TrackedObject object = make_box_object_with_yaw(0.5);
+  const std::vector<std::pair<double, double>> pts = {
+    {0.0, 0.0}, {1.0, 0.2}, {1.8, 0.8}, {2.2, 1.7}, {2.3, 2.7}};
+  PosePath ref_path;
+  FrenetPath frenet_path;
+  for (const auto & [x, y] : pts) {
+    ref_path.push_back(make_pose(x, y, 0.0));
+    frenet_path.push_back(FrenetPoint{});
+  }
+
+  const auto path = convertToPredictedPath(object, frenet_path, ref_path, 0.5, 0.0);
+
+  ASSERT_EQ(path.path.size(), ref_path.size());
+  for (size_t i = 1; i < path.path.size(); ++i) {
+    const double azimuth =
+      autoware_utils::calc_azimuth_angle(path.path[i - 1].position, path.path[i].position);
+    EXPECT_NEAR(tf2::getYaw(path.path[i].orientation), azimuth, 1e-9);
+  }
+}
+
+TEST(ConvertToPredictedPath, idle_object_keeps_heading)
+{
+  // Zero chord between consecutive centers (object not advancing): heading frozen, no NaN, no
+  // azimuth-of-zero-vector garbage.
+  TrackedObject object = make_box_object_with_yaw(0.7);
+  const PosePath ref_path(5, make_pose(0.0, 0.0, 0.0));
+  const FrenetPath frenet_path(5, FrenetPoint{});
+
+  const auto path = convertToPredictedPath(object, frenet_path, ref_path, 0.5, 1.0);
+
+  ASSERT_EQ(path.path.size(), 5u);
+  for (const auto & pose : path.path) {
+    const double yaw = tf2::getYaw(pose.orientation);
+    EXPECT_FALSE(std::isnan(yaw));
+    EXPECT_NEAR(yaw, 0.7, 1e-9);
+  }
+}
+
+TEST(ConvertToPredictedPath, low_speed_heading_no_overshoot)
+{
+  // Small chords (~L) with an initial heading error: heading approaches the straight-path tangent
+  // (0) monotonically and never overshoots past it.
+  const double init_yaw = 0.4;
+  TrackedObject object = make_box_object_with_yaw(init_yaw);
+  const auto [ref_path, frenet_path] = make_straight_inputs(30, 1.0);
+
+  const auto path = convertToPredictedPath(object, frenet_path, ref_path, 0.5, 1.0);
+
+  ASSERT_EQ(path.path.size(), ref_path.size());
+  double prev = init_yaw;
+  for (size_t i = 1; i < path.path.size(); ++i) {
+    const double yaw = tf2::getYaw(path.path[i].orientation);
+    EXPECT_GE(yaw, -1e-9);        // never overshoots below the tangent
+    EXPECT_LE(yaw, prev + 1e-9);  // monotonic decrease
+    prev = yaw;
+  }
+}
+
+TEST(ConvertToPredictedPath, cornering_heading_lags_tangent)
+{
+  // Constant-curvature left turn: in steady state the body heading lags the path tangent by a
+  // positive, bounded, roughly constant angle -- the emergent bicycle slip.
+  TrackedObject object = make_box_object_with_yaw(0.0);
+  const double radius = 20.0;
+  const double d_phi = 0.05;  // [rad] per step
+  const size_t count = 40;
+  PosePath ref_path;
+  FrenetPath frenet_path;
+  for (size_t i = 0; i < count; ++i) {
+    const double phi = d_phi * static_cast<double>(i);
+    ref_path.push_back(make_pose(radius * std::sin(phi), radius * (1.0 - std::cos(phi)), 0.0));
+    frenet_path.push_back(FrenetPoint{});
+  }
+
+  const auto path = convertToPredictedPath(object, frenet_path, ref_path, 0.5, 1.5);
+
+  ASSERT_EQ(path.path.size(), count);
+  double prev_lag = 0.0;
+  for (size_t i = count / 2; i < count; ++i) {
+    const double tangent =
+      autoware_utils::calc_azimuth_angle(path.path[i - 1].position, path.path[i].position);
+    const double lag =
+      autoware_utils::normalize_radian(tangent - tf2::getYaw(path.path[i].orientation));
+    EXPECT_GT(lag, 0.0);          // heading is behind the tangent on a left turn
+    EXPECT_LT(lag, d_phi * 3.0);  // bounded and small
+    if (i > count / 2) {
+      EXPECT_NEAR(lag, prev_lag, 5e-3);  // ~constant -> steady state reached
+    }
+    prev_lag = lag;
+  }
 }


### PR DESCRIPTION
## Description

This PR refines the **motion reference point** used when `map_based_prediction` integrates the predicted path of a vehicle.

The `multi_object_tracker` bicycle motion model estimates the rear-axle state internally but exports the object pose at the **body-box center**. Integrating the predicted path from the center over-cuts corners, because a real vehicle pivots about its **rear axle**.

On-lane vehicle path generation now keeps the body-box center on the Frenet reference path (preserving lane-centering) while integrating the body **heading forward as a state**, relaxing it toward the center-velocity direction with a rear-axle lag:

```text
gain = 1 - exp(-chord / lr)
psi += gain * normalize_radian(theta_c - psi)
```

where `chord` is the inter-point center displacement, `theta_c` the center-velocity direction, and `lr = dimensions.x * wheel_pos_ratio_rear` the rear lever arm. The lag equals the bicycle slip angle, so cornering produces correct rear-tucking geometry. The formulation is unconditionally stable (`gain ∈ (0,1)`), replacing an earlier post-pass that finite-differenced positions and divided by `lr` — a feedback loop that diverged at high speed / fine sampling.

On straight / constant-heading motion this is an identity, so only turns and lane changes are affected.

|Before|After|
|---------|------|
|<img width="1986" height="1254" alt="Screenshot from 2026-06-26 18-04-57" src="https://github.com/user-attachments/assets/4e4ded0a-c181-482d-8ba2-b67938b45d14" /> | <img width="1986" height="1254" alt="Screenshot from 2026-06-26 18-30-31" src="https://github.com/user-attachments/assets/3737c94f-4d1e-4e19-b38d-618d7a8ecbb3" /> |

## Related links

- Follow-up (stacked on this PR): footprint-aware bounding-box expansion — **merge this PR first**.

## How was this PR tested?

- New unit tests in `test/map_based_prediction/test_path_generator.cpp` (`ConvertToPredictedPath` suite, 6/6): first-point identity, high-speed non-divergence, zero-lever-arm azimuth parity, idle-object heading hold, low-speed no-overshoot, steady-state cornering lag.
- `colcon build` + `colcon test` for `autoware_map_based_prediction` pass cleanly (12/12 tests, all lint green).

## Notes for reviewers

- The `wheel_pos_ratio_rear` values are intentionally duplicated as documented constants (mirroring `autoware_multi_object_tracker`'s `object_model.hpp`: `0.25` car/bus/truck/trailer, `0.30` motorcycle) rather than introduced as a tracker dependency or new ROS parameters.

## Interface changes

None.

## Effects on system behavior

- Predicted paths for **turning / lane-changing vehicles** trace the rear-axle pivot, reducing corner over-cut; straight-line and low-speed motion are unchanged (identity).
