### PR TITLE
feat(autoware_multi_object_tracker): add tracked-object input via UUID and polar association

### DIFF
--- a/perception/autoware_multi_object_tracker/CMakeLists.txt
+++ b/perception/autoware_multi_object_tracker/CMakeLists.txt
@@ -45,6 +45,7 @@ set(${PROJECT_NAME}_lib
   lib/association/tracker_overlap_manager.cpp
   lib/association/polar_association.cpp
   lib/association/scoring/bev_assignment_scoring.cpp
+  lib/association/uuid_association.cpp
   lib/association/scoring/polar_assignment_scoring.cpp
   lib/association/scoring/redundancy_check.cpp
   lib/association/mu_successive_shortest_path/mu_ssp.cpp

--- a/perception/autoware_multi_object_tracker/config/input_channels.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/input_channels.param.yaml
@@ -4,12 +4,14 @@
       # Merged detected objects, i.e. "/perception/object_recognition/detection/objects"
       detected_objects:
         associator_type: bev
+        input_type: "detected_objects"
         optional:
           name: "detected_objects"
           short_name: "all"
       # LIDAR - rule-based
       lidar_clustering:
         associator_type: polar
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: false
@@ -22,6 +24,7 @@
       # LIDAR - DNN
       lidar_centerpoint:
         associator_type: bev
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: true
@@ -33,6 +36,7 @@
           short_name: "Lcp"
       lidar_centerpoint_short_range:
         associator_type: bev
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: true
@@ -44,6 +48,7 @@
           short_name: "LcpS"
       lidar_apollo:
         associator_type: bev
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: true
@@ -57,6 +62,7 @@
       # cspell:ignore lidar_pointpainting pointpainting
       lidar_pointpainting:
         associator_type: bev
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: true
@@ -69,6 +75,7 @@
       # CAMERA - DNN
       camera_streampetr:
         associator_type: bev
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: true
@@ -81,6 +88,7 @@
       # CAMERA-LIDAR
       camera_lidar_fusion:
         associator_type: polar
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: false
@@ -93,6 +101,7 @@
       # CAMERA-LIDAR-IRREGULAR
       camera_lidar_fusion_irregular:
         associator_type: polar
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: false
@@ -105,6 +114,7 @@
       # CAMERA-LIDAR+TRACKER
       detection_by_tracker:
         associator_type: bev
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: false
           can_trust_existence_probability: false
@@ -117,6 +127,7 @@
       # RADAR
       radar:
         associator_type: bev
+        input_type: "tracked_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: true
@@ -129,6 +140,7 @@
       # CAMERA VRU
       camera_vru:
         associator_type: polar
+        input_type: "detected_objects"
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: true

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/association/association_manager.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/association/association_manager.hpp
@@ -18,6 +18,7 @@
 #include "autoware/multi_object_tracker/association/association_base.hpp"
 #include "autoware/multi_object_tracker/association/bev_association.hpp"
 #include "autoware/multi_object_tracker/association/polar_association.hpp"
+#include "autoware/multi_object_tracker/association/uuid_association.hpp"
 #include "autoware/multi_object_tracker/configurations.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 
@@ -69,6 +70,7 @@ private:
   double ego_pose_max_age_sec_;
   std::unique_ptr<BevAssociation> bev_association_;
   std::unique_ptr<PolarAssociation> polar_association_;
+  std::unique_ptr<UUIDAssociation> uuid_association_;
 
   rclcpp::Clock steady_clock_{RCL_STEADY_TIME};
 };

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/association/uuid_association.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/association/uuid_association.hpp
@@ -1,0 +1,43 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MULTI_OBJECT_TRACKER__ASSOCIATION__UUID_ASSOCIATION_HPP_
+#define AUTOWARE__MULTI_OBJECT_TRACKER__ASSOCIATION__UUID_ASSOCIATION_HPP_
+
+#include "autoware/multi_object_tracker/association/association_base.hpp"
+
+#include <list>
+#include <memory>
+
+namespace autoware::multi_object_tracker
+{
+
+/// Association by direct UUID matching.
+/// Used when the input channel carries TrackedObjects: each measurement's UUID
+/// is compared against all active tracker UUIDs and matched on equality.
+/// Unmatched measurements are passed to the spawn path; unmatched trackers
+/// are left to age out normally.
+class UUIDAssociation : public AssociationBase
+{
+public:
+  UUIDAssociation() = default;
+
+  types::AssociationResult associate(
+    const types::DynamicObjectList & measurements,
+    const std::list<std::shared_ptr<Tracker>> & trackers) override;
+};
+
+}  // namespace autoware::multi_object_tracker
+
+#endif  // AUTOWARE__MULTI_OBJECT_TRACKER__ASSOCIATION__UUID_ASSOCIATION_HPP_

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/types.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/types.hpp
@@ -25,6 +25,7 @@
 #include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_perception_msgs/msg/tracked_object.hpp>
 #include <autoware_perception_msgs/msg/tracked_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/pose_with_covariance.hpp>
@@ -209,10 +210,16 @@ inline constexpr std::array<ShapeType, 3> ALL_SHAPE_TYPES = {
 // constants
 constexpr float default_existence_probability = 0.75;
 
-// Association algorithm selection per input channel
+// Input message type per channel
+enum class InputType {
+  DETECTED_OBJECTS,  // standard DetectedObjects input (default)
+  TRACKED_OBJECTS,   // TrackedObjects input, association by UUID
+};
+
+// Geometric association algorithm selection per input channel.
 enum class AssociationType {
-  BEV,   // BevAssociation: bird's-eye-view area scoring + GNN linear assignment
-  POLAR  // PolarAssociation: polar-coordinate (range-bearing) based scoring
+  BEV,    // BevAssociation: bird's-eye-view area scoring + GNN linear assignment
+  POLAR,  // PolarAssociation: polar-coordinate (range-bearing) based scoring
 };
 
 // channel configuration
@@ -227,6 +234,7 @@ struct InputChannel
   bool trust_extension = true;                             // trust object extension
   bool trust_classification = true;                        // trust object classification
   bool trust_orientation = true;                           // trust object orientation(yaw)
+  InputType input_type = InputType::DETECTED_OBJECTS;      // input message type
   AssociationType associator_type = AssociationType::BEV;  // which associator to use
 };
 
@@ -428,6 +436,14 @@ DynamicObject toDynamicObject(
 
 DynamicObjectList toDynamicObjectList(
   const autoware_perception_msgs::msg::DetectedObjects & det_objects, const uint channel_index = 0);
+
+DynamicObject toDynamicObject(
+  const autoware_perception_msgs::msg::TrackedObject & tracked_object,
+  const uint channel_index = 0);
+
+DynamicObjectList toDynamicObjectList(
+  const autoware_perception_msgs::msg::TrackedObjects & tracked_objects,
+  const uint channel_index = 0);
 
 autoware_perception_msgs::msg::TrackedObject toTrackedObjectMsg(const DynamicObject & dyn_object);
 autoware_perception_msgs::msg::DetectedObject toDetectedObjectMsg(const DynamicObject & dyn_object);

--- a/perception/autoware_multi_object_tracker/lib/association/association_manager.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/association_manager.cpp
@@ -21,6 +21,7 @@
 #include <limits>
 #include <list>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -33,7 +34,8 @@ AssociationManager::AssociationManager(
 : channels_config_(channels_config),
   ego_pose_max_age_sec_(association_config.ego_pose_max_age_sec),
   bev_association_(std::make_unique<BevAssociation>(association_config)),
-  polar_association_(std::make_unique<PolarAssociation>(association_config))
+  polar_association_(std::make_unique<PolarAssociation>(association_config)),
+  uuid_association_(std::make_unique<UUIDAssociation>())
 {
 }
 
@@ -68,8 +70,10 @@ types::AssociationResult AssociationManager::associate(
   const rclcpp::Time meas_time{measurements.header.stamp};
   const bool polar_viable = isPolarViable(ego_pose, meas_time);
 
+  const auto channel_index = measurements.channel_index;
+
   const bool channel_wants_polar =
-    channels_config_[measurements.channel_index].associator_type == types::AssociationType::POLAR;
+    channels_config_[channel_index].associator_type == types::AssociationType::POLAR;
   if (channel_wants_polar && !polar_viable) {
     const double dt = ego_pose ? (meas_time - rclcpp::Time{ego_pose->header.stamp}).seconds()
                                : std::numeric_limits<double>::infinity();
@@ -80,8 +84,58 @@ types::AssociationResult AssociationManager::associate(
       dt, ego_pose_max_age_sec_);
   }
 
-  return getAssociationForChannel(measurements.channel_index, polar_viable)
-    .associate(measurements, trackers);
+  // For DETECTED_OBJECTS channels: single-stage geometric association
+  if (
+    channel_index >= channels_config_.size() ||
+    channels_config_[channel_index].input_type != types::InputType::TRACKED_OBJECTS) {
+    return getAssociationForChannel(channel_index, polar_viable).associate(measurements, trackers);
+  }
+
+  // For TRACKED_OBJECTS channels: two-stage association
+  // Stage 1 — UUID identity matching
+  auto result = uuid_association_->associate(measurements, trackers);
+
+  if (result.unassigned_measurements.empty() || result.unassigned_trackers.empty()) {
+    return result;
+  }
+
+  // Stage 2 — geometric fallback for unmatched pairs
+  // Build unmatched measurement list using the existing UUID index
+  types::DynamicObjectList unmatched_measurements;
+  unmatched_measurements.header = measurements.header;
+  unmatched_measurements.channel_index = measurements.channel_index;
+  for (const auto & meas_uuid : result.unassigned_measurements) {
+    const auto idx = measurements.getObjectIndexByUuid(meas_uuid);
+    if (idx) {
+      unmatched_measurements.objects.push_back(measurements.objects[*idx]);
+    }
+  }
+
+  // Build unmatched tracker list using a hash set for O(n + m) filtering
+  std::unordered_set<unique_identifier_msgs::msg::UUID, types::UUIDHash, types::UUIDEqual>
+    unassigned_tracker_set(result.unassigned_trackers.begin(), result.unassigned_trackers.end());
+  std::list<std::shared_ptr<Tracker>> unmatched_trackers;
+  for (const auto & tracker : trackers) {
+    if (unassigned_tracker_set.count(tracker->getUUID())) {
+      unmatched_trackers.push_back(tracker);
+    }
+  }
+
+  // Run geometric association on the unmatched subsets
+  const auto fallback_result = getAssociationForChannel(channel_index, polar_viable)
+                                 .associate(unmatched_measurements, unmatched_trackers);
+
+  // Merge fallback into the main result
+  for (const auto & [tracker_uuid, meas_uuid] : fallback_result.tracker_to_measurement) {
+    result.add(tracker_uuid, meas_uuid);
+  }
+  for (const auto & uuid : fallback_result.trackers_with_shape_change) {
+    result.trackers_with_shape_change.insert(uuid);
+  }
+  result.unassigned_measurements = fallback_result.unassigned_measurements;
+  result.unassigned_trackers = fallback_result.unassigned_trackers;
+
+  return result;
 }
 
 void AssociationManager::setTimeKeeper(

--- a/perception/autoware_multi_object_tracker/lib/association/uuid_association.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/uuid_association.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/multi_object_tracker/association/uuid_association.hpp"
+
+#include <algorithm>
+#include <list>
+#include <memory>
+
+namespace autoware::multi_object_tracker
+{
+
+types::AssociationResult UUIDAssociation::associate(
+  const types::DynamicObjectList & measurements,
+  const std::list<std::shared_ptr<Tracker>> & trackers)
+{
+  types::AssociationResult result;
+
+  // All trackers start as unassigned
+  for (const auto & tracker : trackers) {
+    result.unassigned_trackers.push_back(tracker->getUUID());
+  }
+
+  // Match each measurement to a tracker with the same UUID
+  const types::UUIDEqual uuid_equal;
+  for (const auto & measurement : measurements.objects) {
+    auto it = std::find_if(
+      result.unassigned_trackers.begin(), result.unassigned_trackers.end(),
+      [&](const auto & tracker_uuid) { return uuid_equal(tracker_uuid, measurement.uuid); });
+
+    if (it != result.unassigned_trackers.end()) {
+      result.add(*it, measurement.uuid);
+      result.unassigned_trackers.erase(it);
+    } else {
+      result.unassigned_measurements.push_back(measurement.uuid);
+    }
+  }
+
+  return result;
+}
+
+}  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/lib/types.cpp
+++ b/perception/autoware_multi_object_tracker/lib/types.cpp
@@ -111,6 +111,59 @@ DynamicObjectList toDynamicObjectList(
   return dynamic_objects;
 }
 
+DynamicObject toDynamicObject(
+  const autoware_perception_msgs::msg::TrackedObject & tracked_object, const uint channel_index)
+{
+  DynamicObject dynamic_object;
+
+  // Preserve the original UUID from the tracked object for UUID-based association
+  dynamic_object.uuid = tracked_object.object_id;
+
+  dynamic_object.channel_index = channel_index;
+  if (tracked_object.existence_probability < 1e-6) {
+    dynamic_object.existence_probability = default_existence_probability;
+  } else if (tracked_object.existence_probability > 0.999) {
+    dynamic_object.existence_probability = 0.999;
+  } else {
+    dynamic_object.existence_probability = tracked_object.existence_probability;
+  }
+  dynamic_object.existence_probabilities.push_back(
+    {channel_index, dynamic_object.existence_probability});
+
+  dynamic_object.classification = classes::toClassifications(tracked_object.classification);
+
+  dynamic_object.pose = tracked_object.kinematics.pose_with_covariance.pose;
+  dynamic_object.pose_covariance = tracked_object.kinematics.pose_with_covariance.covariance;
+  dynamic_object.twist = tracked_object.kinematics.twist_with_covariance.twist;
+  dynamic_object.twist_covariance = tracked_object.kinematics.twist_with_covariance.covariance;
+
+  // TrackedObjectKinematics always carries covariance
+  dynamic_object.kinematics.has_position_covariance = true;
+  dynamic_object.kinematics.orientation_availability =
+    convertOrientationAvailabilityFromMsg(tracked_object.kinematics.orientation_availability);
+  dynamic_object.kinematics.has_twist = true;
+  dynamic_object.kinematics.has_twist_covariance = true;
+
+  dynamic_object.shape = tracked_object.shape;
+  dynamic_object.area = getArea(tracked_object.shape);
+
+  return dynamic_object;
+}
+
+DynamicObjectList toDynamicObjectList(
+  const autoware_perception_msgs::msg::TrackedObjects & tracked_objects, const uint channel_index)
+{
+  DynamicObjectList dynamic_objects;
+  dynamic_objects.header = tracked_objects.header;
+  dynamic_objects.channel_index = channel_index;
+  dynamic_objects.objects.reserve(tracked_objects.objects.size());
+  for (const auto & tracked_object : tracked_objects.objects) {
+    dynamic_objects.objects.emplace_back(toDynamicObject(tracked_object, channel_index));
+  }
+  dynamic_objects.buildUuidIndex();
+  return dynamic_objects;
+}
+
 void DynamicObjectList::buildUuidIndex() const
 {
   uuid_to_index_.clear();

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -167,9 +167,9 @@ std::optional<autoware_perception_msgs::msg::DetectedObjects> get_merged_objects
 }
 
 //// Low-level processing functions
+template <typename MsgT>
 MeasurementProcessingResult process_measurement(
-  const size_t channel_index,
-  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg,
+  const size_t channel_index, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MsgT) msg,
   const rclcpp::Time & current_time, MultiObjectTrackerInternalState & state,
   TrackerDebugger & debugger)
 {
@@ -206,6 +206,15 @@ MeasurementProcessingResult process_measurement(
 
   return result;
 }
+
+template MeasurementProcessingResult
+process_measurement<autoware_perception_msgs::msg::DetectedObjects>(
+  const size_t, AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects),
+  const rclcpp::Time &, MultiObjectTrackerInternalState &, TrackerDebugger &);
+template MeasurementProcessingResult
+process_measurement<autoware_perception_msgs::msg::TrackedObjects>(
+  const size_t, AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects),
+  const rclcpp::Time &, MultiObjectTrackerInternalState &, TrackerDebugger &);
 
 void process_objects_(
   const types::ObjectsWithAssociation & objects_with_associations,

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
@@ -130,9 +130,9 @@ std::optional<autoware_perception_msgs::msg::DetectedObjects> get_merged_objects
   const MultiObjectTrackerInternalState & state, const rclcpp::Logger & logger);
 
 //// Low-level processing functions
+template <typename MsgT>
 MeasurementProcessingResult process_measurement(
-  const size_t channel_index,
-  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg,
+  const size_t channel_index, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MsgT) msg,
   const rclcpp::Time & current_time, MultiObjectTrackerInternalState & state,
   TrackerDebugger & debugger);
 

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -283,18 +283,16 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
       sub_tracked_objects_array_.at(index) =
         create_subscription<autoware_perception_msgs::msg::TrackedObjects>(
           input_channel_topic, rclcpp::QoS{1},
-          [this, index](
-            AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) msg) {
-            this->onTrackedMeasurement(index, std::move(msg));
-          });
+          [this,
+           index](AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects)
+                    msg) { this->onTrackedMeasurement(index, std::move(msg)); });
     } else {
       sub_objects_array_.at(index) =
         create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
           input_channel_topic, rclcpp::QoS{1},
-          [this, index](
-            AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg) {
-            this->onMeasurement(index, std::move(msg));
-          });
+          [this,
+           index](AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects)
+                    msg) { this->onMeasurement(index, std::move(msg)); });
     }
   }
 

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -124,7 +124,16 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
       input_channel_config.trust_orientation =
         declare_parameter<bool>(input_channel_config_name + ".flags.can_trust_orientation", true);
 
-      // association algorithm selection for this channel (default: "bev")
+      // input message type for this channel (default: "detected_objects")
+      {
+        const std::string input_type_str = declare_parameter<std::string>(
+          input_channel_config_name + ".input_type", "detected_objects");
+        input_channel_config.input_type = (input_type_str == "tracked_objects")
+                                            ? types::InputType::TRACKED_OBJECTS
+                                            : types::InputType::DETECTED_OBJECTS;
+      }
+
+      // geometric association algorithm for this channel (default: "bev")
       {
         const std::string associator_type_str =
           declare_parameter<std::string>(input_channel_config_name + ".associator_type", "bev");
@@ -259,6 +268,7 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   ////// Create subscriptions and publishers
   // subscriptions
   sub_objects_array_.resize(params_.input_channels_config.size());
+  sub_tracked_objects_array_.resize(params_.input_channels_config.size());
   for (const auto & input_channel : params_.input_channels_config) {
     if (!input_channel.is_enabled) {
       continue;
@@ -267,14 +277,25 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
     const auto & index = input_channel.index;
     std::ostringstream oss;
     oss << "~/input/detection" << std::setfill('0') << std::setw(2) << (index + 1) << "/objects";
-    std::string input_channel_topic = oss.str();
+    const std::string input_channel_topic = oss.str();
 
-    sub_objects_array_.at(index) =
-      create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
-        input_channel_topic, rclcpp::QoS{1},
-        [this,
-         index](AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects)
-                  msg) { this->onMeasurement(index, std::move(msg)); });
+    if (input_channel.input_type == types::InputType::TRACKED_OBJECTS) {
+      sub_tracked_objects_array_.at(index) =
+        create_subscription<autoware_perception_msgs::msg::TrackedObjects>(
+          input_channel_topic, rclcpp::QoS{1},
+          [this, index](
+            AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) msg) {
+            this->onTrackedMeasurement(index, std::move(msg));
+          });
+    } else {
+      sub_objects_array_.at(index) =
+        create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
+          input_channel_topic, rclcpp::QoS{1},
+          [this, index](
+            AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg) {
+            this->onMeasurement(index, std::move(msg));
+          });
+    }
   }
 
   // odometry subscription (ego pose source when ego_source == "odometry")
@@ -320,6 +341,26 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
     time_keeper_ =
       std::make_shared<autoware_utils_debug::TimeKeeper>(detailed_processing_time_publisher_);
     state_.processor->setTimeKeeper(time_keeper_);
+  }
+}
+
+void MultiObjectTracker::onTrackedMeasurement(
+  const size_t channel_index,
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) msg)
+{
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
+  const rclcpp::Time current_time = this->now();
+  const auto result =
+    core::process_measurement(channel_index, msg, current_time, state_, *debugger_);
+
+  if (!result.has_objects) {
+    return;
+  }
+
+  if (result.should_process) {
+    processObjects();
   }
 }
 

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -43,6 +43,8 @@ private:
   // ROS interface
   std::vector<AUTOWARE_SUBSCRIPTION_PTR(autoware_perception_msgs::msg::DetectedObjects)>
     sub_objects_array_{};
+  std::vector<AUTOWARE_SUBSCRIPTION_PTR(autoware_perception_msgs::msg::TrackedObjects)>
+    sub_tracked_objects_array_{};
   AUTOWARE_SUBSCRIPTION_PTR(nav_msgs::msg::Odometry) sub_odometry_ {};
 
   AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrackedObjects) tracked_objects_pub_;
@@ -71,6 +73,9 @@ private:
   void onMeasurement(
     const size_t channel_index,
     AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg);
+  void onTrackedMeasurement(
+    const size_t channel_index,
+    AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) msg);
 
   // publish processes
   void publish();

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -66,32 +66,45 @@ void InputStream::push(
   }
 }
 
+bool InputStream::transformInPlace(types::DynamicObjectList & objects)
+{
+  auto transformed = odometry_->transformObjects(objects);
+  if (!transformed) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 1000, "InputManager::processMessage %s: Failed to transform objects.",
+      channel_.long_name.c_str());
+    return false;
+  }
+  objects = std::move(*transformed);
+  return true;
+}
+
+void InputStream::applyChannelConfig(types::DynamicObjectList & objects) const
+{
+  for (auto & object : objects.objects) {
+    object.trust_extension = channel_.trust_extension;
+  }
+  if (!channel_.trust_existence_probability) {
+    for (auto & object : objects.objects) {
+      object.existence_probability = types::default_existence_probability;
+    }
+  }
+}
+
 std::optional<types::DynamicObjectList> InputStream::processMessage(
   AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg)
 {
-  const autoware_perception_msgs::msg::DetectedObjects & objects = *msg;
-  const rclcpp::Time timestamp = objects.header.stamp;
+  types::DynamicObjectList dynamic_objects = types::toDynamicObjectList(*msg, channel_.index);
 
-  types::DynamicObjectList dynamic_objects = types::toDynamicObjectList(objects, channel_.index);
-
-  // Set trust_extension information from channel configuration
-  for (auto & object : dynamic_objects.objects) {
-    object.trust_extension = channel_.trust_extension;
-  }
-
-  // Model the object uncertainty only if it is not available
+  // Model the object uncertainty
   types::DynamicObjectList objects_with_uncertainty =
     uncertainty::modelUncertainty(dynamic_objects);
 
   // Transform the objects to the world frame
-  auto transformed_objects = odometry_->transformObjects(objects_with_uncertainty);
-  if (!transformed_objects) {
-    RCLCPP_WARN_THROTTLE(
-      logger_, *clock_, 1000, "InputManager::onMessage %s: Failed to transform objects.",
-      channel_.long_name.c_str());
+  if (!transformInPlace(objects_with_uncertainty)) {
     return std::nullopt;
   }
-  dynamic_objects = transformed_objects.value();
+  dynamic_objects = std::move(objects_with_uncertainty);
 
   // object shape processing
   for (auto & object : dynamic_objects.objects) {
@@ -106,12 +119,24 @@ std::optional<types::DynamicObjectList> InputStream::processMessage(
   // Normalize the object uncertainty
   uncertainty::normalizeUncertainty(dynamic_objects);
 
-  // If the channel does not trust existence probability, set it to default
-  if (!channel_.trust_existence_probability) {
-    for (auto & object : dynamic_objects.objects) {
-      object.existence_probability = types::default_existence_probability;
-    }
+  // Apply channel configuration (trust_extension, existence probability)
+  applyChannelConfig(dynamic_objects);
+
+  return dynamic_objects;
+}
+
+std::optional<types::DynamicObjectList> InputStream::processMessage(
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) msg)
+{
+  types::DynamicObjectList dynamic_objects = types::toDynamicObjectList(*msg, channel_.index);
+
+  // Transform the objects to the world frame
+  if (!transformInPlace(dynamic_objects)) {
+    return std::nullopt;
   }
+
+  // Apply channel configuration (trust_extension, existence probability)
+  applyChannelConfig(dynamic_objects);
 
   return dynamic_objects;
 }
@@ -277,6 +302,19 @@ void InputManager::push(
 std::optional<types::DynamicObjectList> InputManager::processMessage(
   const size_t channel_index,
   AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg)
+{
+  if (channel_index >= input_streams_.size()) {
+    RCLCPP_WARN(
+      logger_, "InputManager::processMessage Invalid channel index: %lu, input_streams_ size: %lu",
+      channel_index, input_streams_.size());
+    return std::nullopt;
+  }
+  return input_streams_.at(channel_index)->processMessage(msg);
+}
+
+std::optional<types::DynamicObjectList> InputManager::processMessage(
+  const size_t channel_index,
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) msg)
 {
   if (channel_index >= input_streams_.size()) {
     RCLCPP_WARN(

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
@@ -22,6 +22,7 @@
 #include <autoware/agnocast_wrapper/node.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 
 #include <deque>
 #include <functional>
@@ -46,6 +47,8 @@ public:
 
   std::optional<types::DynamicObjectList> processMessage(
     AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg);
+  std::optional<types::DynamicObjectList> processMessage(
+    AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) msg);
   void push(const types::DynamicObjectList & objects, const types::AssociationResult & association);
   void updateTimingStatus(const rclcpp::Time & now, const rclcpp::Time & objects_time);
 
@@ -68,6 +71,9 @@ public:
   rclcpp::Time getLatestMeasurementTime() const { return latest_measurement_time_; }
 
 private:
+  bool transformInPlace(types::DynamicObjectList & objects);
+  void applyChannelConfig(types::DynamicObjectList & objects) const;
+
   const types::InputChannel channel_;
   std::shared_ptr<Odometry> odometry_;
   rclcpp::Logger logger_;
@@ -100,6 +106,9 @@ public:
   std::optional<types::DynamicObjectList> processMessage(
     const size_t channel_index,
     AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg);
+  std::optional<types::DynamicObjectList> processMessage(
+    const size_t channel_index,
+    AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) msg);
   void push(
     const size_t channel_index, const types::DynamicObjectList & objects,
     const types::AssociationResult & association);


### PR DESCRIPTION
## Description

Adds support for **TrackedObjects** as a tracker input channel and a new **polar association** algorithm to `autoware_multi_object_tracker`.

### UUID-based association
- New `UUIDAssociation` class for direct UUID matching of tracked-object inputs.
- `AssociationManager` now performs two-stage association: UUID match first, geometric fallback for unmatched pairs.
- Input channel config extended with an input *type* (detected vs. tracked objects); processing pipeline handles both `DetectedObjects` and `TrackedObjects`.

### Polar association
- New polar association algorithm with dedicated scoring (`polar_assignment_scoring`), combining azimuth IoU, radial/depth gating, and height compatibility.
- Azimuth-bin spatial indexing replaces R-tree for candidate lookup.
- Range-adaptive depth gate based on the tracker's closest surface; 3D footprint distance via `ego_z`.
- `associator_type` switched from `bev` to `polar` for camera-lidar and camera-vru channels.

### Tracker update refinements
- `selectUpdatePath` / `preferConditionedUpdate` / `useShapeFilter` to choose update strategy by measurement trust and shape change, preventing partial detections from overwriting vehicle length.
- Absolute alignment threshold for large vehicles; bounding-box z handling delegated to upstream converter.

## Tests
- TODO: CI / regression evaluation.

## Notes
Draft — opened for early review and CI.
