### PR TITLE
refactor(autoware_tensorrt_yolox): remove roi_overlay_segmentation_label parameter

### DIFF
--- a/perception/autoware_tensorrt_yolox/config/roi_to_semseg_label_remap.csv
+++ b/perception/autoware_tensorrt_yolox/config/roi_to_semseg_label_remap.csv
@@ -1,8 +1,8 @@
-from, to
+from, to # The label remapped to -1 will not overlay the segmentation mask.
 UNKNOWN,3
-CAR,7
-TRUCK,7
-BUS,7
+CAR,-1
+TRUCK,-1
+BUS,-1
 BICYCLE,8
 MOTORBIKE,8
 PEDESTRIAN,6

--- a/perception/autoware_tensorrt_yolox/config/yolox_s_plus_opt.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_s_plus_opt.param.yaml
@@ -11,17 +11,6 @@
     # publish color mask for result visualization
     is_publish_color_mask: false
 
-    roi_overlay_segmentation_label:
-      UNKNOWN : true
-      CAR : false
-      TRUCK : false
-      BUS : false
-      MOTORCYCLE : true
-      BICYCLE : true
-      PEDESTRIAN : true
-      ANIMAL: true
-      HAZARD: true
-
     score_threshold: 0.35
     nms_threshold: 0.7
 

--- a/perception/autoware_tensorrt_yolox/config/yolox_tiny.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_tiny.param.yaml
@@ -11,17 +11,6 @@
     # publish color mask for result visualization
     is_publish_color_mask: false
 
-    roi_overlay_segmentation_label:
-      UNKNOWN : true
-      CAR : false
-      TRUCK : false
-      BUS : false
-      MOTORCYCLE : true
-      BICYCLE : true
-      PEDESTRIAN : true
-      ANIMAL: true
-      HAZARD: true
-
     score_threshold: 0.35 # Objects with a score lower than this value will be ignored. This threshold will be ignored if specified model contains EfficientNMS_TRT module in it.
     nms_threshold: 0.7 # Detection results will be ignored if IoU over this value. This threshold will be ignored if specified model contains EfficientNMS_TRT module in it.
 

--- a/perception/autoware_tensorrt_yolox/config/yolox_traffic_light_detector.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_traffic_light_detector.param.yaml
@@ -18,13 +18,3 @@
     is_roi_overlap_segmentation: false
     overlap_roi_score_threshold: 0.3
     is_publish_color_mask: false
-    roi_overlay_segmentation_label:
-      UNKNOWN : false
-      CAR : false
-      TRUCK : false
-      BUS : false
-      MOTORCYCLE : false
-      BICYCLE : false
-      PEDESTRIAN : false
-      ANIMAL: false
-      HAZARD: false

--- a/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/tensorrt_yolox_detector.hpp
+++ b/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/tensorrt_yolox_detector.hpp
@@ -23,7 +23,6 @@
 
 #include <sensor_msgs/msg/image.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
-#include <tier4_perception_msgs/msg/semantic.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -31,34 +30,10 @@
 #include <string>
 #include <vector>
 
-// cspell: ignore Semseg semseg
+// cspell: ignore semseg
 
 namespace autoware::tensorrt_yolox
 {
-using Label = tier4_perception_msgs::msg::Semantic;
-
-struct RoiOverlaySemsegLabel
-{
-  bool UNKNOWN;
-  bool CAR;
-  bool TRUCK;
-  bool BUS;
-  bool MOTORCYCLE;
-  bool BICYCLE;
-  bool PEDESTRIAN;
-  bool ANIMAL;
-  bool HAZARD;
-
-  bool isOverlay(const uint8_t label) const
-  {
-    return (label == Label::UNKNOWN && UNKNOWN) || (label == Label::CAR && CAR) ||
-           (label == Label::TRUCK && TRUCK) || (label == Label::BUS && BUS) ||
-           (label == Label::ANIMAL && ANIMAL) || (label == Label::MOTORBIKE && MOTORCYCLE) ||
-           (label == Label::BICYCLE && BICYCLE) || (label == Label::PEDESTRIAN && PEDESTRIAN) ||
-           (label == Label::HAZARD && HAZARD);
-  };
-};  // struct RoiOverlaySemsegLabel
-
 /**
  * @struct TrtYoloXDetectorConfig
  * @brief Configuration that does not change frame-by-frame. The detector is reconstructed when any
@@ -89,7 +64,6 @@ struct TrtYoloXDetectorConfig
   bool is_roi_overlap_semseg;
   bool is_publish_color_mask;
   float overlap_roi_score_threshold;
-  RoiOverlaySemsegLabel roi_overlay_semseg_labels;
 };
 
 /**
@@ -127,7 +101,6 @@ public:
     const sensor_msgs::msg::Image & image_msg);
 
 private:
-  int mapRoiLabel2SegLabel(const int32_t roi_label_index);
   void overlapSegmentByRoi(
     const tensorrt_yolox::Object & object, cv::Mat & mask, const int width, const int height);
   void getColorizedMask(const cv::Mat & mask, cv::Mat & cmask);

--- a/perception/autoware_tensorrt_yolox/schema/yolox_s_plus_opt.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_s_plus_opt.schema.json
@@ -18,13 +18,6 @@
           "type": "boolean",
           "description": "Publish color mask for result visualization."
         },
-        "roi_overlay_segmentation_label": {
-          "type": "object",
-          "description": "Enable/disable ROI overlay for specific labels.",
-          "additionalProperties": {
-            "type": "boolean"
-          }
-        },
         "score_threshold": {
           "type": "number",
           "minimum": 0.0,
@@ -89,7 +82,6 @@
         "is_roi_overlap_segmentation",
         "overlap_roi_score_threshold",
         "is_publish_color_mask",
-        "roi_overlay_segmentation_label",
         "score_threshold",
         "nms_threshold",
         "precision",

--- a/perception/autoware_tensorrt_yolox/schema/yolox_tiny.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_tiny.schema.json
@@ -18,13 +18,6 @@
           "type": "boolean",
           "description": "Publish color mask for result visualization."
         },
-        "roi_overlay_segmentation_label": {
-          "type": "object",
-          "description": "Enable/disable ROI overlay for specific labels.",
-          "additionalProperties": {
-            "type": "boolean"
-          }
-        },
         "score_threshold": {
           "type": "number",
           "description": "Threshold for object detection scores. Objects with scores below this value are ignored.",
@@ -89,7 +82,6 @@
         "is_roi_overlap_segmentation",
         "overlap_roi_score_threshold",
         "is_publish_color_mask",
-        "roi_overlay_segmentation_label",
         "score_threshold",
         "nms_threshold",
         "precision",

--- a/perception/autoware_tensorrt_yolox/schema/yolox_traffic_light_detector.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_traffic_light_detector.schema.json
@@ -76,13 +76,6 @@
         "is_publish_color_mask": {
           "type": "boolean",
           "description": "Publish color mask for result visualization."
-        },
-        "roi_overlay_segmentation_label": {
-          "type": "object",
-          "description": "Enable/disable ROI overlay for specific labels.",
-          "additionalProperties": {
-            "type": "boolean"
-          }
         }
       },
       "required": [
@@ -99,8 +92,7 @@
         "calibration_image_list_path",
         "is_roi_overlap_segmentation",
         "overlap_roi_score_threshold",
-        "is_publish_color_mask",
-        "roi_overlay_segmentation_label"
+        "is_publish_color_mask"
       ],
       "additionalProperties": false
     }

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_detector.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_detector.cpp
@@ -177,20 +177,13 @@ tl::expected<TrtYoloXDetectorResult, std::string> TrtYoloXDetector::detect(
   return result;
 }
 
-int TrtYoloXDetector::mapRoiLabel2SegLabel(const int32_t roi_label_index)
-{
-  if (config_.roi_overlay_semseg_labels.isOverlay(static_cast<uint8_t>(roi_label_index))) {
-    return config_.roi_labels[roi_label_index].semseg_id;
-  }
-  return g_unmapped_label_id;
-}
-
 void TrtYoloXDetector::overlapSegmentByRoi(
   const tensorrt_yolox::Object & roi_object, cv::Mat & mask, const int orig_width,
   const int orig_height)
 {
   if (roi_object.score < config_.overlap_roi_score_threshold) return;
-  int seg_class_index = mapRoiLabel2SegLabel(roi_object.type);
+  // A negative semseg ID marks a ROI class that should not overlay the segmentation mask.
+  const int seg_class_index = config_.roi_labels[roi_object.type].semseg_id;
   if (seg_class_index < 0) return;
 
   const float scale_x = static_cast<float>(mask.cols) / static_cast<float>(orig_width);

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -69,24 +69,6 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
   config.is_roi_overlap_semseg = declare_parameter<bool>("is_roi_overlap_segmentation");
   config.is_publish_color_mask = declare_parameter<bool>("is_publish_color_mask");
   config.overlap_roi_score_threshold = declare_parameter<float>("overlap_roi_score_threshold");
-  config.roi_overlay_semseg_labels.UNKNOWN =
-    declare_parameter<bool>("roi_overlay_segmentation_label.UNKNOWN");
-  config.roi_overlay_semseg_labels.CAR =
-    declare_parameter<bool>("roi_overlay_segmentation_label.CAR");
-  config.roi_overlay_semseg_labels.TRUCK =
-    declare_parameter<bool>("roi_overlay_segmentation_label.TRUCK");
-  config.roi_overlay_semseg_labels.BUS =
-    declare_parameter<bool>("roi_overlay_segmentation_label.BUS");
-  config.roi_overlay_semseg_labels.MOTORCYCLE =
-    declare_parameter<bool>("roi_overlay_segmentation_label.MOTORCYCLE");
-  config.roi_overlay_semseg_labels.BICYCLE =
-    declare_parameter<bool>("roi_overlay_segmentation_label.BICYCLE");
-  config.roi_overlay_semseg_labels.PEDESTRIAN =
-    declare_parameter<bool>("roi_overlay_segmentation_label.PEDESTRIAN");
-  config.roi_overlay_semseg_labels.ANIMAL =
-    declare_parameter<bool>("roi_overlay_segmentation_label.ANIMAL");
-  config.roi_overlay_semseg_labels.HAZARD =
-    declare_parameter<bool>("roi_overlay_segmentation_label.HAZARD");
 
   try {
     detector_ = std::make_unique<TrtYoloXDetector>(config);

--- a/perception/autoware_tensorrt_yolox/test/test_tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/test/test_tensorrt_yolox_node.cpp
@@ -135,15 +135,6 @@ rclcpp::NodeOptions make_traffic_light_detector_options(
   options.append_parameter_override("is_roi_overlap_segmentation", false);
   options.append_parameter_override("is_publish_color_mask", false);
   options.append_parameter_override("overlap_roi_score_threshold", 0.3);
-  options.append_parameter_override("roi_overlay_segmentation_label.UNKNOWN", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.CAR", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.TRUCK", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.BUS", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.MOTORCYCLE", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.BICYCLE", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.PEDESTRIAN", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.ANIMAL", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.HAZARD", false);
   append_common_overrides(options);
   return options;
 }
@@ -169,15 +160,6 @@ rclcpp::NodeOptions make_segmentation_options(
   options.append_parameter_override("is_roi_overlap_segmentation", true);
   options.append_parameter_override("is_publish_color_mask", true);
   options.append_parameter_override("overlap_roi_score_threshold", 0.3);
-  options.append_parameter_override("roi_overlay_segmentation_label.UNKNOWN", true);
-  options.append_parameter_override("roi_overlay_segmentation_label.CAR", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.TRUCK", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.BUS", false);
-  options.append_parameter_override("roi_overlay_segmentation_label.MOTORCYCLE", true);
-  options.append_parameter_override("roi_overlay_segmentation_label.BICYCLE", true);
-  options.append_parameter_override("roi_overlay_segmentation_label.PEDESTRIAN", true);
-  options.append_parameter_override("roi_overlay_segmentation_label.ANIMAL", true);
-  options.append_parameter_override("roi_overlay_segmentation_label.HAZARD", true);
   append_common_overrides(options);
   return options;
 }


### PR DESCRIPTION
## Description

Removes the redundant `roi_overlay_segmentation_label` parameter from `autoware_tensorrt_yolox`. The per-class boolean flags (`UNKNOWN`, `CAR`, `TRUCK`, ...) duplicated gating already provided by the ROI-to-segmentation remap: a ROI class whose `semseg_id` is `-1` (`g_unmapped_label_id`) is never overlaid onto the segmentation mask. Whether a class overlays the mask is now expressed solely in `roi_to_semseg_label_remap.csv`.

## Related links

I will also change following file after this PR is merged.
https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/perception/traffic_light_recognition/tensorrt_yolox/yolox_traffic_light_detector.param.yaml

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

`colcon build --packages-select autoware_tensorrt_yolox` succeeds and `colcon test --packages-select autoware_tensorrt_yolox` passes

## Notes for reviewers

This is a behavior-preserving refactoring. 

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--|:--|:--|:--|:--|
| Removed | `roi_overlay_segmentation_label.<LABEL>` | `bool` | `true`/`false` per label | Per-class enable/disable of ROI overlay onto the segmentation mask; replaced by the `-1` convention in `roi_to_semseg_label_remap.csv` |

## Effects on system behavior

None.

