### PR TITLE
feat(diffusion planner): filter unknown agent

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
@@ -49,7 +49,13 @@ using autoware_perception_msgs::msg::TrackedObject;
 using autoware_perception_msgs::msg::TrackedObjects;
 constexpr size_t AGENT_STATE_DIM = 11;
 
-enum AgentLabel { VEHICLE = 0, PEDESTRIAN = 1, BICYCLE = 2 };
+enum class AgentLabel : u_char {
+  VEHICLE = 0,
+  PEDESTRIAN = 1,
+  BICYCLE = 2,
+  STATIC_OBJECT = 3,
+  UNKNOWN = 255
+};
 
 /**
  * @brief A class to represent a single state of an agent.
@@ -66,7 +72,7 @@ struct AgentState
   Eigen::Matrix4d pose{Eigen::Matrix4d::Identity()};
 
   const rclcpp::Time timestamp;
-  const AgentLabel label{AgentLabel::VEHICLE};
+  const AgentLabel label{AgentLabel::UNKNOWN};
   const std::string object_id;
   const TrackedObject original_info;
 };

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -43,16 +43,17 @@ AgentLabel get_model_label(const TrackedObject & object)
       return AgentLabel::BICYCLE;
     case autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN:
       return AgentLabel::PEDESTRIAN;
+    case autoware_perception_msgs::msg::ObjectClassification::HAZARD:
+      return AgentLabel::UNKNOWN;
+      // TODO: replace to STATIC_OBJECT
     default:
-      return AgentLabel::VEHICLE;
+      return AgentLabel::UNKNOWN;
   }
 }
 
-bool is_unknown_object(const TrackedObject & object)
+bool is_unknown_agent(const TrackedObject & object)
 {
-  const auto autoware_label =
-    autoware::object_recognition_utils::getHighestProbLabel(object.classification);
-  return autoware_label == autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
+  return AgentLabel::UNKNOWN == get_model_label(object);
 }
 
 }  // namespace
@@ -95,7 +96,7 @@ void AgentData::update_histories(const TrackedObjects & objects, const bool igno
   const rclcpp::Time objects_timestamp(objects.header.stamp);
   std::vector<std::string> found_ids;
   for (const TrackedObject & object : objects.objects) {
-    if (ignore_unknown_agents && is_unknown_object(object)) {
+    if (ignore_unknown_agents && is_unknown_agent(object)) {
       continue;
     }
     const std::string object_id = autoware_utils_uuid::to_hex_string(object.object_id);

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -45,7 +45,7 @@ AgentLabel get_model_label(const TrackedObject & object)
       return AgentLabel::PEDESTRIAN;
     case autoware_perception_msgs::msg::ObjectClassification::HAZARD:
       return AgentLabel::UNKNOWN;
-      // TODO: replace to STATIC_OBJECT
+      // TODO(yukkysaito): replace to STATIC_OBJECT
     default:
       return AgentLabel::UNKNOWN;
   }


### PR DESCRIPTION
## Description

This PR updates the agent label handling in the diffusion planner.

### Changes

* Replace `AgentLabel` with a scoped `enum class`.
* Add `STATIC_OBJECT` and `UNKNOWN` labels to improve label representation.
* Change the default agent label from `VEHICLE` to `UNKNOWN`.
* Update the object filtering logic to ignore only objects whose highest-probability perception label is `UNKNOWN`.
* Return `UNKNOWN` instead of `VEHICLE` for unsupported or unmapped perception labels.

### Motivation

Previously, unsupported perception labels were implicitly treated as `VEHICLE`, which could lead to incorrect agent classification. This change makes the behavior explicit by introducing an `UNKNOWN` label and ensures that only perception objects explicitly classified as `UNKNOWN` are filtered when `ignore_unknown_agents` is enabled.

`STATIC_OBJECT` is also introduced as a placeholder for future support of static obstacles.
