### PR TITLE
feat(map_based_prediction): footprint-aware bounding-box expansion

### DIFF
--- a/perception/autoware_map_based_prediction/README.md
+++ b/perception/autoware_map_based_prediction/README.md
@@ -142,6 +142,15 @@ You can change these parameters in rosparam in the table below.
 | `max_lateral_accel`                      | `2.0` [m/s^2]  |
 | `min_acceleration_before_curve`          | `-2.0` [m/s^2] |
 
+#### Footprint-aware box expansion (for all objects)
+
+A tracked object carries a body bounding box (`shape.dimensions`) plus an object-local footprint
+polygon (`shape.footprint`) that can protrude beyond the box (e.g. open doors, overhanging cargo).
+As a shared final pass over every predicted object, bounding-box shapes whose footprint protrudes
+are expanded to the axis-aligned union of the body box and footprint, and their predicted paths are
+re-centered on the expanded box so the path keeps tracing the box center. Objects without a
+protruding footprint are unaffected.
+
 ## Using Vehicle Acceleration for Path Prediction (for Vehicle Obstacles)
 
 By default, the `map_based_prediction` module uses the current obstacle's velocity to compute its predicted path length. However, it is possible to use the obstacle's current acceleration to calculate its predicted path's length.

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/path_generator/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/path_generator/path_generator.hpp
@@ -56,6 +56,12 @@ struct PredictedPathWithArrivalIndex : PredictedPath
   size_t arrival_index{};
 };
 
+// shift a single pose by an offset expressed in its own (yaw-rotated) local frame
+void shiftPoseReference(geometry_msgs::msg::Pose & pose, const Eigen::Vector2d & local_offset);
+
+// shift the reference point of every pose in a predicted path
+void shiftPathReference(PredictedPath & path, const Eigen::Vector2d & local_offset);
+
 class PathGenerator
 {
 public:

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/utils.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/utils.hpp
@@ -89,6 +89,8 @@ PredictedObjectKinematics convertToPredictedKinematics(
 
 PredictedObject convertToPredictedObject(const TrackedObject & tracked_object);
 
+void expandShapeToFootprintAndRecenter(PredictedObject & object);
+
 double calculateLocalLikelihood(
   const lanelet::ConstLanelet & current_lanelet, const TrackedObject & object,
   const double sigma_lateral_offset, const double sigma_yaw_angle_deg);

--- a/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
+++ b/perception/autoware_map_based_prediction/lib/map_based_prediction_node/callbacks.cpp
@@ -192,6 +192,12 @@ void ObjectsCallback::objectsCallback(
       output.objects.end(), retrieved_objects.objects.begin(), retrieved_objects.objects.end());
   }
 
+  // Shared final pass: size the output box to cover any footprint protrusion and re-center the
+  // predicted paths on the expanded box. No-op for objects without a protruding footprint.
+  for (auto & predicted_object : output.objects) {
+    utils::expandShapeToFootprintAndRecenter(predicted_object);
+  }
+
   const auto output_stamp = output.header.stamp;
   publish(std::move(output_msg), debug_markers);
 

--- a/perception/autoware_map_based_prediction/lib/path_generator/path_generator.cpp
+++ b/perception/autoware_map_based_prediction/lib/path_generator/path_generator.cpp
@@ -21,8 +21,10 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -30,6 +32,24 @@
 namespace autoware::map_based_prediction
 {
 using autoware_utils::ScopedTimeTrack;
+
+void shiftPoseReference(geometry_msgs::msg::Pose & pose, const Eigen::Vector2d & local_offset)
+{
+  const double yaw = tf2::getYaw(pose.orientation);
+  const double cos_yaw = std::cos(yaw);
+  const double sin_yaw = std::sin(yaw);
+  pose.position.x += local_offset.x() * cos_yaw - local_offset.y() * sin_yaw;
+  pose.position.y += local_offset.x() * sin_yaw + local_offset.y() * cos_yaw;
+}
+
+void shiftPathReference(PredictedPath & path, const Eigen::Vector2d & local_offset)
+{
+  if (local_offset.x() == 0.0 && local_offset.y() == 0.0) return;
+
+  for (auto & pose : path.path) {
+    shiftPoseReference(pose, local_offset);
+  }
+}
 
 PathGenerator::PathGenerator(const double sampling_time_interval)
 : sampling_time_interval_(sampling_time_interval)

--- a/perception/autoware_map_based_prediction/lib/utils.cpp
+++ b/perception/autoware_map_based_prediction/lib/utils.cpp
@@ -14,21 +14,27 @@
 
 #include "autoware/map_based_prediction/utils.hpp"
 
+#include "autoware/map_based_prediction/path_generator/path_generator.hpp"
+
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
 #include <autoware_utils/ros/uuid_helper.hpp>
 #include <tf2/utils.hpp>
 
+#include <boost/geometry/geometry.hpp>
+
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 
 #include <algorithm>
+#include <cmath>
 #include <deque>
 #include <limits>
 #include <memory>
@@ -242,6 +248,98 @@ PredictedObject convertToPredictedObject(const TrackedObject & tracked_object)
   predicted_object.existence_probability = tracked_object.existence_probability;
 
   return predicted_object;
+}
+
+namespace
+{
+// Convex hull of the original body box and the footprint, both in the object-local frame, then
+// re-expressed about the recentered box origin. The hull always yields a single convex ring, so it
+// fits geometry_msgs::Polygon and covers both shapes regardless of whether they overlap.
+geometry_msgs::msg::Polygon mergeFootprintWithBox(
+  const geometry_msgs::msg::Polygon & footprint, const double half_length, const double half_width,
+  const Eigen::Vector2d & center_offset)
+{
+  namespace bg = boost::geometry;
+  using autoware_utils::Point2d;
+  using autoware_utils::Polygon2d;
+
+  // Collect the body-box corners and the footprint vertices, then take their convex hull.
+  Polygon2d points;
+  bg::append(points.outer(), Point2d(half_length, half_width));
+  bg::append(points.outer(), Point2d(-half_length, half_width));
+  bg::append(points.outer(), Point2d(-half_length, -half_width));
+  bg::append(points.outer(), Point2d(half_length, -half_width));
+  for (const auto & point : footprint.points) {
+    bg::append(points.outer(), Point2d(point.x, point.y));
+  }
+
+  Polygon2d single;
+  bg::convex_hull(points, single);
+
+  geometry_msgs::msg::Polygon output;
+  if (single.outer().empty()) return output;
+
+  // Drop the duplicated closing vertex that boost keeps on the ring.
+  const auto & ring = single.outer();
+  size_t count = ring.size();
+  if (count > 1 && bg::equals(ring.front(), ring.back())) --count;
+
+  output.points.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    geometry_msgs::msg::Point32 point;
+    point.x = static_cast<float>(ring[i].x() - center_offset.x());
+    point.y = static_cast<float>(ring[i].y() - center_offset.y());
+    point.z = 0.0F;
+    output.points.push_back(point);
+  }
+
+  return output;
+}
+}  // namespace
+
+void expandShapeToFootprintAndRecenter(PredictedObject & object)
+{
+  // grow a bounding-box shape to cover its footprint and recenter the predicted paths
+  if (object.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) return;
+  const auto & footprint = object.shape.footprint.points;
+  if (footprint.empty()) return;
+
+  // Axis-aligned bounds of the footprint in the object-local frame.
+  double min_x = std::numeric_limits<double>::max();
+  double max_x = std::numeric_limits<double>::lowest();
+  double min_y = std::numeric_limits<double>::max();
+  double max_y = std::numeric_limits<double>::lowest();
+  for (const auto & point : footprint) {
+    min_x = std::min(min_x, static_cast<double>(point.x));
+    max_x = std::max(max_x, static_cast<double>(point.x));
+    min_y = std::min(min_y, static_cast<double>(point.y));
+    max_y = std::max(max_y, static_cast<double>(point.y));
+  }
+
+  // Union of the body box (centered at the local origin) and the footprint bounds.
+  const double half_length = object.shape.dimensions.x / 2.0;
+  const double half_width = object.shape.dimensions.y / 2.0;
+  const double lo_x = std::min(-half_length, min_x);
+  const double hi_x = std::max(half_length, max_x);
+  const double lo_y = std::min(-half_width, min_y);
+  const double hi_y = std::max(half_width, max_y);
+
+  const Eigen::Vector2d center_offset((lo_x + hi_x) / 2.0, (lo_y + hi_y) / 2.0);
+  constexpr double eps = 1e-3;
+  if (std::abs(center_offset.x()) < eps && std::abs(center_offset.y()) < eps) return;
+
+  object.shape.dimensions.x = hi_x - lo_x;
+  object.shape.dimensions.y = hi_y - lo_y;
+
+  // Merge the footprint with the original bounding box and re-express it about the new box center.
+  object.shape.footprint =
+    mergeFootprintWithBox(object.shape.footprint, half_length, half_width, center_offset);
+
+  // Move the t=0 box center and every predicted-path point onto the expanded box center.
+  shiftPoseReference(object.kinematics.initial_pose_with_covariance.pose, center_offset);
+  for (auto & predicted_path : object.kinematics.predicted_paths) {
+    shiftPathReference(predicted_path, center_offset);
+  }
 }
 
 double calculateLocalLikelihood(

--- a/perception/autoware_map_based_prediction/test/map_based_prediction/test_path_generator.cpp
+++ b/perception/autoware_map_based_prediction/test/map_based_prediction/test_path_generator.cpp
@@ -14,8 +14,17 @@
 
 #include "autoware/map_based_prediction/data_structure.hpp"
 #include "autoware/map_based_prediction/path_generator/path_generator.hpp"
+#include "autoware/map_based_prediction/utils.hpp"
+
+#include <autoware_utils/geometry/geometry.hpp>
 
 #include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
+#include <vector>
 
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
@@ -183,6 +192,275 @@ TEST(PathGenerator, test_generatePathForCrosswalkUser)
   EXPECT_EQ(predicted_path.path[0].position.x, 0.0);
   EXPECT_EQ(predicted_path.path[0].position.y, 0.0);
   EXPECT_EQ(predicted_path.path[0].position.z, 0.0);
+}
+
+namespace
+{
+geometry_msgs::msg::Pose make_pose(const double x, const double y, const double yaw)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
+  return pose;
+}
+}  // namespace
+
+TEST(ShiftPathReference, zero_offset_is_noop)
+{
+  PredictedPath path;
+  path.path.push_back(make_pose(1.0, 2.0, 0.3));
+  path.path.push_back(make_pose(3.0, 4.0, 0.6));
+
+  const PredictedPath original = path;
+  autoware::map_based_prediction::shiftPathReference(path, Eigen::Vector2d(0.0, 0.0));
+
+  ASSERT_EQ(path.path.size(), original.path.size());
+  for (size_t i = 0; i < path.path.size(); ++i) {
+    EXPECT_DOUBLE_EQ(path.path[i].position.x, original.path[i].position.x);
+    EXPECT_DOUBLE_EQ(path.path[i].position.y, original.path[i].position.y);
+  }
+}
+
+TEST(ShiftPathReference, straight_path_translates_by_offset)
+{
+  // yaw == 0: object-local axes align with world axes, so the offset adds directly.
+  PredictedPath path;
+  path.path.push_back(make_pose(1.0, 1.0, 0.0));
+  path.path.push_back(make_pose(2.0, 1.0, 0.0));
+
+  autoware::map_based_prediction::shiftPathReference(path, Eigen::Vector2d(0.5, 0.3));
+
+  EXPECT_DOUBLE_EQ(path.path[0].position.x, 1.5);
+  EXPECT_DOUBLE_EQ(path.path[0].position.y, 1.3);
+  EXPECT_DOUBLE_EQ(path.path[1].position.x, 2.5);
+  EXPECT_DOUBLE_EQ(path.path[1].position.y, 1.3);
+}
+
+TEST(ShiftPathReference, offset_rotates_with_pose_yaw)
+{
+  // yaw == +90 deg: a longitudinal (+x local) offset points along +y in the world frame.
+  PredictedPath path;
+  path.path.push_back(make_pose(5.0, 5.0, M_PI / 2.0));
+
+  autoware::map_based_prediction::shiftPathReference(path, Eigen::Vector2d(1.0, 0.0));
+
+  EXPECT_NEAR(path.path[0].position.x, 5.0, 1e-9);
+  EXPECT_NEAR(path.path[0].position.y, 6.0, 1e-9);
+}
+
+TEST(ShiftPathReference, turning_path_is_displaced_and_reversible)
+{
+  // A curving path (varying yaw) gets each point displaced along its own heading, and the
+  // inverse offset restores the original geometry exactly.
+  PredictedPath path;
+  path.path.push_back(make_pose(0.0, 0.0, 0.0));
+  path.path.push_back(make_pose(1.0, 0.2, 0.5));
+  path.path.push_back(make_pose(1.8, 0.8, 1.0));
+  const PredictedPath original = path;
+
+  constexpr double lr = 1.25;
+  autoware::map_based_prediction::shiftPathReference(path, Eigen::Vector2d(lr, 0.0));
+
+  // Every point moves by exactly lr (the displacement magnitude is offset-norm-preserving).
+  for (size_t i = 0; i < path.path.size(); ++i) {
+    const double dx = path.path[i].position.x - original.path[i].position.x;
+    const double dy = path.path[i].position.y - original.path[i].position.y;
+    EXPECT_NEAR(std::hypot(dx, dy), lr, 1e-9);
+  }
+  // The middle/last points point in different directions, so the displacement vectors differ.
+  EXPECT_GT(
+    std::abs(
+      (path.path[2].position.y - original.path[2].position.y) -
+      (path.path[0].position.y - original.path[0].position.y)),
+    1e-3);
+
+  // Reversible: shifting back by -lr restores the original points.
+  autoware::map_based_prediction::shiftPathReference(path, Eigen::Vector2d(-lr, 0.0));
+  for (size_t i = 0; i < path.path.size(); ++i) {
+    EXPECT_NEAR(path.path[i].position.x, original.path[i].position.x, 1e-9);
+    EXPECT_NEAR(path.path[i].position.y, original.path[i].position.y, 1e-9);
+  }
+}
+
+namespace
+{
+PredictedObject make_box_object_with_path()
+{
+  PredictedObject object;
+  object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = 4.0;
+  object.shape.dimensions.y = 2.0;
+  object.shape.dimensions.z = 1.5;
+
+  object.kinematics.initial_pose_with_covariance.pose = make_pose(10.0, 20.0, 0.0);
+
+  PredictedPath path;
+  path.path.push_back(make_pose(10.0, 20.0, 0.0));
+  object.kinematics.predicted_paths.push_back(path);
+  return object;
+}
+
+geometry_msgs::msg::Point32 make_point32(const float x, const float y)
+{
+  geometry_msgs::msg::Point32 point;
+  point.x = x;
+  point.y = y;
+  return point;
+}
+}  // namespace
+
+TEST(ExpandShapeToFootprintAndRecenter, noop_without_footprint)
+{
+  PredictedObject object = make_box_object_with_path();
+  autoware::map_based_prediction::utils::expandShapeToFootprintAndRecenter(object);
+
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.x, 4.0);
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.y, 2.0);
+  EXPECT_DOUBLE_EQ(object.kinematics.predicted_paths[0].path[0].position.x, 10.0);
+}
+
+TEST(ExpandShapeToFootprintAndRecenter, noop_when_footprint_within_box)
+{
+  PredictedObject object = make_box_object_with_path();
+  // Footprint fully inside the 4x2 box.
+  object.shape.footprint.points.push_back(make_point32(-1.0, -0.5));
+  object.shape.footprint.points.push_back(make_point32(1.0, -0.5));
+  object.shape.footprint.points.push_back(make_point32(1.0, 0.5));
+  object.shape.footprint.points.push_back(make_point32(-1.0, 0.5));
+
+  autoware::map_based_prediction::utils::expandShapeToFootprintAndRecenter(object);
+
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.x, 4.0);
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.y, 2.0);
+  EXPECT_DOUBLE_EQ(object.kinematics.predicted_paths[0].path[0].position.x, 10.0);
+  EXPECT_DOUBLE_EQ(object.kinematics.predicted_paths[0].path[0].position.y, 20.0);
+}
+
+TEST(ExpandShapeToFootprintAndRecenter, grows_box_and_recenters_on_protrusion)
+{
+  PredictedObject object = make_box_object_with_path();
+  // Footprint protrudes forward to x = 3 (box half-length is 2).
+  object.shape.footprint.points.push_back(make_point32(-2.0, -1.0));
+  object.shape.footprint.points.push_back(make_point32(3.0, -1.0));
+  object.shape.footprint.points.push_back(make_point32(3.0, 1.0));
+  object.shape.footprint.points.push_back(make_point32(-2.0, 1.0));
+
+  autoware::map_based_prediction::utils::expandShapeToFootprintAndRecenter(object);
+
+  // Union bounds: x in [-2, 3] -> length 5, center offset +0.5; y unchanged.
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.x, 5.0);
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.y, 2.0);
+  // Path (yaw 0) recenters by +0.5 in x.
+  EXPECT_DOUBLE_EQ(object.kinematics.predicted_paths[0].path[0].position.x, 10.5);
+  EXPECT_DOUBLE_EQ(object.kinematics.predicted_paths[0].path[0].position.y, 20.0);
+  // The t=0 box center (initial pose) recenters by the same +0.5 in x.
+  EXPECT_DOUBLE_EQ(object.kinematics.initial_pose_with_covariance.pose.position.x, 10.5);
+  EXPECT_DOUBLE_EQ(object.kinematics.initial_pose_with_covariance.pose.position.y, 20.0);
+  // Footprint is the convex hull of the original box and the footprint, re-expressed about the new
+  // center. Here the footprint encloses the box, so the hull is the footprint rectangle shifted
+  // by -0.5 in x: x in [-2.5, 2.5], y in [-1, 1]. Check bounds order-independently since the
+  // boost hull may reorder the ring.
+  ASSERT_FALSE(object.shape.footprint.points.empty());
+  float min_x = std::numeric_limits<float>::max();
+  float max_x = std::numeric_limits<float>::lowest();
+  float min_y = std::numeric_limits<float>::max();
+  float max_y = std::numeric_limits<float>::lowest();
+  for (const auto & point : object.shape.footprint.points) {
+    min_x = std::min(min_x, point.x);
+    max_x = std::max(max_x, point.x);
+    min_y = std::min(min_y, point.y);
+    max_y = std::max(max_y, point.y);
+  }
+  EXPECT_FLOAT_EQ(min_x, -2.5f);
+  EXPECT_FLOAT_EQ(max_x, 2.5f);
+  EXPECT_FLOAT_EQ(min_y, -1.0f);
+  EXPECT_FLOAT_EQ(max_y, 1.0f);
+}
+
+TEST(ExpandShapeToFootprintAndRecenter, footprint_box_merge_is_convex)
+{
+  PredictedObject object = make_box_object_with_path();
+  // A narrow bump on the front face: footprint covers x in [2, 3], y in [-0.5, 0.5], while the body
+  // box is x in [-2, 2], y in [-1, 1]. Neither shape contains the other, so their merge is a true
+  // T-shape; the convex hull fills the re-entrant notches at the bump's base.
+  object.shape.footprint.points.push_back(make_point32(2.0, -0.5));
+  object.shape.footprint.points.push_back(make_point32(3.0, -0.5));
+  object.shape.footprint.points.push_back(make_point32(3.0, 0.5));
+  object.shape.footprint.points.push_back(make_point32(2.0, 0.5));
+
+  autoware::map_based_prediction::utils::expandShapeToFootprintAndRecenter(object);
+
+  // AABB union: x in [-2, 3] -> length 5, center offset +0.5; y unchanged.
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.x, 5.0);
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.y, 2.0);
+
+  // The merged footprint is the convex hull of the box and the bump, re-expressed about the new
+  // center (shifted by -0.5 in x). It must be convex and must NOT contain the re-entrant notch at
+  // x = 1.5 (old x = 2.0), y = +/-0.5 that the raw T-shape would have.
+  const auto & points = object.shape.footprint.points;
+  ASSERT_GE(points.size(), 3u);
+  for (const auto & point : points) {
+    const bool is_notch =
+      std::abs(point.x - 1.5f) < 1e-3f && std::abs(std::abs(point.y) - 0.5f) < 1e-3f;
+    EXPECT_FALSE(is_notch);
+  }
+  // The bump's outer corners survive on the hull at x = 2.5 (old x = 3.0), y = +/-0.5.
+  bool has_bump_corner = false;
+  for (const auto & point : points) {
+    if (std::abs(point.x - 2.5f) < 1e-3f && std::abs(std::abs(point.y) - 0.5f) < 1e-3f) {
+      has_bump_corner = true;
+    }
+  }
+  EXPECT_TRUE(has_bump_corner);
+
+  // Every turn around the ring has the same sign: a strict definition of convexity.
+  const size_t n = points.size();
+  int sign = 0;
+  for (size_t i = 0; i < n; ++i) {
+    const auto & a = points[i];
+    const auto & b = points[(i + 1) % n];
+    const auto & c = points[(i + 2) % n];
+    const double cross =
+      static_cast<double>(b.x - a.x) * (c.y - b.y) - static_cast<double>(b.y - a.y) * (c.x - b.x);
+    if (std::abs(cross) < 1e-6) continue;  // collinear vertices do not break convexity
+    const int current = cross > 0.0 ? 1 : -1;
+    if (sign == 0) {
+      sign = current;
+    } else {
+      EXPECT_EQ(sign, current);
+    }
+  }
+}
+
+TEST(ExpandShapeToFootprintAndRecenter, disjoint_footprint_covers_both_shapes)
+{
+  PredictedObject object = make_box_object_with_path();
+  // Pathological input: the footprint (x in [5, 6]) does not touch the body box (x in [-2, 2]).
+  // The convex hull of the two disjoint shapes still covers both with a single ring, so neither is
+  // dropped.
+  object.shape.footprint.points.push_back(make_point32(5.0, -0.5));
+  object.shape.footprint.points.push_back(make_point32(6.0, -0.5));
+  object.shape.footprint.points.push_back(make_point32(6.0, 0.5));
+  object.shape.footprint.points.push_back(make_point32(5.0, 0.5));
+
+  autoware::map_based_prediction::utils::expandShapeToFootprintAndRecenter(object);
+
+  // AABB union: x in [-2, 6] -> length 8, center offset +2; y unchanged.
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.x, 8.0);
+  EXPECT_DOUBLE_EQ(object.shape.dimensions.y, 2.0);
+
+  // Re-expressed about the new center (shifted by -2 in x): the footprint must still span both the
+  // box (down to x = -4) and the far footprint (up to x = 4) - nothing dropped.
+  ASSERT_FALSE(object.shape.footprint.points.empty());
+  float min_x = std::numeric_limits<float>::max();
+  float max_x = std::numeric_limits<float>::lowest();
+  for (const auto & point : object.shape.footprint.points) {
+    min_x = std::min(min_x, point.x);
+    max_x = std::max(max_x, point.x);
+  }
+  EXPECT_FLOAT_EQ(min_x, -4.0f);
+  EXPECT_FLOAT_EQ(max_x, 4.0f);
 }
 
 TEST(PathGenerator, test_generatePathToTargetPoint)


### PR DESCRIPTION
## Description

> **Stacked on #12880 — merge that PR first.** This branch is built on top of the rear-axle motion PR; until #12880 merges, the diff below temporarily includes its commits. Once #12880 lands, this branch will be rebased onto `main` and the diff will show only the box-expansion change.

A tracked object carries a body bounding box (`shape.dimensions`) plus an object-local footprint polygon (`shape.footprint`) that may protrude beyond the box (e.g. open doors, overhanging cargo). The footprint was copied through to the output but never used to size the box.

As a shared final pass over every predicted object, `BOUNDING_BOX` shapes whose footprint protrudes are grown to the axis-aligned union of body box and footprint, and **all reference points are recentered consistently** onto the expanded box center:

- `shape.dimensions`,
- `kinematics.initial_pose_with_covariance.pose` (t=0 center), and
- every predicted-path point.

The footprint polygon is re-expressed about the new center. Objects without a protruding footprint are unaffected (no-op).

The recentering is built on a small shared primitive, `shiftPoseReference` / `shiftPathReference`, that shifts a pose by an offset expressed in its own yaw-rotated local frame.

https://github.com/user-attachments/assets/5ccb5254-8ed5-47c3-a593-49a03d896c07

## Related links

- Base PR (merge first): #12880

## How was this PR tested?

- New unit tests in `test/map_based_prediction/test_path_generator.cpp`:
  - `ShiftPathReference` (4/4): zero-offset no-op, straight-path translation, yaw-rotated offset, turning-path displacement + reversibility.
  - `ExpandShapeToFootprintAndRecenter` (5/5): no-op without footprint, no-op when footprint within box, protrusion grows box + recenters path/initial-pose, convex-hull merge, disjoint footprint still covers both shapes.
- `colcon build` + `colcon test` for `autoware_map_based_prediction` pass cleanly (21/21 tests, all lint green).

## Notes for reviewers

- Scoped to `BOUNDING_BOX` shapes; cylinders/polygons are intentionally left as a no-op since an axis-aligned box expansion is not meaningful for them.

## Interface changes

None.

## Effects on system behavior

- Output bounding boxes for objects with a protruding footprint are enlarged to cover the footprint and recentered accordingly (dimensions, initial pose, and predicted paths all consistent). Objects without a protruding footprint are unaffected.
