### PR TITLE
feat(autoware_mpc_lateral_controller): make steer rate limit and stop state params dynamic

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_lateral_controller.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_lateral_controller.hpp
@@ -87,6 +87,12 @@ private:
   // Target vehicle speed threshold to enter the stop state.
   double m_stop_state_entry_target_speed;
 
+  // Raw parameter lists used to (re)build the steering rate limit maps on dynamic update.
+  std::vector<double> m_steer_rate_lim_dps_list_by_velocity;
+  std::vector<double> m_velocity_list_for_steer_rate_lim;
+  std::vector<double> m_steer_rate_lim_dps_list_by_curvature;
+  std::vector<double> m_curvature_list_for_steer_rate_lim;
+
   // Convergence threshold for steering control.
   double m_converged_steer_rad;
 
@@ -279,6 +285,23 @@ private:
    * @param node Reference to the node.
    */
   void declareMPCparameters(rclcpp::Node & node);
+
+  /**
+   * @brief (Re)build the velocity-based steering rate limit map from the raw parameter lists.
+   * @param steer_rate_lim_dps_list Steering rate limits [deg/s].
+   * @param velocity_list Velocities [m/s] corresponding to each rate limit.
+   */
+  void updateSteerRateLimitByVelocityMap(
+    const std::vector<double> & steer_rate_lim_dps_list, const std::vector<double> & velocity_list);
+
+  /**
+   * @brief (Re)build the curvature-based steering rate limit map from the raw parameter lists.
+   * @param steer_rate_lim_dps_list Steering rate limits [deg/s].
+   * @param curvature_list Curvatures [1/m] corresponding to each rate limit.
+   */
+  void updateSteerRateLimitByCurvatureMap(
+    const std::vector<double> & steer_rate_lim_dps_list,
+    const std::vector<double> & curvature_list);
 
   /**
    * @brief Callback function called when parameters are changed outside of the node.

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -74,29 +74,23 @@ MpcLateralController::MpcLateralController(
   /* mpc parameters */
   const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
   const double wheelbase = vehicle_info.wheel_base_m;
-  constexpr double deg2rad = static_cast<double>(M_PI) / 180.0;
   m_mpc->m_steer_lim = vehicle_info.max_steer_angle_rad;
 
   // steer rate limit depending on curvature
-  const auto steer_rate_lim_dps_list_by_curvature =
+  m_steer_rate_lim_dps_list_by_curvature =
     node.declare_parameter<std::vector<double>>("steer_rate_lim_dps_list_by_curvature");
-  const auto curvature_list_for_steer_rate_lim =
+  m_curvature_list_for_steer_rate_lim =
     node.declare_parameter<std::vector<double>>("curvature_list_for_steer_rate_lim");
-  for (size_t i = 0; i < steer_rate_lim_dps_list_by_curvature.size(); ++i) {
-    m_mpc->m_steer_rate_lim_map_by_curvature.emplace_back(
-      curvature_list_for_steer_rate_lim.at(i),
-      steer_rate_lim_dps_list_by_curvature.at(i) * deg2rad);
-  }
+  updateSteerRateLimitByCurvatureMap(
+    m_steer_rate_lim_dps_list_by_curvature, m_curvature_list_for_steer_rate_lim);
 
   // steer rate limit depending on velocity
-  const auto steer_rate_lim_dps_list_by_velocity =
+  m_steer_rate_lim_dps_list_by_velocity =
     node.declare_parameter<std::vector<double>>("steer_rate_lim_dps_list_by_velocity");
-  const auto velocity_list_for_steer_rate_lim =
+  m_velocity_list_for_steer_rate_lim =
     node.declare_parameter<std::vector<double>>("velocity_list_for_steer_rate_lim");
-  for (size_t i = 0; i < steer_rate_lim_dps_list_by_velocity.size(); ++i) {
-    m_mpc->m_steer_rate_lim_map_by_velocity.emplace_back(
-      velocity_list_for_steer_rate_lim.at(i), steer_rate_lim_dps_list_by_velocity.at(i) * deg2rad);
-  }
+  updateSteerRateLimitByVelocityMap(
+    m_steer_rate_lim_dps_list_by_velocity, m_velocity_list_for_steer_rate_lim);
 
   /* vehicle model setup */
   auto vehicle_model_ptr =
@@ -602,6 +596,30 @@ void MpcLateralController::declareMPCparameters(rclcpp::Node & node)
   m_mpc->m_param.min_prediction_length = dp("mpc_min_prediction_length");
 }
 
+void MpcLateralController::updateSteerRateLimitByVelocityMap(
+  const std::vector<double> & steer_rate_lim_dps_list, const std::vector<double> & velocity_list)
+{
+  constexpr double deg2rad = static_cast<double>(M_PI) / 180.0;
+  std::vector<std::pair<double, double>> map;
+  map.reserve(steer_rate_lim_dps_list.size());
+  for (size_t i = 0; i < steer_rate_lim_dps_list.size(); ++i) {
+    map.emplace_back(velocity_list.at(i), steer_rate_lim_dps_list.at(i) * deg2rad);
+  }
+  m_mpc->m_steer_rate_lim_map_by_velocity = std::move(map);
+}
+
+void MpcLateralController::updateSteerRateLimitByCurvatureMap(
+  const std::vector<double> & steer_rate_lim_dps_list, const std::vector<double> & curvature_list)
+{
+  constexpr double deg2rad = static_cast<double>(M_PI) / 180.0;
+  std::vector<std::pair<double, double>> map;
+  map.reserve(steer_rate_lim_dps_list.size());
+  for (size_t i = 0; i < steer_rate_lim_dps_list.size(); ++i) {
+    map.emplace_back(curvature_list.at(i), steer_rate_lim_dps_list.at(i) * deg2rad);
+  }
+  m_mpc->m_steer_rate_lim_map_by_curvature = std::move(map);
+}
+
 rcl_interfaces::msg::SetParametersResult MpcLateralController::paramCallback(
   const std::vector<rclcpp::Parameter> & parameters)
 {
@@ -612,8 +630,39 @@ rcl_interfaces::msg::SetParametersResult MpcLateralController::paramCallback(
   // strong exception safety wrt MPCParam
   MPCParam param = m_mpc->m_param;
 
+  // local copies so that the whole request is committed atomically (or rejected as a whole)
+  double stop_state_entry_ego_speed = m_stop_state_entry_ego_speed;
+  double stop_state_entry_target_speed = m_stop_state_entry_target_speed;
+  auto steer_rate_dps_by_vel = m_steer_rate_lim_dps_list_by_velocity;
+  auto velocity_list = m_velocity_list_for_steer_rate_lim;
+  auto steer_rate_dps_by_curvature = m_steer_rate_lim_dps_list_by_curvature;
+  auto curvature_list = m_curvature_list_for_steer_rate_lim;
+
   using MPCUtils::update_param;
   try {
+    // Validate the steering rate limit lists before applying any side effect so that a
+    // length mismatch rejects the whole request instead of crashing later on .at().
+    update_param(parameters, "stop_state_entry_ego_speed", stop_state_entry_ego_speed);
+    update_param(parameters, "stop_state_entry_target_speed", stop_state_entry_target_speed);
+    update_param(parameters, "steer_rate_lim_dps_list_by_velocity", steer_rate_dps_by_vel);
+    update_param(parameters, "velocity_list_for_steer_rate_lim", velocity_list);
+    update_param(parameters, "steer_rate_lim_dps_list_by_curvature", steer_rate_dps_by_curvature);
+    update_param(parameters, "curvature_list_for_steer_rate_lim", curvature_list);
+    if (steer_rate_dps_by_vel.size() != velocity_list.size()) {
+      result.successful = false;
+      result.reason =
+        "steer_rate_lim_dps_list_by_velocity and velocity_list_for_steer_rate_lim "
+        "must have the same length";
+      return result;
+    }
+    if (steer_rate_dps_by_curvature.size() != curvature_list.size()) {
+      result.successful = false;
+      result.reason =
+        "steer_rate_lim_dps_list_by_curvature and curvature_list_for_steer_rate_lim "
+        "must have the same length";
+      return result;
+    }
+
     auto & nw = param.nominal_weight;
     auto & lcw = param.low_curvature_weight;
 
@@ -661,6 +710,14 @@ rcl_interfaces::msg::SetParametersResult MpcLateralController::paramCallback(
 
     // transaction succeeds, now assign values
     m_mpc->m_param = param;
+    m_stop_state_entry_ego_speed = stop_state_entry_ego_speed;
+    m_stop_state_entry_target_speed = stop_state_entry_target_speed;
+    m_steer_rate_lim_dps_list_by_velocity = steer_rate_dps_by_vel;
+    m_velocity_list_for_steer_rate_lim = velocity_list;
+    m_steer_rate_lim_dps_list_by_curvature = steer_rate_dps_by_curvature;
+    m_curvature_list_for_steer_rate_lim = curvature_list;
+    updateSteerRateLimitByVelocityMap(steer_rate_dps_by_vel, velocity_list);
+    updateSteerRateLimitByCurvatureMap(steer_rate_dps_by_curvature, curvature_list);
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;
     result.reason = e.what();


### PR DESCRIPTION
## Description

Make the following `autoware_mpc_lateral_controller` parameters updatable at runtime via `ros2 param set` by wiring them into the node's existing `add_on_set_parameters_callback`. Until now they were only read once in the constructor, so changes made with `ros2 param set` were silently accepted (they are plain, non-read-only params) but never took effect until a node restart:

- `stop_state_entry_ego_speed`
- `stop_state_entry_target_speed`
- `steer_rate_lim_dps_list_by_velocity` / `velocity_list_for_steer_rate_lim`
- `steer_rate_lim_dps_list_by_curvature` / `curvature_list_for_steer_rate_lim`

The raw parameter lists are now stored as members, and the velocity- and curvature-based steering-rate-limit maps are (re)built through small dedicated helpers shared by the constructor and the callback. The `_by_curvature` pair is handled symmetrically with the `_by_velocity` pair for consistency.

Because each rate-limit map is a zip of two lists (`{value, rate}` pairs), the callback validates that the two lists have equal length and **rejects the whole request atomically** (no partial commit) on mismatch — otherwise the later `.at()` indexing would throw `std::out_of_range` and crash the node. This reuses the same copy → validate → commit transaction pattern already used for `MPCParam` in the callback.

## Related links

**Parent Issue:**

- N/A

## How was this PR tested?

- `pre-commit` C++ hooks (`clang-format`, `cpplint`) pass on the changed files.
- Manual runtime check (reproducible): with the controller running, set the parameters and confirm they take effect immediately, and that a length-mismatched list is rejected without crashing the node. Note the defaults are 3-element lists, so single-parameter `set` must keep the length equal to the other list; to change the list length, set both lists in one atomic request (e.g. `ros2 param load`).

```bash
ros2 param set /controller stop_state_entry_ego_speed 0.25
ros2 param set /controller steer_rate_lim_dps_list_by_velocity "[12.5, 10.0, 8.0]"   # 3 elems -> accepted
ros2 param set /controller velocity_list_for_steer_rate_lim   "[1.0, 3.5, 10.0]"      # 3 elems -> accepted
ros2 param set /controller steer_rate_lim_dps_list_by_velocity "[10.0]"               # length mismatch -> rejected, node stays alive
```

## Notes for reviewers

- No new parameters, no default-value changes, and no schema/yaml changes — default behavior is unchanged. The parameters only start taking effect when a user explicitly sets them at runtime.
- The equal-length validation is intentional: since the two lists are zipped into a single interpolation map, changing the *length* of one list alone would be inconsistent and is rejected. Independent value tuning (same length) works with individual `ros2 param set` calls.

## Interface changes

None.

## Effects on system behavior

None by default. When a user explicitly changes one of these parameters at runtime, it now takes effect immediately instead of being ignored until a node restart.
