### PR TITLE
feat(autoware_tensorrt_yolox): split node and model parameters

### DIFF
--- a/perception/autoware_tensorrt_yolox/config/yolox_s_plus_opt.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_s_plus_opt.param.yaml
@@ -11,15 +11,6 @@
     # publish color mask for result visualization
     is_publish_color_mask: false
 
-    score_threshold: 0.35
-    nms_threshold: 0.7
-
-    precision: "int8" # Operation precision to be used on inference. Valid value is one of: [fp32, fp16, int8].
-    calibration_algorithm: "Entropy" # Calibration algorithm to be used for quantization when precision==int8. Valid value is one of: [Entropy, (Legacy | Percentile), MinMax].
     dla_core_id: -1 # If positive ID value is specified, the node assign inference task to the DLA core.
-    quantize_first_layer: false # If true, set the operating precision for the first (input) layer to be fp16. This option is valid only when precision==int8.
-    quantize_last_layer: false # If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.
-    profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
-    clip_value: 6.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
     gpu_id: 0 # GPU ID to select CUDA Device
     calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.

--- a/perception/autoware_tensorrt_yolox/config/yolox_tiny.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_tiny.param.yaml
@@ -11,15 +11,6 @@
     # publish color mask for result visualization
     is_publish_color_mask: false
 
-    score_threshold: 0.35 # Objects with a score lower than this value will be ignored. This threshold will be ignored if specified model contains EfficientNMS_TRT module in it.
-    nms_threshold: 0.7 # Detection results will be ignored if IoU over this value. This threshold will be ignored if specified model contains EfficientNMS_TRT module in it.
-
-    precision: "fp16" # Operation precision to be used on inference. Valid value is one of: [fp32, fp16, int8].
-    calibration_algorithm: "MinMax" # Calibration algorithm to be used for quantization when precision==int8. Valid value is one of: [Entropy, (Legacy | Percentile), MinMax].
     dla_core_id: -1 # If positive ID value is specified, the node assign inference task to the DLA core.
-    quantize_first_layer: false # If true, set the operating precision for the first (input) layer to be fp16. This option is valid only when precision==int8.
-    quantize_last_layer: false # If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.
-    profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
-    clip_value: 0.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
     gpu_id: 0 # GPU ID to select CUDA Device
     calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.

--- a/perception/autoware_tensorrt_yolox/config/yolox_traffic_light_detector.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_traffic_light_detector.param.yaml
@@ -1,16 +1,6 @@
 /**:
   ros__parameters:
-
-    score_threshold: 0.35
-    nms_threshold: 0.7
-
-    precision: "fp16" # Operation precision to be used on inference. Valid value is one of: [fp32, fp16, int8].
-    calibration_algorithm: "Entropy" # Calibration algorithm to be used for quantization when precision==int8. Valid value is one of: [Entropy, (Legacy | Percentile), MinMax].
     dla_core_id: -1 # If positive ID value is specified, the node assign inference task to the DLA core.
-    quantize_first_layer: false # If true, set the operating precision for the first (input) layer to be fp16. This option is valid only when precision==int8.
-    quantize_last_layer: false # If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.
-    profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
-    clip_value: 6.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
     gpu_id: 0 # GPU ID to select CUDA Device
     calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.
 

--- a/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
@@ -11,6 +11,7 @@
   <arg name="output/mask" default="/perception/object_recognition/detection/mask0"/>
 
   <arg name="yolox_param_path" default="$(find-pkg-share autoware_tensorrt_yolox)/config/yolox_s_plus_opt.param.yaml"/>
+  <arg name="ml_package_param_path" default="$(var data_path)/tensorrt_yolox/ml_package_yolox.param.yaml"/>
   <arg
     name="model_path"
     default="$(var data_path)/tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx"
@@ -36,6 +37,7 @@
     <remap from="~/out/objects" to="$(var output/objects)"/>
     <remap from="~/out/mask" to="$(var output/mask)"/>
     <param from="$(var yolox_param_path)" allow_substs="true"/>
+    <param from="$(var ml_package_param_path)" allow_substs="true"/>
     <param name="model_path" value="$(var model_path)"/>
     <param name="label_path" value="$(var label_path)"/>
     <param name="semantic_segmentation_color_map_path" value="$(var semantic_segmentation_color_map_path)"/>

--- a/perception/autoware_tensorrt_yolox/launch/yolox_tiny.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_tiny.launch.xml
@@ -6,6 +6,7 @@
   <arg name="input/image" default="/sensing/camera/camera0/image_rect_color"/>
   <arg name="output/objects" default="/perception/object_recognition/detection/rois0"/>
   <arg name="yolox_param_path" default="$(find-pkg-share autoware_tensorrt_yolox)/config/yolox_tiny.param.yaml"/>
+  <arg name="ml_package_param_path" default="$(var data_path)/tensorrt_yolox/ml_package_yolox.param.yaml"/>
   <arg name="model_path" default="$(var data_path)/tensorrt_yolox/yolox-tiny.onnx" description="model path"/>
   <arg name="label_path" default="$(var data_path)/tensorrt_yolox/label.txt" description="label path"/>
   <arg name="semantic_segmentation_color_map_path" default="$(var data_path)/tensorrt_yolox/semseg_color_map.csv" description="color map path"/>
@@ -30,6 +31,7 @@
     <remap from="~/in/image" to="$(var input/image)"/>
     <remap from="~/out/objects" to="$(var output/objects)"/>
     <param from="$(var yolox_param_path)" allow_substs="true"/>
+    <param from="$(var ml_package_param_path)" allow_substs="true"/>
     <param name="model_path" value="$(var model_path)"/>
     <param name="label_path" value="$(var label_path)"/>
     <param name="semantic_segmentation_color_map_path" value="$(var semantic_segmentation_color_map_path)"/>

--- a/perception/autoware_tensorrt_yolox/launch/yolox_traffic_light_detector.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_traffic_light_detector.launch.xml
@@ -6,6 +6,7 @@
   <arg name="input/image" default="/sensing/camera/camera6/image_raw"/>
   <arg name="output/objects" default="/perception/traffic_light_recognition/camera6/detection/rois"/>
   <arg name="yolox_param_path" default="$(find-pkg-share autoware_tensorrt_yolox)/config/yolox_traffic_light_detector.param.yaml"/>
+  <arg name="ml_package_param_path" default="$(var data_path)/tensorrt_yolox/ml_package_yolox.param.yaml"/>
   <arg name="model_path" default="$(var data_path)/tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx" description="model path for traffic light detection"/>
   <arg name="label_path" default="$(var data_path)/tensorrt_yolox/car_ped_tl_detector_labels.txt" description="path name for traffic light detection"/>
   <arg name="semantic_segmentation_color_map_path" default="$(var data_path)/tensorrt_yolox/semseg_color_map.csv" description="sematic segmentation color map path"/>
@@ -26,6 +27,7 @@
     <remap from="~/in/image" to="$(var input/image)"/>
     <remap from="~/out/objects" to="$(var output/objects)"/>
     <param from="$(var yolox_param_path)" allow_substs="true"/>
+    <param from="$(var ml_package_param_path)" allow_substs="true"/>
     <param name="model_path" value="$(var model_path)"/>
     <param name="label_path" value="$(var label_path)"/>
     <param name="semantic_segmentation_color_map_path" value="$(var semantic_segmentation_color_map_path)"/>

--- a/perception/autoware_tensorrt_yolox/schema/ml_package_yolox.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/ml_package_yolox.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ML package parameters for autoware_tensorrt_yolox",
+  "type": "object",
+  "definitions": {
+    "ml_package_yolox": {
+      "type": "object",
+      "properties": {
+        "precision": {
+          "type": "string",
+          "description": "Operation precision to be used on inference. Valid value is one of: [fp32, fp16, int8].",
+          "default": "fp16"
+        },
+        "calibration_algorithm": {
+          "type": "string",
+          "description": "Calibration algorithm to be used for quantization when precision==int8. Valid value is one of: [Entropy, (Legacy | Percentile), MinMax].",
+          "default": "Entropy"
+        },
+        "quantize_first_layer": {
+          "type": "boolean",
+          "description": "If true, set the operating precision for the first (input) layer to be fp16. This option is valid only when precision==int8.",
+          "default": false
+        },
+        "quantize_last_layer": {
+          "type": "boolean",
+          "description": "If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.",
+          "default": false
+        },
+        "profile_per_layer": {
+          "type": "boolean",
+          "description": "If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.",
+          "default": false
+        },
+        "clip_value": {
+          "type": "number",
+          "description": "If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.",
+          "default": 6.0
+        },
+        "score_threshold": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Threshold for object existence probability. Objects with scores below this value are ignored.",
+          "default": 0.35
+        },
+        "nms_threshold": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Threshold value for Non-Maximum Suppression (NMS).",
+          "default": 0.7
+        }
+      },
+      "required": [
+        "precision",
+        "calibration_algorithm",
+        "quantize_first_layer",
+        "quantize_last_layer",
+        "profile_per_layer",
+        "clip_value",
+        "score_threshold",
+        "nms_threshold"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/ml_package_yolox"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/perception/autoware_tensorrt_yolox/schema/yolox_s_plus_opt.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_s_plus_opt.schema.json
@@ -18,54 +18,10 @@
           "type": "boolean",
           "description": "Publish color mask for result visualization."
         },
-        "score_threshold": {
-          "type": "number",
-          "minimum": 0.0,
-          "maximum": 1.0,
-          "description": "Threshold for object existence probability. Objects with scores below this value are ignored.",
-          "default": 0.35
-        },
-        "nms_threshold": {
-          "type": "number",
-          "minimum": 0.0,
-          "maximum": 1.0,
-          "description": "Threshold value for Non-Maximum Suppression (NMS).",
-          "default": 0.7
-        },
-        "precision": {
-          "type": "string",
-          "description": "Operation precision for inference. Options: fp32, fp16, int8.",
-          "default": "int8"
-        },
-        "calibration_algorithm": {
-          "type": "string",
-          "description": "Algorithm for quantization calibration when precision is int8. Options: Entropy, (Legacy | Percentile), MinMax.",
-          "default": "Entropy"
-        },
         "dla_core_id": {
           "type": "integer",
           "description": "DLA core ID for inference. If positive, assigns inference task to the specified DLA core.",
           "default": -1
-        },
-        "quantize_first_layer": {
-          "type": "boolean",
-          "description": "Enable fp16 precision for the first (input) layer when precision is int8.",
-          "default": false
-        },
-        "quantize_last_layer": {
-          "type": "boolean",
-          "description": "Enable fp16 precision for the last (output) layer when precision is int8.",
-          "default": false
-        },
-        "profile_per_layer": {
-          "type": "boolean",
-          "description": "Enable profiler for each layer. Recommended only for development.",
-          "default": false
-        },
-        "clip_value": {
-          "type": "number",
-          "description": "Maximum clipping value for layer output. Valid only for int8 precision.",
-          "default": 6.0
         },
         "gpu_id": {
           "type": "integer",
@@ -82,15 +38,7 @@
         "is_roi_overlap_segmentation",
         "overlap_roi_score_threshold",
         "is_publish_color_mask",
-        "score_threshold",
-        "nms_threshold",
-        "precision",
-        "calibration_algorithm",
         "dla_core_id",
-        "quantize_first_layer",
-        "quantize_last_layer",
-        "profile_per_layer",
-        "clip_value",
         "gpu_id",
         "calibration_image_list_path"
       ],

--- a/perception/autoware_tensorrt_yolox/schema/yolox_tiny.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_tiny.schema.json
@@ -18,54 +18,10 @@
           "type": "boolean",
           "description": "Publish color mask for result visualization."
         },
-        "score_threshold": {
-          "type": "number",
-          "description": "Threshold for object detection scores. Objects with scores below this value are ignored.",
-          "default": 0.35,
-          "minimum": 0.0,
-          "maximum": 1.0
-        },
-        "nms_threshold": {
-          "type": "number",
-          "description": "Threshold for Non-Maximum Suppression (NMS). Detections with IoU above this value are ignored.",
-          "default": 0.7,
-          "minimum": 0.0,
-          "maximum": 1.0
-        },
-        "precision": {
-          "type": "string",
-          "description": "Operation precision for inference. Valid options: [fp32, fp16, int8].",
-          "default": "fp16"
-        },
-        "calibration_algorithm": {
-          "type": "string",
-          "description": "Calibration algorithm for quantization when precision is int8. Valid options: [Entropy, (Legacy | Percentile), MinMax].",
-          "default": "MinMax"
-        },
         "dla_core_id": {
           "type": "integer",
           "description": "DLA core ID for inference. If positive, assigns inference task to the specified DLA core.",
           "default": -1
-        },
-        "quantize_first_layer": {
-          "type": "boolean",
-          "description": "Enable fp16 precision for the first (input) layer when precision is int8.",
-          "default": false
-        },
-        "quantize_last_layer": {
-          "type": "boolean",
-          "description": "Enable fp16 precision for the last (output) layer when precision is int8.",
-          "default": false
-        },
-        "profile_per_layer": {
-          "type": "boolean",
-          "description": "Enable profiling for each layer. Recommended only for development purposes.",
-          "default": false
-        },
-        "clip_value": {
-          "type": "number",
-          "description": "Maximum clipping value for layer outputs. Valid only for int8 precision.",
-          "default": 0.0
         },
         "gpu_id": {
           "type": "integer",
@@ -82,15 +38,7 @@
         "is_roi_overlap_segmentation",
         "overlap_roi_score_threshold",
         "is_publish_color_mask",
-        "score_threshold",
-        "nms_threshold",
-        "precision",
-        "calibration_algorithm",
         "dla_core_id",
-        "quantize_first_layer",
-        "quantize_last_layer",
-        "profile_per_layer",
-        "clip_value",
         "gpu_id",
         "calibration_image_list_path"
       ],

--- a/perception/autoware_tensorrt_yolox/schema/yolox_traffic_light_detector.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_traffic_light_detector.schema.json
@@ -6,54 +6,10 @@
     "yolox_traffic_light_detector": {
       "type": "object",
       "properties": {
-        "score_threshold": {
-          "type": "number",
-          "default": 0.35,
-          "minimum": 0.0,
-          "maximum": 1.0,
-          "description": "A threshold value of existence probability score, all of objects with score less than this threshold are ignored."
-        },
-        "nms_threshold": {
-          "type": "number",
-          "default": 0.7,
-          "minimum": 0.0,
-          "maximum": 1.0,
-          "description": "A threshold value of NMS."
-        },
-        "precision": {
-          "type": "string",
-          "default": "fp16",
-          "description": "Operation precision to be used on inference. Valid value is one of: [fp32, fp16, int8]."
-        },
-        "calibration_algorithm": {
-          "type": "string",
-          "default": "MinMax",
-          "description": "Calibration algorithm to be used for quantization when precision==int8. Valid value is one of: [Entropy, (Legacy | Percentile), MinMax]."
-        },
         "dla_core_id": {
           "type": "number",
           "default": -1,
           "description": "If positive ID value is specified, the node assign inference task to the DLA core."
-        },
-        "quantize_first_layer": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, set the operating precision for the first (input) layer to be fp16. This option is valid only when precision==int8."
-        },
-        "quantize_last_layer": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8."
-        },
-        "profile_per_layer": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose."
-        },
-        "clip_value": {
-          "type": "number",
-          "default": 0.0,
-          "description": "If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration."
         },
         "gpu_id": {
           "type": "integer",
@@ -79,15 +35,7 @@
         }
       },
       "required": [
-        "score_threshold",
-        "nms_threshold",
-        "precision",
-        "calibration_algorithm",
         "dla_core_id",
-        "quantize_first_layer",
-        "quantize_last_layer",
-        "profile_per_layer",
-        "clip_value",
         "gpu_id",
         "calibration_image_list_path",
         "is_roi_overlap_segmentation",


### PR DESCRIPTION
## Description
This PR will split the model related parameters in to ml_package_yolox.param.yaml which will included in the model folder.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
