### PR TITLE
feat(euclidean_cluster): filter cluster by confidence

### DIFF
--- a/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
+++ b/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
@@ -9,7 +9,12 @@
     large_cluster_voxel_count_threshold: 50
     large_cluster_max_points_per_voxel: 100
     max_voxels_per_cluster: 2000
-    # Per-label clustering parameter overrides.
+
+    # Cluster filtering by average confidence
+    min_probability: 0.3
+
+    # Per-label clustering and filtering parameter overrides.
+    # Optional min_probability in each label block overrides global min_probability.
     label_cluster_params:
       pedestrian:
         tolerance_m: 0.3
@@ -42,9 +47,6 @@
         labels: ["truck", "trailer"]
         cross_label_tolerance_m: 0.5
         max_merged_size_m: 25.0
-
-    # Point filtering by semantic confidence
-    min_probability: 0.3
 
     # Semantic label selection and mapping
     # YAML declaration order is treated as the input class_id order.

--- a/perception/autoware_euclidean_cluster/docs/label-based-euclidean-cluster.md
+++ b/perception/autoware_euclidean_cluster/docs/label-based-euclidean-cluster.md
@@ -42,7 +42,7 @@ The packaged launch file remaps these by default to the following topics:
 5. Run `VoxelGridBasedEuclideanCluster` independently for each label bucket, using the per-label parameter overrides from `label_cluster_params.*` where configured and the global defaults otherwise.
 6. Merge over-segmented clusters across labels that belong to the same confusable label group (`confusable_label_groups.*`).
 7. Compute the average semantic probability for each cluster from the points that ended up in that cluster. This uses the source-point indices returned by the clustering backend for the per-label cloud, rather than rematching points by coordinate.
-8. Drop clusters whose average semantic probability is below `min_probability`.
+8. Drop clusters whose average semantic probability is below the label-specific threshold, or `min_probability` when no label-specific threshold is configured.
 9. Estimate a shape and pose for each remaining cluster with `ShapeEstimator`.
 10. If shape estimation does not produce a usable shape, fall back to an axis-aligned bounding shape computed from the clustered points.
 11. Publish one `DetectedObject` per cluster.
@@ -78,6 +78,7 @@ After clustering, the node converts each cluster into a `DetectedObject`.
 - The output classification label is the mapped object label for that bucket.
 - The output existence probability is the average of the clustered point probabilities for that object instance.
 - `min_probability` is applied to that cluster-average probability, not to individual points before clustering.
+- `label_cluster_params.<label>.min_probability` overrides `min_probability` for clusters with that output label.
 - Shape estimation is delegated to `autoware::shape_estimation::ShapeEstimator`.
 - `shape_policy=0` (`ALL_POLYGON`) estimates whole shapes as polygon.
 - `shape_policy=1` (`LABEL_DEPEND`) estimates shapes with the mapped object label.
@@ -95,27 +96,29 @@ Parameters are loaded from [config/label_based_euclidean_cluster.param.yaml](../
 
 {{ json_to_markdown("perception/autoware_euclidean_cluster/schema/label_based_euclidean_cluster.schema.json") }}
 
-## Per-Label Clustering Parameter Overrides
+## Per-Label Clustering And Filtering Parameter Overrides
 
 The clustering parameters at the top level (`use_height`, `tolerance_m`, `voxel_leaf_size_m`,
 `min_points_per_voxel`, `min_points_per_cluster`, `large_cluster_voxel_count_threshold`,
 `large_cluster_max_points_per_voxel`, `max_voxels_per_cluster`) define a single global
 `VoxelGridBasedEuclideanCluster` that is used for every label bucket by default.
 
-`label_cluster_params.<label>` lets each label run with its own tuned clustering instance instead.
+`label_cluster_params.<label>` lets each label run with its own tuned clustering and output filtering settings instead.
 This is useful because the spatial density and size of objects differ by class: pedestrians and
 hazards need a tighter tolerance and finer voxels than cars or trucks.
 
 - `<label>` must be one of the supported Autoware object labels (`unknown`, `car`, `bus`, `truck`,
   `trailer`, `motorcycle`, `bicycle`, `pedestrian`, `animal`, `hazard`).
-- Each override block accepts the same keys as the global clustering parameters.
+- Each override block accepts the same keys as the global clustering parameters, plus `min_probability`.
 - Any key omitted inside an override block falls back to the corresponding global value, so a block
   only needs to list the parameters that differ.
-- A label with no override block (or an empty one) keeps using the global default cluster.
-- When a label-specific cluster is created, the node logs `Using custom cluster params for label '<label>'` at startup.
+- A label with no override block keeps using the global options.
+- A label with an override block gets its own cluster executor. Omitted clustering keys are copied
+  from the global defaults.
+- When label-specific options are created, the node logs `Using per-label cluster options for label '<label>'` at startup.
 
-Example: give pedestrians a tighter tolerance and finer voxels while leaving everything else on the
-global defaults.
+Example: give pedestrians a tighter tolerance, finer voxels, and a higher output confidence
+threshold while leaving everything else on the global defaults.
 
 ```yaml
 tolerance_m: 0.65
@@ -130,6 +133,7 @@ label_cluster_params:
     large_cluster_voxel_count_threshold: 5
     large_cluster_max_points_per_voxel: 30
     max_voxels_per_cluster: 200
+    min_probability: 0.5
 ```
 
 ## Confusable-Label Merge

--- a/perception/autoware_euclidean_cluster/docs/label-based-euclidean-cluster.md
+++ b/perception/autoware_euclidean_cluster/docs/label-based-euclidean-cluster.md
@@ -38,12 +38,12 @@ The packaged launch file remaps these by default to the following topics:
 1. Validate that the incoming pointcloud contains `x`, `y`, and `z`.
 2. Read the configured `class_names.*` mapping in YAML declaration order and treat that order as the incoming `class_id` index.
 3. Drop points whose mapped class is configured as `ignore`.
-4. If the pointcloud has a `probability` field, drop points with `probability < min_probability`.
-5. Split the remaining points into buckets keyed by the mapped Autoware object label.
-6. Run `VoxelGridBasedEuclideanCluster` independently for each label bucket, using the per-label parameter overrides from `label_cluster_params.*` where configured and the global defaults otherwise.
-7. Merge over-segmented clusters across labels that belong to the same confusable label group (`confusable_label_groups.*`).
-8. Compute the average semantic probability for each output cluster from the points that ended up in that cluster. This uses the source-point indices returned by the clustering backend for the per-label filtered cloud, rather than rematching points by coordinate.
-9. Estimate a shape and pose for each cluster with `ShapeEstimator`.
+4. Split the remaining points into buckets keyed by the mapped Autoware object label.
+5. Run `VoxelGridBasedEuclideanCluster` independently for each label bucket, using the per-label parameter overrides from `label_cluster_params.*` where configured and the global defaults otherwise.
+6. Merge over-segmented clusters across labels that belong to the same confusable label group (`confusable_label_groups.*`).
+7. Compute the average semantic probability for each cluster from the points that ended up in that cluster. This uses the source-point indices returned by the clustering backend for the per-label cloud, rather than rematching points by coordinate.
+8. Drop clusters whose average semantic probability is below `min_probability`.
+9. Estimate a shape and pose for each remaining cluster with `ShapeEstimator`.
 10. If shape estimation does not produce a usable shape, fall back to an axis-aligned bounding shape computed from the clustered points.
 11. Publish one `DetectedObject` per cluster.
 
@@ -77,6 +77,7 @@ After clustering, the node converts each cluster into a `DetectedObject`.
 
 - The output classification label is the mapped object label for that bucket.
 - The output existence probability is the average of the clustered point probabilities for that object instance.
+- `min_probability` is applied to that cluster-average probability, not to individual points before clustering.
 - Shape estimation is delegated to `autoware::shape_estimation::ShapeEstimator`.
 - `shape_policy=0` (`ALL_POLYGON`) estimates whole shapes as polygon.
 - `shape_policy=1` (`LABEL_DEPEND`) estimates shapes with the mapped object label.

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
@@ -25,8 +25,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::euclidean_cluster
@@ -34,6 +36,20 @@ namespace autoware::euclidean_cluster
 enum ShapePolicy : uint8_t {
   ALL_POLYGON = 0,
   LABEL_DEPEND = 1,
+};
+
+struct ClusterOptions
+{
+  ClusterOptions(std::shared_ptr<EuclideanClusterInterface> executor, const float min_probability)
+  : executor(std::move(executor)), min_probability(min_probability)
+  {
+    if (!this->executor) {
+      throw std::invalid_argument("ClusterOptions: executor is null");
+    }
+  }
+
+  std::shared_ptr<EuclideanClusterInterface> executor;
+  float min_probability{};
 };
 
 /// @brief Core clustering logic without ROS dependencies.
@@ -55,18 +71,15 @@ public:
 
   /// @brief Construct with full configuration for clustering and shape estimation.
   /// @param class_id_to_object_label Mapping from input class ID to Autoware object label.
-  /// @param min_probability Minimum average semantic probability required for output clusters.
   /// @param shape_policy Strategy for shape estimation (ALL_POLYGON or LABEL_DEPEND).
-  /// @param default_cluster Default cluster executer used when no per-label override exists.
-  /// @param label_cluster_executers Optional per-label cluster executer overrides.
+  /// @param default_options Default cluster options used when no per-label override exists.
+  /// @param label_options Optional effective per-label cluster options.
   /// @param shape_estimator Shape estimator for converting clusters to DetectedObjects.
   /// @param confusable_groups Optional label groups for post-clustering merge.
   LabelBasedEuclideanCluster(
     const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label,
-    float min_probability, ShapePolicy shape_policy,
-    std::shared_ptr<EuclideanClusterInterface> default_cluster,
-    const std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>> &
-      label_cluster_executers,
+    ShapePolicy shape_policy, const ClusterOptions & default_options,
+    const std::unordered_map<std::uint8_t, ClusterOptions> & label_options,
     std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator,
     const std::vector<ConfusableLabelGroup> & confusable_groups = {});
 
@@ -81,17 +94,15 @@ public:
 
 private:
   std::unordered_map<std::uint8_t, std::uint8_t> class_id_to_object_label_;
-  float min_probability_;
   ShapePolicy shape_policy_;
-  std::shared_ptr<EuclideanClusterInterface> default_cluster_;
-  std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>>
-    label_cluster_executers_;
+  ClusterOptions default_options_;
+  std::unordered_map<std::uint8_t, ClusterOptions> label_options_;
   std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator_;
   std::vector<ConfusableLabelGroup> confusable_groups_;
   std::unordered_map<std::uint8_t, std::size_t> label_to_group_idx_;
 
-  /// @brief Return the cluster executer for the given label, or default if no override exists.
-  EuclideanClusterInterface & get_cluster_executer(std::uint8_t label) const;
+  /// @brief Return the cluster options for the given label, or default if no override exists.
+  const ClusterOptions & get_options(std::uint8_t label) const;
 };
 
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
@@ -55,7 +55,7 @@ public:
 
   /// @brief Construct with full configuration for clustering and shape estimation.
   /// @param class_id_to_object_label Mapping from input class ID to Autoware object label.
-  /// @param min_probability Minimum confidence threshold for points.
+  /// @param min_probability Minimum average semantic probability required for output clusters.
   /// @param shape_policy Strategy for shape estimation (ALL_POLYGON or LABEL_DEPEND).
   /// @param default_cluster Default cluster executer used when no per-label override exists.
   /// @param label_cluster_executers Optional per-label cluster executer overrides.

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -122,7 +122,7 @@ std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_pointcloud(
 }
 
 /// @brief Compute the average semantic probability for one clustered object instance.
-/// @details `indices` are relative to the per-label filtered cloud built from `points`.
+/// @details `indices` are relative to the per-label cloud built from `points`.
 float cluster_probability_from_indices(
   const std::vector<SemanticPoint> & points, const pcl::Indices & indices)
 {
@@ -196,23 +196,17 @@ std::pair<Shape, geometry_msgs::msg::Pose> create_fallback_shape_and_pose(
 
 LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
   const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label,
-  float min_probability, ShapePolicy shape_policy,
-  std::shared_ptr<EuclideanClusterInterface> default_cluster,
-  const std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>> &
-    label_cluster_executers,
+  ShapePolicy shape_policy, const ClusterOptions & default_options,
+  const std::unordered_map<std::uint8_t, ClusterOptions> & label_options,
   std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator,
   const std::vector<ConfusableLabelGroup> & confusable_groups)
 : class_id_to_object_label_(class_id_to_object_label),
-  min_probability_(min_probability),
   shape_policy_(shape_policy),
-  default_cluster_(std::move(default_cluster)),
-  label_cluster_executers_(label_cluster_executers),
+  default_options_(default_options),
+  label_options_(label_options),
   shape_estimator_(std::move(shape_estimator)),
   confusable_groups_(confusable_groups)
 {
-  if (!default_cluster_) {
-    throw std::invalid_argument("LabelBasedEuclideanCluster: default_cluster is null");
-  }
   if (!shape_estimator_) {
     throw std::invalid_argument("LabelBasedEuclideanCluster: shape_estimator is null");
   }
@@ -229,11 +223,10 @@ LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
   }
 }
 
-EuclideanClusterInterface & LabelBasedEuclideanCluster::get_cluster_executer(
-  const std::uint8_t label) const
+const ClusterOptions & LabelBasedEuclideanCluster::get_options(const std::uint8_t label) const
 {
-  const auto it = label_cluster_executers_.find(label);
-  return (it != label_cluster_executers_.end()) ? *it->second : *default_cluster_;
+  const auto it = label_options_.find(label);
+  return it != label_options_.end() ? it->second : default_options_;
 }
 
 LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
@@ -250,7 +243,7 @@ LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
     return tl::unexpected(std::string("Input pointcloud missing required float32 fields: x, y, z"));
   }
 
-  // 1. Split points by label and filter by probability
+  // 1. Split points by label while preserving per-point probability for cluster scoring.
   const auto split_points = split_pointcloud(input_msg, class_id_to_object_label_);
 
   // 2. Run per-label clustering and collect all cluster entries
@@ -263,14 +256,15 @@ LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
     }
 
     std::vector<IndexedCluster> clusters;
-    get_cluster_executer(label).cluster(label_cloud, clusters);
+    const auto & options = get_options(label);
+    options.executor->cluster(label_cloud, clusters);
 
     for (auto & cluster : clusters) {
       if (cluster.cloud.empty()) continue;
 
       const float cluster_probability =
         cluster_probability_from_indices(semantic_points, cluster.indices);
-      if (cluster_probability < min_probability_) continue;
+      if (cluster_probability < options.min_probability) continue;
 
       all_entries.push_back({std::move(cluster.cloud), label, cluster_probability});
     }

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -63,8 +63,7 @@ bool has_field(
 /// @brief Split semantic points into buckets keyed by mapped object label.
 std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_pointcloud(
   const sensor_msgs::msg::PointCloud2 & pointcloud,
-  const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label,
-  const float min_probability)
+  const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label)
 {
   std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> buckets;
 
@@ -80,10 +79,6 @@ std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_pointcloud(
     sensor_msgs::PointCloud2ConstIterator<std::uint8_t> iter_class(pointcloud, "class_id");
     sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
     for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_class, ++iter_probability) {
-      if (*iter_probability < min_probability) {
-        continue;
-      }
-
       const auto mapping = class_id_to_object_label.find(*iter_class);
       if (mapping == class_id_to_object_label.end()) {
         continue;
@@ -112,10 +107,6 @@ std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_pointcloud(
   if (has_probability) {
     sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
     for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_probability) {
-      if (*iter_probability < min_probability) {
-        continue;
-      }
-
       buckets[ObjectClassification::UNKNOWN].push_back(
         SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), *iter_probability});
     }
@@ -260,7 +251,7 @@ LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
   }
 
   // 1. Split points by label and filter by probability
-  auto split_points = split_pointcloud(input_msg, class_id_to_object_label_, min_probability_);
+  const auto split_points = split_pointcloud(input_msg, class_id_to_object_label_);
 
   // 2. Run per-label clustering and collect all cluster entries
   std::vector<ClusterEntry> all_entries;
@@ -275,11 +266,13 @@ LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
     get_cluster_executer(label).cluster(label_cloud, clusters);
 
     for (auto & cluster : clusters) {
-      if (!cluster.cloud.empty()) {
-        const float cluster_probability =
-          cluster_probability_from_indices(semantic_points, cluster.indices);
-        all_entries.push_back({std::move(cluster.cloud), label, cluster_probability});
-      }
+      if (cluster.cloud.empty()) continue;
+
+      const float cluster_probability =
+        cluster_probability_from_indices(semantic_points, cluster.indices);
+      if (cluster_probability < min_probability_) continue;
+
+      all_entries.push_back({std::move(cluster.cloud), label, cluster_probability});
     }
   }
 

--- a/perception/autoware_euclidean_cluster/schema/label_based_euclidean_cluster.schema.json
+++ b/perception/autoware_euclidean_cluster/schema/label_based_euclidean_cluster.schema.json
@@ -49,7 +49,7 @@
         },
         "min_probability": {
           "type": "number",
-          "description": "Minimum semantic probability required for a point to be used.",
+          "description": "Minimum average semantic probability required for an output cluster.",
           "default": 0.3
         },
         "class_names": {

--- a/perception/autoware_euclidean_cluster/schema/label_based_euclidean_cluster.schema.json
+++ b/perception/autoware_euclidean_cluster/schema/label_based_euclidean_cluster.schema.json
@@ -78,7 +78,7 @@
         },
         "label_cluster_params": {
           "type": "object",
-          "description": "Optional per-label overrides. Keys are label names (car, truck, bus, trailer, motorcycle, bicycle, pedestrian, animal, hazard, unknown).",
+          "description": "Optional per-label clustering and cluster filtering overrides. Keys are label names (car, truck, bus, trailer, motorcycle, bicycle, pedestrian, animal, hazard, unknown).",
           "properties": {
             "unknown": { "$ref": "#/definitions/cluster_override_params" },
             "car": { "$ref": "#/definitions/cluster_override_params" },
@@ -117,7 +117,7 @@
     },
     "cluster_override_params": {
       "type": "object",
-      "description": "Per-label overrides for VoxelGridBasedEuclideanCluster. Omitted keys fall back to the global default.",
+      "description": "Per-label overrides for VoxelGridBasedEuclideanCluster and output cluster filtering. Omitted keys fall back to the global default.",
       "properties": {
         "use_height": { "type": "boolean" },
         "tolerance_m": { "type": "number" },
@@ -126,7 +126,8 @@
         "min_points_per_voxel": { "type": "integer" },
         "large_cluster_voxel_count_threshold": { "type": "integer" },
         "large_cluster_max_points_per_voxel": { "type": "integer" },
-        "max_voxels_per_cluster": { "type": "integer", "minimum": 1 }
+        "max_voxels_per_cluster": { "type": "integer", "minimum": 1 },
+        "min_probability": { "type": "number" }
       },
       "additionalProperties": false
     },

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -256,26 +256,22 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
   const auto max_voxels_per_cluster = static_cast<int>(
     autoware_utils_rclcpp::get_or_declare_parameter<int64_t>(*this, "max_voxels_per_cluster"));
 
-  auto default_cluster = std::make_shared<VoxelGridBasedEuclideanCluster>(
-    use_height, min_points_per_cluster, tolerance, voxel_leaf_size, min_points_per_voxel,
-    large_cluster_voxel_count_threshold, large_cluster_max_points_per_voxel,
-    max_voxels_per_cluster);
+  const ClusterOptions default_options{
+    std::make_shared<VoxelGridBasedEuclideanCluster>(
+      use_height, min_points_per_cluster, tolerance, voxel_leaf_size, min_points_per_voxel,
+      large_cluster_voxel_count_threshold, large_cluster_max_points_per_voxel,
+      max_voxels_per_cluster),
+    min_probability};
 
-  // Build per-label cluster overrides from label_cluster_params.<label_name>.* parameters
-  std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>>
-    label_cluster_executers;
+  // Build effective per-label options from label_cluster_params.<label_name>.* parameters.
+  // Give every configured label its own executor so future executor-local caches or buffers cannot
+  // leak state across labels, even when a block only overrides output filtering.
+  std::unordered_map<std::uint8_t, ClusterOptions> label_options;
   {
     for (const auto & entry : load_label_cluster_parameter_prefixes(options)) {
       const auto & label_name = entry.first;
       const auto & label_prefix = entry.second;
       auto has = [&](const std::string & key) { return this->has_parameter(label_prefix + key); };
-      if (
-        !has("tolerance_m") && !has("min_points_per_cluster") && !has("use_height") &&
-        !has("voxel_leaf_size_m") && !has("min_points_per_voxel") &&
-        !has("large_cluster_voxel_count_threshold") && !has("large_cluster_max_points_per_voxel") &&
-        !has("max_voxels_per_cluster")) {
-        continue;
-      }
 
       auto get_bool = [&](const std::string & key, bool def) -> bool {
         return has(key) ? this->get_parameter(label_prefix + key).as_bool() : def;
@@ -300,16 +296,21 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
       };
 
       const auto label = object_recognition_utils::toLabel(normalize_object_label_name(label_name));
-      label_cluster_executers[label] = std::make_shared<VoxelGridBasedEuclideanCluster>(
-        get_bool("use_height", use_height),
-        get_int("min_points_per_cluster", min_points_per_cluster),
-        get_float("tolerance_m", tolerance), get_float("voxel_leaf_size_m", voxel_leaf_size),
-        get_int("min_points_per_voxel", min_points_per_voxel),
-        get_int("large_cluster_voxel_count_threshold", large_cluster_voxel_count_threshold),
-        get_int("large_cluster_max_points_per_voxel", large_cluster_max_points_per_voxel),
-        get_int("max_voxels_per_cluster", max_voxels_per_cluster));
+      label_options.emplace(
+        label,
+        ClusterOptions{
+          std::make_shared<VoxelGridBasedEuclideanCluster>(
+            get_bool("use_height", use_height),
+            get_int("min_points_per_cluster", min_points_per_cluster),
+            get_float("tolerance_m", tolerance), get_float("voxel_leaf_size_m", voxel_leaf_size),
+            get_int("min_points_per_voxel", min_points_per_voxel),
+            get_int("large_cluster_voxel_count_threshold", large_cluster_voxel_count_threshold),
+            get_int("large_cluster_max_points_per_voxel", large_cluster_max_points_per_voxel),
+            get_int("max_voxels_per_cluster", max_voxels_per_cluster)),
+          get_float("min_probability", min_probability)});
 
-      RCLCPP_INFO(get_logger(), "Using custom cluster params for label '%s'", label_name.c_str());
+      RCLCPP_INFO(
+        get_logger(), "Using per-label cluster options for label '%s'", label_name.c_str());
     }
   }
 
@@ -324,8 +325,8 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
 
   // Create the core clustering processor
   processor_ = std::make_unique<LabelBasedEuclideanCluster>(
-    class_id_to_object_label, min_probability, shape_policy, default_cluster,
-    label_cluster_executers, shape_estimator, confusable_groups);
+    class_id_to_object_label, shape_policy, default_options, label_options, shape_estimator,
+    confusable_groups);
 
   // Set up ROS pub/sub
   using std::placeholders::_1;

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
@@ -247,7 +247,7 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsAreGroupedByLabel)
 // Probability Filtering Tests
 // ============================================================================
 
-TEST_F(LabelBasedEuclideanClusterTest, PointsBelowMinProbabilityAreFiltered)
+TEST_F(LabelBasedEuclideanClusterTest, ClusterBelowMinProbabilityIsFiltered)
 {
   // Arrange
   std::unordered_map<uint8_t, uint8_t> class_map;
@@ -257,22 +257,49 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsBelowMinProbabilityAreFiltered)
     class_map, 0.8f, ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
 
-  // Create points with varying probabilities
+  // A few high-confidence points are not enough when the cluster average is below the threshold.
   auto pc = create_pointcloud(
-    {0.0f, 0.1f, 0.2f, 0.3f},  // x
-    {0.0f, 0.0f, 0.0f, 0.0f},  // y
-    {0.0f, 0.0f, 0.0f, 0.0f},  // z
-    {0, 0, 0, 0},              // class_id
-    {0.5f, 0.9f, 0.7f, 0.95f}  // probability
+    {0.0f, 0.1f, 0.2f, 0.3f},   // x
+    {0.0f, 0.0f, 0.0f, 0.0f},   // y
+    {0.0f, 0.0f, 0.0f, 0.0f},   // z
+    {0, 0, 0, 0},               // class_id
+    {0.95f, 0.95f, 0.1f, 0.1f}  // probability
   );
 
   // Act
   auto result = cluster.process(pc);
 
-  // Assert - only points with prob >= 0.8 should be kept (indices 1, 3)
-  // These should form a cluster or be filtered out if too small
+  // Assert
   ASSERT_TRUE(result.has_value());
-  EXPECT_LE(result->objects.size(), 2U);
+  EXPECT_TRUE(result->objects.empty());
+}
+
+TEST_F(LabelBasedEuclideanClusterTest, ClusterAverageProbabilityIsUsedForThreshold)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.8f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  // The first point is below the threshold, but the cluster average is above 0.8.
+  auto pc = create_pointcloud(
+    {0.0f, 0.1f, 0.2f},   // x
+    {0.0f, 0.0f, 0.0f},   // y
+    {0.0f, 0.0f, 0.0f},   // z
+    {0, 0, 0},            // class_id
+    {0.7f, 0.85f, 0.95f}  // probability
+  );
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->objects.size(), 1U);
+  EXPECT_NEAR(result->objects[0].existence_probability, 0.8333333f, 1e-5f);
 }
 
 TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
@@ -58,6 +58,11 @@ protected:
   std::shared_ptr<VoxelGridBasedEuclideanCluster> default_cluster_;
   std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator_;
 
+  ClusterOptions make_default_options(const float min_probability = 0.0F) const
+  {
+    return ClusterOptions{default_cluster_, min_probability};
+  }
+
   /// @brief Create a minimal PointCloud2 message with xyz and optionally class_id/probability
   sensor_msgs::msg::PointCloud2 create_pointcloud(
     const std::vector<float> & x, const std::vector<float> & y, const std::vector<float> & z,
@@ -147,8 +152,7 @@ TEST_F(LabelBasedEuclideanClusterTest, EmptyPointCloudReturnsEmptyObjects)
   class_map[0] = ObjectClassification::UNKNOWN;
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(), {}, shape_estimator_);
 
   auto pc = create_pointcloud({}, {}, {});
 
@@ -167,8 +171,7 @@ TEST_F(LabelBasedEuclideanClusterTest, PointCloudWithoutClassIdUsesDefaultLabel)
   class_map[0] = ObjectClassification::CAR;
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(), {}, shape_estimator_);
 
   // Create enough points to potentially form a cluster
   // Add more points in close proximity to exceed min_points_per_cluster
@@ -200,8 +203,7 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsAreGroupedByLabel)
   class_map[1] = ObjectClassification::PEDESTRIAN;
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(), {}, shape_estimator_);
 
   // Create two well-separated clusters: car at origin and pedestrian at (5,0)
   std::vector<float> x_vals, y_vals, z_vals, class_vals, prob_vals;
@@ -254,8 +256,7 @@ TEST_F(LabelBasedEuclideanClusterTest, ClusterBelowMinProbabilityIsFiltered)
   class_map[0] = ObjectClassification::CAR;
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.8f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(0.8F), {}, shape_estimator_);
 
   // A few high-confidence points are not enough when the cluster average is below the threshold.
   auto pc = create_pointcloud(
@@ -281,8 +282,7 @@ TEST_F(LabelBasedEuclideanClusterTest, ClusterAverageProbabilityIsUsedForThresho
   class_map[0] = ObjectClassification::CAR;
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.8f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(0.8F), {}, shape_estimator_);
 
   // The first point is below the threshold, but the cluster average is above 0.8.
   auto pc = create_pointcloud(
@@ -302,6 +302,35 @@ TEST_F(LabelBasedEuclideanClusterTest, ClusterAverageProbabilityIsUsedForThresho
   EXPECT_NEAR(result->objects[0].existence_probability, 0.8333333f, 1e-5f);
 }
 
+TEST_F(LabelBasedEuclideanClusterTest, LabelMinProbabilityOverridesGlobalThreshold)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+  class_map[1] = ObjectClassification::PEDESTRIAN;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(0.3F),
+    {{ObjectClassification::CAR, make_default_options(0.8F)}}, shape_estimator_);
+
+  auto pc = create_pointcloud(
+    {0.0f, 0.1f, 0.2f, 5.0f, 5.1f, 5.2f},  // x
+    {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},  // y
+    {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},  // z
+    {0, 0, 0, 1, 1, 1},                    // class_id
+    {0.7f, 0.7f, 0.7f, 0.7f, 0.7f, 0.7f}   // probability
+  );
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->objects.size(), 1U);
+  EXPECT_EQ(result->objects[0].classification[0].label, ObjectClassification::PEDESTRIAN);
+  EXPECT_NEAR(result->objects[0].existence_probability, 0.7f, 1e-5f);
+}
+
 TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)
 {
   // Arrange
@@ -309,8 +338,7 @@ TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)
   class_map[0] = ObjectClassification::CAR;
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(), {}, shape_estimator_);
 
   // Create cluster with known probabilities
   std::vector<float> x_vals, y_vals, z_vals, prob_vals;
@@ -347,8 +375,7 @@ TEST_F(LabelBasedEuclideanClusterTest, ShapeIsPopulated)
   class_map[0] = ObjectClassification::CAR;
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(), {}, shape_estimator_);
 
   // Create a reasonable cluster
   std::vector<float> x_vals, y_vals, z_vals;
@@ -388,8 +415,7 @@ TEST_F(LabelBasedEuclideanClusterTest, UnmappedLabelsAreIgnored)
   // class_id 1 is unmapped, should be ignored
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(), {}, shape_estimator_);
 
   // Create points: some mapped (0), some unmapped (1)
   auto pc = create_pointcloud(
@@ -416,8 +442,7 @@ TEST_F(LabelBasedEuclideanClusterTest, ReturnsErrorWhenRequiredFieldsAreMissing)
   class_map[0] = ObjectClassification::CAR;
 
   LabelBasedEuclideanCluster cluster(
-    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+    class_map, ShapePolicy::ALL_POLYGON, make_default_options(), {}, shape_estimator_);
 
   sensor_msgs::msg::PointCloud2 pc;
   pc.height = 1;

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
@@ -142,6 +142,7 @@ TEST_F(LabelClusterConfigBehavior, AcceptsLowercaseConfiguredLabels)
     rclcpp::Parameter("class_names.truck", std::string("truck")),
     rclcpp::Parameter("class_names.tractor_unit", std::string("trailer")),
     rclcpp::Parameter("class_names.pedestrian", std::string("pedestrian")),
+    rclcpp::Parameter("label_cluster_params.pedestrian.min_probability", 0.6),
     rclcpp::Parameter("label_cluster_params.pedestrian.tolerance_m", 0.3),
     rclcpp::Parameter(
       "confusable_label_groups.truck_trailer.labels", std::vector<std::string>{"truck", "trailer"}),
@@ -157,6 +158,7 @@ TEST_F(LabelClusterConfigBehavior, AcceptsLowercaseConfiguredLabels)
   EXPECT_TRUE(node->has_parameter("class_names.truck"));
   EXPECT_TRUE(node->has_parameter("class_names.tractor_unit"));
   EXPECT_TRUE(node->has_parameter("class_names.pedestrian"));
+  EXPECT_TRUE(node->has_parameter("label_cluster_params.pedestrian.min_probability"));
   EXPECT_TRUE(node->has_parameter("label_cluster_params.pedestrian.tolerance_m"));
   EXPECT_TRUE(node->has_parameter("confusable_label_groups.truck_trailer.labels"));
   EXPECT_TRUE(node->has_parameter("confusable_label_groups.truck_trailer.cross_label_tolerance_m"));


### PR DESCRIPTION
## Description

This pull request updates the Autoware Euclidean clusterer to improve how semantic probability thresholds are applied and configured. The main change is shifting from filtering individual points by probability before clustering, to filtering entire clusters based on their average semantic probability after clustering. This is now configurable globally and per-label, both in code and configuration files, and is reflected in the documentation and schema.

**Cluster filtering and configuration improvements:**

* The clustering logic now filters clusters (not individual points) whose average semantic probability falls below a configurable threshold (`min_probability`), which can be set globally or overridden per label via `label_cluster_params.<label>.min_probability` in the YAML config. [[1]](diffhunk://#diff-bb0e02c1389e663105d932aa20af2d03064f05b2ef22bb27cd711be5e38d99a9L12-R17) [[2]](diffhunk://#diff-3ef9b93fb36640b4628f74d8b33ab88686c940afed7ce10b0bcaec5b4014bbe1R41-R54) [[3]](diffhunk://#diff-3ef9b93fb36640b4628f74d8b33ab88686c940afed7ce10b0bcaec5b4014bbe1L58-R82) [[4]](diffhunk://#diff-3ef9b93fb36640b4628f74d8b33ab88686c940afed7ce10b0bcaec5b4014bbe1L84-R105) [[5]](diffhunk://#diff-f123fe0c1cf1f4170eef98541c9920295f216333924f8054efe28f885c068e03L275-L284) [[6]](diffhunk://#diff-04251c0b155d43317473c68bb84c037a269d99aa7e6b2b756a585b033af6dbacL52-R52) [[7]](diffhunk://#diff-04251c0b155d43317473c68bb84c037a269d99aa7e6b2b756a585b033af6dbacL81-R81) [[8]](diffhunk://#diff-04251c0b155d43317473c68bb84c037a269d99aa7e6b2b756a585b033af6dbacL120-R120) [[9]](diffhunk://#diff-04251c0b155d43317473c68bb84c037a269d99aa7e6b2b756a585b033af6dbacL129-R130)

* The configuration file (`label_based_euclidean_cluster.param.yaml`) and schema (`label_based_euclidean_cluster.schema.json`) have been updated to support per-label `min_probability` overrides, and the documentation has been revised to clarify the new filtering behavior and configuration options. [[1]](diffhunk://#diff-bb0e02c1389e663105d932aa20af2d03064f05b2ef22bb27cd711be5e38d99a9L12-R17) [[2]](diffhunk://#diff-bb0e02c1389e663105d932aa20af2d03064f05b2ef22bb27cd711be5e38d99a9L46-L48) [[3]](diffhunk://#diff-1f747bb9f4dcdb8a50a7714ac10b60acdfd62263f8624685f8744e3aa6b7549dL97-R121) [[4]](diffhunk://#diff-1f747bb9f4dcdb8a50a7714ac10b60acdfd62263f8624685f8744e3aa6b7549dR136) [[5]](diffhunk://#diff-04251c0b155d43317473c68bb84c037a269d99aa7e6b2b756a585b033af6dbacL52-R52) [[6]](diffhunk://#diff-04251c0b155d43317473c68bb84c037a269d99aa7e6b2b756a585b033af6dbacL81-R81) [[7]](diffhunk://#diff-04251c0b155d43317473c68bb84c037a269d99aa7e6b2b756a585b033af6dbacL120-R120) [[8]](diffhunk://#diff-04251c0b155d43317473c68bb84c037a269d99aa7e6b2b756a585b033af6dbacL129-R130)

**Documentation updates:**

* The documentation now explains that `min_probability` is applied to the average probability of clusters after clustering, not to individual points before clustering, and describes how per-label overrides work. Example configurations have been updated accordingly. [[1]](diffhunk://#diff-1f747bb9f4dcdb8a50a7714ac10b60acdfd62263f8624685f8744e3aa6b7549dL41-R46) [[2]](diffhunk://#diff-1f747bb9f4dcdb8a50a7714ac10b60acdfd62263f8624685f8744e3aa6b7549dR80-R81) [[3]](diffhunk://#diff-1f747bb9f4dcdb8a50a7714ac10b60acdfd62263f8624685f8744e3aa6b7549dL97-R121) [[4]](diffhunk://#diff-1f747bb9f4dcdb8a50a7714ac10b60acdfd62263f8624685f8744e3aa6b7549dR136)

**Refactoring and API changes:**

* The `LabelBasedEuclideanCluster` class and related code have been refactored to use a new `ClusterOptions` struct, which encapsulates both the cluster executor and the minimum probability threshold, simplifying per-label option handling and improving code clarity. [[1]](diffhunk://#diff-3ef9b93fb36640b4628f74d8b33ab88686c940afed7ce10b0bcaec5b4014bbe1R41-R54) [[2]](diffhunk://#diff-3ef9b93fb36640b4628f74d8b33ab88686c940afed7ce10b0bcaec5b4014bbe1L58-R82) [[3]](diffhunk://#diff-3ef9b93fb36640b4628f74d8b33ab88686c940afed7ce10b0bcaec5b4014bbe1L84-R105) [[4]](diffhunk://#diff-f123fe0c1cf1f4170eef98541c9920295f216333924f8054efe28f885c068e03L208-L224) [[5]](diffhunk://#diff-f123fe0c1cf1f4170eef98541c9920295f216333924f8054efe28f885c068e03L241-R229)

**Behavioral change:**

* Points are no longer filtered by probability before clustering; instead, all points are used for clustering, and clusters are dropped if their average probability is below the threshold. This results in more robust cluster formation and filtering. [[1]](diffhunk://#diff-f123fe0c1cf1f4170eef98541c9920295f216333924f8054efe28f885c068e03L66-R66) [[2]](diffhunk://#diff-f123fe0c1cf1f4170eef98541c9920295f216333924f8054efe28f885c068e03L83-L86) [[3]](diffhunk://#diff-f123fe0c1cf1f4170eef98541c9920295f216333924f8054efe28f885c068e03L115-L118) [[4]](diffhunk://#diff-f123fe0c1cf1f4170eef98541c9920295f216333924f8054efe28f885c068e03L262-R247) [[5]](diffhunk://#diff-1f747bb9f4dcdb8a50a7714ac10b60acdfd62263f8624685f8744e3aa6b7549dL41-R46) [[6]](diffhunk://#diff-1f747bb9f4dcdb8a50a7714ac10b60acdfd62263f8624685f8744e3aa6b7549dR80-R81)

These changes make the cluster filtering process more flexible and accurate, and provide clearer configuration and documentation for users.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
