### PR TITLE
feat(diffusion_planner): add a range mask to neighbors

### DIFF
--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/diffusion_planner/conversion/agent.hpp"
 
+#include "autoware/diffusion_planner/constants.hpp"
 #include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/utils/utils.hpp"
 
@@ -125,6 +126,20 @@ std::vector<AgentHistory> AgentData::transformed_and_trimmed_histories(
   for (auto & history : histories) {
     history.apply_transform(transform);
   }
+
+  // Keep only agents inside the same square range as the map (LANE_MASK_RANGE_M around the ego).
+  // After apply_transform the poses are in the ego frame, so the ego sits at the origin and the
+  // range check reduces to |x| <= range && |y| <= range.
+  constexpr double RANGE_M = autoware::diffusion_planner::constants::LANE_MASK_RANGE_M;
+  histories.erase(
+    std::remove_if(
+      histories.begin(), histories.end(),
+      [](const AgentHistory & history) {
+        const AgentState & latest_state = history.get_latest_state();
+        return std::abs(latest_state.pose(0, 3)) > RANGE_M ||
+               std::abs(latest_state.pose(1, 3)) > RANGE_M;
+      }),
+    histories.end());
 
   std::sort(histories.begin(), histories.end(), [](const AgentHistory & a, const AgentHistory & b) {
     const double a_dist =


### PR DESCRIPTION
## Description

In the current implementation, it is possible for very distant neighbors to be included as inputs. This pull request introduces an implementation that restricts neighbors to the same range used for the map.

However, there may be valid reasons to consider neighbors beyond the map's range. While the 100m range is sufficient for the ego vehicle's planning needs, it might be appropriate to include more distant objects as inputs. (e.g. vehicles approaching at high speeds)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
