### PR TITLE
fix(pid_longitudinal_controller): guard lerp against zero-length segments

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -97,7 +97,12 @@ std::pair<TrajectoryPoint, size_t> lerpTrajectoryPoint(
     autoware::motion_utils::calcLongitudinalOffsetToSegment(points, seg_idx, pose.position);
   const double len_segment =
     autoware::motion_utils::calcSignedArcLength(points, seg_idx, seg_idx + 1);
-  const double interpolate_ratio = std::clamp(len_to_interpolated / len_segment, 0.0, 1.0);
+
+  constexpr double min_len_segment = 1e-6;
+  const bool zero_length_segment =
+    !std::isfinite(len_segment) || std::abs(len_segment) < min_len_segment;
+  const double interpolate_ratio =
+    zero_length_segment ? 0.0 : std::clamp(len_to_interpolated / len_segment, 0.0, 1.0);
 
   {
     const size_t i = seg_idx;

--- a/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -460,6 +460,34 @@ TEST(TestLongitudinalControllerUtils, lerpTrajectoryPoint)
   EXPECT_NEAR(result.first.acceleration_mps2, 15.0, abs_err);
 }
 
+TEST(TestLongitudinalControllerUtils, lerpTrajectoryPoint_zeroLengthSegment)
+{
+  using autoware_planning_msgs::msg::TrajectoryPoint;
+  using geometry_msgs::msg::Pose;
+  const double abs_err = 1e-5;
+  std::vector<TrajectoryPoint> points;
+  TrajectoryPoint p;
+  p.pose.position.x = 0.0;
+  p.pose.position.y = 0.0;
+  p.pose.position.z = 0.0;
+  p.longitudinal_velocity_mps = 1.5;
+  p.acceleration_mps2 = -2.5;
+  points.push_back(p);
+  points.push_back(p);
+
+  Pose pose;
+  pose.position.x = 0.0;
+  pose.position.y = 0.0;
+  pose.position.z = 0.0;
+
+  const auto result = longitudinal_utils::lerpTrajectoryPoint(points, pose, 3.0, 0.7);
+
+  EXPECT_TRUE(std::isfinite(result.first.longitudinal_velocity_mps));
+  EXPECT_TRUE(std::isfinite(result.first.acceleration_mps2));
+  EXPECT_NEAR(result.first.longitudinal_velocity_mps, 1.5, abs_err);
+  EXPECT_NEAR(result.first.acceleration_mps2, -2.5, abs_err);
+}
+
 TEST(TestLongitudinalControllerUtils, lerpTrajectoryPointByTimeStopHold)
 {
   using autoware_planning_msgs::msg::TrajectoryPoint;


### PR DESCRIPTION
## Summary
- Guard `lerpTrajectoryPoint` when trajectory segment arc length is zero or non-finite, avoiding division-by-zero that produced NaN interpolated velocity/acceleration.
- Fall back to the segment start point (`interpolate_ratio = 0.0`) when consecutive points overlap after `removeOverlapPoints`.
- Add unit test `lerpTrajectoryPoint_zeroLengthSegment` for overlapping consecutive points.

Cherry-picked from [tier4/autoware_universe#3194](https://github.com/tier4/autoware_universe/pull/3194).

Reproduced with rosbag during STOPPING: NaN inserted nearest/delay target points led to `slope=nan`, NaN acceleration commands, and vehicle_cmd_gate errors. After this fix, interpolation returns finite values.

## Test plan
- [x] `colcon test --packages-select autoware_pid_longitudinal_controller` passes locally (tier4 PR)
- [x] Rosbag replay: zero-length segment case no longer produces NaN acceleration; finite brake commands at vehicle_cmd_gate (tier4 PR)
- [ ] CI on autowarefoundation/autoware_universe

## Notes for reviewers
- Root cause was `std::clamp(len_to_interpolated / len_segment, ...)` with `len_segment == 0` after overlapping trajectory points near stop.
- Only `longitudinal_controller_utils.hpp` and its unit test are changed; no logging or defensive guards elsewhere.
- Cherry-pick conflict in tests resolved by keeping both the new zero-length segment test and existing `lerpTrajectoryPointByTime*` tests on `main`.

## Related links
- [tier4/autoware_universe#3194](https://github.com/tier4/autoware_universe/pull/3194)


Made with [Cursor](https://cursor.com)