### PR TITLE
fix(traffic_light_compliance_checker): improve stop point detection

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -285,7 +285,9 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
     input.current_velocity, input.current_acceleration,
     params_.checked_trajectory_length.deceleration_limit,
     params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
-  const auto max_trajectory_length = ego_stopping_distance.value_or(0.0);
+  // add the stop_overshoot_margin to not skip points beyond the stop line but within the margin
+  const auto max_trajectory_length =
+    ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin;
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;
@@ -305,12 +307,11 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
     trajectory.push_back(p);
     trajectory_ls.emplace_back(lanelet_p);
 
-    // skip points beyond the first stop, or skip once we reach the maximum length
-    if (p.longitudinal_velocity_mps <= 1e-6) {
+    // search for a stop point beyond the current ego position
+    if (length > 0.0 && p.longitudinal_velocity_mps <= params_.ego_stopped_velocity_threshold) {
       stop_point = trajectory_ls.back();
       break;
     }
-
     if (length > max_trajectory_length) break;
   }
 


### PR DESCRIPTION
## Description

Fix an issue with the stop margin used in the `traffic_light_compliance_checker`.
For this margin to work as expected, we need to correctly detect the stop point. However, in the current implementation, the trajectory can be cut too short, excluding a stop point within the margin and thus potentially causing a wrong violation detection. 


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
