### PR TITLE
feat(traffic_light_compliance_checker): allow commiting to a decision while crossing

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -5,6 +5,7 @@ The `traffic_light_compliance_checker` package provides a deterministic validati
 ## Core Features
 
 1. **Signal State Tracking (`TrafficLightStatusTracker`)**
+
    - Eliminates perception jitter and signal flickering by maintaining a temporal state history for each traffic light group ID.
    - Leverages stable duration thresholds before validating a transition to `RED` or `AMBER`.
    - Utilizes a hysteresis buffer to sustain known states during transient object occlusions.
@@ -13,6 +14,7 @@ The `traffic_light_compliance_checker` package provides a deterministic validati
    - Scans forward trajectory segments sequentially to isolate intersection entry points.
    - Appends a physical front-bumper projection to ensure the vehicle footprint stays behind regulatory stop lines.
    - Implements a kinematic pass/stop feasibility matrix for `AMBER` signals based on comfortable braking and intersection clearance times.
+   - Remembers an accepted nearby, non-stopping crossing for a configurable duration so a subsequent signal change does not force an unsafe stop.
    - Returns prioritized, chronological arrays of `Violation` metadata if an unvalidated stop line overshoot is detected.
 
 ## Inner Workings
@@ -116,19 +118,21 @@ The interfaces pass inputs and output results through the following standard dat
 
 ## Parameters
 
-| Parameter Name                                 | Type     | Description                                                                                |
-| :--------------------------------------------- | :------- | :----------------------------------------------------------------------------------------- |
-| `deceleration_limit`                           | `double` | Max deceleration limit during braking ($m/s^2$) for assessing stopping feasibility.        |
-| `jerk_limit`                                   | `double` | Max jerk limit during braking ($m/s^3$) for assessing stopping feasibility.                |
-| `delay_response_time`                          | `double` | Combined latency buffer for compute cycle lag and brake actuation (seconds).               |
-| `crossing_time_limit`                          | `double` | Maximum duration allowed for the vehicle to clear an amber light intersection (seconds).   |
-| `stop_overshoot_margin`                        | `double` | Allowed physical distance buffer beyond a stop line for a stopped vehicle (meters).        |
-| `stable_duration_threshold_red`                | `double` | Required continuous duration for a `RED` state to be confirmed as valid (seconds).         |
-| `stable_duration_threshold_amber`              | `double` | Required continuous duration for an `AMBER` state to be confirmed as valid (seconds).      |
-| `stable_duration_threshold_unknown`            | `double` | Required continuous duration for an `UNKNOWN` state to be confirmed as valid (seconds).    |
-| `amber_rejection_hysteresis_duration`          | `double` | Duration to retain an active amber light state if perception updates drop out (seconds).   |
-| `ego_stopped_velocity_threshold`               | `double` | Velocity threshold beneath which the ego vehicle is considered completely stopped ($m/s$). |
-| `treat_amber_light_as_red_light`               | `bool`   | If true, disables amber passing logic and treats all amber states as strict red signals.   |
-| `treat_unknown_light_as_red_light`             | `bool`   | If true, evaluates unclassified or blank signal states as strict red signals.              |
-| `checked_trajectory_length.deceleration_limit` | `double` | Comfortable stop deceleration limit ($m/s^2$) for computing trajectory checking length.    |
-| `checked_trajectory_length.jerk_limit`         | `double` | Comfortable stop jerk limit ($m/s^3$) for computing trajectory checking length.            |
+| Parameter Name                                 | Type     | Description                                                                                                                                                                 |
+| :--------------------------------------------- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `deceleration_limit`                           | `double` | Max deceleration limit during braking ($m/s^2$) for assessing stopping feasibility.                                                                                         |
+| `jerk_limit`                                   | `double` | Max jerk limit during braking ($m/s^3$) for assessing stopping feasibility.                                                                                                 |
+| `delay_response_time`                          | `double` | Combined latency buffer for compute cycle lag and brake actuation (seconds).                                                                                                |
+| `crossing_time_limit`                          | `double` | Maximum duration allowed for the vehicle to clear an amber light intersection (seconds).                                                                                    |
+| `crossing_commitment_distance`                 | `double` | Maximum 2D distance before the stop line at which an accepted crossing is remembered (meters); zero still permits commitment once the ego front reaches or passes the line. |
+| `crossing_commitment_duration`                 | `double` | Duration for which an accepted stop-line crossing remains valid (seconds); zero disables the feature.                                                                       |
+| `stop_overshoot_margin`                        | `double` | Allowed physical distance buffer beyond a stop line for a stopped vehicle (meters).                                                                                         |
+| `stable_duration_threshold_red`                | `double` | Required continuous duration for a `RED` state to be confirmed as valid (seconds).                                                                                          |
+| `stable_duration_threshold_amber`              | `double` | Required continuous duration for an `AMBER` state to be confirmed as valid (seconds).                                                                                       |
+| `stable_duration_threshold_unknown`            | `double` | Required continuous duration for an `UNKNOWN` state to be confirmed as valid (seconds).                                                                                     |
+| `amber_rejection_hysteresis_duration`          | `double` | Duration to retain an active amber light state if perception updates drop out (seconds).                                                                                    |
+| `ego_stopped_velocity_threshold`               | `double` | Velocity threshold beneath which the ego vehicle is considered completely stopped ($m/s$).                                                                                  |
+| `treat_amber_light_as_red_light`               | `bool`   | If true, disables amber passing logic and treats all amber states as strict red signals.                                                                                    |
+| `treat_unknown_light_as_red_light`             | `bool`   | If true, evaluates unclassified or blank signal states as strict red signals.                                                                                               |
+| `checked_trajectory_length.deceleration_limit` | `double` | Comfortable stop deceleration limit ($m/s^2$) for computing trajectory checking length.                                                                                     |
+| `checked_trajectory_length.jerk_limit`         | `double` | Comfortable stop jerk limit ($m/s^3$) for computing trajectory checking length.                                                                                             |

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -84,6 +84,16 @@ struct ComplianceResult
   std::vector<Violation> violations;
 };
 
+/// @brief debug information about an active crossing commitment
+struct CrossingCommitmentDebugInfo
+{
+  int64_t traffic_light_id;
+  lanelet::BasicLineString2d stop_line;
+  rclcpp::Time committed_at;
+  double elapsed_time;
+  double remaining_time;
+};
+
 /// @brief parameters for traffic light signal status tracking
 struct StatusTrackerParameters
 {

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -25,6 +25,8 @@
 #include <lanelet2_core/geometry/LineString.h>
 
 #include <cstdint>
+#include <optional>
+#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light_compliance_checker
@@ -49,30 +51,39 @@ struct StopLineInfo
   int64_t traffic_light_id;
 };
 
-/// @brief type of traffic light violation
-enum class ViolationType { RED_LIGHT, AMBER_LIGHT };
-
-/// @brief violation detail
-struct Violation
+/// @brief information about stop lines
+struct StopLineInfos
 {
-  ViolationType type;
+  std::vector<StopLineInfo> red_stop_lines;
+  std::vector<StopLineInfo> amber_stop_lines;
+  std::vector<StopLineInfo> unknown_stop_lines;
+  std::vector<StopLineInfo> green_stop_lines;
+};
+
+/// @brief type of traffic light violation
+enum class ViolationType { NONE, RED_LIGHT, AMBER_LIGHT };
+
+/// @brief Information about stop line crossing
+struct StopLineCrossing
+{
   lanelet::BasicLineString2d stop_line;
   int64_t traffic_light_id;
-  lanelet::BasicPoint2d cross_point;
+  std::optional<lanelet::BasicPoint2d> cross_point;
   double arc_length_to_cross_point;
+  std::optional<double> distance_between_stop_point_and_stop_line;
+  ViolationType violation_type{ViolationType::NONE};
 
-  Violation(
-    ViolationType type, lanelet::BasicLineString2d stop_line, int64_t traffic_light_id,
+  StopLineCrossing(
+    lanelet::BasicLineString2d stop_line, int64_t traffic_light_id,
     lanelet::BasicPoint2d cross_point, double arc_length_to_cross_point)
-  : type(type),
-    stop_line(stop_line),
+  : stop_line(std::move(stop_line)),
     traffic_light_id(traffic_light_id),
     cross_point(cross_point),
     arc_length_to_cross_point(arc_length_to_cross_point)
   {
   }
 
-  bool operator<(const Violation & other) const
+  bool operator<(const StopLineCrossing & other) const
   {
     return arc_length_to_cross_point < other.arc_length_to_cross_point;
   }
@@ -81,7 +92,7 @@ struct Violation
 /// @brief result of compliance check
 struct ComplianceResult
 {
-  std::vector<Violation> violations;
+  std::vector<StopLineCrossing> crossings;
 };
 
 /// @brief debug information about an active crossing commitment

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -99,6 +99,8 @@ struct Parameters
   double jerk_limit;
   double delay_response_time;
   double crossing_time_limit;
+  double crossing_commitment_distance;
+  double crossing_commitment_duration;
   bool treat_amber_light_as_red_light;
   bool treat_unknown_light_as_red_light;
   double stop_overshoot_margin;

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -27,12 +27,12 @@
 
 #include <lanelet2_core/LaneletMap.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light_compliance_checker
@@ -49,8 +49,6 @@ public:
    */
   TrafficLightComplianceChecker(
     const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info);
-
-  ~TrafficLightComplianceChecker();
 
   /**
    * @brief check if the trajectory complies with traffic lights
@@ -91,39 +89,52 @@ private:
 
   void cleanup_crossing_commitment_history(const rclcpp::Time & current_time);
 
-  [[nodiscard]] tl::expected<ComplianceResult, std::string> check_with_filtered_signals(
+  [[nodiscard]] tl::expected<ComplianceResult, std::string> get_crossings_with_filtered_signals(
     const Inputs & input,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
     const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
     const bool check_amber_lights);
 
-  std::vector<Violation> get_red_light_violations(
-    const std::vector<StopLineInfo> & red_stop_lines,
-    const lanelet::BasicLineString2d & trajectory_ls,
-    const std::optional<lanelet::BasicPoint2d> & stop_point,
-    const double distance_offset = 0.0) const;
-  std::vector<Violation> get_amber_light_violations(
+  std::vector<StopLineCrossing> get_stop_line_crossings(
+    const std::vector<StopLineInfo> & stop_lines, const lanelet::BasicLineString2d & trajectory_ls,
+    const std::optional<lanelet::BasicPoint2d> & stop_point, const double distance_offset = 0.0,
+    const ViolationType violation_type_for_crossing = ViolationType::NONE) const;
+  std::vector<StopLineCrossing> get_amber_light_crossings(
     const std::vector<StopLineInfo> & amber_stop_lines,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
     const lanelet::BasicLineString2d & trajectory_ls,
     const std::optional<lanelet::BasicPoint2d> & stop_point,
     const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset = 0.0) const;
 
-  /// @brief return the red and amber stop lines related to the given traffic light groups
-  [[nodiscard]] std::pair<std::vector<StopLineInfo>, std::vector<StopLineInfo>> get_stop_lines(
+  /// @brief return the stop lines related to the given traffic light groups
+  [[nodiscard]] StopLineInfos get_stop_lines(
     const lanelet::LaneletMap & lanelet_map,
     const autoware_planning_msgs::msg::LaneletRoute & route,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_lights) const;
-
-  /// @brief return true if there is a stop point and it is within margin distance of the stop line
-  [[nodiscard]] bool is_stop_point_within_margin_from_stop_line(
-    const std::optional<lanelet::BasicPoint2d> & stop_point,
-    const lanelet::BasicLineString2d & stop_line) const;
 
   /// @brief return true if ego can safely pass an amber traffic light
   [[nodiscard]] bool can_pass_amber_light(
     const double distance_to_stop_line, const double current_velocity,
     const double current_acceleration, const double time_to_cross_stop_line) const;
+
+  /// @brief update commited stop lines
+  void update_commitments(
+    const std::vector<StopLineCrossing> & crossings, const rclcpp::Time & current_time,
+    const double crossing_commitment_distance, const lanelet::BasicPoint2d & ego_base_point,
+    const lanelet::BasicPoint2d & ego_front_point);
+
+  /// @brief remove violations for commited stop lines
+  void remove_violations_for_commited_stop_lines(std::vector<StopLineCrossing> & crossings)
+  {
+    crossings.erase(
+      std::remove_if(
+        crossings.begin(), crossings.end(),
+        [this](const StopLineCrossing & crossing) {
+          return crossing_commitment_history_.find(crossing.traffic_light_id) !=
+                 crossing_commitment_history_.end();
+        }),
+      crossings.end());
+  }
 
   Parameters params_;
   vehicle_info_utils::VehicleInfo vehicle_info_;

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -76,11 +76,13 @@ private:
 
   void cleanup_amber_rejection_history(const rclcpp::Time & current_time);
 
+  void cleanup_crossing_commitment_history(const rclcpp::Time & current_time);
+
   [[nodiscard]] tl::expected<ComplianceResult, std::string> check_with_filtered_signals(
     const Inputs & input,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
     const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-    const bool check_amber_lights) const;
+    const bool check_amber_lights);
 
   std::vector<Violation> get_red_light_violations(
     const std::vector<StopLineInfo> & red_stop_lines,
@@ -114,6 +116,7 @@ private:
   vehicle_info_utils::VehicleInfo vehicle_info_;
   std::unique_ptr<TrafficLightStatusTracker> status_tracker_;
   std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
+  std::unordered_map<int64_t, rclcpp::Time> crossing_commitment_history_;
 };
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -66,7 +66,20 @@ public:
    */
   void update_parameters(const Parameters & parameters);
 
+  /**
+   * @brief return debug information for active crossing commitments
+   * @param current_time time used to calculate elapsed and remaining durations
+   */
+  [[nodiscard]] std::vector<CrossingCommitmentDebugInfo> get_crossing_commitment_debug_info(
+    const rclcpp::Time & current_time) const;
+
 private:
+  struct CrossingCommitment
+  {
+    rclcpp::Time committed_at;
+    lanelet::BasicLineString2d stop_line;
+  };
+
   [[nodiscard]] std::vector<int64_t> get_force_reject_amber_ids(
     const rclcpp::Time & current_time, bool is_ego_stopped) const;
 
@@ -116,7 +129,7 @@ private:
   vehicle_info_utils::VehicleInfo vehicle_info_;
   std::unique_ptr<TrafficLightStatusTracker> status_tracker_;
   std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
-  std::unordered_map<int64_t, rclcpp::Time> crossing_commitment_history_;
+  std::unordered_map<int64_t, CrossingCommitment> crossing_commitment_history_;
 };
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -171,6 +171,29 @@ void TrafficLightComplianceChecker::update_parameters(const Parameters & paramet
   }
 }
 
+std::vector<CrossingCommitmentDebugInfo>
+TrafficLightComplianceChecker::get_crossing_commitment_debug_info(
+  const rclcpp::Time & current_time) const
+{
+  std::vector<CrossingCommitmentDebugInfo> debug_info;
+  if (params_.crossing_commitment_duration <= 0.0) {
+    return debug_info;
+  }
+
+  debug_info.reserve(crossing_commitment_history_.size());
+  for (const auto & [traffic_light_id, commitment] : crossing_commitment_history_) {
+    const auto elapsed_time = (current_time - commitment.committed_at).seconds();
+    if (elapsed_time < 0.0 || elapsed_time > params_.crossing_commitment_duration) {
+      continue;
+    }
+    debug_info.push_back(
+      CrossingCommitmentDebugInfo{
+        traffic_light_id, commitment.stop_line, commitment.committed_at, elapsed_time,
+        params_.crossing_commitment_duration - elapsed_time});
+  }
+  return debug_info;
+}
+
 tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
   const Inputs & input, const bool check_red_lights, const bool check_amber_lights)
 {
@@ -243,7 +266,7 @@ void TrafficLightComplianceChecker::cleanup_crossing_commitment_history(
   const rclcpp::Time & current_time)
 {
   for (auto it = crossing_commitment_history_.begin(); it != crossing_commitment_history_.end();) {
-    const auto elapsed = (current_time - it->second).seconds();
+    const auto elapsed = (current_time - it->second.committed_at).seconds();
     if (elapsed < 0.0 || elapsed > params_.crossing_commitment_duration) {
       it = crossing_commitment_history_.erase(it);
     } else {
@@ -488,7 +511,8 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
       if (
         !has_violation && is_within_commitment_distance &&
         trajectory_crosses_stop_line(trajectory_ls, stop_line.line)) {
-        crossing_commitment_history_[stop_line.traffic_light_id] = input.current_time;
+        crossing_commitment_history_[stop_line.traffic_light_id] =
+          CrossingCommitment{input.current_time, stop_line.line};
       }
     }
   }

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp"
 
+#include "autoware/traffic_light_compliance_checker/structs.hpp"
+
 #include <autoware/interpolation/linear_interpolation.hpp>
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
@@ -48,14 +50,19 @@ autoware::traffic_light_compliance_checker::StatusTrackerParameters to_status_tr
 
 using autoware::traffic_light_compliance_checker::StopLineInfo;
 
-/// @brief get stop lines where ego need to stop, and their corresponding signals from the given
-/// traffic light groups
-std::vector<std::pair<StopLineInfo, autoware_perception_msgs::msg::TrafficLightGroup>>
-collect_stop_lines(
+struct CollectedStopLine
+{
+  StopLineInfo stop_line_info;
+  autoware_perception_msgs::msg::TrafficLightGroup signal;
+  bool is_stop_signal;
+};
+
+/// @brief get route stop lines and their corresponding signals from the given traffic light groups
+std::vector<CollectedStopLine> collect_stop_lines(
   const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
   const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups)
 {
-  std::vector<std::pair<StopLineInfo, autoware_perception_msgs::msg::TrafficLightGroup>> stop_lines;
+  std::vector<CollectedStopLine> stop_lines;
   std::unordered_map<lanelet::Id, lanelet::Id> route_lanelet_id_per_traffic_light_id;
   for (const auto & segment : route.segments) {
     for (const auto & tl : lanelet_map.laneletLayer.get(segment.preferred_primitive.id)
@@ -75,77 +82,33 @@ collect_stop_lines(
       continue;
     }
 
-    if (!autoware::traffic_light_utils::isTrafficSignalStop(
-          lanelet_map.laneletLayer.get(hit->second), signal)) {
-      continue;
-    }
-
-    const auto traffic_light =
-      std::dynamic_pointer_cast<const lanelet::TrafficLight>(*traffic_light_it);
-    if (!traffic_light || !traffic_light->stopLine().has_value()) {
-      continue;
-    }
-    stop_lines.emplace_back(
-      StopLineInfo{
-        lanelet::utils::to2D(traffic_light->stopLine()->basicLineString()),
-        signal.traffic_light_group_id},
-      signal);
-  }
-  return stop_lines;
-}
-
-/// @brief get all stop lines associated with signals on the route, including permissive signals
-std::vector<StopLineInfo> collect_route_stop_lines(
-  const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
-  const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups)
-{
-  std::vector<StopLineInfo> stop_lines;
-  std::unordered_map<lanelet::Id, lanelet::Id> route_lanelet_id_per_traffic_light_id;
-  for (const auto & segment : route.segments) {
-    for (const auto & tl : lanelet_map.laneletLayer.get(segment.preferred_primitive.id)
-                             .regulatoryElementsAs<lanelet::TrafficLight>()) {
-      route_lanelet_id_per_traffic_light_id.emplace(tl->id(), segment.preferred_primitive.id);
-    }
-  }
-
-  for (const auto & signal : traffic_light_groups) {
-    if (
-      signal.elements.empty() ||
-      route_lanelet_id_per_traffic_light_id.find(signal.traffic_light_group_id) ==
-        route_lanelet_id_per_traffic_light_id.end()) {
-      continue;
-    }
-    const auto traffic_light_it =
-      lanelet_map.regulatoryElementLayer.find(signal.traffic_light_group_id);
-    if (traffic_light_it == lanelet_map.regulatoryElementLayer.end()) {
-      continue;
-    }
     const auto traffic_light =
       std::dynamic_pointer_cast<const lanelet::TrafficLight>(*traffic_light_it);
     if (!traffic_light || !traffic_light->stopLine().has_value()) {
       continue;
     }
     stop_lines.push_back(
-      StopLineInfo{
-        lanelet::utils::to2D(traffic_light->stopLine()->basicLineString()),
-        signal.traffic_light_group_id});
+      CollectedStopLine{
+        StopLineInfo{
+          lanelet::utils::to2D(traffic_light->stopLine()->basicLineString()),
+          signal.traffic_light_group_id},
+        signal,
+        autoware::traffic_light_utils::isTrafficSignalStop(
+          lanelet_map.laneletLayer.get(hit->second), signal)});
   }
   return stop_lines;
 }
 
-bool trajectory_crosses_stop_line(
-  const lanelet::BasicLineString2d & trajectory, const lanelet::BasicLineString2d & stop_line)
+std::optional<double> distance_between_stop_point_and_stop_line(
+  const std::optional<lanelet::BasicPoint2d> & stop_point,
+  const lanelet::BasicLineString2d & stop_line)
 {
-  for (size_t i = 0; i + 1 < trajectory.size(); ++i) {
-    const lanelet::BasicLineString2d segment{trajectory[i], trajectory[i + 1]};
-    lanelet::BasicPoints2d intersection_points;
-    boost::geometry::intersection(segment, stop_line, intersection_points);
-    if (!intersection_points.empty()) {
-      return true;
-    }
+  if (stop_point.has_value()) {
+    return boost::geometry::distance(*stop_point, stop_line);
   }
-  return false;
+  return std::nullopt;
 }
+
 }  // namespace
 
 namespace autoware::traffic_light_compliance_checker
@@ -159,8 +122,6 @@ TrafficLightComplianceChecker::TrafficLightComplianceChecker(
     std::make_unique<TrafficLightStatusTracker>(to_status_tracker_parameters(parameters)))
 {
 }
-
-TrafficLightComplianceChecker::~TrafficLightComplianceChecker() = default;
 
 void TrafficLightComplianceChecker::update_parameters(const Parameters & parameters)
 {
@@ -206,11 +167,31 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
     get_force_reject_amber_ids(input.current_time, is_ego_stopped);
   cleanup_crossing_commitment_history(input.current_time);
 
-  auto result = check_with_filtered_signals(
+  auto result = get_crossings_with_filtered_signals(
     input, filtered_signals, force_reject_amber_ids, check_red_lights, check_amber_lights);
   if (!result) {
     return result;
   }
+
+  if (params_.crossing_commitment_duration > 0.0 && !input.trajectory.empty()) {
+    const auto front_pose = autoware_utils_geometry::calc_offset_pose(
+      input.trajectory.front().pose, vehicle_info_.max_longitudinal_offset_m, 0.0, 0.0);
+    const lanelet::BasicPoint2d ego_base_point(
+      input.trajectory.front().pose.position.x, input.trajectory.front().pose.position.y);
+    const lanelet::BasicPoint2d ego_front_point(front_pose.position.x, front_pose.position.y);
+    update_commitments(
+      result->crossings, input.current_time, params_.crossing_commitment_distance, ego_base_point,
+      ego_front_point);
+    remove_violations_for_commited_stop_lines(result->crossings);
+  }
+
+  result->crossings.erase(
+    std::remove_if(
+      result->crossings.begin(), result->crossings.end(),
+      [&](const StopLineCrossing & crossing) {
+        return crossing.violation_type == ViolationType::NONE;
+      }),
+    result->crossings.end());
 
   update_amber_rejection_history(*result, input.current_time, force_reject_amber_ids);
   cleanup_amber_rejection_history(input.current_time);
@@ -237,15 +218,15 @@ void TrafficLightComplianceChecker::update_amber_rejection_history(
   const ComplianceResult & result, const rclcpp::Time & current_time,
   const std::vector<int64_t> & force_reject_amber_ids)
 {
-  for (const auto & violation : result.violations) {
-    if (violation.type != ViolationType::AMBER_LIGHT) {
+  for (const auto & crossing : result.crossings) {
+    if (crossing.violation_type != ViolationType::AMBER_LIGHT) {
       continue;
     }
     if (
       std::find(
-        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), violation.traffic_light_id) ==
+        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), crossing.traffic_light_id) ==
       force_reject_amber_ids.end()) {
-      amber_rejection_history_[violation.traffic_light_id] = current_time;
+      amber_rejection_history_[crossing.traffic_light_id] = current_time;
     }
   }
 }
@@ -275,18 +256,53 @@ void TrafficLightComplianceChecker::cleanup_crossing_commitment_history(
   }
 }
 
-std::vector<Violation> TrafficLightComplianceChecker::get_red_light_violations(
-  const std::vector<StopLineInfo> & red_stop_lines,
-  const lanelet::BasicLineString2d & trajectory_ls,
-  const std::optional<lanelet::BasicPoint2d> & stop_point, const double distance_offset) const
+void TrafficLightComplianceChecker::update_commitments(
+  const std::vector<StopLineCrossing> & crossings, const rclcpp::Time & current_time,
+  const double crossing_commitment_distance, const lanelet::BasicPoint2d & ego_base_point,
+  const lanelet::BasicPoint2d & ego_front_point)
 {
-  std::vector<Violation> violations;
-  for (const auto & red_stop_line : red_stop_lines) {
+  const lanelet::BasicLineString2d ego_to_front{ego_base_point, ego_front_point};
+  for (const auto & crossing : crossings) {
+    if (
+      crossing_commitment_history_.find(crossing.traffic_light_id) !=
+      crossing_commitment_history_.end()) {
+      continue;
+    }
+    if (
+      crossing.violation_type != ViolationType::NONE ||
+      crossing.distance_between_stop_point_and_stop_line.has_value()) {
+      continue;
+    }
+
+    auto front_has_reached_stop_line = false;
+    if (vehicle_info_.max_longitudinal_offset_m > 0.0) {
+      lanelet::BasicPoints2d intersection_points;
+      boost::geometry::intersection(ego_to_front, crossing.stop_line, intersection_points);
+      front_has_reached_stop_line = !intersection_points.empty();
+    }
+    const bool is_within_commitment_distance =
+      front_has_reached_stop_line ||
+      boost::geometry::distance(ego_front_point, crossing.stop_line) <=
+        crossing_commitment_distance;
+    if (is_within_commitment_distance) {
+      crossing_commitment_history_[crossing.traffic_light_id] =
+        CrossingCommitment{current_time, crossing.stop_line};
+    }
+  }
+}
+
+std::vector<StopLineCrossing> TrafficLightComplianceChecker::get_stop_line_crossings(
+  const std::vector<StopLineInfo> & stop_lines, const lanelet::BasicLineString2d & trajectory_ls,
+  const std::optional<lanelet::BasicPoint2d> & stop_point, const double distance_offset,
+  const ViolationType violation_type_for_crossing) const
+{
+  std::vector<StopLineCrossing> crossings;
+  for (const auto & stop_line : stop_lines) {
     auto distance_to_stop_line = 0.0;
     lanelet::BasicPoints2d intersection_points;
     for (size_t i = 0; i + 1 < trajectory_ls.size(); ++i) {
       const lanelet::BasicLineString2d segment{trajectory_ls[i], trajectory_ls[i + 1]};
-      boost::geometry::intersection(segment, red_stop_line.line, intersection_points);
+      boost::geometry::intersection(segment, stop_line.line, intersection_points);
       if (!intersection_points.empty()) {
         distance_to_stop_line += static_cast<double>(
           boost::geometry::distance(segment.front(), intersection_points.front()));
@@ -294,25 +310,34 @@ std::vector<Violation> TrafficLightComplianceChecker::get_red_light_violations(
       }
       distance_to_stop_line += static_cast<double>(boost::geometry::length(segment));
     }
-    if (
-      intersection_points.empty() ||
-      is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line))
+    if (intersection_points.empty()) {
       continue;
-    violations.emplace_back(
-      ViolationType::RED_LIGHT, red_stop_line.line, red_stop_line.traffic_light_id,
-      intersection_points.front(), distance_to_stop_line + distance_offset);
+    }
+    StopLineCrossing crossing(
+      stop_line.line, stop_line.traffic_light_id, intersection_points.front(),
+      distance_to_stop_line + distance_offset);
+    crossing.distance_between_stop_point_and_stop_line =
+      distance_between_stop_point_and_stop_line(stop_point, stop_line.line);
+    if (
+      violation_type_for_crossing != ViolationType::NONE &&
+      (!crossing.distance_between_stop_point_and_stop_line.has_value() ||
+       crossing.distance_between_stop_point_and_stop_line.value() >
+         params_.stop_overshoot_margin)) {
+      crossing.violation_type = violation_type_for_crossing;
+    }
+    crossings.push_back(crossing);
   }
-  return violations;
+  return crossings;
 }
 
-std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations(
+std::vector<StopLineCrossing> TrafficLightComplianceChecker::get_amber_light_crossings(
   const std::vector<StopLineInfo> & amber_stop_lines,
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
   const lanelet::BasicLineString2d & trajectory_ls,
   const std::optional<lanelet::BasicPoint2d> & stop_point,
   const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset) const
 {
-  std::vector<Violation> violations;
+  std::vector<StopLineCrossing> crossings;
   for (const auto & amber_stop_line : amber_stop_lines) {
     auto distance_to_stop_line = 0.0;
     std::optional<double> amber_stop_line_crossing_time;
@@ -336,11 +361,15 @@ std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations
       intersection_point = intersection_points.front();
       break;
     }
-
-    if (
-      !amber_stop_line_crossing_time ||
-      is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line))
+    if (!amber_stop_line_crossing_time.has_value()) {
       continue;
+    }
+
+    StopLineCrossing crossing(
+      amber_stop_line.line, amber_stop_line.traffic_light_id, intersection_point,
+      distance_to_stop_line + distance_offset);
+    crossing.distance_between_stop_point_and_stop_line =
+      distance_between_stop_point_and_stop_line(stop_point, amber_stop_line.line);
 
     const auto current_velocity = trajectory.front().longitudinal_velocity_mps;
     const auto current_acceleration = trajectory.front().acceleration_mps2;
@@ -353,16 +382,20 @@ std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations
       is_force_reject || !can_pass_amber_light(
                            distance_to_stop_line, current_velocity, current_acceleration,
                            *amber_stop_line_crossing_time)) {
-      violations.emplace_back(
-        ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id,
-        intersection_point, distance_to_stop_line + distance_offset);
+      if (
+        !crossing.distance_between_stop_point_and_stop_line.has_value() ||
+        crossing.distance_between_stop_point_and_stop_line.value() >
+          params_.stop_overshoot_margin) {
+        crossing.violation_type = ViolationType::AMBER_LIGHT;
+      }
     }
+    crossings.push_back(crossing);
   }
-  return violations;
+  return crossings;
 }
 
 tl::expected<ComplianceResult, std::string>
-TrafficLightComplianceChecker::check_with_filtered_signals(
+TrafficLightComplianceChecker::get_crossings_with_filtered_signals(
   const Inputs & input,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
   const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
@@ -426,109 +459,48 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
     if (stop_point.has_value()) stop_point.value() = offset_point;
   }
 
-  const auto [red_stop_lines, amber_stop_lines] =
-    get_stop_lines(*input.map, input.route, filtered_signals);
-
-  const auto is_committed = [this](const StopLineInfo & stop_line) {
-    return crossing_commitment_history_.find(stop_line.traffic_light_id) !=
-           crossing_commitment_history_.end();
-  };
-  auto uncommitted_red_stop_lines = red_stop_lines;
-  uncommitted_red_stop_lines.erase(
-    std::remove_if(
-      uncommitted_red_stop_lines.begin(), uncommitted_red_stop_lines.end(), is_committed),
-    uncommitted_red_stop_lines.end());
-  auto uncommitted_amber_stop_lines = amber_stop_lines;
-  uncommitted_amber_stop_lines.erase(
-    std::remove_if(
-      uncommitted_amber_stop_lines.begin(), uncommitted_amber_stop_lines.end(), is_committed),
-    uncommitted_amber_stop_lines.end());
+  const auto stop_line_infos = get_stop_lines(*input.map, input.route, filtered_signals);
 
   ComplianceResult result;
   if (check_red_lights) {
-    result.violations = get_red_light_violations(
-      uncommitted_red_stop_lines, trajectory_ls, stop_point, backward_length);
+    const auto red_light_crossings = get_stop_line_crossings(
+      stop_line_infos.red_stop_lines, trajectory_ls, stop_point, backward_length,
+      ViolationType::RED_LIGHT);
+    result.crossings.insert(
+      result.crossings.end(), red_light_crossings.begin(), red_light_crossings.end());
   }
   if (check_amber_lights) {
-    const auto amber_light_violations =
+    const auto amber_light_crossings =
       params_.treat_amber_light_as_red_light
-        ? get_red_light_violations(
-            uncommitted_amber_stop_lines, trajectory_ls, stop_point, backward_length)
-        : get_amber_light_violations(
-            uncommitted_amber_stop_lines, trajectory, trajectory_ls, stop_point,
+        ? get_stop_line_crossings(
+            stop_line_infos.amber_stop_lines, trajectory_ls, stop_point, backward_length,
+            ViolationType::RED_LIGHT)
+        : get_amber_light_crossings(
+            stop_line_infos.amber_stop_lines, trajectory, trajectory_ls, stop_point,
             force_reject_amber_ids, backward_length);
-    result.violations.insert(
-      result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
+    result.crossings.insert(
+      result.crossings.end(), amber_light_crossings.begin(), amber_light_crossings.end());
   }
-
-  if (params_.crossing_commitment_duration > 0.0 && !stop_point.has_value()) {
-    const auto front_pose = autoware_utils_geometry::calc_offset_pose(
-      trajectory.front().pose, vehicle_info_.max_longitudinal_offset_m, 0.0, 0.0);
-    const lanelet::BasicPoint2d base_point(
-      trajectory.front().pose.position.x, trajectory.front().pose.position.y);
-    const lanelet::BasicPoint2d front_point(front_pose.position.x, front_pose.position.y);
-    const auto route_stop_lines =
-      collect_route_stop_lines(*input.map, input.route, filtered_signals.traffic_light_groups);
-    for (const auto & stop_line : route_stop_lines) {
-      if (is_committed(stop_line)) {
-        continue;
-      }
-      const auto signal_it = std::find_if(
-        filtered_signals.traffic_light_groups.begin(), filtered_signals.traffic_light_groups.end(),
-        [&](const auto & signal) {
-          return signal.traffic_light_group_id == stop_line.traffic_light_id;
-        });
-      if (signal_it == filtered_signals.traffic_light_groups.end()) {
-        continue;
-      }
-      const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-        signal_it->elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-        autoware_perception_msgs::msg::TrafficLightElement::RED);
-      const bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-        signal_it->elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-        autoware_perception_msgs::msg::TrafficLightElement::AMBER);
-      const bool is_unknown = autoware::traffic_light_utils::hasTrafficLightColor(
-        signal_it->elements, autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN);
-      const bool is_red_policy = is_red ||
-                                 (is_unknown && params_.treat_unknown_light_as_red_light) ||
-                                 (is_amber && params_.treat_amber_light_as_red_light);
-      if (
-        (is_red_policy && !check_red_lights) ||
-        (is_amber && !params_.treat_amber_light_as_red_light && !check_amber_lights)) {
-        continue;
-      }
-      const bool has_violation = std::any_of(
-        result.violations.begin(), result.violations.end(), [&](const auto & violation) {
-          return violation.traffic_light_id == stop_line.traffic_light_id;
-        });
-      const lanelet::BasicLineString2d ego_to_front{base_point, front_point};
-      const bool front_has_reached_stop_line =
-        vehicle_info_.max_longitudinal_offset_m > 0.0 &&
-        trajectory_crosses_stop_line(ego_to_front, stop_line.line);
-      const bool is_within_commitment_distance =
-        front_has_reached_stop_line || boost::geometry::distance(front_point, stop_line.line) <=
-                                         params_.crossing_commitment_distance;
-      if (
-        !has_violation && is_within_commitment_distance &&
-        trajectory_crosses_stop_line(trajectory_ls, stop_line.line)) {
-        crossing_commitment_history_[stop_line.traffic_light_id] =
-          CrossingCommitment{input.current_time, stop_line.line};
-      }
-    }
-  }
-
+  const auto green_light_crossings = get_stop_line_crossings(
+    stop_line_infos.green_stop_lines, trajectory_ls, stop_point, backward_length);
+  result.crossings.insert(
+    result.crossings.end(), green_light_crossings.begin(), green_light_crossings.end());
+  const auto unknown_light_crossings = get_stop_line_crossings(
+    stop_line_infos.unknown_stop_lines, trajectory_ls, stop_point, backward_length);
+  result.crossings.insert(
+    result.crossings.end(), unknown_light_crossings.begin(), unknown_light_crossings.end());
   return result;
 }
 
-std::pair<std::vector<StopLineInfo>, std::vector<StopLineInfo>>
-TrafficLightComplianceChecker::get_stop_lines(
+StopLineInfos TrafficLightComplianceChecker::get_stop_lines(
   const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_lights) const
 {
-  std::vector<StopLineInfo> red_stop_lines;
-  std::vector<StopLineInfo> amber_stop_lines;
-  for (const auto & [stop_line_info, signal] :
+  StopLineInfos stop_line_infos;
+  for (const auto & collected_stop_line :
        collect_stop_lines(lanelet_map, route, traffic_lights.traffic_light_groups)) {
+    const auto & stop_line_info = collected_stop_line.stop_line_info;
+    const auto & signal = collected_stop_line.signal;
     const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
       signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
       autoware_perception_msgs::msg::TrafficLightElement::RED);
@@ -537,29 +509,23 @@ TrafficLightComplianceChecker::get_stop_lines(
       autoware_perception_msgs::msg::TrafficLightElement::AMBER);
     const bool is_unknown = autoware::traffic_light_utils::hasTrafficLightColor(
       signal.elements, autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN);
+    const bool is_green = autoware::traffic_light_utils::hasTrafficLightColor(
+      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::GREEN);
 
     const auto is_treated_as_red = is_red ||
                                    (is_unknown && params_.treat_unknown_light_as_red_light) ||
                                    (is_amber && params_.treat_amber_light_as_red_light);
-    if (is_treated_as_red) {
-      red_stop_lines.push_back(stop_line_info);
-    } else if (is_amber) {
-      amber_stop_lines.push_back(stop_line_info);
+    if (is_treated_as_red && collected_stop_line.is_stop_signal) {
+      stop_line_infos.red_stop_lines.push_back(stop_line_info);
+    } else if (is_amber && collected_stop_line.is_stop_signal) {
+      stop_line_infos.amber_stop_lines.push_back(stop_line_info);
+    } else if (is_green) {
+      stop_line_infos.green_stop_lines.push_back(stop_line_info);
+    } else {
+      stop_line_infos.unknown_stop_lines.push_back(stop_line_info);
     }
   }
-  return {red_stop_lines, amber_stop_lines};
-}
-
-bool TrafficLightComplianceChecker::is_stop_point_within_margin_from_stop_line(
-  const std::optional<lanelet::BasicPoint2d> & stop_point,
-  const lanelet::BasicLineString2d & stop_line) const
-{
-  if (stop_point.has_value()) {
-    if (boost::geometry::distance(*stop_point, stop_line) <= params_.stop_overshoot_margin) {
-      return true;
-    }
-  }
-  return false;
+  return stop_line_infos;
 }
 
 bool TrafficLightComplianceChecker::can_pass_amber_light(

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -416,8 +416,8 @@ TrafficLightComplianceChecker::get_crossings_with_filtered_signals(
                                          ? std::max(0.0, params_.crossing_commitment_distance) +
                                              vehicle_info_.max_longitudinal_offset_m
                                          : 0.0;
-  const auto max_trajectory_length =
-    std::max(ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin, commitment_check_length);
+  const auto max_trajectory_length = std::max(
+    ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin, commitment_check_length);
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -93,6 +93,59 @@ collect_stop_lines(
   }
   return stop_lines;
 }
+
+/// @brief get all stop lines associated with signals on the route, including permissive signals
+std::vector<StopLineInfo> collect_route_stop_lines(
+  const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups)
+{
+  std::vector<StopLineInfo> stop_lines;
+  std::unordered_map<lanelet::Id, lanelet::Id> route_lanelet_id_per_traffic_light_id;
+  for (const auto & segment : route.segments) {
+    for (const auto & tl : lanelet_map.laneletLayer.get(segment.preferred_primitive.id)
+                             .regulatoryElementsAs<lanelet::TrafficLight>()) {
+      route_lanelet_id_per_traffic_light_id.emplace(tl->id(), segment.preferred_primitive.id);
+    }
+  }
+
+  for (const auto & signal : traffic_light_groups) {
+    if (
+      signal.elements.empty() ||
+      route_lanelet_id_per_traffic_light_id.find(signal.traffic_light_group_id) ==
+        route_lanelet_id_per_traffic_light_id.end()) {
+      continue;
+    }
+    const auto traffic_light_it =
+      lanelet_map.regulatoryElementLayer.find(signal.traffic_light_group_id);
+    if (traffic_light_it == lanelet_map.regulatoryElementLayer.end()) {
+      continue;
+    }
+    const auto traffic_light =
+      std::dynamic_pointer_cast<const lanelet::TrafficLight>(*traffic_light_it);
+    if (!traffic_light || !traffic_light->stopLine().has_value()) {
+      continue;
+    }
+    stop_lines.push_back(
+      StopLineInfo{
+        lanelet::utils::to2D(traffic_light->stopLine()->basicLineString()),
+        signal.traffic_light_group_id});
+  }
+  return stop_lines;
+}
+
+bool trajectory_crosses_stop_line(
+  const lanelet::BasicLineString2d & trajectory, const lanelet::BasicLineString2d & stop_line)
+{
+  for (size_t i = 0; i + 1 < trajectory.size(); ++i) {
+    const lanelet::BasicLineString2d segment{trajectory[i], trajectory[i + 1]};
+    lanelet::BasicPoints2d intersection_points;
+    boost::geometry::intersection(segment, stop_line, intersection_points);
+    if (!intersection_points.empty()) {
+      return true;
+    }
+  }
+  return false;
+}
 }  // namespace
 
 namespace autoware::traffic_light_compliance_checker
@@ -113,6 +166,9 @@ void TrafficLightComplianceChecker::update_parameters(const Parameters & paramet
 {
   params_ = parameters;
   status_tracker_->update_parameters(to_status_tracker_parameters(parameters));
+  if (params_.crossing_commitment_duration <= 0.0) {
+    crossing_commitment_history_.clear();
+  }
 }
 
 tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
@@ -125,6 +181,7 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
 
   const auto force_reject_amber_ids =
     get_force_reject_amber_ids(input.current_time, is_ego_stopped);
+  cleanup_crossing_commitment_history(input.current_time);
 
   auto result = check_with_filtered_signals(
     input, filtered_signals, force_reject_amber_ids, check_red_lights, check_amber_lights);
@@ -176,6 +233,19 @@ void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
     if ((current_time - it->second).seconds() > params_.amber_rejection_hysteresis_duration) {
       it = amber_rejection_history_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void TrafficLightComplianceChecker::cleanup_crossing_commitment_history(
+  const rclcpp::Time & current_time)
+{
+  for (auto it = crossing_commitment_history_.begin(); it != crossing_commitment_history_.end();) {
+    const auto elapsed = (current_time - it->second).seconds();
+    if (elapsed < 0.0 || elapsed > params_.crossing_commitment_duration) {
+      it = crossing_commitment_history_.erase(it);
     } else {
       ++it;
     }
@@ -273,7 +343,7 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
   const Inputs & input,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
   const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
-  const bool check_amber_lights) const
+  const bool check_amber_lights)
 {
   if (input.trajectory.empty() || (!check_red_lights && !check_amber_lights)) {
     return ComplianceResult{};
@@ -286,8 +356,12 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
     params_.checked_trajectory_length.deceleration_limit,
     params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
   // add the stop_overshoot_margin to not skip points beyond the stop line but within the margin
+  const auto commitment_check_length = params_.crossing_commitment_duration > 0.0
+                                         ? std::max(0.0, params_.crossing_commitment_distance) +
+                                             vehicle_info_.max_longitudinal_offset_m
+                                         : 0.0;
   const auto max_trajectory_length =
-    ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin;
+    std::max(ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin, commitment_check_length);
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;
@@ -332,20 +406,91 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
   const auto [red_stop_lines, amber_stop_lines] =
     get_stop_lines(*input.map, input.route, filtered_signals);
 
+  const auto is_committed = [this](const StopLineInfo & stop_line) {
+    return crossing_commitment_history_.find(stop_line.traffic_light_id) !=
+           crossing_commitment_history_.end();
+  };
+  auto uncommitted_red_stop_lines = red_stop_lines;
+  uncommitted_red_stop_lines.erase(
+    std::remove_if(
+      uncommitted_red_stop_lines.begin(), uncommitted_red_stop_lines.end(), is_committed),
+    uncommitted_red_stop_lines.end());
+  auto uncommitted_amber_stop_lines = amber_stop_lines;
+  uncommitted_amber_stop_lines.erase(
+    std::remove_if(
+      uncommitted_amber_stop_lines.begin(), uncommitted_amber_stop_lines.end(), is_committed),
+    uncommitted_amber_stop_lines.end());
+
   ComplianceResult result;
   if (check_red_lights) {
-    result.violations =
-      get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
+    result.violations = get_red_light_violations(
+      uncommitted_red_stop_lines, trajectory_ls, stop_point, backward_length);
   }
   if (check_amber_lights) {
     const auto amber_light_violations =
       params_.treat_amber_light_as_red_light
-        ? get_red_light_violations(amber_stop_lines, trajectory_ls, stop_point, backward_length)
+        ? get_red_light_violations(
+            uncommitted_amber_stop_lines, trajectory_ls, stop_point, backward_length)
         : get_amber_light_violations(
-            amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
-            backward_length);
+            uncommitted_amber_stop_lines, trajectory, trajectory_ls, stop_point,
+            force_reject_amber_ids, backward_length);
     result.violations.insert(
       result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
+  }
+
+  if (params_.crossing_commitment_duration > 0.0 && !stop_point.has_value()) {
+    const auto front_pose = autoware_utils_geometry::calc_offset_pose(
+      trajectory.front().pose, vehicle_info_.max_longitudinal_offset_m, 0.0, 0.0);
+    const lanelet::BasicPoint2d base_point(
+      trajectory.front().pose.position.x, trajectory.front().pose.position.y);
+    const lanelet::BasicPoint2d front_point(front_pose.position.x, front_pose.position.y);
+    const auto route_stop_lines =
+      collect_route_stop_lines(*input.map, input.route, filtered_signals.traffic_light_groups);
+    for (const auto & stop_line : route_stop_lines) {
+      if (is_committed(stop_line)) {
+        continue;
+      }
+      const auto signal_it = std::find_if(
+        filtered_signals.traffic_light_groups.begin(), filtered_signals.traffic_light_groups.end(),
+        [&](const auto & signal) {
+          return signal.traffic_light_group_id == stop_line.traffic_light_id;
+        });
+      if (signal_it == filtered_signals.traffic_light_groups.end()) {
+        continue;
+      }
+      const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+        signal_it->elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+        autoware_perception_msgs::msg::TrafficLightElement::RED);
+      const bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+        signal_it->elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+        autoware_perception_msgs::msg::TrafficLightElement::AMBER);
+      const bool is_unknown = autoware::traffic_light_utils::hasTrafficLightColor(
+        signal_it->elements, autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN);
+      const bool is_red_policy = is_red ||
+                                 (is_unknown && params_.treat_unknown_light_as_red_light) ||
+                                 (is_amber && params_.treat_amber_light_as_red_light);
+      if (
+        (is_red_policy && !check_red_lights) ||
+        (is_amber && !params_.treat_amber_light_as_red_light && !check_amber_lights)) {
+        continue;
+      }
+      const bool has_violation = std::any_of(
+        result.violations.begin(), result.violations.end(), [&](const auto & violation) {
+          return violation.traffic_light_id == stop_line.traffic_light_id;
+        });
+      const lanelet::BasicLineString2d ego_to_front{base_point, front_point};
+      const bool front_has_reached_stop_line =
+        vehicle_info_.max_longitudinal_offset_m > 0.0 &&
+        trajectory_crosses_stop_line(ego_to_front, stop_line.line);
+      const bool is_within_commitment_distance =
+        front_has_reached_stop_line || boost::geometry::distance(front_point, stop_line.line) <=
+                                         params_.crossing_commitment_distance;
+      if (
+        !has_violation && is_within_commitment_distance &&
+        trajectory_crosses_stop_line(trajectory_ls, stop_line.line)) {
+        crossing_commitment_history_[stop_line.traffic_light_id] = input.current_time;
+      }
+    }
   }
 
   return result;

--- a/planning/autoware_trajectory_processor/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_modifier.param.yaml
@@ -139,3 +139,5 @@
       th_stable_duration_amber: 0.2 # [s]
       th_amber_rejection_hysteresis: 0.5 # [s]
       crossing_time_limit: 2.75 # [s]
+      crossing_commitment_distance: 0.0 # [m] zero disables
+      crossing_commitment_duration: 0.0 # [s] zero disables

--- a/planning/autoware_trajectory_processor/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_modifier.param.yaml
@@ -139,5 +139,5 @@
       th_stable_duration_amber: 0.2 # [s]
       th_amber_rejection_hysteresis: 0.5 # [s]
       crossing_time_limit: 2.75 # [s]
-      crossing_commitment_distance: 0.0 # [m] zero disables
+      crossing_commitment_distance: 0.0 # [m] zero commits once the ego front reaches or passes the stop line
       crossing_commitment_duration: 0.0 # [s] zero disables

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/traffic_light_stop.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/traffic_light_stop.hpp
@@ -26,7 +26,6 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
-#include <string>
 
 namespace autoware::trajectory_modifier::plugin
 {
@@ -55,7 +54,7 @@ private:
   TrajectoryModifierParams::TrafficLightStop params_;
   TrajectoryModifierParams::StoppingConstraints stopping_params_;
 
-  std::optional<autoware::traffic_light_compliance_checker::Violation> nearest_violation_;
+  std::optional<autoware::traffic_light_compliance_checker::StopLineCrossing> nearest_violation_;
 
   std::unique_ptr<autoware::traffic_light_compliance_checker::TrafficLightComplianceChecker>
     checker_;
@@ -74,7 +73,7 @@ private:
 
   bool set_stop_point(TrajectoryPoints & traj_points, const InputData & input);
 
-  bool check_inputs(const InputData & input);
+  static bool check_inputs(const InputData & input);
 
   void publish_debug_string() const;
 };

--- a/planning/autoware_trajectory_processor/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_modifier_parameter_struct.yaml
@@ -507,3 +507,17 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
+    crossing_commitment_distance:
+      type: double
+      default_value: 0.0
+      description: Maximum distance at which an accepted stop-line crossing is remembered [m]
+      validation:
+        bounds<>: [0.0, 100.0]
+      read_only: false
+    crossing_commitment_duration:
+      type: double
+      default_value: 0.0
+      description: Duration to remember an accepted stop-line crossing [s]
+      validation:
+        bounds<>: [0.0, 60.0]
+      read_only: false

--- a/planning/autoware_trajectory_processor/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_modifier.schema.json
@@ -579,6 +579,18 @@
               "description": "Crossing time limit [s]",
               "default": 2.75,
               "minimum": 0.0
+            },
+            "crossing_commitment_distance": {
+              "type": "number",
+              "description": "Maximum distance at which an accepted stop-line crossing is remembered [m]",
+              "default": 0.0,
+              "minimum": 0.0
+            },
+            "crossing_commitment_duration": {
+              "type": "number",
+              "description": "Duration for which an accepted stop-line crossing remains valid (seconds); zero disables the feature.",
+              "default": 0.0,
+              "minimum": 0.0
             }
           },
           "required": [],

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -28,7 +28,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
 {
   const auto tl_stop_p = params.traffic_light_stop;
   const auto stopping_params = params.stopping_constraints;
-  autoware::traffic_light_compliance_checker::Parameters p;
+  autoware::traffic_light_compliance_checker::Parameters p{};
   p.deceleration_limit = stopping_params.maximum_deceleration;
   p.jerk_limit = stopping_params.jerk_limit;
   p.crossing_time_limit = tl_stop_p.crossing_time_limit;
@@ -115,12 +115,12 @@ bool TrafficLightStop::check_traffic_lights(
     checker_->check(inputs, params_.stop_for_red_light, params_.stop_for_amber_light);
   if (!result) return false;
 
-  if (result->violations.empty()) return false;
+  if (result->crossings.empty()) return false;
 
-  const auto nearest_it = std::min_element(result->violations.begin(), result->violations.end());
+  const auto nearest_it = std::min_element(result->crossings.begin(), result->crossings.end());
   nearest_violation_ = *nearest_it;
 
-  debug_data_.violations_count = result->violations.size();
+  debug_data_.violations_count = result->crossings.size();
   debug_data_.nearest_violation_arc_length = nearest_it->arc_length_to_cross_point;
 
   RCLCPP_WARN_THROTTLE(

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -32,6 +32,8 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.deceleration_limit = stopping_params.maximum_deceleration;
   p.jerk_limit = stopping_params.jerk_limit;
   p.crossing_time_limit = tl_stop_p.crossing_time_limit;
+  p.crossing_commitment_distance = tl_stop_p.crossing_commitment_distance;
+  p.crossing_commitment_duration = tl_stop_p.crossing_commitment_duration;
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
   p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
@@ -199,13 +201,19 @@ void TrafficLightStop::publish_debug_string() const
 {
   std::ostringstream ss;
   ss << std::fixed << std::setprecision(2) << std::boolalpha;
-  ss << "TRAFFIC LIGHT STOP MODIFIER: " << "\n";
-  ss << "\t\t" << "ACTIVE: " << debug_data_.active << "\n";
+  ss << "TRAFFIC LIGHT STOP MODIFIER: "
+     << "\n";
+  ss << "\t\t"
+     << "ACTIVE: " << debug_data_.active << "\n";
   if (debug_data_.active) {
-    ss << "\t\t" << "VIOLATIONS: " << debug_data_.violations_count << "\n";
-    ss << "\t\t" << "NEAREST VIOLATION: " << debug_data_.nearest_violation_arc_length << " m"
+    ss << "\t\t"
+       << "VIOLATIONS: " << debug_data_.violations_count << "\n";
+    ss << "\t\t"
+       << "NEAREST VIOLATION: " << debug_data_.nearest_violation_arc_length << " m"
        << "\n";
-    ss << "\t\t" << "STOP POINT: " << debug_data_.stop_point_arc_length << " m" << "\n";
+    ss << "\t\t"
+       << "STOP POINT: " << debug_data_.stop_point_arc_length << " m"
+       << "\n";
   }
   StringStamped string_stamp;
   string_stamp.stamp = get_clock()->now();

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -22,6 +22,8 @@
       jerk_limit: 5.0  # [m/s^3] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
       delay_response_time: 0.5 # [s] delay response time used to estimate the minimum ego stopping distance
       crossing_time_limit: 2.75 # [s] trajectories crossing an amber light are rejected if they cannot cross before this time
+      crossing_commitment_distance: 0.0 # [m] maximum distance at which an accepted crossing is remembered; zero disables
+      crossing_commitment_duration: 0.0 # [s] duration to remember an accepted crossing; zero disables
       treat_amber_light_as_red_light: true # [-] when true, amber lights are handled like red lights
       treat_unknown_light_as_red_light: false # [-] when true, unknown lights are handled like red lights
       stop_overshoot_margin: 0.5 # [m] maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -22,7 +22,7 @@
       jerk_limit: 5.0  # [m/s^3] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
       delay_response_time: 0.5 # [s] delay response time used to estimate the minimum ego stopping distance
       crossing_time_limit: 2.75 # [s] trajectories crossing an amber light are rejected if they cannot cross before this time
-      crossing_commitment_distance: 0.0 # [m] maximum distance at which an accepted crossing is remembered; zero disables
+      crossing_commitment_distance: 0.0 # [m] maximum distance before the line; zero commits once the ego front reaches or passes it
       crossing_commitment_duration: 0.0 # [s] duration to remember an accepted crossing; zero disables
       treat_amber_light_as_red_light: true # [-] when true, amber lights are handled like red lights
       treat_unknown_light_as_red_light: false # [-] when true, unknown lights are handled like red lights

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
+#include <autoware/traffic_light_compliance_checker/structs.hpp>
 #include <autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp>
 
 #include <geometry_msgs/msg/point.hpp>
@@ -56,7 +57,7 @@ private:
   std::optional<rclcpp::Time> last_frame_time_;
 
   void update_debug_data(
-    const std::vector<traffic_light_compliance_checker::Violation> & violations,
+    const std::vector<traffic_light_compliance_checker::StopLineCrossing> & violations,
     const std::vector<traffic_light_compliance_checker::CrossingCommitmentDebugInfo> &
       crossing_commitments,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_light_signals,

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -57,6 +57,8 @@ private:
 
   void update_debug_data(
     const std::vector<traffic_light_compliance_checker::Violation> & violations,
+    const std::vector<traffic_light_compliance_checker::CrossingCommitmentDebugInfo> &
+      crossing_commitments,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_light_signals,
     const rclcpp::Time & current_time, const double z);
 };

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -59,6 +59,16 @@ validator:
       default_value: 2.75
       description: trajectories crossing an amber light are rejected if they cannot cross before this time
       read_only: false
+    crossing_commitment_distance:
+      type: double
+      default_value: 0.0
+      description: Maximum distance to a stop line at which an accepted crossing trajectory commits ego to crossing (m); zero disables the feature
+      read_only: false
+    crossing_commitment_duration:
+      type: double
+      default_value: 0.0
+      description: Duration for which a stop-line crossing commitment remains valid (seconds); zero disables the feature
+      read_only: false
     treat_amber_light_as_red_light:
       type: bool
       default_value: true

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -62,7 +62,7 @@ validator:
     crossing_commitment_distance:
       type: double
       default_value: 0.0
-      description: Maximum distance to a stop line at which an accepted crossing trajectory commits ego to crossing (m); zero disables the feature
+      description: Maximum distance before a stop line at which an accepted crossing trajectory commits ego to crossing (m); zero permits commitment once the ego front reaches or passes the line
       read_only: false
     crossing_commitment_duration:
       type: double

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -142,6 +142,18 @@
               },
               "required": [],
               "additionalProperties": false
+            },
+            "crossing_commitment_distance": {
+              "type": "number",
+              "description": "Maximum distance at which an accepted stop-line crossing is remembered [m]",
+              "default": 0.0,
+              "minimum": 0.0
+            },
+            "crossing_commitment_duration": {
+              "type": "number",
+              "description": "Duration for which an accepted stop-line crossing remains valid (seconds); zero disables the feature.",
+              "default": 0.0,
+              "minimum": 0.0
             }
           },
           "required": [],

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -16,7 +16,10 @@
 
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 
+#include <algorithm>
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -95,6 +98,13 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.checked_trajectory_length.jerk_limit = params.checked_trajectory_length.jerk_limit;
   return p;
 }
+
+std::string format_seconds(const double seconds)
+{
+  std::ostringstream stream;
+  stream << std::fixed << std::setprecision(2) << seconds;
+  return stream.str();
+}
 }  // namespace
 
 namespace autoware::trajectory_validator::plugin::traffic_rule
@@ -164,8 +174,8 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   }
 
   update_debug_data(
-    result->violations, *context.traffic_light_signals, current_time,
-    context.odometry->pose.pose.position.z);
+    result->violations, checker_->get_crossing_commitment_debug_info(current_time),
+    *context.traffic_light_signals, current_time, context.odometry->pose.pose.position.z);
 
   std::vector<MetricReport> metrics;
 
@@ -198,6 +208,8 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
 
 void TrafficLightFilter::update_debug_data(
   const std::vector<traffic_light_compliance_checker::Violation> & violations,
+  const std::vector<traffic_light_compliance_checker::CrossingCommitmentDebugInfo> &
+    crossing_commitments,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_light_signals,
   const rclcpp::Time & current_time, const double z)
 {
@@ -247,6 +259,22 @@ void TrafficLightFilter::update_debug_data(
 
     marker.text = "TL: " + std::to_string(tl_id) + ", " + info.signal_label +
                   ", Rejections: " + std::to_string(info.rejection_count);
+
+    debug_markers_.markers.push_back(marker);
+  }
+
+  marker.ns = "crossing_commitment_info";
+  marker.color.r = 0.0;
+  marker.color.g = 0.8;
+  marker.color.b = 1.0;
+  for (const auto & commitment : crossing_commitments) {
+    marker.id = static_cast<int>(debug_markers_.markers.size());
+    marker.pose.position.x = commitment.stop_line.front().x();
+    marker.pose.position.y = commitment.stop_line.front().y();
+    marker.pose.position.z = z + 2.8;
+    marker.text = "TL: " + std::to_string(commitment.traffic_light_id) +
+                  ", crossing committed, Remaining: " + format_seconds(commitment.remaining_time) +
+                  "s";
 
     debug_markers_.markers.push_back(marker);
   }

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -80,6 +80,8 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.jerk_limit = params.jerk_limit;
   p.delay_response_time = params.delay_response_time;
   p.crossing_time_limit = params.crossing_time_limit;
+  p.crossing_commitment_distance = params.crossing_commitment_distance;
+  p.crossing_commitment_duration = params.crossing_commitment_duration;
   p.treat_amber_light_as_red_light = params.treat_amber_light_as_red_light;
   p.treat_unknown_light_as_red_light = params.treat_unknown_light_as_red_light;
   p.stop_overshoot_margin = params.stop_overshoot_margin;

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp"
 
+#include <autoware/traffic_light_compliance_checker/structs.hpp>
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 
 #include <algorithm>
@@ -165,16 +166,17 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   bool is_crossing_red = false;
   bool is_crossing_amber = false;
 
-  for (const auto & violation : result->violations) {
-    if (violation.type == traffic_light_compliance_checker::ViolationType::RED_LIGHT) {
+  for (const auto & violation : result->crossings) {
+    if (violation.violation_type == traffic_light_compliance_checker::ViolationType::RED_LIGHT) {
       is_crossing_red = true;
-    } else if (violation.type == traffic_light_compliance_checker::ViolationType::AMBER_LIGHT) {
+    } else if (
+      violation.violation_type == traffic_light_compliance_checker::ViolationType::AMBER_LIGHT) {
       is_crossing_amber = true;
     }
   }
 
   update_debug_data(
-    result->violations, checker_->get_crossing_commitment_debug_info(current_time),
+    result->crossings, checker_->get_crossing_commitment_debug_info(current_time),
     *context.traffic_light_signals, current_time, context.odometry->pose.pose.position.z);
 
   std::vector<MetricReport> metrics;
@@ -207,7 +209,7 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
 }
 
 void TrafficLightFilter::update_debug_data(
-  const std::vector<traffic_light_compliance_checker::Violation> & violations,
+  const std::vector<traffic_light_compliance_checker::StopLineCrossing> & violations,
   const std::vector<traffic_light_compliance_checker::CrossingCommitmentDebugInfo> &
     crossing_commitments,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_light_signals,

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -352,6 +352,52 @@ TEST_F(TrafficLightFilterTest, AcceptedCrossingOutsideCommitmentDistanceIsNotRem
     "A crossing farther away than the configured distance should not create a commitment");
 }
 
+TEST_F(TrafficLightFilterTest, CrossingCommitmentDistanceIsMeasuredFromEgoFrontPoint)
+{
+  constexpr lanelet::Id light_id = 116;
+  constexpr double stop_x = 5.0;
+  set_crossing_commitment_parameters(4.0, 2.0);
+
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+  vehicle_info.max_longitudinal_offset_m = 2.0;
+  filter_->set_vehicle_info(vehicle_info);
+  create_and_set_map(light_id, stop_x);
+
+  // The stop line is 5 m from base_link but only 3 m from the 2 m front offset.
+  const auto crossing_trajectory = create_trajectory(0.0, 10.0);
+  set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
+  expect_feasibility(crossing_trajectory, true);
+
+  advance_time(0.1);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  expect_feasibility(
+    crossing_trajectory, true,
+    "The crossing should be remembered because the ego front is within the distance threshold");
+}
+
+TEST_F(TrafficLightFilterTest, ZeroCommitmentDistanceAllowsEgoFrontBeyondStopLine)
+{
+  constexpr lanelet::Id light_id = 117;
+  constexpr double stop_x = 1.5;
+  set_crossing_commitment_parameters(0.0, 2.0);
+
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+  vehicle_info.max_longitudinal_offset_m = 2.0;
+  filter_->set_vehicle_info(vehicle_info);
+  create_and_set_map(light_id, stop_x);
+
+  // The base_link is before the stop line while the ego front is 0.5 m beyond it.
+  const auto crossing_trajectory = create_trajectory(0.0, 10.0);
+  set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
+  expect_feasibility(crossing_trajectory, true);
+
+  advance_time(0.1);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  expect_feasibility(
+    crossing_trajectory, true,
+    "A zero distance should still remember a crossing once the ego front passed the stop line");
+}
+
 TEST_F(TrafficLightFilterTest, NonCrossingTrajectoryDoesNotCreateCrossingCommitment)
 {
   constexpr lanelet::Id light_id = 113;

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -56,6 +56,8 @@ protected:
     node_->declare_parameter("traffic_light.jerk_limit", 5.0);
     node_->declare_parameter("traffic_light.delay_response_time", 0.5);
     node_->declare_parameter("traffic_light.crossing_time_limit", 2.75);
+    node_->declare_parameter("traffic_light.crossing_commitment_distance", 0.0);
+    node_->declare_parameter("traffic_light.crossing_commitment_duration", 0.0);
     node_->declare_parameter("traffic_light.treat_amber_light_as_red_light", false);
     node_->declare_parameter("traffic_light.treat_unknown_light_as_red_light", false);
     node_->declare_parameter("traffic_light.stable_duration_threshold_red", 0.0);
@@ -66,21 +68,22 @@ protected:
     node_->declare_parameter("traffic_light.checked_trajectory_length.deceleration_limit", 999.9);
     node_->declare_parameter("traffic_light.checked_trajectory_length.jerk_limit", 999.9);
 
-    validator::Params params;
-    params.traffic_light.deceleration_limit = 2.8;
-    params.traffic_light.jerk_limit = 5.0;
-    params.traffic_light.delay_response_time = 0.5;
-    params.traffic_light.crossing_time_limit = 2.75;
-    params.traffic_light.treat_amber_light_as_red_light = false;
-    params.traffic_light.treat_unknown_light_as_red_light = false;
-    params.traffic_light.stable_duration_threshold_red = 0.0;
-    params.traffic_light.stable_duration_threshold_amber = 0.0;
-    params.traffic_light.stable_duration_threshold_unknown = 0.0;
-    params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
-    params.traffic_light.ego_stopped_velocity_threshold = 0.01;
-    params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
-    params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
-    filter_->update_parameters(params);
+    params_.traffic_light.deceleration_limit = 2.8;
+    params_.traffic_light.jerk_limit = 5.0;
+    params_.traffic_light.delay_response_time = 0.5;
+    params_.traffic_light.crossing_time_limit = 2.75;
+    params_.traffic_light.crossing_commitment_distance = 0.0;
+    params_.traffic_light.crossing_commitment_duration = 0.0;
+    params_.traffic_light.treat_amber_light_as_red_light = false;
+    params_.traffic_light.treat_unknown_light_as_red_light = false;
+    params_.traffic_light.stable_duration_threshold_red = 0.0;
+    params_.traffic_light.stable_duration_threshold_amber = 0.0;
+    params_.traffic_light.stable_duration_threshold_unknown = 0.0;
+    params_.traffic_light.amber_rejection_hysteresis_duration = 0.0;
+    params_.traffic_light.ego_stopped_velocity_threshold = 0.01;
+    params_.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
+    params_.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+    filter_->update_parameters(params_);
 
     context_.traffic_light_signals = std::make_shared<TrafficLightGroupArray>();
     context_.route = std::make_shared<autoware_planning_msgs::msg::LaneletRoute>();
@@ -186,9 +189,25 @@ protected:
     EXPECT_EQ(res->is_feasible, expected_feasible) << message;
   }
 
+  void set_crossing_commitment_parameters(const double distance, const double duration)
+  {
+    params_.traffic_light.crossing_commitment_distance = distance;
+    params_.traffic_light.crossing_commitment_duration = duration;
+    filter_->update_parameters(params_);
+  }
+
+  void advance_time(const double duration)
+  {
+    auto odometry = *context_.odometry;
+    odometry.header.stamp =
+      rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(duration);
+    context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+  }
+
   std::shared_ptr<TrafficLightFilter> filter_;
   std::shared_ptr<rclcpp::Node> node_;
   FilterContext context_;
+  validator::Params params_;
 };
 
 TEST_F(TrafficLightFilterTest, IsFeasibleEmptyInput)
@@ -272,6 +291,125 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithGreenLight)
   auto points = create_trajectory(0.0, 10.0);
 
   expect_feasibility(points, true, "Should return true for green light");
+}
+
+TEST_F(TrafficLightFilterTest, AcceptedCrossingRemainsFeasibleAfterSignalTurnsRed)
+{
+  constexpr lanelet::Id light_id = 110;
+  constexpr double stop_x = 5.0;
+  set_crossing_commitment_parameters(6.0, 2.0);
+  create_and_set_map(light_id, stop_x);
+
+  const auto crossing_trajectory = create_trajectory(0.0, 10.0);
+  set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
+  expect_feasibility(crossing_trajectory, true, "The green-light crossing should be accepted");
+
+  advance_time(1.0);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  expect_feasibility(
+    crossing_trajectory, true,
+    "An accepted nearby crossing should remain feasible while its commitment is active");
+}
+
+TEST_F(TrafficLightFilterTest, CrossingCommitmentExpiresAfterConfiguredDuration)
+{
+  constexpr lanelet::Id light_id = 111;
+  constexpr double stop_x = 5.0;
+  set_crossing_commitment_parameters(6.0, 2.0);
+  create_and_set_map(light_id, stop_x);
+
+  const auto crossing_trajectory = create_trajectory(0.0, 10.0);
+  set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
+  expect_feasibility(crossing_trajectory, true);
+
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  advance_time(2.0);
+  expect_feasibility(
+    crossing_trajectory, true,
+    "The commitment should remain active at exactly the configured duration");
+
+  advance_time(0.001);
+  expect_feasibility(
+    crossing_trajectory, false,
+    "A red-light crossing should be rejected once the commitment duration has elapsed");
+}
+
+TEST_F(TrafficLightFilterTest, AcceptedCrossingOutsideCommitmentDistanceIsNotRemembered)
+{
+  constexpr lanelet::Id light_id = 112;
+  constexpr double stop_x = 5.0;
+  set_crossing_commitment_parameters(4.0, 2.0);
+  create_and_set_map(light_id, stop_x);
+
+  const auto crossing_trajectory = create_trajectory(0.0, 10.0);
+  set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
+  expect_feasibility(crossing_trajectory, true);
+
+  advance_time(0.1);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  expect_feasibility(
+    crossing_trajectory, false,
+    "A crossing farther away than the configured distance should not create a commitment");
+}
+
+TEST_F(TrafficLightFilterTest, NonCrossingTrajectoryDoesNotCreateCrossingCommitment)
+{
+  constexpr lanelet::Id light_id = 113;
+  constexpr double stop_x = 5.0;
+  set_crossing_commitment_parameters(6.0, 2.0);
+  create_and_set_map(light_id, stop_x);
+
+  set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
+  expect_feasibility(create_trajectory(0.0, 4.0), true);
+
+  advance_time(0.1);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  expect_feasibility(
+    create_trajectory(0.0, 10.0), false,
+    "A previously accepted trajectory that did not cross the line should not grant permission");
+}
+
+TEST_F(TrafficLightFilterTest, TrajectoryStoppingBeforeLineDoesNotCreateCrossingCommitment)
+{
+  constexpr lanelet::Id light_id = 114;
+  constexpr double stop_x = 5.0;
+  set_crossing_commitment_parameters(6.0, 2.0);
+  create_and_set_map(light_id, stop_x);
+
+  auto stopping_trajectory = create_trajectory(0.0, 10.0);
+  auto stop_point = stopping_trajectory.front();
+  stop_point.pose.position.x = 4.0;
+  stop_point.longitudinal_velocity_mps = 0.0;
+  stop_point.time_from_start = rclcpp::Duration::from_seconds(0.8);
+  stopping_trajectory.insert(stopping_trajectory.begin() + 1, stop_point);
+
+  set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
+  expect_feasibility(stopping_trajectory, true);
+
+  advance_time(0.1);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  expect_feasibility(
+    create_trajectory(0.0, 10.0), false,
+    "A trajectory stopping before the line should not create a crossing commitment");
+}
+
+TEST_F(TrafficLightFilterTest, AcceptedAmberCrossingCreatesCrossingCommitment)
+{
+  constexpr lanelet::Id light_id = 115;
+  constexpr double stop_x = 5.0;
+  set_crossing_commitment_parameters(6.0, 2.0);
+  create_and_set_map(light_id, stop_x);
+
+  const auto crossing_trajectory = create_trajectory(0.0, 10.0, 10.0);
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+  expect_feasibility(
+    crossing_trajectory, true, "The nearby amber crossing is safe because ego cannot stop");
+
+  advance_time(0.1);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  expect_feasibility(
+    crossing_trajectory, true,
+    "A safe amber crossing should create the same commitment as a green crossing");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithRedLightNoIntersection)


### PR DESCRIPTION
## Description
This PR introduces a crossing commitment feature to the autoware_traffic_light_compliance_checker to prevent unsafe sudden stops when a traffic light signal changes (e.g., from Green to Red) just as the ego vehicle is crossing or about to cross the stop line.

## Related links

**Parent Issue:**

https://tier4.atlassian.net/browse/T4DEV-55774

## How was this PR tested?

Unit tests
Psim
DLR

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | crossing_commitment_distance | double | 0.0 | Maximum 2D distance before the stop line at which an accepted crossing is remembered (meters). Zero still permits commitment once the ego front reaches or passes the line. |
| Added | crossing_commitment_duration | double | 0.0 | Duration for which an accepted stop-line crossing remains valid (seconds). Zero disables the feature. |

## Effects on system behavior

If `crossing_commitment_duration` is configured to a value `> 0.0`, the ego vehicle will commit to crossing an intersection without stopping if it receives a valid crossing trajectory and is within `crossing_commitment_distance` of the stop line. This prevents harsh, late braking if perception drops out or the light transitions to red right at the intersection entry point.
