### PR TITLE
perf(crosswalk): skip polygon intersections for disjoint bounds

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -788,15 +788,35 @@ std::optional<CollisionPoint> CrosswalkModule::getCollisionPoint(
 
   double minimum_stop_dist = std::numeric_limits<double>::max();
   std::optional<CollisionPoint> nearest_collision_point{std::nullopt};
+
+  // Precompute a bounding box of the attention area once, plus the object's bounding radius, for
+  // a cheap broad-phase reject in the per-step loop below (profiling showed most steps are far
+  // from the crosswalk, so their polygon intersection is empty -- wasted convex_hull + intersection).
+  boost::geometry::model::box<Point2d> attention_bbox;
+  boost::geometry::envelope(attention_area, attention_bbox);
+  const double obj_bounding_radius =
+    0.5 * std::hypot(object.shape.dimensions.x, object.shape.dimensions.y);
+
   for (const auto & obj_path : object.kinematics.predicted_paths) {
     size_t start_idx{0};
     bool is_start_idx_initialized{false};
     for (size_t i = 0; i < obj_path.path.size(); ++i) {
-      // For effective computation, the point and polygon intersection is calculated first.
-      const auto obj_one_step_polygon = createMultiStepPolygon(obj_path.path, obj_polygon, i, i);
-      const auto one_step_intersection_polygons =
-        calcOverlappingPoints(obj_one_step_polygon, attention_area);
-      if (!one_step_intersection_polygons.empty()) {
+      // Broad-phase reject: if the object's bounding box at this step cannot reach the attention
+      // area, the one-step polygon intersection is necessarily empty; skip the expensive
+      // convex_hull + intersection.
+      const auto & obj_pos_i = autoware_utils::get_pose(obj_path.path.at(i)).position;
+      const boost::geometry::model::box<Point2d> obj_bbox(
+        Point2d(obj_pos_i.x - obj_bounding_radius, obj_pos_i.y - obj_bounding_radius),
+        Point2d(obj_pos_i.x + obj_bounding_radius, obj_pos_i.y + obj_bounding_radius));
+      bool one_step_overlaps = false;
+      if (boost::geometry::intersects(obj_bbox, attention_bbox)) {
+        // For effective computation, the point and polygon intersection is calculated first.
+        const auto obj_one_step_polygon =
+          createMultiStepPolygon(obj_path.path, obj_polygon, i, i);
+        one_step_overlaps =
+          !calcOverlappingPoints(obj_one_step_polygon, attention_area).empty();
+      }
+      if (one_step_overlaps) {
         if (!is_start_idx_initialized) {
           start_idx = i;
           is_start_idx_initialized = true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -166,6 +166,27 @@ std::vector<Polygon2d> calcOverlappingPoints(const Polygon2d & polygon1, const P
   return intersection_polygons;
 }
 
+template <class T>
+bool isObjectPathStepOverlappingAttentionArea(
+  const T & object_path, const geometry_msgs::msg::Polygon & object_polygon,
+  const size_t path_index, const double object_bounding_radius,
+  const bg::model::box<Point2d> & attention_bbox, const Polygon2d & attention_area)
+{
+  const auto & object_position = autoware_utils::get_pose(object_path.at(path_index)).position;
+  const bg::model::box<Point2d> object_bbox(
+    Point2d(object_position.x - object_bounding_radius, object_position.y - object_bounding_radius),
+    Point2d(
+      object_position.x + object_bounding_radius, object_position.y + object_bounding_radius));
+  if (!bg::intersects(object_bbox, attention_bbox)) {
+    return false;
+  }
+
+  return !calcOverlappingPoints(
+            createMultiStepPolygon(object_path, object_polygon, path_index, path_index),
+            attention_area)
+            .empty();
+}
+
 autoware_internal_debug_msgs::msg::StringStamped createStringStampedMessage(
   const rclcpp::Time & now, const int64_t module_id_,
   const std::vector<std::tuple<std::string, CollisionPoint, CollisionState>> & collision_points)
@@ -788,15 +809,19 @@ std::optional<CollisionPoint> CrosswalkModule::getCollisionPoint(
 
   double minimum_stop_dist = std::numeric_limits<double>::max();
   std::optional<CollisionPoint> nearest_collision_point{std::nullopt};
+
+  boost::geometry::model::box<Point2d> attention_bbox;
+  boost::geometry::envelope(attention_area, attention_bbox);
+  const double obj_bounding_radius =
+    0.5 * std::hypot(object.shape.dimensions.x, object.shape.dimensions.y);
+
   for (const auto & obj_path : object.kinematics.predicted_paths) {
     size_t start_idx{0};
     bool is_start_idx_initialized{false};
     for (size_t i = 0; i < obj_path.path.size(); ++i) {
-      // For effective computation, the point and polygon intersection is calculated first.
-      const auto obj_one_step_polygon = createMultiStepPolygon(obj_path.path, obj_polygon, i, i);
-      const auto one_step_intersection_polygons =
-        calcOverlappingPoints(obj_one_step_polygon, attention_area);
-      if (!one_step_intersection_polygons.empty()) {
+      const auto one_step_overlaps = isObjectPathStepOverlappingAttentionArea(
+        obj_path.path, obj_polygon, i, obj_bounding_radius, attention_bbox, attention_area);
+      if (one_step_overlaps) {
         if (!is_start_idx_initialized) {
           start_idx = i;
           is_start_idx_initialized = true;


### PR DESCRIPTION
## Description

`CrosswalkModule::getCollisionPoint()` builds a convex hull and runs a polygon intersection for every predicted-path step. Many of those steps are far from the crosswalk attention area and cannot intersect it.

This change adds an AABB broad-phase check before that polygon work. The attention-area bounding box is computed once, and each object step uses a conservative bounding box based on the object half-diagonal. When the boxes are disjoint, the convex hull and exact intersection are skipped.

## Related links

**Parent Issue:**

- None — small, self-contained performance optimization.

## How was this PR tested?

A standalone harness using the relevant functions from `scene_crosswalk.cpp` and real Boost.Geometry types was run across different object counts and predicted-path spans.

| Workload | Base (ns/cycle) | This PR (ns/cycle) | Speedup |
|---|---:|---:|---:|
| 6 objects, 20 m span | 318504 | 155898 | 2.04x |
| 12 objects, 20 m span | 632367 | 311142 | 2.03x |
| 24 objects, 20 m span | 1179034 | 459637 | 2.57x |
| 12 objects, 8 m span | 314793 | 179056 | 1.76x |
| 12 objects, 40 m span | 686740 | 323504 | 2.12x |

The accumulated collision-point state matched the base implementation in every tested workload.

All applicable pre-commit hooks passed on the changed file, including `clang-format` and `cpplint`.

Not run: a full `colcon` build or Autoware scenario test.

## Notes for reviewers

The object box uses the shape half-diagonal, so it remains conservative regardless of object orientation. The broad-phase logic is isolated in a helper to avoid increasing the complexity of `getCollisionPoint()`.

## Interface changes

None.

## Effects on system behavior

No expected change to collision points. Crosswalk collision checks require less computation when predicted object steps are outside the attention area.

## AI usage and verification

AI usage: I used OpenAI Codex to identify and implement this optimization and to help prepare the standalone benchmark.

Self-review: I personally reviewed the full diff and benchmark setup and confirmed that I understand every changed line.

Verification: The benchmark and checks described above were run and reviewed by me.
