### PR TITLE
chore(autoware_trajectory_follower_base, autoware_trajectory_follower_node): add maintainer

### DIFF
--- a/control/autoware_trajectory_follower_base/package.xml
+++ b/control/autoware_trajectory_follower_base/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
   <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>
+  <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
 
   <license>Apache 2.0</license>
 

--- a/control/autoware_trajectory_follower_node/package.xml
+++ b/control/autoware_trajectory_follower_node/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
   <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>
+  <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
 
   <license>Apache License 2.0</license>
 


### PR DESCRIPTION
## Description
Add Takumi Odashima (@Kotakku) as a maintainer of `autoware_trajectory_follower_base` and `autoware_trajectory_follower_node`.

This gives review/merge responsibility for the trajectory follower packages (context: maintenance and review around #13029).

## Tests performed
Metadata-only change to `package.xml` maintainers. `sort-package-xml` / `prettier` pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)