### PR TITLE
perf(behavior_path_planner): add broad phase to collision checks

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -572,6 +572,45 @@ bool checkSafetyWithIntegralPredictedPolygon(
   return true;
 }
 
+namespace
+{
+// Cheap axis-aligned bounding-box disjoint test used as a broad-phase before the exact polygon
+// intersects test. AABB-disjoint implies the polygons are disjoint, so it is exact (never a false
+// reject) to skip boost::geometry::intersects when the boxes don't overlap.
+struct Aabb
+{
+  double min_x, min_y, max_x, max_y;
+};
+
+Aabb aabbOf(const Polygon2d & p)
+{
+  Aabb b{
+    std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
+    std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest()};
+  for (const auto & pt : p.outer()) {
+    b.min_x = std::min(b.min_x, pt.x());
+    b.min_y = std::min(b.min_y, pt.y());
+    b.max_x = std::max(b.max_x, pt.x());
+    b.max_y = std::max(b.max_y, pt.y());
+  }
+  return b;
+}
+
+bool aabbDisjoint(const Aabb & a, const Aabb & b)
+{
+  return a.max_x < b.min_x || b.max_x < a.min_x || a.max_y < b.min_y || b.max_y < a.min_y;
+}
+
+// Exact equivalent of boost::geometry::intersects(a, b), with an AABB broad-phase reject in front.
+bool intersectsWithBroadPhase(const Polygon2d & a, const Polygon2d & b)
+{
+  if (aabbDisjoint(aabbOf(a), aabbOf(b))) {
+    return false;
+  }
+  return boost::geometry::intersects(a, b);
+}
+}  // namespace
+
 bool checkCollision(
   const PathWithLaneId & planned_path,
   const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
@@ -639,7 +678,7 @@ std::optional<Polygon2d> check_collision(
     return std::nullopt;
   }
 
-  if (boost::geometry::intersects(ego_polygon, obj_polygon)) {
+  if (intersectsWithBroadPhase(ego_polygon, obj_polygon)) {
     if (debug) {
       debug->unsafe_reason = "overlap_polygon";
       debug->expected_ego_pose = ego_pose;
@@ -683,7 +722,7 @@ std::optional<Polygon2d> check_collision(
                         obj_pose_with_poly, lon_offset, lat_margin, is_stopping_object, debug);
 
   // check intersects with extended polygon
-  if (!boost::geometry::intersects(*extended_ego_polygon_opt, extended_obj_polygon)) {
+  if (!intersectsWithBroadPhase(*extended_ego_polygon_opt, extended_obj_polygon)) {
     return std::nullopt;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -572,6 +572,44 @@ bool checkSafetyWithIntegralPredictedPolygon(
   return true;
 }
 
+namespace
+{
+struct Aabb
+{
+  double min_x;
+  double min_y;
+  double max_x;
+  double max_y;
+};
+
+Aabb aabb_of(const Polygon2d & polygon)
+{
+  Aabb aabb{
+    std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
+    std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest()};
+  for (const auto & point : polygon.outer()) {
+    aabb.min_x = std::min(aabb.min_x, point.x());
+    aabb.min_y = std::min(aabb.min_y, point.y());
+    aabb.max_x = std::max(aabb.max_x, point.x());
+    aabb.max_y = std::max(aabb.max_y, point.y());
+  }
+  return aabb;
+}
+
+bool aabb_disjoint(const Aabb & a, const Aabb & b)
+{
+  return a.max_x < b.min_x || b.max_x < a.min_x || a.max_y < b.min_y || b.max_y < a.min_y;
+}
+
+bool intersects_with_broad_phase(const Polygon2d & a, const Polygon2d & b)
+{
+  if (aabb_disjoint(aabb_of(a), aabb_of(b))) {
+    return false;
+  }
+  return boost::geometry::intersects(a, b);
+}
+}  // namespace
+
 bool checkCollision(
   const PathWithLaneId & planned_path,
   const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
@@ -639,7 +677,7 @@ std::optional<Polygon2d> check_collision(
     return std::nullopt;
   }
 
-  if (boost::geometry::intersects(ego_polygon, obj_polygon)) {
+  if (intersects_with_broad_phase(ego_polygon, obj_polygon)) {
     if (debug) {
       debug->unsafe_reason = "overlap_polygon";
       debug->expected_ego_pose = ego_pose;
@@ -683,7 +721,7 @@ std::optional<Polygon2d> check_collision(
                         obj_pose_with_poly, lon_offset, lat_margin, is_stopping_object, debug);
 
   // check intersects with extended polygon
-  if (!boost::geometry::intersects(*extended_ego_polygon_opt, extended_obj_polygon)) {
+  if (!intersects_with_broad_phase(*extended_ego_polygon_opt, extended_obj_polygon)) {
     return std::nullopt;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -25,9 +25,9 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
-#include <boost/geometry/geometries/box.hpp>
 #include <boost/geometry/algorithms/overlaps.hpp>
 #include <boost/geometry/algorithms/union.hpp>
+#include <boost/geometry/geometries/box.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 
 #include <algorithm>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -23,7 +23,9 @@
 #include <tf2/utils.hpp>
 
 #include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
+#include <boost/geometry/geometries/box.hpp>
 #include <boost/geometry/algorithms/overlaps.hpp>
 #include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
@@ -574,39 +576,13 @@ bool checkSafetyWithIntegralPredictedPolygon(
 
 namespace
 {
-struct Aabb
-{
-  double min_x;
-  double min_y;
-  double max_x;
-  double max_y;
-};
-
-Aabb aabb_of(const Polygon2d & polygon)
-{
-  Aabb aabb{
-    std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
-    std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest()};
-  for (const auto & point : polygon.outer()) {
-    aabb.min_x = std::min(aabb.min_x, point.x());
-    aabb.min_y = std::min(aabb.min_y, point.y());
-    aabb.max_x = std::max(aabb.max_x, point.x());
-    aabb.max_y = std::max(aabb.max_y, point.y());
-  }
-  return aabb;
-}
-
-bool aabb_disjoint(const Aabb & a, const Aabb & b)
-{
-  return a.max_x < b.min_x || b.max_x < a.min_x || a.max_y < b.min_y || b.max_y < a.min_y;
-}
-
 bool intersects_with_broad_phase(const Polygon2d & a, const Polygon2d & b)
 {
-  if (aabb_disjoint(aabb_of(a), aabb_of(b))) {
-    return false;
-  }
-  return boost::geometry::intersects(a, b);
+  bg::model::box<Point2d> a_box;
+  bg::model::box<Point2d> b_box;
+  bg::envelope(a, a_box);
+  bg::envelope(b, b_box);
+  return bg::intersects(a_box, b_box) && bg::intersects(a, b);
 }
 }  // namespace
 


### PR DESCRIPTION
## Description

`check_collision()` runs exact Boost.Geometry intersection tests for the base and RSS-extended polygons at every predicted-path step. Most polygon pairs are spatially separated, so many of these exact checks can be rejected using their axis-aligned bounding boxes.

This change adds an AABB broad-phase check before both exact intersection tests. When the bounding boxes are disjoint, the polygons cannot intersect and the exact test is skipped.

## Related links

**Parent Issue:**

- None — small, self-contained performance optimization.
- #13059 currently evaluates this broad phase together with interpolation caching.

## How was this PR tested?

A standalone benchmark of `checkCollision()` was run across different object distributions and counts.

| Workload | Base (µs/cycle) | This PR (µs/cycle) | Speedup |
|---|---:|---:|---:|
| 12 objects, mixed | 180.2 | 55.0 | 3.28x |
| Near objects | 141.9 | 44.5 | 3.19x |
| Adjacent-lane objects | 159.2 | 47.7 | 3.34x |
| Objects two or more lanes away | 197.4 | 57.2 | 3.45x |
| 32 objects | 465.2 | 134.9 | 3.45x |

The safe-object count matched the base implementation in every tested workload.

All applicable pre-commit hooks passed on the changed file, including `clang-format` and `cpplint`.

Not run: a full `colcon` build or Autoware scenario test.

## Notes for reviewers

The broad phase uses Boost.Geometry envelopes and only runs exact polygon intersection tests when the bounding boxes overlap.

## Interface changes

None.

## Effects on system behavior

No expected change to collision decisions. Collision checks require less computation for non-overlapping polygon pairs.

## AI usage and verification

AI usage: I used OpenAI Codex to identify and implement this optimization and to help prepare the standalone benchmark.

Self-review: I personally reviewed the full diff and benchmark setup and confirmed that I understand every changed line.

Verification: The benchmark and checks described above were run and reviewed by me.
