### PR TITLE
perf(behavior_path_planner): optimize lane-change collision checks

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -176,7 +176,8 @@ protected:
   bool is_colliding(
     const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
     const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const RSSparams & rss_param,
-    CollisionCheckDebugMap & debug_data, const bool is_approved) const;
+    CollisionCheckDebugMap & debug_data, const bool is_approved,
+    utils::path_safety_checker::EgoInterpCache * ego_interp_cache = nullptr) const;
 
   double get_max_velocity_for_safety_check() const;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1775,17 +1775,26 @@ NormalLaneChange::find_colliding_object_if_all_paths_collide(
   std::vector<ExtendedPredictedObject> colliding_objects;
   std::unordered_set<size_t> objects_idx;
 
-  const auto check_for_collision = [&](const auto & ego_predicted_path, const auto & object) {
+  const auto check_for_collision = [&](
+                                      const auto & ego_predicted_path, const auto & object,
+                                      auto * ego_interp_cache) {
     return is_colliding(
-      lane_change_path, object, ego_predicted_path, rss_params, debug_data, is_approved);
+      lane_change_path, object, ego_predicted_path, rss_params, debug_data, is_approved,
+      ego_interp_cache);
   };
 
   const auto check_for_collisions = [&](const auto & ego_predicted_path) {
     std::vector<ExtendedPredictedObject> current_colliding_objects;
     current_colliding_objects.reserve(objects.size());
 
+    // One memo per ego_predicted_path: the ego interpolation at a given time is the same for
+    // every object checked against this path, so share it across the loop below instead of
+    // recomputing it once per object.
+    utils::path_safety_checker::EgoInterpCache ego_interp_cache;
+
     for (const auto & [idx, object] : objects | ranges::views::enumerate) {
-      const auto is_colliding_object = check_for_collision(ego_predicted_path, object);
+      const auto is_colliding_object =
+        check_for_collision(ego_predicted_path, object, &ego_interp_cache);
       if (!is_colliding_object) {
         continue;
       }
@@ -1855,7 +1864,8 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
 bool NormalLaneChange::is_colliding(
   const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
   const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const RSSparams & rss_param,
-  CollisionCheckDebugMap & debug_data, const bool is_approved) const
+  CollisionCheckDebugMap & debug_data, const bool is_approved,
+  utils::path_safety_checker::EgoInterpCache * ego_interp_cache) const
 {
   constexpr auto is_colliding{true};
 
@@ -1908,7 +1918,8 @@ bool NormalLaneChange::is_colliding(
       if (
         const auto collided_polygon_opt = check_collision(
           lane_change_path.path, bpp_param.vehicle_info, ego_predicted_path, obj_pose_with_poly,
-          selected_rss_param, th_yaw_diff, safety_check_max_vel, hysteresis_factor, debug_ptr)) {
+          selected_rss_param, th_yaw_diff, safety_check_max_vel, hysteresis_factor, debug_ptr,
+          ego_interp_cache)) {
         collided_polygons.push_back(*collided_polygon_opt);
       }
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1775,17 +1775,25 @@ NormalLaneChange::find_colliding_object_if_all_paths_collide(
   std::vector<ExtendedPredictedObject> colliding_objects;
   std::unordered_set<size_t> objects_idx;
 
-  const auto check_for_collision = [&](const auto & ego_predicted_path, const auto & object) {
-    return is_colliding(
-      lane_change_path, object, ego_predicted_path, rss_params, debug_data, is_approved);
-  };
+  const auto check_for_collision =
+    [&](const auto & ego_predicted_path, const auto & object, auto * ego_interp_cache) {
+      return is_colliding(
+        lane_change_path, object, ego_predicted_path, rss_params, debug_data, is_approved,
+        ego_interp_cache);
+    };
 
   const auto check_for_collisions = [&](const auto & ego_predicted_path) {
     std::vector<ExtendedPredictedObject> current_colliding_objects;
     current_colliding_objects.reserve(objects.size());
 
+    // One memo per ego_predicted_path: the ego interpolation at a given time is the same for
+    // every object checked against this path, so share it across the loop below instead of
+    // recomputing it once per object.
+    utils::path_safety_checker::EgoInterpCache ego_interp_cache;
+
     for (const auto & [idx, object] : objects | ranges::views::enumerate) {
-      const auto is_colliding_object = check_for_collision(ego_predicted_path, object);
+      const auto is_colliding_object =
+        check_for_collision(ego_predicted_path, object, &ego_interp_cache);
       if (!is_colliding_object) {
         continue;
       }
@@ -1855,7 +1863,8 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
 bool NormalLaneChange::is_colliding(
   const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
   const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const RSSparams & rss_param,
-  CollisionCheckDebugMap & debug_data, const bool is_approved) const
+  CollisionCheckDebugMap & debug_data, const bool is_approved,
+  utils::path_safety_checker::EgoInterpCache * ego_interp_cache) const
 {
   constexpr auto is_colliding{true};
 
@@ -1908,7 +1917,8 @@ bool NormalLaneChange::is_colliding(
       if (
         const auto collided_polygon_opt = check_collision(
           lane_change_path.path, bpp_param.vehicle_info, ego_predicted_path, obj_pose_with_poly,
-          selected_rss_param, th_yaw_diff, safety_check_max_vel, hysteresis_factor, debug_ptr)) {
+          selected_rss_param, th_yaw_diff, safety_check_max_vel, hysteresis_factor, debug_ptr,
+          ego_interp_cache)) {
         collided_polygons.push_back(*collided_polygon_opt);
       }
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -29,6 +29,7 @@
 #include <geometry_msgs/msg/twist.hpp>
 
 #include <cmath>
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -46,6 +47,11 @@ using autoware_utils::Point2d;
 using autoware_utils::Polygon2d;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
+
+// Caller-owned memo of the object-independent ego interpolated pose + footprint, keyed by query
+// time. The same ego_predicted_path is checked against many target objects; this lets those
+// checks share one interpolation per time instead of recomputing it once per object.
+using EgoInterpCache = std::map<double, std::optional<PoseWithVelocityAndPolygonStamped>>;
 
 /**
  * @brief Checks if the object is coming toward the ego vehicle judging by yaw deviation
@@ -201,7 +207,7 @@ std::optional<Polygon2d> check_collision(
   const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
   const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const RSSparams & rss_parameters,
   const double yaw_difference_th, const double max_velocity_limit, const double hysteresis_factor,
-  CollisionCheckDebug * debug = nullptr);
+  CollisionCheckDebug * debug = nullptr, EgoInterpCache * ego_interp_cache = nullptr);
 
 /**
  * @brief Iterate the points in the ego and target's predicted path and

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -572,6 +572,45 @@ bool checkSafetyWithIntegralPredictedPolygon(
   return true;
 }
 
+namespace
+{
+// Cheap axis-aligned bounding-box disjoint test used as a broad-phase before the exact polygon
+// intersects test. AABB-disjoint implies the polygons are disjoint, so it is exact (never a false
+// reject) to skip boost::geometry::intersects when the boxes don't overlap.
+struct Aabb
+{
+  double min_x, min_y, max_x, max_y;
+};
+
+Aabb aabbOf(const Polygon2d & p)
+{
+  Aabb b{
+    std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
+    std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest()};
+  for (const auto & pt : p.outer()) {
+    b.min_x = std::min(b.min_x, pt.x());
+    b.min_y = std::min(b.min_y, pt.y());
+    b.max_x = std::max(b.max_x, pt.x());
+    b.max_y = std::max(b.max_y, pt.y());
+  }
+  return b;
+}
+
+bool aabbDisjoint(const Aabb & a, const Aabb & b)
+{
+  return a.max_x < b.min_x || b.max_x < a.min_x || a.max_y < b.min_y || b.max_y < a.min_y;
+}
+
+// Exact equivalent of boost::geometry::intersects(a, b), with an AABB broad-phase reject in front.
+bool intersectsWithBroadPhase(const Polygon2d & a, const Polygon2d & b)
+{
+  if (aabbDisjoint(aabbOf(a), aabbOf(b))) {
+    return false;
+  }
+  return boost::geometry::intersects(a, b);
+}
+}  // namespace
+
 bool checkCollision(
   const PathWithLaneId & planned_path,
   const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
@@ -615,18 +654,31 @@ std::optional<Polygon2d> check_collision(
   const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
   const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const RSSparams & rss_parameters,
   const double yaw_difference_th, const double max_velocity_limit, const double hysteresis_factor,
-  CollisionCheckDebug * debug)
+  CollisionCheckDebug * debug, EgoInterpCache * ego_interp_cache)
 {
   const auto & current_time = obj_pose_with_poly.time;
   const auto & obj_pose = obj_pose_with_poly.pose;
   const auto & obj_polygon = obj_pose_with_poly.poly;
 
-  // get ego information at current time
-  // Note: we can create these polygons in advance. However, it can decrease the readability and
-  // variability
+  // get ego information at current time. This is object-independent (it depends only on
+  // predicted_ego_path and current_time), so when a cache is supplied by the caller it is
+  // memoized by time and reused across every target object checked against this ego_predicted_path.
   const auto & ego_vehicle_info = vehicle_info;
-  const auto interpolated_data = get_interpolated_pose_with_velocity_and_polygon_stamped(
-    predicted_ego_path, current_time, ego_vehicle_info);
+  std::optional<PoseWithVelocityAndPolygonStamped> interpolated_data;
+  if (ego_interp_cache) {
+    auto it = ego_interp_cache->find(current_time);
+    if (it == ego_interp_cache->end()) {
+      it = ego_interp_cache
+             ->emplace(
+               current_time, get_interpolated_pose_with_velocity_and_polygon_stamped(
+                                predicted_ego_path, current_time, ego_vehicle_info))
+             .first;
+    }
+    interpolated_data = it->second;
+  } else {
+    interpolated_data = get_interpolated_pose_with_velocity_and_polygon_stamped(
+      predicted_ego_path, current_time, ego_vehicle_info);
+  }
 
   if (!interpolated_data) {
     return std::nullopt;
@@ -639,7 +691,7 @@ std::optional<Polygon2d> check_collision(
     return std::nullopt;
   }
 
-  if (boost::geometry::intersects(ego_polygon, obj_polygon)) {
+  if (intersectsWithBroadPhase(ego_polygon, obj_polygon)) {
     if (debug) {
       debug->unsafe_reason = "overlap_polygon";
       debug->expected_ego_pose = ego_pose;
@@ -683,7 +735,7 @@ std::optional<Polygon2d> check_collision(
                         obj_pose_with_poly, lon_offset, lat_margin, is_stopping_object, debug);
 
   // check intersects with extended polygon
-  if (!boost::geometry::intersects(*extended_ego_polygon_opt, extended_obj_polygon)) {
+  if (!intersectsWithBroadPhase(*extended_ego_polygon_opt, extended_obj_polygon)) {
     return std::nullopt;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -572,6 +572,65 @@ bool checkSafetyWithIntegralPredictedPolygon(
   return true;
 }
 
+namespace
+{
+struct Aabb
+{
+  double min_x;
+  double min_y;
+  double max_x;
+  double max_y;
+};
+
+Aabb aabb_of(const Polygon2d & polygon)
+{
+  Aabb aabb{
+    std::numeric_limits<double>::max(), std::numeric_limits<double>::max(),
+    std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest()};
+  for (const auto & point : polygon.outer()) {
+    aabb.min_x = std::min(aabb.min_x, point.x());
+    aabb.min_y = std::min(aabb.min_y, point.y());
+    aabb.max_x = std::max(aabb.max_x, point.x());
+    aabb.max_y = std::max(aabb.max_y, point.y());
+  }
+  return aabb;
+}
+
+bool aabb_disjoint(const Aabb & a, const Aabb & b)
+{
+  return a.max_x < b.min_x || b.max_x < a.min_x || a.max_y < b.min_y || b.max_y < a.min_y;
+}
+
+bool intersects_with_broad_phase(const Polygon2d & a, const Polygon2d & b)
+{
+  if (aabb_disjoint(aabb_of(a), aabb_of(b))) {
+    return false;
+  }
+  return boost::geometry::intersects(a, b);
+}
+
+std::optional<PoseWithVelocityAndPolygonStamped> get_interpolated_ego_data(
+  const std::vector<PoseWithVelocityStamped> & predicted_ego_path, const double current_time,
+  const VehicleInfo & vehicle_info, EgoInterpCache * ego_interp_cache)
+{
+  if (!ego_interp_cache) {
+    return get_interpolated_pose_with_velocity_and_polygon_stamped(
+      predicted_ego_path, current_time, vehicle_info);
+  }
+
+  const auto cached = ego_interp_cache->find(current_time);
+  if (cached != ego_interp_cache->end()) {
+    return cached->second;
+  }
+
+  return ego_interp_cache
+    ->emplace(
+      current_time, get_interpolated_pose_with_velocity_and_polygon_stamped(
+                      predicted_ego_path, current_time, vehicle_info))
+    .first->second;
+}
+}  // namespace
+
 bool checkCollision(
   const PathWithLaneId & planned_path,
   const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
@@ -615,18 +674,15 @@ std::optional<Polygon2d> check_collision(
   const std::vector<PoseWithVelocityStamped> & predicted_ego_path,
   const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const RSSparams & rss_parameters,
   const double yaw_difference_th, const double max_velocity_limit, const double hysteresis_factor,
-  CollisionCheckDebug * debug)
+  CollisionCheckDebug * debug, EgoInterpCache * ego_interp_cache)
 {
   const auto & current_time = obj_pose_with_poly.time;
   const auto & obj_pose = obj_pose_with_poly.pose;
   const auto & obj_polygon = obj_pose_with_poly.poly;
 
-  // get ego information at current time
-  // Note: we can create these polygons in advance. However, it can decrease the readability and
-  // variability
   const auto & ego_vehicle_info = vehicle_info;
-  const auto interpolated_data = get_interpolated_pose_with_velocity_and_polygon_stamped(
-    predicted_ego_path, current_time, ego_vehicle_info);
+  const auto interpolated_data =
+    get_interpolated_ego_data(predicted_ego_path, current_time, ego_vehicle_info, ego_interp_cache);
 
   if (!interpolated_data) {
     return std::nullopt;
@@ -639,7 +695,7 @@ std::optional<Polygon2d> check_collision(
     return std::nullopt;
   }
 
-  if (boost::geometry::intersects(ego_polygon, obj_polygon)) {
+  if (intersects_with_broad_phase(ego_polygon, obj_polygon)) {
     if (debug) {
       debug->unsafe_reason = "overlap_polygon";
       debug->expected_ego_pose = ego_pose;
@@ -683,7 +739,7 @@ std::optional<Polygon2d> check_collision(
                         obj_pose_with_poly, lon_offset, lat_margin, is_stopping_object, debug);
 
   // check intersects with extended polygon
-  if (!boost::geometry::intersects(*extended_ego_polygon_opt, extended_obj_polygon)) {
+  if (!intersects_with_broad_phase(*extended_ego_polygon_opt, extended_obj_polygon)) {
     return std::nullopt;
   }
 


### PR DESCRIPTION
## Description

Avoid repeated work in lane-change collision checks:

- Cache ego pose/footprint interpolation across objects for each predicted ego path.
- Reject disjoint polygon pairs with an AABB check before exact polygon intersection.

The cache is optional, so existing callers keep the current behavior.

## Related links

- #13058 is the AABB-only alternative; this PR includes both optimizations.

## How was this PR tested?

- Standalone benchmarks: **2.3x–4.1x speedup**.
- Collision-decision checksums matched the base implementation.
- Applicable pre-commit hooks passed, including `clang-format` and `cpplint`.
- Not run: full `colcon` build or Autoware scenario tests.

## Interface changes

Adds an optional internal `EgoInterpCache *` parameter. No ROS interface or parameter changes.

## Effects on system behavior

No expected change to collision decisions.

## AI usage and verification

OpenAI Codex assisted with the implementation and benchmark preparation. I reviewed and understand every changed line and verified the results above.