### PR TITLE
chore: update planning param.yaml comments

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -51,7 +51,7 @@
       safety_check:
         allow_loose_check_for_cancel: true
         enable_target_lane_bound_check: true
-        stopped_object_velocity_threshold: 1.0 # [m/s]
+        stopped_object_velocity_threshold: 1.0 # [m/s] Object whose velocity is less than the threshold is treated as static object.
         prepare:                                        # RSS parameters used during the prepare phase, regardless of whether the ego is searching for a safe path, canceling, or transitioning to another state.
           expected_front_deceleration: -1.0             # [m/s2]
           expected_rear_deceleration: -1.0              # [m/s2]
@@ -149,7 +149,7 @@
         max_lateral_jerk: 100.0            # [m/s3]
         overhang_tolerance: 0.0             # [m]
         unsafe_hysteresis_threshold: 5     # [/]
-        deceleration_sampling_num: 5 # [/]
+        deceleration_sampling_num: 5 # [/] Used to sample the approved lane change path, specifically for checking safety against leading objects.
 
       lane_change_finish_judge_buffer: 2.0      # [m]
       finish_judge_lateral_threshold: 0.1        # [m]

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -9,7 +9,7 @@
     dynamic_expansion:
       enabled: true
       print_runtime: false
-      max_expansion_distance: 0.0 # [m] maximum distance by which the drivable area can be expended (0.0 means no limit)
+      max_expansion_distance: 0.0 # [m] maximum distance by which the drivable area can be expanded (0.0 means no limit)
       min_bound_interval: 1.0  # [m] minimum interval between two consecutive bound points (before expansion)
       smoothing:
         curvature_average_window: 3  # window size used for smoothing the curvatures using a moving window average
@@ -27,7 +27,7 @@
           front: 0.75 # [m] margin to add to the front of object footprint
           rear: 0.75 # [m] margin to add to the rear of object footprint
           left: 0.75 # [m] margin to add to the left of object footprint
-          right: 0.75 # [m] margin to add to the rear of object footprint
+          right: 0.75 # [m] margin to add to the right of object footprint
       path_preprocessing:
         max_arc_length: 100.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
         resample_interval: 2.0 # [m] fixed interval between resampled path points (0.0 means path points are directly used)

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
@@ -144,7 +144,7 @@
         merging_vehicle:
           th_overhang_distance: 0.0                     # [m]
 
-        unstable_classification_time: 2.0                # [s] If the object is classified as UNKNOWN type for less than unstable_classification_time seconds, it is probably not an unknown type.
+        unstable_classification_time: 2.0                # [s] If the object is classified as UNKNOWN for less than unstable_classification_time seconds, we cannot be confident that it truly does not belong to any known class..
 
         # params for avoidance of vehicle type objects that are ambiguous as to whether they are parked.
         avoidance_for_ambiguous_vehicle:
@@ -173,7 +173,7 @@
           # "ignore" : never avoid it.
           policy: "ignore"                              # [-]
           condition:
-            th_road_border_distance: 0.8                  # [m]
+            th_road_border_distance: 0.8                  # [m] threshold distance from road border to parking vehicle
 
         avoidance_for_adjacent_lane_stop_vehicle:
           # policy for ego behavior for adjacent lane stop vehicle.

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/config/crosswalk.param.yaml
@@ -54,7 +54,7 @@
           min_acc: -1.5 # min acceleration [m/ss]
           min_jerk: -1.5 # min jerk [m/sss]
 
-        stop_object_velocity_threshold: 0.25 # [m/s] velocity threshold for the module to judge whether the objects is stopped (0.28 m/s = 1.0 kmph)
+        stop_object_velocity_threshold: 0.25 # [m/s] velocity threshold for the module to judge whether the objects is stopped (0.25 m/s = 0.9 kmph)
         min_object_velocity: 1.39 # [m/s] minimum object velocity (compare the estimated velocity by perception module with this parameter and adopt the larger one to calculate TTV. 1.39 m/s = 5.0 kmph)
         ## param for yielding
         disable_yield_for_new_stopped_object: true # for the crosswalks with traffic signal

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/config/run_out.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/config/run_out.param.yaml
@@ -44,7 +44,7 @@
         # for each target labels we can specify the following parameters
         DEFAULT:
           ignore:  # options to ignore some objects
-            if_stopped: false # if true, object with a velocity bellow the threshold are ignored
+            if_stopped: false # if true, object with a velocity less than the threshold are ignored
             stopped_velocity_threshold: 0.25  # [m/s]
             if_on_ego_trajectory: true  # if true, object located on the ego trajectory footprint are ignored
             if_behind_ego: true  # if true, objects located behind the ego vehicles are ignored


### PR DESCRIPTION
## Description

Update and fix planning param.yaml file comments available in autoware_launch side but not in autoware_universe side.

## Related links

This is to sync contents (including comments) of corresponding param.yaml files in autoware_launch.
See https://github.com/autowarefoundation/autoware_launch/pull/1896 as well. (autoware_launch PR will be updated after this PR has been merged.)

## How was this PR tested?

None. The parameter values are not modified, only their comments.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
