### PR TITLE
feat(cuda_pointcloud_preprocessor): add input bounds diagnostics

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
@@ -8,6 +8,9 @@
     processing_time_threshold_sec: 0.01
     timestamp_mismatch_fraction_threshold: 0.01
     enable_ring_outlier_filter: true
+    max_input_point_count: 691200  # Hesai OT128, dual return, high resolution mode
+    max_twist_frequency_hz: 200.0
+    max_imu_frequency_hz: 200.0
 
     crop_box.min_x: [0.0]
     crop_box.min_y: [0.0]

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -30,6 +30,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <memory>
@@ -56,6 +57,7 @@ public:
   void setRingOutlierFilterParameters(const RingOutlierFilterParameters & ring_outlier_parameters);
   void setRingOutlierFilterActive(const bool enable_filter);
   void setUndistortionType(const UndistortionType & undistortion_type);
+  void setMaxInputPointCount(const std::size_t max_input_point_count);
 
   void preallocateOutput();
   [[nodiscard]] ProcessingStats getProcessingStats() const { return stats_; }
@@ -80,8 +82,9 @@ private:
 
   int num_rings_{};
   int max_points_per_ring_{};
-  size_t num_raw_points_{};
-  size_t num_organized_points_{};
+  std::size_t num_raw_points_{};
+  std::size_t num_organized_points_{};
+  std::size_t max_input_point_count_{};
 
   std::vector<sensor_msgs::msg::PointField> point_fields_;
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> output_pointcloud_ptr_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -39,6 +39,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <cstddef>
 #include <deque>
 #include <memory>
 #include <string>
@@ -73,6 +74,23 @@ CHECK_OFFSET(OutputPointType, autoware::point_types::PointXYZIRCAEDT, intensity)
 CHECK_OFFSET(OutputPointType, autoware::point_types::PointXYZIRCAEDT, return_type);
 CHECK_OFFSET(OutputPointType, autoware::point_types::PointXYZIRCAEDT, channel);
 
+struct InputBoundsParams
+{
+  std::size_t max_input_point_count{};
+  std::size_t max_twist_subscriber_queue_size{};
+  std::size_t max_imu_subscriber_queue_size{};
+  std::size_t max_twist_queue_size{};
+  std::size_t max_imu_queue_size{};
+};
+
+struct InputBoundsStatus
+{
+  std::size_t input_point_count{};
+  std::size_t truncated_point_count{};
+  std::size_t dropped_twist_count{};
+  std::size_t dropped_imu_count{};
+};
+
 class CudaPointcloudPreprocessorNode : public rclcpp::Node
 {
 public:
@@ -97,6 +115,8 @@ private:
 
   void updateTwistQueue(std::uint64_t first_point_stamp);
   void updateImuQueue(std::uint64_t first_point_stamp);
+  void boundTwistQueue();
+  void boundImuQueue();
   std::optional<geometry_msgs::msg::TransformStamped> lookupTransformToBase(
     const std::string & source_frame);
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> processPointcloud(
@@ -119,6 +139,8 @@ private:
   bool use_imu_;
   double processing_time_threshold_sec_;
   double timestamp_mismatch_fraction_threshold_;
+  InputBoundsParams input_bounds_params_{};
+  InputBoundsStatus latest_input_bounds_status_{};
 
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> twist_queue_;
   std::deque<geometry_msgs::msg::Vector3Stamped> angular_velocity_queue_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
@@ -48,6 +48,24 @@
           "description": "Enable/disable ring outlier filter in the cuda_pointcloud_preprocessor pipeline.",
           "default": "true"
         },
+        "max_input_point_count": {
+          "type": "integer",
+          "description": "Maximum number of input points processed per cloud. Larger inputs are reported as errors and truncated to the first N points.",
+          "default": 691200,
+          "minimum": 1
+        },
+        "max_twist_frequency_hz": {
+          "type": "number",
+          "description": "Maximum expected twist input frequency. Used with twist_imu_queue_window_sec to bound the twist queue.",
+          "default": 200.0,
+          "exclusiveMinimum": 0.0
+        },
+        "max_imu_frequency_hz": {
+          "type": "number",
+          "description": "Maximum expected IMU input frequency. Used with twist_imu_queue_window_sec to bound the IMU queue.",
+          "default": 200.0,
+          "exclusiveMinimum": 0.0
+        },
         "crop_box.min_x": {
           "type": "array",
           "description": "An array in which each element is the minimum x value in a crop box",
@@ -92,6 +110,9 @@
         "object_length_threshold",
         "processing_time_threshold_sec",
         "timestamp_mismatch_fraction_threshold",
+        "max_input_point_count",
+        "max_twist_frequency_hz",
+        "max_imu_frequency_hz",
         "crop_box.min_x",
         "crop_box.min_y",
         "crop_box.min_z",

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -36,7 +36,9 @@
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <stdexcept>
 
 namespace autoware::cuda_pointcloud_preprocessor
 {
@@ -140,6 +142,14 @@ void CudaPointcloudPreprocessor::setUndistortionType(const UndistortionType & un
   }
 
   undistortion_type_ = undistortion_type;
+}
+
+void CudaPointcloudPreprocessor::setMaxInputPointCount(const std::size_t max_input_point_count)
+{
+  if (max_input_point_count == 0) {
+    throw std::runtime_error("max_input_point_count must be positive");
+  }
+  max_input_point_count_ = max_input_point_count;
 }
 
 void CudaPointcloudPreprocessor::preallocateOutput()
@@ -281,8 +291,10 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   const std::uint32_t first_point_rel_stamp_nsec)
 {
   auto frame_id = input_pointcloud_msg.header.frame_id;
-  num_raw_points_ = static_cast<int>(input_pointcloud_msg.width * input_pointcloud_msg.height);
-  num_organized_points_ = num_rings_ * max_points_per_ring_;
+  const auto input_point_count =
+    static_cast<std::size_t>(input_pointcloud_msg.width) * input_pointcloud_msg.height;
+  num_raw_points_ = std::min(input_point_count, max_input_point_count_);
+  num_organized_points_ = static_cast<std::size_t>(num_rings_) * max_points_per_ring_;
 
   if (num_raw_points_ == 0) {
     output_pointcloud_ptr_->row_step = 0;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -146,6 +146,7 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
     queue_size_from_frequency(max_twist_frequency_hz);
   input_bounds_params_.max_imu_subscriber_queue_size =
     queue_size_from_frequency(max_imu_frequency_hz);
+  // TODO(mojomex): equates to 1s of messages, should be made tighter in the future
   input_bounds_params_.max_twist_queue_size =
     static_cast<std::size_t>(std::ceil(max_twist_frequency_hz));
   input_bounds_params_.max_imu_queue_size =

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -17,6 +17,7 @@
 #include "autoware/cuda_pointcloud_preprocessor/memory.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/crop_box_diagnostics.hpp"
+#include "autoware/pointcloud_preprocessor/diagnostics/diagnostics_base.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/distortion_corrector_diagnostics.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/latency_diagnostics.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/pass_rate_diagnostics.hpp"
@@ -34,7 +35,9 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <deque>
 #include <memory>
 #include <string>
@@ -44,6 +47,79 @@
 namespace autoware::cuda_pointcloud_preprocessor
 {
 using sensor_msgs::msg::PointCloud2;
+namespace
+{
+
+std::size_t queue_size_from_frequency(const double max_frequency_hz)
+{
+  // TODO(mojomex): derive from a future pointcloud_frequency param instead of assuming 10 Hz.
+  constexpr double assumed_pointcloud_frequency_hz = 10.0;
+  if (max_frequency_hz <= 0.0) {
+    throw std::runtime_error("Queue frequency parameters must be positive");
+  }
+  return static_cast<std::size_t>(std::ceil(max_frequency_hz / assumed_pointcloud_frequency_hz)) +
+         1U;
+}
+
+class InputBoundsDiagnostics : public autoware::pointcloud_preprocessor::DiagnosticsBase
+{
+public:
+  InputBoundsDiagnostics(
+    const std::size_t input_points, const std::size_t max_input_points,
+    const std::size_t truncated_points, const std::size_t twist_queue_size,
+    const std::size_t max_twist_queue_size, const std::size_t dropped_twists,
+    const std::size_t imu_queue_size, const std::size_t max_imu_queue_size,
+    const std::size_t dropped_imus)
+  : input_points_(input_points),
+    max_input_points_(max_input_points),
+    truncated_points_(truncated_points),
+    twist_queue_size_(twist_queue_size),
+    max_twist_queue_size_(max_twist_queue_size),
+    dropped_twists_(dropped_twists),
+    imu_queue_size_(imu_queue_size),
+    max_imu_queue_size_(max_imu_queue_size),
+    dropped_imus_(dropped_imus)
+  {
+  }
+
+  void add_to_interface(autoware_utils::DiagnosticsInterface & interface) const override
+  {
+    interface.add_key_value("Input point count", input_points_);
+    interface.add_key_value("Maximum input point count", max_input_points_);
+    interface.add_key_value("Truncated input point count", truncated_points_);
+    interface.add_key_value("Twist queue size", twist_queue_size_);
+    interface.add_key_value("Maximum twist queue size", max_twist_queue_size_);
+    interface.add_key_value("Dropped twist count", dropped_twists_);
+    interface.add_key_value("IMU queue size", imu_queue_size_);
+    interface.add_key_value("Maximum IMU queue size", max_imu_queue_size_);
+    interface.add_key_value("Dropped IMU count", dropped_imus_);
+  }
+
+  [[nodiscard]] std::optional<std::pair<int, std::string>> evaluate_status() const override
+  {
+    if (truncated_points_ > 0 || dropped_twists_ > 0 || dropped_imus_ > 0) {
+      return std::make_pair(
+        diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+        "[ERROR]: input bounds exceeded; truncated_points=" + std::to_string(truncated_points_) +
+          ", dropped_twists=" + std::to_string(dropped_twists_) +
+          ", dropped_imus=" + std::to_string(dropped_imus_));
+    }
+    return std::nullopt;
+  }
+
+private:
+  std::size_t input_points_;
+  std::size_t max_input_points_;
+  std::size_t truncated_points_;
+  std::size_t twist_queue_size_;
+  std::size_t max_twist_queue_size_;
+  std::size_t dropped_twists_;
+  std::size_t imu_queue_size_;
+  std::size_t max_imu_queue_size_;
+  std::size_t dropped_imus_;
+};
+
+}  // namespace
 
 CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   const rclcpp::NodeOptions & node_options)
@@ -62,6 +138,22 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   use_3d_undistortion_ = declare_parameter<bool>("use_3d_distortion_correction");
   use_imu_ = declare_parameter<bool>("use_imu");
   bool enable_ring_outlier_filter = declare_parameter<bool>("enable_ring_outlier_filter");
+  input_bounds_params_.max_input_point_count =
+    static_cast<std::size_t>(declare_parameter<int64_t>("max_input_point_count"));
+  const auto max_twist_frequency_hz = declare_parameter<double>("max_twist_frequency_hz");
+  const auto max_imu_frequency_hz = declare_parameter<double>("max_imu_frequency_hz");
+  input_bounds_params_.max_twist_subscriber_queue_size =
+    queue_size_from_frequency(max_twist_frequency_hz);
+  input_bounds_params_.max_imu_subscriber_queue_size =
+    queue_size_from_frequency(max_imu_frequency_hz);
+  input_bounds_params_.max_twist_queue_size =
+    static_cast<std::size_t>(std::ceil(max_twist_frequency_hz));
+  input_bounds_params_.max_imu_queue_size =
+    static_cast<std::size_t>(std::ceil(max_imu_frequency_hz));
+
+  if (input_bounds_params_.max_input_point_count == 0) {
+    throw std::runtime_error("max_input_point_count must be positive");
+  }
 
   RingOutlierFilterParameters ring_outlier_filter_parameters;
   ring_outlier_filter_parameters.distance_ratio =
@@ -133,18 +225,16 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
     std::bind(&CudaPointcloudPreprocessorNode::pointcloudCallback, this, std::placeholders::_1),
     sub_options);
 
-  // Twist queue size needs to be larger than 'twist frequency' / 'pointcloud frequency'.
-  // To avoid individual tuning, a sufficiently large value is hard-coded.
-  // With 100, it can handle twist updates up to 1000Hz if the pointcloud is 10Hz.
-  const uint16_t TWIST_QUEUE_SIZE = 100;
   twist_sub_ = autoware_utils::InterProcessPollingSubscriber<
     geometry_msgs::msg::TwistWithCovarianceStamped, autoware_utils::polling_policy::All>::
-    create_subscription(this, "~/input/twist", rclcpp::QoS(TWIST_QUEUE_SIZE));
+    create_subscription(
+      this, "~/input/twist", rclcpp::QoS(input_bounds_params_.max_twist_subscriber_queue_size));
 
   if (use_imu_) {
     imu_sub_ = autoware_utils::InterProcessPollingSubscriber<
       sensor_msgs::msg::Imu, autoware_utils::polling_policy::All>::
-      create_subscription(this, "~/input/imu", rclcpp::QoS(TWIST_QUEUE_SIZE));
+      create_subscription(
+        this, "~/input/imu", rclcpp::QoS(input_bounds_params_.max_imu_subscriber_queue_size));
   }
 
   CudaPointcloudPreprocessor::UndistortionType undistortion_type =
@@ -152,6 +242,7 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
                          : CudaPointcloudPreprocessor::UndistortionType::Undistortion2D;
 
   cuda_pointcloud_preprocessor_ = std::make_unique<CudaPointcloudPreprocessor>();
+  cuda_pointcloud_preprocessor_->setMaxInputPointCount(input_bounds_params_.max_input_point_count);
   cuda_pointcloud_preprocessor_->setRingOutlierFilterParameters(ring_outlier_filter_parameters);
   cuda_pointcloud_preprocessor_->setRingOutlierFilterActive(enable_ring_outlier_filter);
   cuda_pointcloud_preprocessor_->setCropBoxParameters(crop_box_parameters);
@@ -220,6 +311,7 @@ void CudaPointcloudPreprocessorNode::twistCallback(
       return rclcpp::Time(twist.header.stamp) < stamp;
     });
   twist_queue_.insert(it, twist_msg);
+  boundTwistQueue();
 }
 
 void CudaPointcloudPreprocessorNode::imuCallback(const sensor_msgs::msg::Imu & imu_msg)
@@ -260,6 +352,7 @@ void CudaPointcloudPreprocessorNode::imuCallback(const sensor_msgs::msg::Imu & i
       return rclcpp::Time(angular_velocity.header.stamp) < stamp;
     });
   angular_velocity_queue_.insert(it, transformed_angular_velocity);
+  boundImuQueue();
 }
 
 void CudaPointcloudPreprocessorNode::pointcloudCallback(
@@ -267,6 +360,13 @@ void CudaPointcloudPreprocessorNode::pointcloudCallback(
   AUTOWARE_MESSAGE_UNIQUE_PTR(sensor_msgs::msg::PointCloud2) input_pointcloud_msg_ptr)
 {
   const auto & input_pointcloud_msg = *input_pointcloud_msg_ptr;
+  latest_input_bounds_status_ = {};
+  latest_input_bounds_status_.input_point_count =
+    static_cast<std::size_t>(input_pointcloud_msg.width) * input_pointcloud_msg.height;
+  latest_input_bounds_status_.truncated_point_count =
+    latest_input_bounds_status_.input_point_count > input_bounds_params_.max_input_point_count
+      ? latest_input_bounds_status_.input_point_count - input_bounds_params_.max_input_point_count
+      : 0U;
 
   if (!validatePointcloudLayout(input_pointcloud_msg)) {
     return;
@@ -338,20 +438,32 @@ void CudaPointcloudPreprocessorNode::updateTwistQueue(std::uint64_t first_point_
 {
   std::vector<geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr> twist_msgs =
     twist_sub_->take_data();
-  for (const auto & msg : twist_msgs) {
-    twistCallback(*msg);
-  }
 
-  // Find the last twist message that is before the first point's timestamp
-  // and remove all older messages.
   auto it = std::lower_bound(
     twist_queue_.begin(), twist_queue_.end(), first_point_stamp,
     [](const auto & twist, const std::uint64_t stamp) {
       // To prevent potential precision loss, use nanoseconds
-      return rclcpp::Time(twist.header.stamp).nanoseconds() < stamp;
+      return static_cast<std::uint64_t>(rclcpp::Time(twist.header.stamp).nanoseconds()) < stamp;
     });
-
   twist_queue_.erase(twist_queue_.begin(), it);
+
+  twist_msgs.erase(
+    std::remove_if(
+      twist_msgs.begin(), twist_msgs.end(),
+      [first_point_stamp](const auto & twist) {
+        return static_cast<std::uint64_t>(rclcpp::Time(twist->header.stamp).nanoseconds()) <
+               first_point_stamp;
+      }),
+    twist_msgs.end());
+
+  const auto free_capacity = input_bounds_params_.max_twist_queue_size - twist_queue_.size();
+  if (twist_msgs.size() > free_capacity) {
+    latest_input_bounds_status_.dropped_twist_count += twist_msgs.size() - free_capacity;
+    twist_msgs.erase(twist_msgs.begin(), twist_msgs.end() - free_capacity);
+  }
+  for (const auto & msg : twist_msgs) {
+    twistCallback(*msg);
+  }
 }
 
 void CudaPointcloudPreprocessorNode::updateImuQueue(std::uint64_t first_point_stamp)
@@ -359,20 +471,50 @@ void CudaPointcloudPreprocessorNode::updateImuQueue(std::uint64_t first_point_st
   if (!imu_sub_) return;
 
   std::vector<sensor_msgs::msg::Imu::ConstSharedPtr> imu_msgs = imu_sub_->take_data();
-  for (const auto & msg : imu_msgs) {
-    imuCallback(*msg);
-  }
 
-  // Find the last angular velocity message that is before the first point's timestamp
-  // and remove all older messages.
   auto it = std::lower_bound(
     angular_velocity_queue_.begin(), angular_velocity_queue_.end(), first_point_stamp,
     [](const auto & angular_velocity, const std::uint64_t stamp) {
       //  To prevent potential precision loss, use nanoseconds
-      return rclcpp::Time(angular_velocity.header.stamp).nanoseconds() < stamp;
+      return static_cast<std::uint64_t>(rclcpp::Time(angular_velocity.header.stamp).nanoseconds()) <
+             stamp;
     });
-
   angular_velocity_queue_.erase(angular_velocity_queue_.begin(), it);
+
+  imu_msgs.erase(
+    std::remove_if(
+      imu_msgs.begin(), imu_msgs.end(),
+      [first_point_stamp](const auto & imu) {
+        return static_cast<std::uint64_t>(rclcpp::Time(imu->header.stamp).nanoseconds()) <
+               first_point_stamp;
+      }),
+    imu_msgs.end());
+
+  const auto free_capacity =
+    input_bounds_params_.max_imu_queue_size - angular_velocity_queue_.size();
+  if (imu_msgs.size() > free_capacity) {
+    latest_input_bounds_status_.dropped_imu_count += imu_msgs.size() - free_capacity;
+    imu_msgs.erase(imu_msgs.begin(), imu_msgs.end() - free_capacity);
+  }
+  for (const auto & msg : imu_msgs) {
+    imuCallback(*msg);
+  }
+}
+
+void CudaPointcloudPreprocessorNode::boundTwistQueue()
+{
+  while (twist_queue_.size() > input_bounds_params_.max_twist_queue_size) {
+    twist_queue_.pop_front();
+    ++latest_input_bounds_status_.dropped_twist_count;
+  }
+}
+
+void CudaPointcloudPreprocessorNode::boundImuQueue()
+{
+  while (angular_velocity_queue_.size() > input_bounds_params_.max_imu_queue_size) {
+    angular_velocity_queue_.pop_front();
+    ++latest_input_bounds_status_.dropped_imu_count;
+  }
 }
 
 std::optional<geometry_msgs::msg::TransformStamped>
@@ -435,11 +577,18 @@ void CudaPointcloudPreprocessorNode::publishDiagnostics(
 
   auto crop_box_diag =
     std::make_shared<autoware::pointcloud_preprocessor::CropBoxDiagnostics>(skipped_nan_count);
+  auto input_bounds_diag = std::make_shared<InputBoundsDiagnostics>(
+    latest_input_bounds_status_.input_point_count, input_bounds_params_.max_input_point_count,
+    latest_input_bounds_status_.truncated_point_count, twist_queue_.size(),
+    input_bounds_params_.max_twist_queue_size, latest_input_bounds_status_.dropped_twist_count,
+    angular_velocity_queue_.size(), input_bounds_params_.max_imu_queue_size,
+    latest_input_bounds_status_.dropped_imu_count);
 
   diagnostics_interface_->clear();
 
   std::vector<std::shared_ptr<const autoware::pointcloud_preprocessor::DiagnosticsBase>>
-    diagnostics = {latency_diag, pass_rate_diag, crop_box_diag, distortion_corrector_diag};
+    diagnostics = {
+      latency_diag, pass_rate_diag, crop_box_diag, distortion_corrector_diag, input_bounds_diag};
 
   int worst_level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   std::string message;


### PR DESCRIPTION
## Description

Add explicit input bounds to `autoware_cuda_pointcloud_preprocessor`:

- add `max_input_point_count`
- add twist/IMU queue bounds derived from maximum expected frequency and queue window parameters
- truncate point clouds above the configured maximum to the first N points
- discard oldest twist/IMU samples when the bounded queues overflow
- report truncation and dropped input samples through diagnostics as ERROR

This PR keeps the existing dynamic CUDA buffer allocation behavior. The follow-up PRs use these bounds to move internal preprocessor GPU allocations to startup and then remove remaining runtime Thrust allocation paths.

## Stack

This is PR 1 of 5 in a stack. Every PR targets `autowarefoundation:main` (GitHub does not allow cross-repository stacks, and the branches live on a fork), so each **Files changed** tab shows the *cumulative* diff of the stack up to that PR.

**To review only one PR's own changes, use its Own diff link below.**

| # | PR | Own diff |
| --- | --- | --- |
| 1 | #13106 feat: add input bounds diagnostics **← this PR** | [Files changed](https://github.com/autowarefoundation/autoware_universe/pull/13106/files) (bottom of stack) |
| 2 | #13134 perf: allocate fixed GPU buffers at startup | [preproc-bounds-diagnostics → preproc-startup-capacity](https://github.com/mojomex/autoware_universe/compare/preproc-bounds-diagnostics...preproc-startup-capacity) |
| 3 | #13135 perf: avoid runtime thrust allocations | [preproc-startup-capacity → preproc-remove-runtime-thrust-allocs](https://github.com/mojomex/autoware_universe/compare/preproc-startup-capacity...preproc-remove-runtime-thrust-allocs) |
| 4 | #13136 refactor: clarify queue update flow | [preproc-remove-runtime-thrust-allocs → preproc-queue-update-cleanup](https://github.com/mojomex/autoware_universe/compare/preproc-remove-runtime-thrust-allocs...preproc-queue-update-cleanup) |
| 5 | #13137 test: cover capacity bounds behavior | [preproc-queue-update-cleanup → preproc-behavior-tests](https://github.com/mojomex/autoware_universe/compare/preproc-queue-update-cleanup...preproc-behavior-tests) |

Merge in stack order (1 → 5); each PR depends on the one below it. The whole stack is meant as one unit: tests are added at the top to keep the individual PRs small, so please review in stack order but test with the full stack applied (`preproc-behavior-tests`).

## CUDA Blocking Call Flamegraphs

Before/after of this **PR stack**.
Performance improvements come from mojomex/autoware_universe#12 and mojomex/autoware_universe#13.

<!-- Upload before_nvtx_blocking_flame.png here. -->
<img width="3606" height="1545" alt="image" src="https://github.com/user-attachments/assets/7da84b8e-b214-460e-9c3d-398f32811932" />

<!-- Upload after_nvtx_blocking_flame.png here. -->
<img width="3606" height="1545" alt="image" src="https://github.com/user-attachments/assets/f592d259-b00b-4b6a-afc5-8bfe1974065a" />

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `max_input_point_count` | `integer` | `691200` | Maximum number of input points processed per cloud; larger inputs are reported as errors and truncated to the first N points. |
| Added | `max_twist_frequency_hz` | `double` | `200.0` | Maximum expected twist input frequency used to bound the twist queue. |
| Added | `max_imu_frequency_hz` | `double` | `200.0` | Maximum expected IMU input frequency used to bound the IMU queue. |

### Diagnostics Changes

#### Additions and removals

| Change type | DiagnosticStatus name | Diagnostic field / status | Level | Description |
|:------------|:----------------------|:--------------------------|:------|:------------|
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Input point count` | OK | Reports the input point count for the current cloud. |
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Maximum input point count` | OK | Reports the configured maximum accepted input point count. |
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Truncated input point count` | ERROR when non-zero | Reports how many input points were truncated because `max_input_point_count` was exceeded. |
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Twist queue size` | OK | Reports the current bounded twist queue size. |
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Maximum twist queue size` | OK | Reports the configured maximum twist queue size. |
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Dropped twist count` | ERROR when non-zero | Reports how many twist messages were dropped because the bounded queue overflowed. |
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `IMU queue size` | OK | Reports the current bounded IMU queue size. |
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Maximum IMU queue size` | OK | Reports the configured maximum IMU queue size. |
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Dropped IMU count` | ERROR when non-zero | Reports how many IMU messages were dropped because the bounded queue overflowed. |

## Effects on system behavior

- Point clouds larger than `max_input_point_count` are truncated to the first configured maximum number of points instead of being processed at full size.
- Twist and IMU queues are bounded using the configured maximum expected frequencies; when the bounds are exceeded, older/excess samples are dropped.
- Exceeding any of these input bounds is surfaced as an ERROR diagnostic.

## Validation

The below tests have been performed on the **whole PR stack** (on #13137).

Build and whole-system benchmark passed on our test bench.

Also did a side-by-side before (`/a/`) and after (`/b/`) comparison using [TIER IV INTERNAL](https://github.com/tier4/pa-tools). Reproduce: [TIER IV INTERNAL](https://drive.google.com/file/d/180QIIHHrudUi21tAXw7va2S4UK2-R90y/view?usp=sharing)

<img width="3840" height="2160" alt="Screenshot from 2026-08-04 21-32-27" src="https://github.com/user-attachments/assets/18cd6613-5cf1-4b74-a1eb-ab57b33e765d" />

No behavior change observed. The 3 discrepancies between `a` and `b` are due to cuda_blackboard dropping messages when running 2 Autoware instances on my PC.

Unit tests that validate input bound handling are in the top of the stack, #13137.

