### PR TITLE
feat(autoware_trajectory_processor): apply agnocast_wrapper::Node to trajectory_optimizer

### DIFF
--- a/planning/autoware_path_optimizer/CMakeLists.txt
+++ b/planning/autoware_path_optimizer/CMakeLists.txt
@@ -69,6 +69,15 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR})
 target_link_libraries(${PROJECT_NAME} acados_interface)
 
+# The library instantiates the node-type templates for autoware::agnocast_wrapper::Node, so it
+# needs the agnocast headers when Agnocast is enabled and must agree with its consumers on
+# USE_AGNOCAST_ENABLED.
+if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+  find_package(agnocastlib REQUIRED)
+  ament_target_dependencies(${PROJECT_NAME} agnocastlib)
+endif()
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
+
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::path_optimizer::PathOptimizer"
   EXECUTABLE path_optimizer_node

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/mpt_optimizer.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/mpt_optimizer.hpp
@@ -30,6 +30,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Sparse>
+#include <autoware_utils_debug/debug_publisher.hpp>
 
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_msgs/msg/multi_array_dimension.hpp>
@@ -174,14 +175,108 @@ struct ReferencePoint
   }
 };
 
-class MPTOptimizer
+// Node-independent parameter set for the MPT optimizer.
+// Declaration of the parameters lives in the node layer (see declare_mpt_param()),
+// so this struct itself does not depend on any node type.
+struct MPTParam
+{
+  MPTParam() = default;
+  void onParam(const std::vector<rclcpp::Parameter> & parameters);
+
+  // option
+  bool enable_warm_start;
+  bool enable_manual_warm_start;
+  bool enable_optimization_validation;
+  bool steer_limit_constraint;
+  int mpt_visualize_sampling_num;  // for debug
+
+  // common
+  double delta_arc_length;
+  int num_points;
+
+  bool use_acados;
+  // Toggle MPT-style acados road-bound circle constraints (lh/uh on h(x,p)).
+  // When false, we still widen lh/uh to effectively disable generated constraints.
+  bool use_acados_circle_constraints;
+
+  // kinematics
+  double optimization_center_offset;
+  double max_steer_rad;
+
+  // clearance
+  double hard_clearance_from_road;
+  double soft_clearance_from_road;
+  double soft_collision_free_weight;
+
+  // weight
+  double lat_error_weight;
+  double yaw_error_weight;
+  double yaw_error_rate_weight;
+
+  double terminal_lat_error_weight;
+  double terminal_yaw_error_weight;
+  double goal_lat_error_weight;
+  double goal_yaw_error_weight;
+
+  double steer_input_weight;
+  double steer_rate_weight;
+
+  // avoidance
+  double max_bound_fixing_time;
+  double max_longitudinal_margin_for_bound_violation;
+  double max_avoidance_cost;
+  double avoidance_cost_margin;
+  double avoidance_cost_band_length;
+  double avoidance_cost_decrease_rate;
+  double min_drivable_width;
+  double avoidance_lat_error_weight;
+  double avoidance_yaw_error_weight;
+  double avoidance_steer_input_weight;
+
+  // constraint type
+  bool soft_constraint;
+  bool hard_constraint;
+  bool l_inf_norm;
+
+  // vehicle circles
+  std::string vehicle_circles_method;
+  int vehicle_circles_uniform_circle_num;
+  double vehicle_circles_uniform_circle_radius_ratio;
+  int vehicle_circles_bicycle_model_num;
+  double vehicle_circles_bicycle_model_rear_radius_ratio;
+  double vehicle_circles_bicycle_model_front_radius_ratio;
+  int vehicle_circles_fitting_uniform_circle_num;
+
+  // validation
+  double max_validation_lat_error;
+  double max_validation_yaw_error;
+};
+
+// Node-layer factory: declares the "mpt.*" parameters on the given node and returns
+// a Node-independent MPTParam value. Templated on the node type so it works with both
+// rclcpp::Node and autoware::agnocast_wrapper::Node.
+template <typename NodeT>
+MPTParam declare_mpt_param(
+  NodeT * node, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+
+// Node-independent MPT optimizer.
+//
+// As with the elastic band smoother, the only place a node type appears is the debug
+// publisher, injected as a autoware_utils_debug::BasicDebugPublisher<NodeT>. NodeT
+// defaults to rclcpp::Node so existing callers keep working unchanged (see the
+// MPTOptimizer alias below); the agnocast path instantiates it with
+// autoware::agnocast_wrapper::Node. Parameters and logger are passed by value.
+template <typename NodeT = rclcpp::Node>
+class BasicMPTOptimizer
 {
 public:
-  MPTOptimizer(
-    rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
+  BasicMPTOptimizer(
+    const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-    const TrajectoryParam & traj_param, const std::shared_ptr<DebugData> debug_data_ptr,
-    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_);
+    const TrajectoryParam & traj_param, const MPTParam & mpt_param, rclcpp::Logger logger,
+    const std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<NodeT>> & debug_publisher,
+    const std::shared_ptr<DebugData> debug_data_ptr,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
 
   std::optional<std::vector<TrajectoryPoint>> optimizeTrajectory(const PlannerData & planner_data);
   std::optional<std::vector<TrajectoryPoint>> getPrevOptimizedTrajectoryPoints() const;
@@ -242,95 +337,10 @@ private:
     }
   };
 
-  struct MPTParam
-  {
-    explicit MPTParam(
-      rclcpp::Node * node, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
-    MPTParam() = default;
-    void onParam(const std::vector<rclcpp::Parameter> & parameters);
-
-    // option
-    bool enable_warm_start;
-    bool enable_manual_warm_start;
-    bool enable_optimization_validation;
-    bool steer_limit_constraint;
-    int mpt_visualize_sampling_num;  // for debug
-
-    // common
-    double delta_arc_length;
-    int num_points;
-
-    bool use_acados;
-    // Toggle MPT-style acados road-bound circle constraints (lh/uh on h(x,p)).
-    // When false, we still widen lh/uh to effectively disable generated constraints.
-    bool use_acados_circle_constraints;
-
-    // kinematics
-    double optimization_center_offset;
-    double max_steer_rad;
-
-    // clearance
-    double hard_clearance_from_road;
-    double soft_clearance_from_road;
-    double soft_collision_free_weight;
-
-    // weight
-    double lat_error_weight;
-    double yaw_error_weight;
-    double yaw_error_rate_weight;
-
-    double terminal_lat_error_weight;
-    double terminal_yaw_error_weight;
-    double goal_lat_error_weight;
-    double goal_yaw_error_weight;
-
-    double steer_input_weight;
-    double steer_rate_weight;
-
-    // avoidance
-    double max_bound_fixing_time;
-    double max_longitudinal_margin_for_bound_violation;
-    double max_avoidance_cost;
-    double avoidance_cost_margin;
-    double avoidance_cost_band_length;
-    double avoidance_cost_decrease_rate;
-    double min_drivable_width;
-    double avoidance_lat_error_weight;
-    double avoidance_yaw_error_weight;
-    double avoidance_steer_input_weight;
-
-    // constraint type
-    bool soft_constraint;
-    bool hard_constraint;
-    bool l_inf_norm;
-
-    // vehicle circles
-    std::string vehicle_circles_method;
-    int vehicle_circles_uniform_circle_num;
-    double vehicle_circles_uniform_circle_radius_ratio;
-    int vehicle_circles_bicycle_model_num;
-    double vehicle_circles_bicycle_model_rear_radius_ratio;
-    double vehicle_circles_bicycle_model_front_radius_ratio;
-    int vehicle_circles_fitting_uniform_circle_num;
-
-    // validation
-    double max_validation_lat_error;
-    double max_validation_yaw_error;
-  };
-
-  // publisher
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_fixed_traj_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_ref_traj_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_mpt_traj_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_acados_mpt_traj_pub_;
-
-  // Add new publishers for spline coefficients and curvatures
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr debug_optimised_steering_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr
-    debug_acados_optimised_steering_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr debug_optimised_states_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr debug_acados_optimised_states_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr debug_ref_steering_pub_;
+  // debug publisher (injected by the node layer; may be nullptr to disable debug output).
+  // Replaces the previous set of individual rclcpp publishers; each debug topic is now
+  // addressed by name under the "~/debug" namespace.
+  std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<NodeT>> debug_publisher_;
 
   // argument
   bool enable_debug_info_;
@@ -465,5 +475,9 @@ private:
   size_t getNumberOfSlackVariables() const;
   std::optional<double> calcNormalizedAvoidanceCost(const ReferencePoint & ref_point) const;
 };
+
+// Backward-compatible alias: existing callers using a plain rclcpp::Node keep using
+// MPTOptimizer without any change.
+using MPTOptimizer = BasicMPTOptimizer<rclcpp::Node>;
 }  // namespace autoware::path_optimizer
 #endif  // AUTOWARE__PATH_OPTIMIZER__MPT_OPTIMIZER_HPP_

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/node.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/node.hpp
@@ -85,6 +85,8 @@ protected:  // for the static_centerline_generator package
   // core algorithms
   std::shared_ptr<ReplanChecker> replan_checker_ptr_{nullptr};
   std::shared_ptr<MPTOptimizer> mpt_optimizer_ptr_{nullptr};
+  // Debug publisher injected into the (node-independent) MPT optimizer.
+  std::shared_ptr<autoware_utils_debug::DebugPublisher> mpt_debug_publisher_ptr_{nullptr};
 
   // parameters
   TrajectoryParam traj_param_{};

--- a/planning/autoware_path_optimizer/package.xml
+++ b/planning/autoware_path_optimizer/package.xml
@@ -15,6 +15,8 @@
   <buildtool_depend>ament_cmake_export_link_flags</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
@@ -22,6 +24,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>diagnostic_updater</depend>

--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -21,6 +21,7 @@
 #include "autoware/path_optimizer/utils/geometry_utils.hpp"
 #include "autoware/path_optimizer/utils/trajectory_utils.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <rclcpp/logging.hpp>
 #include <tf2/utils.hpp>
@@ -174,126 +175,150 @@ double calcLateralDistToBounds(
 }
 }  // namespace
 
-MPTOptimizer::MPTParam::MPTParam(
-  rclcpp::Node * node, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+template <typename NodeT>
+MPTParam declare_mpt_param(
+  NodeT * node, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
 {
+  MPTParam p;
   {  // option
-    steer_limit_constraint = node->declare_parameter<bool>("mpt.option.steer_limit_constraint");
-    enable_warm_start = node->declare_parameter<bool>("mpt.option.enable_warm_start");
-    enable_manual_warm_start = node->declare_parameter<bool>("mpt.option.enable_manual_warm_start");
-    enable_optimization_validation =
-      node->declare_parameter<bool>("mpt.option.enable_optimization_validation");
-    mpt_visualize_sampling_num = node->declare_parameter<int>("mpt.option.visualize_sampling_num");
+    p.steer_limit_constraint =
+      node->template declare_parameter<bool>("mpt.option.steer_limit_constraint");
+    p.enable_warm_start = node->template declare_parameter<bool>("mpt.option.enable_warm_start");
+    p.enable_manual_warm_start =
+      node->template declare_parameter<bool>("mpt.option.enable_manual_warm_start");
+    p.enable_optimization_validation =
+      node->template declare_parameter<bool>("mpt.option.enable_optimization_validation");
+    p.mpt_visualize_sampling_num =
+      node->template declare_parameter<int>("mpt.option.visualize_sampling_num");
   }
 
   {  // common
-    num_points = node->declare_parameter<int>("mpt.common.num_points");
-    delta_arc_length = node->declare_parameter<double>("mpt.common.delta_arc_length");
+    p.num_points = node->template declare_parameter<int>("mpt.common.num_points");
+    p.delta_arc_length = node->template declare_parameter<double>("mpt.common.delta_arc_length");
   }
 
-  use_acados = node->declare_parameter<bool>("mpt.use_acados");
+  p.use_acados = node->template declare_parameter<bool>("mpt.use_acados");
   // Enable/disable the new MPT-style circle road-bound constraints in acados.
   // Default false so we can A/B test behavior safely.
-  use_acados_circle_constraints =
-    node->declare_parameter<bool>("mpt.use_acados_circle_constraints", false);
+  p.use_acados_circle_constraints =
+    node->template declare_parameter<bool>("mpt.use_acados_circle_constraints", false);
 
   // kinematics
-  max_steer_rad = vehicle_info.max_steer_angle_rad;
+  p.max_steer_rad = vehicle_info.max_steer_angle_rad;
 
   // NOTE: By default, optimization_center_offset will be vehicle_info.wheel_base * 0.8
   //       The 0.8 scale is adopted as it performed the best.
   constexpr double default_wheel_base_ratio = 0.8;
-  optimization_center_offset = node->declare_parameter<double>(
+  p.optimization_center_offset = node->template declare_parameter<double>(
     "mpt.kinematics.optimization_center_offset",
     vehicle_info.wheel_base_m * default_wheel_base_ratio);
 
   {  // clearance
-    hard_clearance_from_road =
-      node->declare_parameter<double>("mpt.clearance.hard_clearance_from_road");
-    soft_clearance_from_road =
-      node->declare_parameter<double>("mpt.clearance.soft_clearance_from_road");
+    p.hard_clearance_from_road =
+      node->template declare_parameter<double>("mpt.clearance.hard_clearance_from_road");
+    p.soft_clearance_from_road =
+      node->template declare_parameter<double>("mpt.clearance.soft_clearance_from_road");
   }
 
   {  // weight
-    soft_collision_free_weight =
-      node->declare_parameter<double>("mpt.weight.soft_collision_free_weight");
+    p.soft_collision_free_weight =
+      node->template declare_parameter<double>("mpt.weight.soft_collision_free_weight");
 
-    lat_error_weight = node->declare_parameter<double>("mpt.weight.lat_error_weight");
-    yaw_error_weight = node->declare_parameter<double>("mpt.weight.yaw_error_weight");
-    yaw_error_rate_weight = node->declare_parameter<double>("mpt.weight.yaw_error_rate_weight");
-    steer_input_weight = node->declare_parameter<double>("mpt.weight.steer_input_weight");
-    steer_rate_weight = node->declare_parameter<double>("mpt.weight.steer_rate_weight");
+    p.lat_error_weight = node->template declare_parameter<double>("mpt.weight.lat_error_weight");
+    p.yaw_error_weight = node->template declare_parameter<double>("mpt.weight.yaw_error_weight");
+    p.yaw_error_rate_weight =
+      node->template declare_parameter<double>("mpt.weight.yaw_error_rate_weight");
+    p.steer_input_weight =
+      node->template declare_parameter<double>("mpt.weight.steer_input_weight");
+    p.steer_rate_weight = node->template declare_parameter<double>("mpt.weight.steer_rate_weight");
 
-    terminal_lat_error_weight =
-      node->declare_parameter<double>("mpt.weight.terminal_lat_error_weight");
-    terminal_yaw_error_weight =
-      node->declare_parameter<double>("mpt.weight.terminal_yaw_error_weight");
-    goal_lat_error_weight = node->declare_parameter<double>("mpt.weight.goal_lat_error_weight");
-    goal_yaw_error_weight = node->declare_parameter<double>("mpt.weight.goal_yaw_error_weight");
+    p.terminal_lat_error_weight =
+      node->template declare_parameter<double>("mpt.weight.terminal_lat_error_weight");
+    p.terminal_yaw_error_weight =
+      node->template declare_parameter<double>("mpt.weight.terminal_yaw_error_weight");
+    p.goal_lat_error_weight =
+      node->template declare_parameter<double>("mpt.weight.goal_lat_error_weight");
+    p.goal_yaw_error_weight =
+      node->template declare_parameter<double>("mpt.weight.goal_yaw_error_weight");
   }
 
   {  // avoidance
-    max_longitudinal_margin_for_bound_violation =
-      node->declare_parameter<double>("mpt.avoidance.max_longitudinal_margin_for_bound_violation");
-    max_bound_fixing_time = node->declare_parameter<double>("mpt.avoidance.max_bound_fixing_time");
-    max_avoidance_cost = node->declare_parameter<double>("mpt.avoidance.max_avoidance_cost");
-    avoidance_cost_margin = node->declare_parameter<double>("mpt.avoidance.avoidance_cost_margin");
-    avoidance_cost_band_length =
-      node->declare_parameter<double>("mpt.avoidance.avoidance_cost_band_length");
-    avoidance_cost_decrease_rate =
-      node->declare_parameter<double>("mpt.avoidance.avoidance_cost_decrease_rate");
-    min_drivable_width = node->declare_parameter<double>("mpt.avoidance.min_drivable_width");
+    p.max_longitudinal_margin_for_bound_violation = node->template declare_parameter<double>(
+      "mpt.avoidance.max_longitudinal_margin_for_bound_violation");
+    p.max_bound_fixing_time =
+      node->template declare_parameter<double>("mpt.avoidance.max_bound_fixing_time");
+    p.max_avoidance_cost =
+      node->template declare_parameter<double>("mpt.avoidance.max_avoidance_cost");
+    p.avoidance_cost_margin =
+      node->template declare_parameter<double>("mpt.avoidance.avoidance_cost_margin");
+    p.avoidance_cost_band_length =
+      node->template declare_parameter<double>("mpt.avoidance.avoidance_cost_band_length");
+    p.avoidance_cost_decrease_rate =
+      node->template declare_parameter<double>("mpt.avoidance.avoidance_cost_decrease_rate");
+    p.min_drivable_width =
+      node->template declare_parameter<double>("mpt.avoidance.min_drivable_width");
 
-    avoidance_lat_error_weight =
-      node->declare_parameter<double>("mpt.avoidance.weight.lat_error_weight");
-    avoidance_yaw_error_weight =
-      node->declare_parameter<double>("mpt.avoidance.weight.yaw_error_weight");
-    avoidance_steer_input_weight =
-      node->declare_parameter<double>("mpt.avoidance.weight.steer_input_weight");
+    p.avoidance_lat_error_weight =
+      node->template declare_parameter<double>("mpt.avoidance.weight.lat_error_weight");
+    p.avoidance_yaw_error_weight =
+      node->template declare_parameter<double>("mpt.avoidance.weight.yaw_error_weight");
+    p.avoidance_steer_input_weight =
+      node->template declare_parameter<double>("mpt.avoidance.weight.steer_input_weight");
   }
 
   {  // collision free constraints
-    l_inf_norm = node->declare_parameter<bool>("mpt.collision_free_constraints.option.l_inf_norm");
-    soft_constraint =
-      node->declare_parameter<bool>("mpt.collision_free_constraints.option.soft_constraint");
-    hard_constraint =
-      node->declare_parameter<bool>("mpt.collision_free_constraints.option.hard_constraint");
+    p.l_inf_norm =
+      node->template declare_parameter<bool>("mpt.collision_free_constraints.option.l_inf_norm");
+    p.soft_constraint = node->template declare_parameter<bool>(
+      "mpt.collision_free_constraints.option.soft_constraint");
+    p.hard_constraint = node->template declare_parameter<bool>(
+      "mpt.collision_free_constraints.option.hard_constraint");
   }
 
   {  // vehicle_circles
     // NOTE: Vehicle shape for collision free constraints is considered as a set of circles
-    vehicle_circles_method =
-      node->declare_parameter<std::string>("mpt.collision_free_constraints.vehicle_circles.method");
+    p.vehicle_circles_method = node->template declare_parameter<std::string>(
+      "mpt.collision_free_constraints.vehicle_circles.method");
 
     // uniform circles
-    vehicle_circles_uniform_circle_num = node->declare_parameter<int>(
+    p.vehicle_circles_uniform_circle_num = node->template declare_parameter<int>(
       "mpt.collision_free_constraints.vehicle_circles.uniform_circle.num");
-    vehicle_circles_uniform_circle_radius_ratio = node->declare_parameter<double>(
+    p.vehicle_circles_uniform_circle_radius_ratio = node->template declare_parameter<double>(
       "mpt.collision_free_constraints.vehicle_circles.uniform_circle.radius_ratio");
 
     // bicycle model
-    vehicle_circles_bicycle_model_num = node->declare_parameter<int>(
+    p.vehicle_circles_bicycle_model_num = node->template declare_parameter<int>(
       "mpt.collision_free_constraints.vehicle_circles.bicycle_model.num_for_"
       "calculation");
-    vehicle_circles_bicycle_model_rear_radius_ratio = node->declare_parameter<double>(
+    p.vehicle_circles_bicycle_model_rear_radius_ratio = node->template declare_parameter<double>(
       "mpt.collision_free_constraints.vehicle_circles."
       "bicycle_model.rear_radius_ratio");
-    vehicle_circles_bicycle_model_front_radius_ratio = node->declare_parameter<double>(
+    p.vehicle_circles_bicycle_model_front_radius_ratio = node->template declare_parameter<double>(
       "mpt.collision_free_constraints.vehicle_circles."
       "bicycle_model.front_radius_ratio");
 
     // fitting uniform circles
-    vehicle_circles_fitting_uniform_circle_num = node->declare_parameter<int>(
+    p.vehicle_circles_fitting_uniform_circle_num = node->template declare_parameter<int>(
       "mpt.collision_free_constraints.vehicle_circles.fitting_uniform_circle.num");
   }
 
   {  // validation
-    max_validation_lat_error = node->declare_parameter<double>("mpt.validation.max_lat_error");
-    max_validation_yaw_error = node->declare_parameter<double>("mpt.validation.max_yaw_error");
+    p.max_validation_lat_error =
+      node->template declare_parameter<double>("mpt.validation.max_lat_error");
+    p.max_validation_yaw_error =
+      node->template declare_parameter<double>("mpt.validation.max_yaw_error");
   }
+  return p;
 }
 
-void MPTOptimizer::MPTParam::onParam(const std::vector<rclcpp::Parameter> & parameters)
+// Explicit instantiations for the supported node types. autoware::agnocast_wrapper::Node is a
+// distinct class from rclcpp::Node in both ENABLE_AGNOCAST=0/1 builds, so both are always needed.
+template MPTParam declare_mpt_param<rclcpp::Node>(
+  rclcpp::Node *, const autoware::vehicle_info_utils::VehicleInfo &);
+template MPTParam declare_mpt_param<autoware::agnocast_wrapper::Node>(
+  autoware::agnocast_wrapper::Node *, const autoware::vehicle_info_utils::VehicleInfo &);
+
+void MPTParam::onParam(const std::vector<rclcpp::Parameter> & parameters)
 {
   using autoware_utils::update_param;
 
@@ -407,21 +432,24 @@ void MPTOptimizer::MPTParam::onParam(const std::vector<rclcpp::Parameter> & para
   }
 }
 
-MPTOptimizer::MPTOptimizer(
-  rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
+template <typename NodeT>
+BasicMPTOptimizer<NodeT>::BasicMPTOptimizer(
+  const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const TrajectoryParam & traj_param, const std::shared_ptr<DebugData> debug_data_ptr,
+  const TrajectoryParam & traj_param, const MPTParam & mpt_param, rclcpp::Logger logger,
+  const std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<NodeT>> & debug_publisher,
+  const std::shared_ptr<DebugData> debug_data_ptr,
   const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
-: enable_debug_info_(enable_debug_info),
+: debug_publisher_(debug_publisher),
+  enable_debug_info_(enable_debug_info),
   ego_nearest_param_(ego_nearest_param),
   vehicle_info_(vehicle_info),
   traj_param_(traj_param),
   debug_data_ptr_(debug_data_ptr),
   time_keeper_(time_keeper),
-  logger_(node->get_logger().get_child("mpt_optimizer"))
+  logger_(logger.get_child("mpt_optimizer")),
+  mpt_param_(mpt_param)
 {
-  // initialize mpt param
-  mpt_param_ = MPTParam(node, vehicle_info);
   updateVehicleCircles();
   debug_data_ptr_->mpt_visualize_sampling_num = mpt_param_.mpt_visualize_sampling_num;
 
@@ -431,26 +459,10 @@ MPTOptimizer::MPTOptimizer(
 
   // osqp solver
   osqp_solver_ptr_ = std::make_unique<autoware::osqp_interface::OSQPInterface>(osqp_epsilon_);
-
-  // publisher
-  debug_fixed_traj_pub_ = node->create_publisher<Trajectory>("~/debug/mpt_fixed_traj", 1);
-  debug_ref_traj_pub_ = node->create_publisher<Trajectory>("~/debug/mpt_ref_traj", 1);
-  debug_mpt_traj_pub_ = node->create_publisher<Trajectory>("~/debug/mpt_traj", 1);
-  debug_optimised_steering_pub_ =
-    node->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/optimised_steering", 1);
-
-  debug_acados_mpt_traj_pub_ = node->create_publisher<Trajectory>("~/debug/acados_mpt_traj", 1);
-  debug_acados_optimised_steering_pub_ = node->create_publisher<std_msgs::msg::Float32MultiArray>(
-    "~/debug/acados_optimised_steering", 1);
-  debug_optimised_states_pub_ =
-    node->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/optimised_states", 1);
-  debug_acados_optimised_states_pub_ =
-    node->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/acados_optimised_states", 1);
-  debug_ref_steering_pub_ =
-    node->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/ref_steering", 1);
 }
 
-void MPTOptimizer::updateVehicleCircles()
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateVehicleCircles()
 {
   const auto & p = mpt_param_;
 
@@ -477,25 +489,30 @@ void MPTOptimizer::updateVehicleCircles()
   debug_data_ptr_->vehicle_circle_longitudinal_offsets = vehicle_circle_longitudinal_offsets_;
 }
 
-void MPTOptimizer::initialize(const bool enable_debug_info, const TrajectoryParam & traj_param)
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::initialize(
+  const bool enable_debug_info, const TrajectoryParam & traj_param)
 {
   enable_debug_info_ = enable_debug_info;
   traj_param_ = traj_param;
 }
 
-void MPTOptimizer::resetPreviousData()
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::resetPreviousData()
 {
   prev_ref_points_ptr_ = nullptr;
   prev_optimized_traj_points_ptr_ = nullptr;
 }
 
-void MPTOptimizer::onParam(const std::vector<rclcpp::Parameter> & parameters)
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::onParam(const std::vector<rclcpp::Parameter> & parameters)
 {
   mpt_param_.onParam(parameters);
   updateVehicleCircles();
   debug_data_ptr_->mpt_visualize_sampling_num = mpt_param_.mpt_visualize_sampling_num;
 }
-std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::optimizeTrajectory(
+template <typename NodeT>
+std::optional<std::vector<TrajectoryPoint>> BasicMPTOptimizer<NodeT>::optimizeTrajectory(
   const PlannerData & planner_data)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
@@ -601,7 +618,9 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::optimizeTrajectory(
   return output_trajectory;
 }
 
-std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::getPrevOptimizedTrajectoryPoints() const
+template <typename NodeT>
+std::optional<std::vector<TrajectoryPoint>>
+BasicMPTOptimizer<NodeT>::getPrevOptimizedTrajectoryPoints() const
 {
   if (prev_optimized_traj_points_ptr_) {
     return *prev_optimized_traj_points_ptr_;
@@ -609,7 +628,9 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::getPrevOptimizedTrajec
   return std::nullopt;
 }
 
-void MPTOptimizer::publishOptimizedSteering(const Eigen::VectorXd & optimized_variables) const
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::publishOptimizedSteering(
+  const Eigen::VectorXd & optimized_variables) const
 {
   std_msgs::msg::Float32MultiArray msg;
   msg.layout.dim.push_back(std_msgs::msg::MultiArrayDimension());
@@ -620,10 +641,14 @@ void MPTOptimizer::publishOptimizedSteering(const Eigen::VectorXd & optimized_va
     msg.data.push_back(static_cast<float>(optimized_variables(i)));
   }
 
-  debug_optimised_steering_pub_->publish(msg);
+  if (debug_publisher_) {
+    debug_publisher_->publish("optimised_steering", msg);
+  }
 }
 
-void MPTOptimizer::publishOptimizedStates(const Eigen::VectorXd & states, const size_t N) const
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::publishOptimizedStates(
+  const Eigen::VectorXd & states, const size_t N) const
 {
   std_msgs::msg::Float32MultiArray msg;
   // Format as flat array: [eY_0, ePsi_0, eY_1, ePsi_1, ..., eY_N-1, ePsi_N-1]
@@ -631,10 +656,13 @@ void MPTOptimizer::publishOptimizedStates(const Eigen::VectorXd & states, const 
     msg.data.push_back(static_cast<float>(states(2 * i)));      // eY
     msg.data.push_back(static_cast<float>(states(2 * i + 1)));  // ePsi
   }
-  debug_optimised_states_pub_->publish(msg);
+  if (debug_publisher_) {
+    debug_publisher_->publish("optimised_states", msg);
+  }
 }
 
-void MPTOptimizer::updateDebugDataAndPublishAcadosSteering(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateDebugDataAndPublishAcadosSteering(
   const AcadosSolution & acados_result, const std::vector<ReferencePoint> & ref_points,
   const std::vector<TrajectoryPoint> & acados_traj_points)
 {
@@ -654,19 +682,25 @@ void MPTOptimizer::updateDebugDataAndPublishAcadosSteering(
     acados_steering_msg.data.push_back(static_cast<float>(delta[0]));
   }
 
-  debug_acados_optimised_steering_pub_->publish(acados_steering_msg);
+  if (debug_publisher_) {
+    debug_publisher_->publish("acados_optimised_steering", acados_steering_msg);
+  }
 }
 
-void MPTOptimizer::publishAcadosTrajectory(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::publishAcadosTrajectory(
   const std::vector<TrajectoryPoint> & acados_traj_points,
   const std_msgs::msg::Header & header) const
 {
   // Publish acados trajectory to separate topic for comparison
   const auto acados_traj = autoware::motion_utils::convertToTrajectory(acados_traj_points, header);
-  debug_acados_mpt_traj_pub_->publish(acados_traj);
+  if (debug_publisher_) {
+    debug_publisher_->publish("acados_mpt_traj", acados_traj);
+  }
 }
 
-void MPTOptimizer::publishAcadosStates(const AcadosSolution & acados_result) const
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::publishAcadosStates(const AcadosSolution & acados_result) const
 {
   // Publish acados states
   const auto acados_states = acados_result.xtraj;
@@ -676,19 +710,25 @@ void MPTOptimizer::publishAcadosStates(const AcadosSolution & acados_result) con
     acados_states_msg.data.push_back(static_cast<float>(acados_states[i][0]));  // eY
     acados_states_msg.data.push_back(static_cast<float>(acados_states[i][1]));  // ePsi
   }
-  debug_acados_optimised_states_pub_->publish(acados_states_msg);
+  if (debug_publisher_) {
+    debug_publisher_->publish("acados_optimised_states", acados_states_msg);
+  }
 }
 
-void MPTOptimizer::publishReferenceTrajectory(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::publishReferenceTrajectory(
   const std::vector<ReferencePoint> & ref_points, const std_msgs::msg::Header & header) const
 {
   // Publish reference trajectory for comparison
   const auto ref_traj = autoware::motion_utils::convertToTrajectory(
     trajectory_utils::convertToTrajectoryPoints(ref_points), header);
-  debug_ref_traj_pub_->publish(ref_traj);
+  if (debug_publisher_) {
+    debug_publisher_->publish("mpt_ref_traj", ref_traj);
+  }
 }
 
-void MPTOptimizer::publishReferenceSteeringAngles(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::publishReferenceSteeringAngles(
   const autoware::interpolation::SplineInterpolationPoints2d & ref_points_spline) const
 {
   // Publish reference trajectory steering angles (from curvature)
@@ -732,7 +772,9 @@ void MPTOptimizer::publishReferenceSteeringAngles(
       }
     }
   }
-  debug_ref_steering_pub_->publish(ref_steering_msg);
+  if (debug_publisher_) {
+    debug_publisher_->publish("ref_steering", ref_steering_msg);
+  }
 }
 
 geometry_msgs::msg::Point getCorner(const geometry_msgs::msg::Pose & ego_pose, double dx, double dy)
@@ -756,7 +798,8 @@ geometry_msgs::msg::Point getCorner(const geometry_msgs::msg::Pose & ego_pose, d
 
 // Build parameter vector and initial state x0 from the request. If a parameter-size mismatch
 // is detected, this will set skipSolve=true and populate the response with empty results.
-std::array<double, NP> MPTOptimizer::buildParameters(
+template <typename NodeT>
+std::array<double, NP> BasicMPTOptimizer<NodeT>::buildParameters(
   const std::vector<double> & knots, const std::vector<double> & curvatures) const
 {
   RCLCPP_DEBUG(logger_, "sizes: knots=%zu curvatures=%zu", knots.size(), curvatures.size());
@@ -808,7 +851,8 @@ std::array<double, NP> MPTOptimizer::buildParameters(
   return parameters;
 }
 
-void MPTOptimizer::setParametersToSolver(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::setParametersToSolver(
   const std::array<double, NP> & parameters, const std::vector<ReferencePoint> & ref_points,
   const double s0)
 {
@@ -874,7 +918,9 @@ void MPTOptimizer::setParametersToSolver(
   }
 }
 
-std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::convertAcadosSolutionToTrajectory(
+template <typename NodeT>
+std::optional<std::vector<TrajectoryPoint>>
+BasicMPTOptimizer<NodeT>::convertAcadosSolutionToTrajectory(
   std::vector<ReferencePoint> & ref_points, const AcadosSolution & acados_solution) const
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
@@ -949,7 +995,8 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::convertAcadosSolutionT
   return traj_points;
 }
 
-AcadosSolution MPTOptimizer::runAcadosMPT(
+template <typename NodeT>
+AcadosSolution BasicMPTOptimizer<NodeT>::runAcadosMPT(
   const std::vector<ReferencePoint> & ref_points,
   autoware::interpolation::SplineInterpolationPoints2d & ref_points_spline,
   const geometry_msgs::msg::Pose & ego_pose)
@@ -1005,8 +1052,9 @@ AcadosSolution MPTOptimizer::runAcadosMPT(
   return acados_solution;
 }
 
+template <typename NodeT>
 std::pair<std::vector<ReferencePoint>, autoware::interpolation::SplineInterpolationPoints2d>
-MPTOptimizer::calcReferencePoints(
+BasicMPTOptimizer<NodeT>::calcReferencePoints(
   const PlannerData & planner_data, const std::vector<TrajectoryPoint> & smoothed_points)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
@@ -1098,7 +1146,8 @@ MPTOptimizer::calcReferencePoints(
   return std::make_pair(ref_points, ref_points_spline);
 }
 
-void MPTOptimizer::updateOrientation(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateOrientation(
   std::vector<ReferencePoint> & ref_points,
   const autoware::interpolation::SplineInterpolationPoints2d & ref_points_spline) const
 {
@@ -1108,7 +1157,8 @@ void MPTOptimizer::updateOrientation(
   }
 }
 
-void MPTOptimizer::updateCurvature(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateCurvature(
   std::vector<ReferencePoint> & ref_points,
   const autoware::interpolation::SplineInterpolationPoints2d & ref_points_spline) const
 {
@@ -1118,7 +1168,8 @@ void MPTOptimizer::updateCurvature(
   }
 }
 
-void MPTOptimizer::updateFixedPoint(std::vector<ReferencePoint> & ref_points) const
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateFixedPoint(std::vector<ReferencePoint> & ref_points) const
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -1164,7 +1215,8 @@ void MPTOptimizer::updateFixedPoint(std::vector<ReferencePoint> & ref_points) co
   }
 }
 
-void MPTOptimizer::updateDeltaArcLength(std::vector<ReferencePoint> & ref_points) const
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateDeltaArcLength(std::vector<ReferencePoint> & ref_points) const
 {
   for (size_t i = 0; i < ref_points.size(); i++) {
     ref_points.at(i).delta_arc_length =
@@ -1174,7 +1226,8 @@ void MPTOptimizer::updateDeltaArcLength(std::vector<ReferencePoint> & ref_points
   }
 }
 
-void MPTOptimizer::updateExtraPoints(std::vector<ReferencePoint> & ref_points) const
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateExtraPoints(std::vector<ReferencePoint> & ref_points) const
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -1266,7 +1319,8 @@ void MPTOptimizer::updateExtraPoints(std::vector<ReferencePoint> & ref_points) c
   }
 }
 
-void MPTOptimizer::updateBounds(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateBounds(
   std::vector<ReferencePoint> & ref_points,
   const std::vector<geometry_msgs::msg::Point> & left_bound,
   const std::vector<geometry_msgs::msg::Point> & right_bound,
@@ -1323,7 +1377,9 @@ void MPTOptimizer::updateBounds(
   return;
 }
 
-void MPTOptimizer::keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_points) const
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::keepMinimumBoundsWidth(
+  std::vector<ReferencePoint> & ref_points) const
 {
   // calculate drivable area width considering the curvature
   std::vector<double> min_dynamic_drivable_width_vec;
@@ -1498,7 +1554,8 @@ void MPTOptimizer::keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_poin
   }
 }
 
-std::vector<ReferencePoint> MPTOptimizer::extendViolatedBounds(
+template <typename NodeT>
+std::vector<ReferencePoint> BasicMPTOptimizer<NodeT>::extendViolatedBounds(
   const std::vector<ReferencePoint> & ref_points) const
 {
   auto extended_ref_points = ref_points;
@@ -1545,7 +1602,8 @@ std::vector<ReferencePoint> MPTOptimizer::extendViolatedBounds(
   return extended_ref_points;
 }
 
-void MPTOptimizer::avoidSuddenSteering(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::avoidSuddenSteering(
   std::vector<ReferencePoint> & ref_points, const geometry_msgs::msg::Pose & ego_pose,
   const double ego_vel) const
 {
@@ -1573,7 +1631,8 @@ void MPTOptimizer::avoidSuddenSteering(
   }
 }
 
-void MPTOptimizer::updateVehicleBounds(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::updateVehicleBounds(
   std::vector<ReferencePoint> & ref_points,
   const autoware::interpolation::SplineInterpolationPoints2d & ref_points_spline) const
 {
@@ -1635,7 +1694,8 @@ void MPTOptimizer::updateVehicleBounds(
 }
 
 // cost function: J = x' Q x + u' R u
-MPTOptimizer::ValueMatrix MPTOptimizer::calcValueMatrix(
+template <typename NodeT>
+typename BasicMPTOptimizer<NodeT>::ValueMatrix BasicMPTOptimizer<NodeT>::calcValueMatrix(
   const std::vector<ReferencePoint> & ref_points,
   const std::vector<TrajectoryPoint> & traj_points) const
 {
@@ -1701,7 +1761,8 @@ MPTOptimizer::ValueMatrix MPTOptimizer::calcValueMatrix(
   return ValueMatrix{Q_sparse_mat, R_sparse_mat};
 }
 
-MPTOptimizer::ObjectiveMatrix MPTOptimizer::calcObjectiveMatrix(
+template <typename NodeT>
+typename BasicMPTOptimizer<NodeT>::ObjectiveMatrix BasicMPTOptimizer<NodeT>::calcObjectiveMatrix(
   [[maybe_unused]] const StateEquationGenerator::Matrix & mpt_mat, const ValueMatrix & val_mat,
   const std::vector<ReferencePoint> & ref_points) const
 {
@@ -1772,7 +1833,8 @@ MPTOptimizer::ObjectiveMatrix MPTOptimizer::calcObjectiveMatrix(
 // Constraint: lb <= A u <= ub
 // decision variable
 // u := [initial state, steer angles, soft variables]
-MPTOptimizer::ConstraintMatrix MPTOptimizer::calcConstraintMatrix(
+template <typename NodeT>
+typename BasicMPTOptimizer<NodeT>::ConstraintMatrix BasicMPTOptimizer<NodeT>::calcConstraintMatrix(
   const StateEquationGenerator::Matrix & mpt_mat,
   const std::vector<ReferencePoint> & ref_points) const
 {
@@ -1953,7 +2015,8 @@ MPTOptimizer::ConstraintMatrix MPTOptimizer::calcConstraintMatrix(
   return ConstraintMatrix{A, lb, ub};
 }
 
-void MPTOptimizer::addSteerWeightR(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::addSteerWeightR(
   std::vector<Eigen::Triplet<double>> & R_triplet_vec,
   const std::vector<ReferencePoint> & ref_points) const
 {
@@ -1971,7 +2034,8 @@ void MPTOptimizer::addSteerWeightR(
   }
 }
 
-std::optional<Eigen::VectorXd> MPTOptimizer::calcOptimizedSteerAngles(
+template <typename NodeT>
+std::optional<Eigen::VectorXd> BasicMPTOptimizer<NodeT>::calcOptimizedSteerAngles(
   const std::vector<ReferencePoint> & ref_points, const ObjectiveMatrix & obj_mat,
   const ConstraintMatrix & const_mat)
 {
@@ -2066,7 +2130,8 @@ std::optional<Eigen::VectorXd> MPTOptimizer::calcOptimizedSteerAngles(
   return optimized_variables;
 }
 
-Eigen::VectorXd MPTOptimizer::calcInitialSolutionForManualWarmStart(
+template <typename NodeT>
+Eigen::VectorXd BasicMPTOptimizer<NodeT>::calcInitialSolutionForManualWarmStart(
   const std::vector<ReferencePoint> & ref_points,
   const std::vector<ReferencePoint> & prev_ref_points) const
 {
@@ -2107,8 +2172,11 @@ Eigen::VectorXd MPTOptimizer::calcInitialSolutionForManualWarmStart(
   return u0;
 }
 
-std::pair<MPTOptimizer::ObjectiveMatrix, MPTOptimizer::ConstraintMatrix>
-MPTOptimizer::updateMatrixForManualWarmStart(
+template <typename NodeT>
+std::pair<
+  typename BasicMPTOptimizer<NodeT>::ObjectiveMatrix,
+  typename BasicMPTOptimizer<NodeT>::ConstraintMatrix>
+BasicMPTOptimizer<NodeT>::updateMatrixForManualWarmStart(
   const ObjectiveMatrix & obj_mat, const ConstraintMatrix & const_mat,
   const std::optional<Eigen::VectorXd> & u0) const
 {
@@ -2138,7 +2206,8 @@ MPTOptimizer::updateMatrixForManualWarmStart(
   return {updated_obj_mat, updated_const_mat};
 }
 
-std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::calcMPTPoints(
+template <typename NodeT>
+std::optional<std::vector<TrajectoryPoint>> BasicMPTOptimizer<NodeT>::calcMPTPoints(
   std::vector<ReferencePoint> & ref_points, const Eigen::VectorXd & optimized_variables,
   [[maybe_unused]] const StateEquationGenerator::Matrix & mpt_mat) const
 {
@@ -2198,7 +2267,8 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::calcMPTPoints(
   return traj_points;
 }
 
-void MPTOptimizer::publishDebugTrajectories(
+template <typename NodeT>
+void BasicMPTOptimizer<NodeT>::publishDebugTrajectories(
   const std_msgs::msg::Header & header, const std::vector<ReferencePoint> & ref_points,
   const std::vector<TrajectoryPoint> & mpt_traj_points) const
 {
@@ -2207,19 +2277,26 @@ void MPTOptimizer::publishDebugTrajectories(
   // reference points
   const auto ref_traj = autoware::motion_utils::convertToTrajectory(
     trajectory_utils::convertToTrajectoryPoints(ref_points), header);
-  debug_ref_traj_pub_->publish(ref_traj);
+  if (debug_publisher_) {
+    debug_publisher_->publish("mpt_ref_traj", ref_traj);
+  }
 
   // fixed reference points
   const auto fixed_traj_points = extractFixedPoints(ref_points);
   const auto fixed_traj = autoware::motion_utils::convertToTrajectory(fixed_traj_points, header);
-  debug_fixed_traj_pub_->publish(fixed_traj);
+  if (debug_publisher_) {
+    debug_publisher_->publish("mpt_fixed_traj", fixed_traj);
+  }
 
   // mpt points
   const auto mpt_traj = autoware::motion_utils::convertToTrajectory(mpt_traj_points, header);
-  debug_mpt_traj_pub_->publish(mpt_traj);
+  if (debug_publisher_) {
+    debug_publisher_->publish("mpt_traj", mpt_traj);
+  }
 }
 
-std::vector<TrajectoryPoint> MPTOptimizer::extractFixedPoints(
+template <typename NodeT>
+std::vector<TrajectoryPoint> BasicMPTOptimizer<NodeT>::extractFixedPoints(
   const std::vector<ReferencePoint> & ref_points) const
 {
   std::vector<TrajectoryPoint> fixed_traj_points;
@@ -2235,24 +2312,28 @@ std::vector<TrajectoryPoint> MPTOptimizer::extractFixedPoints(
   return fixed_traj_points;
 }
 
-double MPTOptimizer::getTrajectoryLength() const
+template <typename NodeT>
+double BasicMPTOptimizer<NodeT>::getTrajectoryLength() const
 {
   const double forward_traj_length = mpt_param_.num_points * mpt_param_.delta_arc_length;
   const double backward_traj_length = traj_param_.output_backward_traj_length;
   return forward_traj_length + backward_traj_length;
 }
 
-double MPTOptimizer::getDeltaArcLength() const
+template <typename NodeT>
+double BasicMPTOptimizer<NodeT>::getDeltaArcLength() const
 {
   return mpt_param_.delta_arc_length;
 }
 
-int MPTOptimizer::getNumberOfPoints() const
+template <typename NodeT>
+int BasicMPTOptimizer<NodeT>::getNumberOfPoints() const
 {
   return mpt_param_.num_points;
 }
 
-size_t MPTOptimizer::getNumberOfSlackVariables() const
+template <typename NodeT>
+size_t BasicMPTOptimizer<NodeT>::getNumberOfSlackVariables() const
 {
   if (mpt_param_.soft_constraint) {
     if (mpt_param_.l_inf_norm) {
@@ -2263,7 +2344,8 @@ size_t MPTOptimizer::getNumberOfSlackVariables() const
   return 0;
 }
 
-std::optional<double> MPTOptimizer::calcNormalizedAvoidanceCost(
+template <typename NodeT>
+std::optional<double> BasicMPTOptimizer<NodeT>::calcNormalizedAvoidanceCost(
   const ReferencePoint & ref_point) const
 {
   const double negative_avoidance_cost = std::min(
@@ -2274,4 +2356,8 @@ std::optional<double> MPTOptimizer::calcNormalizedAvoidanceCost(
   }
   return std::clamp(-negative_avoidance_cost / mpt_param_.max_avoidance_cost, 0.0, 1.0);
 }
+
+// Explicit instantiations for the supported node types (see declare_mpt_param above).
+template class BasicMPTOptimizer<rclcpp::Node>;
+template class BasicMPTOptimizer<autoware::agnocast_wrapper::Node>;
 }  // namespace autoware::path_optimizer

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -149,9 +149,14 @@ PathOptimizer::PathOptimizer(const rclcpp::NodeOptions & node_options)
 
   // create core algorithm pointers with parameter declaration
   replan_checker_ptr_ = std::make_shared<ReplanChecker>(this, ego_nearest_param_);
+  // Declare the MPT parameters in the node layer and inject them, together with a debug
+  // publisher/logger, into the node-independent optimizer.
+  const auto mpt_param = declare_mpt_param(static_cast<rclcpp::Node *>(this), vehicle_info_);
+  mpt_debug_publisher_ptr_ =
+    std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
   mpt_optimizer_ptr_ = std::make_shared<MPTOptimizer>(
-    this, enable_debug_info_, ego_nearest_param_, vehicle_info_, traj_param_, debug_data_ptr_,
-    time_keeper_);
+    enable_debug_info_, ego_nearest_param_, vehicle_info_, traj_param_, mpt_param, get_logger(),
+    mpt_debug_publisher_ptr_, debug_data_ptr_, time_keeper_);
 
   // reset planners
   // NOTE: This function must be called after core algorithms (e.g. mpt_optimizer_) have been

--- a/planning/autoware_path_smoother/CMakeLists.txt
+++ b/planning/autoware_path_smoother/CMakeLists.txt
@@ -15,6 +15,15 @@ target_include_directories(autoware_path_smoother
     ${EIGEN3_INCLUDE_DIR}
 )
 
+# The library instantiates the node-type templates for autoware::agnocast_wrapper::Node, so it
+# needs the agnocast headers when Agnocast is enabled and must agree with its consumers on
+# USE_AGNOCAST_ENABLED.
+if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+  find_package(agnocastlib REQUIRED)
+  ament_target_dependencies(autoware_path_smoother agnocastlib)
+endif()
+autoware_agnocast_wrapper_setup(autoware_path_smoother)
+
 # register node
 rclcpp_components_register_node(autoware_path_smoother
   PLUGIN "autoware::path_smoother::ElasticBandSmoother"

--- a/planning/autoware_path_smoother/include/autoware/path_smoother/common_structs.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/common_structs.hpp
@@ -91,11 +91,16 @@ struct TimeKeeper
 struct CommonParam
 {
   CommonParam() = default;
-  explicit CommonParam(rclcpp::Node * node)
+  // Templated on the node type so the parameters can be declared on either
+  // rclcpp::Node or autoware::agnocast_wrapper::Node. The struct itself stays
+  // node-independent (plain values).
+  template <typename NodeT>
+  explicit CommonParam(NodeT * node)
   {
     output_backward_traj_length =
-      node->declare_parameter<double>("common.output_backward_traj_length");
-    output_delta_arc_length = node->declare_parameter<double>("common.output_delta_arc_length");
+      node->template declare_parameter<double>("common.output_backward_traj_length");
+    output_delta_arc_length =
+      node->template declare_parameter<double>("common.output_delta_arc_length");
   }
 
   void onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -115,10 +120,12 @@ struct CommonParam
 struct EgoNearestParam
 {
   EgoNearestParam() = default;
-  explicit EgoNearestParam(rclcpp::Node * node)
+  // Templated on the node type (see CommonParam above).
+  template <typename NodeT>
+  explicit EgoNearestParam(NodeT * node)
   {
-    dist_threshold = node->declare_parameter<double>("ego_nearest_dist_threshold");
-    yaw_threshold = node->declare_parameter<double>("ego_nearest_yaw_threshold");
+    dist_threshold = node->template declare_parameter<double>("ego_nearest_dist_threshold");
+    yaw_threshold = node->template declare_parameter<double>("ego_nearest_yaw_threshold");
   }
 
   void onParam(const std::vector<rclcpp::Parameter> & parameters)

--- a/planning/autoware_path_smoother/include/autoware/path_smoother/elastic_band.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/elastic_band.hpp
@@ -20,6 +20,7 @@
 #include "autoware/path_smoother/type_alias.hpp"
 
 #include <Eigen/Core>
+#include <autoware_utils_debug/debug_publisher.hpp>
 
 #include <memory>
 #include <optional>
@@ -29,12 +30,72 @@
 
 namespace autoware::path_smoother
 {
-class EBPathSmoother
+// Node-independent parameter set for the elastic band smoother.
+// Declaration of the parameters lives in the node layer (see declare_eb_param()),
+// so this struct itself does not depend on any node type.
+struct EBParam
+{
+  // qp
+  struct QPParam
+  {
+    int max_iteration;
+    double eps_abs;
+    double eps_rel;
+  };
+
+  EBParam() = default;
+  void onParam(const std::vector<rclcpp::Parameter> & parameters);
+
+  // option
+  bool enable_warm_start;
+  bool enable_optimization_validation;
+
+  // common
+  double delta_arc_length;
+  int num_points;
+
+  // clearance
+  int num_joint_points;
+  double clearance_for_fix;
+  double clearance_for_joint;
+  double clearance_for_smooth;
+
+  // weight
+  double smooth_weight;
+  double lat_error_weight;
+
+  // qp
+  QPParam qp_param;
+
+  // validation
+  double max_validation_error;
+};
+
+// Node-layer factory: declares the "elastic_band.*" parameters on the given node
+// and returns a Node-independent EBParam value. Templated on the node type so it
+// works with both rclcpp::Node and autoware::agnocast_wrapper::Node.
+template <typename NodeT>
+EBParam declare_eb_param(NodeT * node);
+
+// Node-independent elastic band smoother.
+//
+// The smoothing logic itself does not depend on any node type; the only place a
+// node type appears is the debug publisher, which is injected as a
+// autoware_utils_debug::BasicDebugPublisher<NodeT>. NodeT defaults to rclcpp::Node
+// so existing callers keep working unchanged (see the EBPathSmoother alias below);
+// the agnocast path instantiates it with autoware::agnocast_wrapper::Node.
+//
+// Parameters, logger and clock are passed by value and are node-type-agnostic.
+template <typename NodeT = rclcpp::Node>
+class BasicEBPathSmoother
 {
 public:
-  EBPathSmoother(
-    rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
-    const CommonParam & common_param, const std::shared_ptr<TimeKeeper> time_keeper_ptr);
+  BasicEBPathSmoother(
+    const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
+    const CommonParam & common_param, const EBParam & eb_param, rclcpp::Logger logger,
+    const rclcpp::Clock & clock,
+    const std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<NodeT>> & debug_publisher,
+    const std::shared_ptr<TimeKeeper> time_keeper_ptr);
 
   std::vector<TrajectoryPoint> smoothTrajectory(
     const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & ego_pose);
@@ -44,45 +105,6 @@ public:
   void onParam(const std::vector<rclcpp::Parameter> & parameters);
 
 private:
-  struct EBParam
-  {
-    // qp
-    struct QPParam
-    {
-      int max_iteration;
-      double eps_abs;
-      double eps_rel;
-    };
-
-    EBParam() = default;
-    explicit EBParam(rclcpp::Node * node);
-    void onParam(const std::vector<rclcpp::Parameter> & parameters);
-
-    // option
-    bool enable_warm_start;
-    bool enable_optimization_validation;
-
-    // common
-    double delta_arc_length;
-    int num_points;
-
-    // clearance
-    int num_joint_points;
-    double clearance_for_fix;
-    double clearance_for_joint;
-    double clearance_for_smooth;
-
-    // weight
-    double smooth_weight;
-    double lat_error_weight;
-
-    // qp
-    QPParam qp_param;
-
-    // validation
-    double max_validation_error;
-  };
-
   struct Constraint2d
   {
     struct Constraint
@@ -105,9 +127,8 @@ private:
   rclcpp::Logger logger_;
   rclcpp::Clock clock_;
 
-  // publisher
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_traj_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_fixed_traj_pub_;
+  // debug publisher (injected by the node layer; may be nullptr to disable debug output)
+  std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<NodeT>> debug_publisher_;
 
   std::unique_ptr<autoware::osqp_interface::OSQPInterface> osqp_solver_ptr_;
   std::shared_ptr<std::vector<TrajectoryPoint>> prev_eb_traj_points_ptr_{nullptr};
@@ -128,6 +149,10 @@ private:
     const std::vector<double> & optimized_points, const std::vector<TrajectoryPoint> & traj_points,
     const int pad_start_idx) const;
 };
+
+// Backward-compatible alias: existing callers using a plain rclcpp::Node keep using
+// EBPathSmoother without any change.
+using EBPathSmoother = BasicEBPathSmoother<rclcpp::Node>;
 }  // namespace autoware::path_smoother
 
 #endif  // AUTOWARE__PATH_SMOOTHER__ELASTIC_BAND_HPP_

--- a/planning/autoware_path_smoother/include/autoware/path_smoother/elastic_band_smoother.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/elastic_band_smoother.hpp
@@ -67,6 +67,8 @@ private:
 
   // algorithms
   std::shared_ptr<EBPathSmoother> eb_path_smoother_ptr_{nullptr};
+  // Debug publisher injected into the (node-independent) elastic band smoother.
+  std::shared_ptr<autoware_utils_debug::DebugPublisher> eb_debug_publisher_ptr_{nullptr};
   std::shared_ptr<ReplanChecker> replan_checker_ptr_{nullptr};
 
   // parameters

--- a/planning/autoware_path_smoother/package.xml
+++ b/planning/autoware_path_smoother/package.xml
@@ -15,6 +15,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
@@ -22,6 +24,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_debug</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/planning/autoware_path_smoother/src/elastic_band.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band.cpp
@@ -22,6 +22,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Sparse>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <tf2/utils.hpp>
 
 #include <algorithm>
@@ -87,44 +88,63 @@ std_msgs::msg::Header createHeader(const rclcpp::Time & now)
 
 namespace autoware::path_smoother
 {
-EBPathSmoother::EBParam::EBParam(rclcpp::Node * node)
+template <typename NodeT>
+EBParam declare_eb_param(NodeT * node)
 {
+  EBParam p;
+
   {  // option
-    enable_warm_start = node->declare_parameter<bool>("elastic_band.option.enable_warm_start");
-    enable_optimization_validation =
-      node->declare_parameter<bool>("elastic_band.option.enable_optimization_validation");
+    p.enable_warm_start =
+      node->template declare_parameter<bool>("elastic_band.option.enable_warm_start");
+    p.enable_optimization_validation =
+      node->template declare_parameter<bool>("elastic_band.option.enable_optimization_validation");
   }
 
   {  // common
-    delta_arc_length = node->declare_parameter<double>("elastic_band.common.delta_arc_length");
-    num_points = node->declare_parameter<int>("elastic_band.common.num_points");
+    p.delta_arc_length =
+      node->template declare_parameter<double>("elastic_band.common.delta_arc_length");
+    p.num_points = node->template declare_parameter<int>("elastic_band.common.num_points");
   }
 
   {  // clearance
-    num_joint_points = node->declare_parameter<int>("elastic_band.clearance.num_joint_points");
-    clearance_for_fix = node->declare_parameter<double>("elastic_band.clearance.clearance_for_fix");
-    clearance_for_joint =
-      node->declare_parameter<double>("elastic_band.clearance.clearance_for_joint");
-    clearance_for_smooth =
-      node->declare_parameter<double>("elastic_band.clearance.clearance_for_smooth");
+    p.num_joint_points =
+      node->template declare_parameter<int>("elastic_band.clearance.num_joint_points");
+    p.clearance_for_fix =
+      node->template declare_parameter<double>("elastic_band.clearance.clearance_for_fix");
+    p.clearance_for_joint =
+      node->template declare_parameter<double>("elastic_band.clearance.clearance_for_joint");
+    p.clearance_for_smooth =
+      node->template declare_parameter<double>("elastic_band.clearance.clearance_for_smooth");
   }
 
   {  // weight
-    smooth_weight = node->declare_parameter<double>("elastic_band.weight.smooth_weight");
-    lat_error_weight = node->declare_parameter<double>("elastic_band.weight.lat_error_weight");
+    p.smooth_weight = node->template declare_parameter<double>("elastic_band.weight.smooth_weight");
+    p.lat_error_weight =
+      node->template declare_parameter<double>("elastic_band.weight.lat_error_weight");
   }
 
   {  // qp
-    qp_param.max_iteration = node->declare_parameter<int>("elastic_band.qp.max_iteration");
-    qp_param.eps_abs = node->declare_parameter<double>("elastic_band.qp.eps_abs");
-    qp_param.eps_rel = node->declare_parameter<double>("elastic_band.qp.eps_rel");
+    p.qp_param.max_iteration =
+      node->template declare_parameter<int>("elastic_band.qp.max_iteration");
+    p.qp_param.eps_abs = node->template declare_parameter<double>("elastic_band.qp.eps_abs");
+    p.qp_param.eps_rel = node->template declare_parameter<double>("elastic_band.qp.eps_rel");
   }
 
   // validation
-  max_validation_error = node->declare_parameter<double>("elastic_band.validation.max_error");
+  p.max_validation_error =
+    node->template declare_parameter<double>("elastic_band.validation.max_error");
+
+  return p;
 }
 
-void EBPathSmoother::EBParam::onParam(const std::vector<rclcpp::Parameter> & parameters)
+// Explicit instantiations for the supported node types. autoware::agnocast_wrapper::Node is a
+// distinct class from rclcpp::Node in both ENABLE_AGNOCAST=0/1 builds, so both instantiations
+// are always required.
+template EBParam declare_eb_param<rclcpp::Node>(rclcpp::Node * node);
+template EBParam declare_eb_param<autoware::agnocast_wrapper::Node>(
+  autoware::agnocast_wrapper::Node * node);
+
+void EBParam::onParam(const std::vector<rclcpp::Parameter> & parameters)
 {
   using autoware_utils::update_param;
 
@@ -161,41 +181,46 @@ void EBPathSmoother::EBParam::onParam(const std::vector<rclcpp::Parameter> & par
   }
 }
 
-EBPathSmoother::EBPathSmoother(
-  rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
-  const CommonParam & common_param, const std::shared_ptr<TimeKeeper> time_keeper_ptr)
+template <typename NodeT>
+BasicEBPathSmoother<NodeT>::BasicEBPathSmoother(
+  const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
+  const CommonParam & common_param, const EBParam & eb_param, rclcpp::Logger logger,
+  const rclcpp::Clock & clock,
+  const std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<NodeT>> & debug_publisher,
+  const std::shared_ptr<TimeKeeper> time_keeper_ptr)
 : enable_debug_info_(enable_debug_info),
   ego_nearest_param_(ego_nearest_param),
   common_param_(common_param),
+  eb_param_(eb_param),
   time_keeper_ptr_(time_keeper_ptr),
-  logger_(node->get_logger().get_child("elastic_band_smoother")),
-  clock_(*node->get_clock())
+  logger_(logger.get_child("elastic_band_smoother")),
+  clock_(clock),
+  debug_publisher_(debug_publisher)
 {
-  // eb param
-  eb_param_ = EBParam(node);
-
-  // publisher
-  debug_eb_traj_pub_ = node->create_publisher<Trajectory>("~/debug/eb_traj", 1);
-  debug_eb_fixed_traj_pub_ = node->create_publisher<Trajectory>("~/debug/eb_fixed_traj", 1);
 }
 
-void EBPathSmoother::onParam(const std::vector<rclcpp::Parameter> & parameters)
+template <typename NodeT>
+void BasicEBPathSmoother<NodeT>::onParam(const std::vector<rclcpp::Parameter> & parameters)
 {
   eb_param_.onParam(parameters);
 }
 
-void EBPathSmoother::initialize(const bool enable_debug_info, const CommonParam & common_param)
+template <typename NodeT>
+void BasicEBPathSmoother<NodeT>::initialize(
+  const bool enable_debug_info, const CommonParam & common_param)
 {
   enable_debug_info_ = enable_debug_info;
   common_param_ = common_param;
 }
 
-void EBPathSmoother::resetPreviousData()
+template <typename NodeT>
+void BasicEBPathSmoother<NodeT>::resetPreviousData()
 {
   prev_eb_traj_points_ptr_ = nullptr;
 }
 
-std::vector<TrajectoryPoint> EBPathSmoother::smoothTrajectory(
+template <typename NodeT>
+std::vector<TrajectoryPoint> BasicEBPathSmoother<NodeT>::smoothTrajectory(
   const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & ego_pose)
 {
   time_keeper_ptr_->tic(__func__);
@@ -263,15 +288,18 @@ std::vector<TrajectoryPoint> EBPathSmoother::smoothTrajectory(
   prev_eb_traj_points_ptr_ = std::make_shared<std::vector<TrajectoryPoint>>(*eb_traj_points);
 
   // 8. publish eb trajectory
-  const auto eb_traj =
-    autoware::motion_utils::convertToTrajectory(*eb_traj_points, createHeader(clock_.now()));
-  debug_eb_traj_pub_->publish(eb_traj);
+  if (debug_publisher_) {
+    const auto eb_traj =
+      autoware::motion_utils::convertToTrajectory(*eb_traj_points, createHeader(clock_.now()));
+    debug_publisher_->publish("eb_traj", eb_traj);
+  }
 
   time_keeper_ptr_->toc(__func__, "      ");
   return *eb_traj_points;
 }
 
-std::vector<TrajectoryPoint> EBPathSmoother::insertFixedPoint(
+template <typename NodeT>
+std::vector<TrajectoryPoint> BasicEBPathSmoother<NodeT>::insertFixedPoint(
   const std::vector<TrajectoryPoint> & traj_points) const
 {
   time_keeper_ptr_->tic(__func__);
@@ -290,7 +318,9 @@ std::vector<TrajectoryPoint> EBPathSmoother::insertFixedPoint(
   return traj_points_with_fixed_point;
 }
 
-std::tuple<std::vector<TrajectoryPoint>, size_t> EBPathSmoother::getPaddedTrajectoryPoints(
+template <typename NodeT>
+std::tuple<std::vector<TrajectoryPoint>, size_t>
+BasicEBPathSmoother<NodeT>::getPaddedTrajectoryPoints(
   const std::vector<TrajectoryPoint> & traj_points) const
 {
   time_keeper_ptr_->tic(__func__);
@@ -308,7 +338,8 @@ std::tuple<std::vector<TrajectoryPoint>, size_t> EBPathSmoother::getPaddedTrajec
   return {padded_traj_points, pad_start_idx};
 }
 
-void EBPathSmoother::updateConstraint(
+template <typename NodeT>
+void BasicEBPathSmoother<NodeT>::updateConstraint(
   const std::vector<TrajectoryPoint> & traj_points, const bool is_goal_contained,
   const int pad_start_idx)
 {
@@ -390,14 +421,17 @@ void EBPathSmoother::updateConstraint(
   }
 
   // publish fixed trajectory
-  const auto eb_fixed_traj = autoware::motion_utils::convertToTrajectory(
-    debug_fixed_traj_points, createHeader(clock_.now()));
-  debug_eb_fixed_traj_pub_->publish(eb_fixed_traj);
+  if (debug_publisher_) {
+    const auto eb_fixed_traj = autoware::motion_utils::convertToTrajectory(
+      debug_fixed_traj_points, createHeader(clock_.now()));
+    debug_publisher_->publish("eb_fixed_traj", eb_fixed_traj);
+  }
 
   time_keeper_ptr_->toc(__func__, "        ");
 }
 
-std::optional<std::vector<double>> EBPathSmoother::calcSmoothedTrajectory()
+template <typename NodeT>
+std::optional<std::vector<double>> BasicEBPathSmoother<NodeT>::calcSmoothedTrajectory()
 {
   time_keeper_ptr_->tic(__func__);
 
@@ -423,7 +457,9 @@ std::optional<std::vector<double>> EBPathSmoother::calcSmoothedTrajectory()
   return optimized_points;
 }
 
-std::optional<std::vector<TrajectoryPoint>> EBPathSmoother::convertOptimizedPointsToTrajectory(
+template <typename NodeT>
+std::optional<std::vector<TrajectoryPoint>>
+BasicEBPathSmoother<NodeT>::convertOptimizedPointsToTrajectory(
   const std::vector<double> & optimized_points, const std::vector<TrajectoryPoint> & traj_points,
   const int pad_start_idx) const
 {
@@ -453,4 +489,8 @@ std::optional<std::vector<TrajectoryPoint>> EBPathSmoother::convertOptimizedPoin
   time_keeper_ptr_->toc(__func__, "        ");
   return eb_traj_points;
 }
+
+// Explicit instantiations for the supported node types (see declare_eb_param above).
+template class BasicEBPathSmoother<rclcpp::Node>;
+template class BasicEBPathSmoother<autoware::agnocast_wrapper::Node>;
 }  // namespace autoware::path_smoother

--- a/planning/autoware_path_smoother/src/elastic_band_smoother.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band_smoother.cpp
@@ -97,8 +97,13 @@ ElasticBandSmoother::ElasticBandSmoother(const rclcpp::NodeOptions & node_option
     common_param_ = CommonParam(this);
   }
 
+  // Declare the elastic band parameters in the node layer and inject them, together
+  // with a debug publisher/logger/clock, into the node-independent smoother.
+  const auto eb_param = declare_eb_param(static_cast<rclcpp::Node *>(this));
+  eb_debug_publisher_ptr_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
   eb_path_smoother_ptr_ = std::make_shared<EBPathSmoother>(
-    this, enable_debug_info_, ego_nearest_param_, common_param_, time_keeper_ptr_);
+    enable_debug_info_, ego_nearest_param_, common_param_, eb_param, get_logger(), *get_clock(),
+    eb_debug_publisher_ptr_, time_keeper_ptr_);
   replan_checker_ptr_ = std::make_shared<ReplanChecker>(this, ego_nearest_param_);
 
   // reset planners

--- a/planning/autoware_trajectory_processor/CMakeLists.txt
+++ b/planning/autoware_trajectory_processor/CMakeLists.txt
@@ -15,10 +15,22 @@ ament_export_dependencies(acados)
 add_subdirectory(src/acados_mpt)
 pluginlib_export_plugin_description_file(${PROJECT_NAME} plugins.xml)
 
+# When Agnocast is enabled, the component/plugin libraries include the agnocast wrapper
+# macro header (which pulls in <agnocast/agnocast.hpp>). The register_node macro only adds
+# agnocastlib to the generated executable, not to the component library itself, so we link
+# agnocastlib explicitly here to make its headers available.
+if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+  find_package(agnocastlib REQUIRED)
+endif()
+
 ament_auto_add_library(autoware_trajectory_optimizer_component SHARED
   src/trajectory_optimizer.cpp
   src/utils.cpp
 )
+
+if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+  ament_target_dependencies(autoware_trajectory_optimizer_component agnocastlib)
+endif()
 
 autoware_agnocast_wrapper_register_node(autoware_trajectory_optimizer_component
   PLUGIN "autoware::trajectory_optimizer::TrajectoryOptimizer"
@@ -92,6 +104,15 @@ target_link_libraries(
   tf2_geometry_msgs::tf2_geometry_msgs
   trajectory_optimizer_param
 )
+
+if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+  ament_target_dependencies(autoware_trajectory_optimizer_plugins agnocastlib)
+endif()
+
+# The plugin library is not passed to autoware_agnocast_wrapper_register_node (only the component
+# is), so USE_AGNOCAST_ENABLED has to be applied explicitly. Both libraries must agree on it
+# because they exchange autoware::agnocast_wrapper::Node across the pluginlib boundary.
+autoware_agnocast_wrapper_setup(autoware_trajectory_optimizer_plugins)
 
 ament_auto_add_library(autoware_trajectory_modifier_plugins SHARED
   src/trajectory_modifier_plugins/stop_point_fixer.cpp

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer.hpp
@@ -18,7 +18,8 @@
 #include "autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp"
 #include "autoware/trajectory_processor/trajectory_optimizer_structs.hpp"
 
-#include <autoware_utils/ros/polling_subscriber.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
 #include <pluginlib/class_loader.hpp>
@@ -43,13 +44,13 @@ using autoware_planning_msgs::msg::Trajectory;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 
-class TrajectoryOptimizer : public rclcpp::Node
+class TrajectoryOptimizer : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit TrajectoryOptimizer(const rclcpp::NodeOptions & options);
 
 private:
-  void on_traj(const CandidateTrajectories::ConstSharedPtr msg);
+  void on_traj(AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) msg);
   void publish_processing_time_ms(double processing_time_ms);
   void update_params();
   void initialize_optimizers();
@@ -61,24 +62,26 @@ private:
   std::vector<std::shared_ptr<plugin::TrajectoryOptimizerPluginBase>> plugins_;
 
   // interface subscriber
-  rclcpp::Subscription<CandidateTrajectories>::SharedPtr trajectories_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(CandidateTrajectories) trajectories_sub_;
   // interface publisher
-  rclcpp::Publisher<Trajectory>::SharedPtr trajectory_pub_;
-  rclcpp::Publisher<CandidateTrajectories>::SharedPtr trajectories_pub_;
+  AUTOWARE_PUBLISHER_PTR(Trajectory) trajectory_pub_;
+  AUTOWARE_PUBLISHER_PTR(CandidateTrajectories) trajectories_pub_;
 
-  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
-    this, "~/input/odometry"};
-  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
-    sub_current_acceleration_{this, "~/input/acceleration"};
+  // Polling subscribers are created in the constructor through the wrapper so they route
+  // through Agnocast when enabled.
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Odometry>::SharedPtr sub_current_odometry_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
+    sub_current_acceleration_;
 
-  Odometry::ConstSharedPtr current_odometry_ptr_;  // current odometry
-  AccelWithCovarianceStamped::ConstSharedPtr current_acceleration_ptr_;
+  // polling::PollingSubscriber::take_data() returns a plain std::shared_ptr in both
+  // ENABLE_AGNOCAST=0/1 builds.
+  std::shared_ptr<const Odometry> current_odometry_ptr_;  // current odometry
+  std::shared_ptr<const AccelWithCovarianceStamped> current_acceleration_ptr_;
   std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
-    debug_processing_time_detail_pub_;
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    debug_processing_time_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_utils::ProcessingTimeDetail) debug_processing_time_detail_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped)
+  debug_processing_time_pub_;
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 
   std::unique_ptr<trajectory_optimizer_node_params::ParamListener> param_listener_;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_eb_smoother_optimizer.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_eb_smoother_optimizer.hpp
@@ -20,6 +20,8 @@
 #include "autoware/path_smoother/replan_checker.hpp"
 #include "autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory.hpp>
@@ -34,10 +36,13 @@ namespace autoware::trajectory_optimizer::plugin
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using autoware::path_smoother::CommonParam;
-using autoware::path_smoother::EBPathSmoother;
 using autoware::path_smoother::EgoNearestParam;
 using autoware::path_smoother::ReplanChecker;
 using SmootherTimekeeper = autoware::path_smoother::TimeKeeper;
+// The elastic band smoother is instantiated against the agnocast wrapper node type so
+// that it can publish through Agnocast when enabled.
+using EBPathSmootherT =
+  autoware::path_smoother::BasicEBPathSmoother<autoware::agnocast_wrapper::Node>;
 
 class TrajectoryEBSmootherOptimizer : public TrajectoryOptimizerPluginBase
 {
@@ -54,7 +59,10 @@ protected:
 private:
   CommonParam common_param_{};
   EgoNearestParam ego_nearest_param_;
-  std::shared_ptr<EBPathSmoother> eb_path_smoother_ptr_{nullptr};
+  std::shared_ptr<EBPathSmootherT> eb_path_smoother_ptr_{nullptr};
+  // Debug publisher injected into the (node-independent) elastic band smoother.
+  std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    eb_debug_publisher_ptr_{nullptr};
   mutable std::shared_ptr<SmootherTimekeeper> smoother_time_keeper_ptr_{nullptr};
 };
 }  // namespace autoware::trajectory_optimizer::plugin

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_kinematic_feasibility_enforcer.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_kinematic_feasibility_enforcer.hpp
@@ -19,6 +19,7 @@
 
 #include "autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/vehicle_info_utils/vehicle_info_utils.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_mpt_optimizer.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_mpt_optimizer.hpp
@@ -21,7 +21,9 @@
 #include "autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp"
 #include "autoware/trajectory_processor/trajectory_optimizer_structs.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_trajectory_processor/trajectory_optimizer_param.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -36,9 +38,11 @@ namespace autoware::trajectory_optimizer::plugin
 
 using autoware::path_optimizer::DebugData;
 using autoware::path_optimizer::EgoNearestParam;
-using autoware::path_optimizer::MPTOptimizer;
 using autoware::path_optimizer::PlannerData;
 using autoware::path_optimizer::TrajectoryParam;
+// The MPT optimizer is instantiated against the agnocast wrapper node type so it can
+// publish through Agnocast when enabled.
+using MPTOptimizerT = autoware::path_optimizer::BasicMPTOptimizer<autoware::agnocast_wrapper::Node>;
 
 struct MPTParams
 {
@@ -80,10 +84,13 @@ protected:
 
 private:
   // Core MPT optimizer instance
-  std::shared_ptr<MPTOptimizer> mpt_optimizer_ptr_;
+  std::shared_ptr<MPTOptimizerT> mpt_optimizer_ptr_;
+  // Debug publisher injected into the (node-independent) MPT optimizer.
+  std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    mpt_debug_publisher_ptr_;
 
   // Debug visualization
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_markers_pub_;
+  AUTOWARE_PUBLISHER_PTR(visualization_msgs::msg::MarkerArray) debug_markers_pub_;
 
   // Vehicle information
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp
@@ -18,6 +18,7 @@
 #define AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_OPTIMIZER_PLUGINS__TRAJECTORY_OPTIMIZER_PLUGIN_BASE_HPP_
 #include "autoware/trajectory_processor/trajectory_optimizer_structs.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -49,9 +50,13 @@ public:
   // Plugin parameter update callback
   virtual void update_params(const TrajectoryOptimizerParams & params) = 0;
 
-  // Initialize plugin with node context (for pluginlib-loaded plugins)
+  // Initialize plugin with node context (for pluginlib-loaded plugins).
+  // The node is an autoware::agnocast_wrapper::Node so that the optimizer components
+  // (path_smoother / path_optimizer) can be created against either rclcpp::Node or
+  // agnocast::Node. The wrapper Node exposes the same parameter/publisher API in both
+  // ENABLE_AGNOCAST=0/1 builds, so plugins do not need to know which one is used.
   virtual void initialize(
-    const std::string & name, rclcpp::Node * node_ptr,
+    const std::string & name, autoware::agnocast_wrapper::Node * node_ptr,
     const std::shared_ptr<autoware_utils_debug::TimeKeeper> & time_keeper,
     const TrajectoryOptimizerParams & params)
   {
@@ -66,13 +71,13 @@ public:
 
 protected:
   virtual void on_initialize(const TrajectoryOptimizerParams & params) = 0;
-  rclcpp::Node * get_node_ptr() const { return node_ptr_; }
+  autoware::agnocast_wrapper::Node * get_node_ptr() const { return node_ptr_; }
   std::shared_ptr<autoware_utils_debug::TimeKeeper> get_time_keeper() const { return time_keeper_; }
   bool enabled_{true};
 
 private:
   std::string name_{"unnamed_plugin"};
-  rclcpp::Node * node_ptr_{nullptr};
+  autoware::agnocast_wrapper::Node * node_ptr_{nullptr};
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 };
 }  // namespace autoware::trajectory_optimizer::plugin

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_temporal_mpt_optimizer.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_temporal_mpt_optimizer.hpp
@@ -19,6 +19,7 @@
 #include "autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp"
 #include "autoware/trajectory_processor/trajectory_optimizer_structs.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <nav_msgs/msg/odometry.hpp>
@@ -86,13 +87,12 @@ private:
     const TrajectoryPoints & reference_before, const nav_msgs::msg::Odometry & initial_odom,
     const temporal_mpt::AcadosSolution & solution);
 
-  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr debug_input_trajectory_pub_;
-  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr debug_input_initial_state_pub_;
-  rclcpp::Publisher<autoware_planning_msgs::msg::Trajectory>::SharedPtr
-    debug_output_trajectory_pub_;
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr debug_solve_status_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr debug_control_accel_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float64MultiArray>::SharedPtr debug_control_delta_cmd_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_planning_msgs::msg::Trajectory) debug_input_trajectory_pub_;
+  AUTOWARE_PUBLISHER_PTR(nav_msgs::msg::Odometry) debug_input_initial_state_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_planning_msgs::msg::Trajectory) debug_output_trajectory_pub_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Int32) debug_solve_status_pub_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Float64MultiArray) debug_control_accel_pub_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Float64MultiArray) debug_control_delta_cmd_pub_;
 };
 
 }  // namespace autoware::trajectory_optimizer::plugin

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_velocity_optimizer.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_velocity_optimizer.hpp
@@ -20,8 +20,9 @@
 #include "autoware/trajectory_processor/trajectory_optimizer_plugins/plugin_utils/continuous_jerk_smoother.hpp"
 #include "autoware/trajectory_processor/trajectory_optimizer_plugins/trajectory_optimizer_plugin_base.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
-#include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
@@ -73,9 +74,9 @@ protected:
 private:
   std::shared_ptr<ContinuousJerkSmoother> continuous_jerk_smoother_{nullptr};
   TrajectoryVelocityOptimizerParams velocity_params_;
-  std::shared_ptr<autoware_utils_rclcpp::InterProcessPollingSubscriber<VelocityLimit>>
+  autoware::agnocast_wrapper::polling::PollingSubscriber<VelocityLimit>::SharedPtr
     sub_planning_velocity_;
-  rclcpp::Publisher<VelocityLimit>::SharedPtr pub_velocity_limit_;
+  AUTOWARE_PUBLISHER_PTR(VelocityLimit) pub_velocity_limit_;
 };
 }  // namespace autoware::trajectory_optimizer::plugin
 

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/utils.hpp
@@ -32,13 +32,13 @@
 #include <nav_msgs/msg/detail/odometry__struct.hpp>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace autoware::trajectory_optimizer::utils
 {
 
 using autoware::path_smoother::CommonParam;
-using autoware::path_smoother::EBPathSmoother;
 using autoware::path_smoother::EgoNearestParam;
 using autoware::path_smoother::PlannerData;
 using autoware::path_smoother::ReplanChecker;
@@ -50,10 +50,6 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
-
-void smooth_trajectory_with_elastic_band(
-  TrajectoryPoints & traj_points, const Odometry & current_odometry,
-  const std::shared_ptr<EBPathSmoother> & eb_path_smoother_ptr);
 
 /**
  * @brief Checks if a trajectory point is valid.
@@ -84,6 +80,13 @@ void copy_trajectory_orientation(
 rclcpp::Logger get_logger();
 
 /**
+ * @brief Logs an error message, throttled to at most once per 5 seconds.
+ *
+ * @param message The message to log.
+ */
+void log_error_throttle(const std::string & message);
+
+/**
  * @brief generates a 3 point trajectory to prevent downstream issues
  * @param trajectory with less than 3 points.
  * @param odom ego odometry. To check if the ego vehicle is properly stopped.
@@ -110,6 +113,28 @@ double compute_dt(const TrajectoryPoint & current, const TrajectoryPoint & next)
 void recalculate_longitudinal_acceleration(
   TrajectoryPoints & trajectory, const bool use_constant_dt = false,
   const double constant_dt = 0.1);
+
+// Templated on the smoother type so the same helper works with the elastic band
+// smoother instantiated against either rclcpp::Node or agnocast_wrapper::Node.
+// Only smoothTrajectory()/resetPreviousData() are required of EBPathSmootherT.
+// Defined here (rather than in utils.cpp) so it can be instantiated for any
+// smoother type by the caller.
+template <typename EBPathSmootherT>
+void smooth_trajectory_with_elastic_band(
+  TrajectoryPoints & traj_points, const Odometry & current_odometry,
+  const std::shared_ptr<EBPathSmootherT> & eb_path_smoother_ptr)
+{
+  if (!eb_path_smoother_ptr) {
+    log_error_throttle("Elastic band path smoother is not initialized");
+    return;
+  }
+  constexpr size_t minimum_points_for_elastic_band = 3;
+  if (traj_points.empty() || traj_points.size() < minimum_points_for_elastic_band) {
+    return;
+  }
+  traj_points = eb_path_smoother_ptr->smoothTrajectory(traj_points, current_odometry.pose.pose);
+  eb_path_smoother_ptr->resetPreviousData();
+}
 
 };  // namespace autoware::trajectory_optimizer::utils
 

--- a/planning/autoware_trajectory_processor/launch/trajectory_optimizer.launch.xml
+++ b/planning/autoware_trajectory_processor/launch/trajectory_optimizer.launch.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
+  <!-- Resolve the Agnocast environment (LD_PRELOAD heaphook / container selection) based on the
+       ENABLE_AGNOCAST environment variable. Provides the ld_preload_value launch configuration. -->
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <arg name="trajectory_optimizer_param_path" default="$(find-pkg-share autoware_trajectory_processor)/config/trajectory_optimizer.param.yaml"/>
   <arg name="elastic_band_param_path" default="$(find-pkg-share autoware_trajectory_processor)/config/trajectory_smoothing/elastic_band_smoother.param.yaml"/>
   <arg name="common_param_path" default="$(find-pkg-share autoware_core_planning)/config/common.param.yaml"/>
@@ -21,6 +25,8 @@
   <arg name="output_current_velocity_limit_mps" default="/planning/scenario_planning/current_max_velocity"/>
 
   <node pkg="autoware_trajectory_processor" exec="autoware_trajectory_optimizer_node" name="trajectory_optimizer_node" output="screen">
+    <!-- Preload the Agnocast heaphook when Agnocast is enabled (no-op otherwise). -->
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <param from="$(var trajectory_optimizer_param_path)" allow_substs="true"/>
     <param from="$(var common_param_path)"/>
     <param from="$(var elastic_band_param_path)" allow_substs="true"/>

--- a/planning/autoware_trajectory_processor/package.xml
+++ b/planning/autoware_trajectory_processor/package.xml
@@ -17,6 +17,9 @@
 
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <!-- Needed only when built with ENABLE_AGNOCAST=1; the component/plugin libraries then
+       include <agnocast/agnocast.hpp> via the agnocast wrapper macros. -->
+  <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>

--- a/planning/autoware_trajectory_processor/src/trajectory_optimizer.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_optimizer.cpp
@@ -56,6 +56,15 @@ TrajectoryOptimizer::TrajectoryOptimizer(const rclcpp::NodeOptions & options)
 
   initialize_optimizers();
 
+  // Polling subscribers. create_polling_subscriber() routes through Agnocast when Agnocast is
+  // enabled (including the AgnocastOnly case, where there is no underlying rclcpp::Node) and
+  // through rclcpp otherwise.
+  sub_current_odometry_ = autoware::agnocast_wrapper::polling::create_polling_subscriber<Odometry>(
+    this, "~/input/odometry", rclcpp::QoS{1});
+  sub_current_acceleration_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<AccelWithCovarianceStamped>(
+      this, "~/input/acceleration", rclcpp::QoS{1});
+
   trajectories_sub_ = create_subscription<CandidateTrajectories>(
     "~/input/trajectories", 1,
     std::bind(&TrajectoryOptimizer::on_traj, this, std::placeholders::_1));
@@ -128,7 +137,8 @@ void TrajectoryOptimizer::publish_processing_time_ms(const double processing_tim
   debug_processing_time_pub_->publish(msg);
 }
 
-void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::ConstSharedPtr msg)
+void TrajectoryOptimizer::on_traj(
+  [[maybe_unused]] AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) msg)
 {
   stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("processing_time");
@@ -139,8 +149,8 @@ void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::
     update_params();
   }
 
-  current_odometry_ptr_ = sub_current_odometry_.take_data();
-  current_acceleration_ptr_ = sub_current_acceleration_.take_data();
+  current_odometry_ptr_ = sub_current_odometry_->take_data();
+  current_acceleration_ptr_ = sub_current_acceleration_->take_data();
 
   if (!current_odometry_ptr_ || !current_acceleration_ptr_) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "No odometry or acceleration data");

--- a/planning/autoware_trajectory_processor/src/trajectory_optimizer_plugins/trajectory_eb_smoother_optimizer.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_optimizer_plugins/trajectory_eb_smoother_optimizer.cpp
@@ -46,8 +46,16 @@ void TrajectoryEBSmootherOptimizer::on_initialize(const TrajectoryOptimizerParam
   ego_nearest_param_ = EgoNearestParam(node_ptr);
   common_param_ = CommonParam(node_ptr);
   smoother_time_keeper_ptr_ = std::make_shared<SmootherTimekeeper>();
-  eb_path_smoother_ptr_ = std::make_shared<EBPathSmoother>(
-    node_ptr, false, ego_nearest_param_, common_param_, smoother_time_keeper_ptr_);
+
+  // Declare the elastic band parameters in the node layer and inject them, together
+  // with a debug publisher/logger/clock, into the node-independent smoother.
+  const auto eb_param = autoware::path_smoother::declare_eb_param(node_ptr);
+  eb_debug_publisher_ptr_ =
+    std::make_shared<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+      node_ptr, "~/debug");
+  eb_path_smoother_ptr_ = std::make_shared<EBPathSmootherT>(
+    false, ego_nearest_param_, common_param_, eb_param, node_ptr->get_logger(),
+    *node_ptr->get_clock(), eb_debug_publisher_ptr_, smoother_time_keeper_ptr_);
   eb_path_smoother_ptr_->initialize(false, common_param_);
   eb_path_smoother_ptr_->resetPreviousData();
 }

--- a/planning/autoware_trajectory_processor/src/trajectory_optimizer_plugins/trajectory_mpt_optimizer.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_optimizer_plugins/trajectory_mpt_optimizer.cpp
@@ -41,7 +41,8 @@ void TrajectoryMPTOptimizer::on_initialize(const TrajectoryOptimizerParams & par
   RCLCPP_INFO(node_ptr->get_logger(), "MPT Optimizer plugin: Starting initialization...");
 
   try {
-    // Get vehicle info
+    // VehicleInfoUtils has a templated constructor, so it also accepts the agnocast wrapper
+    // node (which has no underlying rclcpp::Node in agnocast mode).
     vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*node_ptr).getVehicleInfo();
     RCLCPP_INFO(node_ptr->get_logger(), "MPT: Vehicle info loaded");
 
@@ -79,10 +80,15 @@ void TrajectoryMPTOptimizer::on_initialize(const TrajectoryOptimizerParams & par
     mpt_time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(debug_pub);
     RCLCPP_INFO(node_ptr->get_logger(), "MPT: TimeKeeper created");
 
-    // Initialize MPT optimizer
-    mpt_optimizer_ptr_ = std::make_shared<MPTOptimizer>(
-      node_ptr, mpt_params_.enable_debug_info, ego_nearest_param_, vehicle_info_, traj_param_,
-      debug_data_ptr_, mpt_time_keeper_);
+    // Declare the MPT parameters in the node layer and inject them, together with a debug
+    // publisher/logger, into the node-independent optimizer.
+    const auto mpt_param = autoware::path_optimizer::declare_mpt_param(node_ptr, vehicle_info_);
+    mpt_debug_publisher_ptr_ =
+      std::make_shared<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+        node_ptr, "~/debug");
+    mpt_optimizer_ptr_ = std::make_shared<MPTOptimizerT>(
+      mpt_params_.enable_debug_info, ego_nearest_param_, vehicle_info_, traj_param_, mpt_param,
+      node_ptr->get_logger(), mpt_debug_publisher_ptr_, debug_data_ptr_, mpt_time_keeper_);
     RCLCPP_INFO(node_ptr->get_logger(), "MPT: MPTOptimizer created");
 
     // Create debug markers publisher

--- a/planning/autoware_trajectory_processor/src/trajectory_optimizer_plugins/trajectory_temporal_mpt_optimizer.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_optimizer_plugins/trajectory_temporal_mpt_optimizer.cpp
@@ -346,7 +346,7 @@ void TrajectoryTemporalMPTOptimizer::log_acados_solve_debug(
   const size_t terminal_idx, const TrajectoryOptimizerData & data,
   const TrajectoryPoints & traj_points) const
 {
-  rclcpp::Node * const node = get_node_ptr();
+  autoware::agnocast_wrapper::Node * const node = get_node_ptr();
   const rclcpp::Logger logger = node->get_logger();
 
   if (acados_status != 0) {
@@ -392,7 +392,7 @@ void TrajectoryTemporalMPTOptimizer::ensure_debug_publishers()
   if (!mpt_params_.publish_debug_topics || debug_input_trajectory_pub_) {
     return;
   }
-  rclcpp::Node * const n = get_node_ptr();
+  autoware::agnocast_wrapper::Node * const n = get_node_ptr();
   // Best effort (typical for high-rate planning). Subscribers must use matching reliability
   // (default rclpy reliable will not receive these messages).
   const auto qos = rclcpp::QoS(10).best_effort();
@@ -423,7 +423,7 @@ void TrajectoryTemporalMPTOptimizer::publish_temporal_mpt_debug_io(
   const TrajectoryPoints trajectory_after =
     trajectory_from_solution_overlay(reference_before, solution, n_out);
 
-  rclcpp::Node * const node = get_node_ptr();
+  autoware::agnocast_wrapper::Node * const node = get_node_ptr();
   std_msgs::msg::Header header;
   header.stamp = node->now();
   header.frame_id = initial_odom.header.frame_id.empty() ? "map" : initial_odom.header.frame_id;

--- a/planning/autoware_trajectory_processor/src/trajectory_optimizer_plugins/trajectory_velocity_optimizer.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_optimizer_plugins/trajectory_velocity_optimizer.cpp
@@ -67,7 +67,7 @@ void TrajectoryVelocityOptimizer::on_initialize(const TrajectoryOptimizerParams 
   cjs.min_jerk = params.limit.min_jerk;
 
   sub_planning_velocity_ =
-    std::make_shared<autoware_utils_rclcpp::InterProcessPollingSubscriber<VelocityLimit>>(
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<VelocityLimit>(
       node_ptr, "~/input/external_velocity_limit_mps", rclcpp::QoS{1});
 
   pub_velocity_limit_ = node_ptr->create_publisher<VelocityLimit>(

--- a/planning/autoware_trajectory_processor/src/utils.cpp
+++ b/planning/autoware_trajectory_processor/src/utils.cpp
@@ -86,22 +86,6 @@ TrajectoryPoints generate_three_point_stopped_trajectory(
   return {base_link_point, offset_point_1, offset_point_2};
 }
 
-void smooth_trajectory_with_elastic_band(
-  TrajectoryPoints & traj_points, const Odometry & current_odometry,
-  const std::shared_ptr<EBPathSmoother> & eb_path_smoother_ptr)
-{
-  if (!eb_path_smoother_ptr) {
-    log_error_throttle("Elastic band path smoother is not initialized");
-    return;
-  }
-  constexpr size_t minimum_points_for_elastic_band = 3;
-  if (traj_points.empty() || traj_points.size() < minimum_points_for_elastic_band) {
-    return;
-  }
-  traj_points = eb_path_smoother_ptr->smoothTrajectory(traj_points, current_odometry.pose.pose);
-  eb_path_smoother_ptr->resetPreviousData();
-}
-
 double compute_dt(const TrajectoryPoint & current, const TrajectoryPoint & next)
 {
   constexpr double min_dt_threshold = 1e-9;

--- a/planning/autoware_trajectory_processor/tests/test_trajectory_processor_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_trajectory_processor_integration.cpp
@@ -210,7 +210,9 @@ protected:
 
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor_->add_node(modifier_node_);
-    executor_->add_node(optimizer_node_);
+    // TrajectoryOptimizer is an autoware::agnocast_wrapper::Node, which is not an rclcpp::Node,
+    // so it is added through its node base interface.
+    executor_->add_node(optimizer_node_->get_node_base_interface());
     executor_->add_node(test_node_);
   }
 


### PR DESCRIPTION
## Description

Migrates `trajectory_optimizer_node` to `autoware::agnocast_wrapper::Node`.

Because the optimizer plugins are loaded through pluginlib, the virtual boundary `TrajectoryOptimizerPluginBase::initialize()` cannot be templated on the node type, so it now takes `autoware::agnocast_wrapper::Node *`. The two node-dependent components used by those plugins are made node-type independent instead of being duplicated:

- `autoware_path_smoother`: `EBPathSmoother` is split into a node-independent `EBParam` (declared by `declare_eb_param<NodeT>()`) and `BasicEBPathSmoother<NodeT>`, whose only node-dependent member is an injected `autoware_utils_debug::BasicDebugPublisher<NodeT>`. `using EBPathSmoother = BasicEBPathSmoother<rclcpp::Node>` keeps existing callers unchanged.
- `autoware_path_optimizer`: same treatment for `MPTOptimizer` (`declare_mpt_param<NodeT>()` + `BasicMPTOptimizer<NodeT>`, `using MPTOptimizer = BasicMPTOptimizer<rclcpp::Node>`).

Both are explicitly instantiated for `rclcpp::Node` and `autoware::agnocast_wrapper::Node`, so the `elastic_band_smoother` / `path_optimizer` nodes keep running on plain `rclcpp::Node` while the optimizer plugins use the wrapper.

Other changes in `autoware_trajectory_processor`:

- publishers/subscriptions of `trajectory_optimizer` and of the plugins that own one (velocity / mpt / temporal_mpt) go through the wrapper.
- polling subscribers use `autoware::agnocast_wrapper::polling::create_polling_subscriber()`.
- `smooth_trajectory_with_elastic_band()` is templated on the smoother type and moved to the header.
- `trajectory_optimizer.launch.xml` includes `agnocast_env.launch.xml` and sets `LD_PRELOAD` (no-op when Agnocast is disabled).

The trajectory modifier side of the package is untouched.

## Related links

None.

## How was this PR tested?

- Built with `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1` (`autoware_path_smoother`, `autoware_path_optimizer`, `autoware_trajectory_processor`).
- `colcon test` on the three packages with `ENABLE_AGNOCAST=0`: 477 tests, 0 failures.
- Runtime verification with the planning simulator is not done yet; this PR stays draft until then.

## Notes for reviewers

- `TrajectoryOptimizerPluginBase::initialize()` changes its node parameter type, so out-of-tree optimizer plugins need the same change. There are no in-tree users other than `autoware_trajectory_processor`.
- `EBPathSmoother` / `MPTOptimizer` constructors now take parameters and a debug publisher instead of a node pointer. Both aliases keep the old type name, and there are no in-tree users outside these packages.
- The debug publishers are created lazily on first publish (`BasicDebugPublisher`), so `~/debug/eb_traj`, `~/debug/eb_fixed_traj` and the MPT debug topics only appear once they are published. Topic names and QoS are unchanged.

## Interface changes

None.

## Effects on system behavior

None.
