### PR TITLE
refactor(autoware_traffic_light_classifier): simplify the node layer (always-on subscribe, drop the Nodelet suffix)

### DIFF
--- a/perception/autoware_traffic_light_classifier/CMakeLists.txt
+++ b/perception/autoware_traffic_light_classifier/CMakeLists.txt
@@ -75,7 +75,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     stdc++fs
   )
   rclcpp_components_register_node(${PROJECT_NAME}
-    PLUGIN "autoware::traffic_light::TrafficLightClassifierNodelet"
+    PLUGIN "autoware::traffic_light::TrafficLightClassifierNode"
     EXECUTABLE traffic_light_classifier_node
   )
 
@@ -124,7 +124,7 @@ else()
   )
 
   rclcpp_components_register_node(${PROJECT_NAME}
-    PLUGIN "autoware::traffic_light::TrafficLightClassifierNodelet"
+    PLUGIN "autoware::traffic_light::TrafficLightClassifierNode"
     EXECUTABLE traffic_light_classifier_node
   )
 

--- a/perception/autoware_traffic_light_classifier/design/TrafficLightClassifierCar.node.yaml
+++ b/perception/autoware_traffic_light_classifier/design/TrafficLightClassifierCar.node.yaml
@@ -8,7 +8,7 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::traffic_light::TrafficLightClassifierNodelet
+  plugin: autoware::traffic_light::TrafficLightClassifierNode
   executable: traffic_light_classifier_node
   node_output: screen
 

--- a/perception/autoware_traffic_light_classifier/design/TrafficLightClassifierPedestrian.node.yaml
+++ b/perception/autoware_traffic_light_classifier/design/TrafficLightClassifierPedestrian.node.yaml
@@ -8,7 +8,7 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::traffic_light::TrafficLightClassifierNodelet
+  plugin: autoware::traffic_light::TrafficLightClassifierNode
   executable: traffic_light_classifier_node
   node_output: screen
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_classifier.cpp
@@ -101,19 +101,19 @@ std::vector<tier4_perception_msgs::msg::TrafficLightElement> CNNClassifier::deco
       // found "-" delimiter in the label string
       std::vector<std::string> color_and_shape;
       boost::algorithm::split(color_and_shape, lamp_label, boost::is_any_of("-"));
-      element.color = utils::convertColorStringtoT4(color_and_shape.at(0));
-      element.shape = utils::convertShapeStringtoT4(color_and_shape.at(1));
+      element.color = utils::convert_color_string_to_t4(color_and_shape.at(0));
+      element.shape = utils::convert_shape_string_to_t4(color_and_shape.at(1));
     } else {
       if (lamp_label == std::string("unknown")) {
         // if the label is unknown, set UNKNOWN to color and shape
         element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
         element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-      } else if (utils::isColorLabel(lamp_label)) {
-        element.color = utils::convertColorStringtoT4(lamp_label);
+      } else if (utils::is_color_label(lamp_label)) {
+        element.color = utils::convert_color_string_to_t4(lamp_label);
         element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
       } else {
         element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-        element.shape = utils::convertShapeStringtoT4(lamp_label);
+        element.shape = utils::convert_shape_string_to_t4(lamp_label);
       }
     }
     element.confidence = confidence;
@@ -129,8 +129,8 @@ cv::Mat CNNClassifier::make_debug_image(
   std::string label;
   for (std::size_t i = 0; i < signal.elements.size(); i++) {
     const auto & light = signal.elements.at(i);
-    const auto light_label =
-      utils::convertColorT4toString(light.color) + "-" + utils::convertShapeT4toString(light.shape);
+    const auto light_label = utils::convert_color_t4_to_string(light.color) + "-" +
+                             utils::convert_shape_t4_to_string(light.shape);
     label += light_label;
     // all lamp confidences are the same
     confidence = light.confidence;

--- a/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/cnn_lamp_recognizer.cpp
@@ -522,8 +522,8 @@ cv::Mat CnnLampRecognizer::make_debug_image(
   std::string label;
   for (std::size_t i = 0; i < traffic_signal.elements.size(); i++) {
     auto light = traffic_signal.elements.at(i);
-    const auto light_label =
-      utils::convertColorT4toString(light.color) + "-" + utils::convertShapeT4toString(light.shape);
+    const auto light_label = utils::convert_color_t4_to_string(light.color) + "-" +
+                             utils::convert_shape_t4_to_string(light.shape);
     label += light_label;
     // all lamp confidence are the same
     probability = light.confidence;

--- a/perception/autoware_traffic_light_classifier/src/single_image_debug_inference_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/single_image_debug_inference_node.cpp
@@ -27,7 +27,7 @@
 
 namespace
 {
-std::string toString(const uint8_t state)
+std::string state_to_string(const uint8_t state)
 {
   if (state == tier4_perception_msgs::msg::TrafficLightElement::RED) {
     return "red";
@@ -72,11 +72,10 @@ public:
     const auto image_path = declare_parameter("image_path", "");
 
     int classifier_type = this->declare_parameter(
-      "classifier_type",
-      static_cast<int>(TrafficLightClassifierNodelet::ClassifierType::HSVFilter));
-    if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::HSVFilter) {
+      "classifier_type", static_cast<int>(TrafficLightClassifierNode::ClassifierType::HSVFilter));
+    if (classifier_type == TrafficLightClassifierNode::ClassifierType::HSVFilter) {
       classifier_ptr_ = std::make_unique<ColorClassifier>(declare_hsv_config(this));
-    } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::CNN) {
+    } else if (classifier_type == TrafficLightClassifierNode::ClassifierType::CNN) {
 #if ENABLE_GPU
       classifier_ptr_ = std::make_unique<CNNClassifier>(declare_cnn_config(this));
 #else
@@ -90,7 +89,7 @@ public:
       return;
     }
     cv::namedWindow("inference image", cv::WINDOW_NORMAL);
-    cv::setMouseCallback("inference image", SingleImageDebugInferenceNode::onMouse, this);
+    cv::setMouseCallback("inference image", SingleImageDebugInferenceNode::on_mouse, this);
 
     cv::imshow("inference image", image_);
 
@@ -102,15 +101,15 @@ public:
   }
 
 private:
-  static void onMouse(int event, int x, int y, int flags, void * param)
+  static void on_mouse(int event, int x, int y, int flags, void * param)
   {
     SingleImageDebugInferenceNode * node = static_cast<SingleImageDebugInferenceNode *>(param);
     if (node) {
-      node->inferWithCrop(event, x, y, flags);
+      node->infer_with_crop(event, x, y, flags);
     }
   }
 
-  void inferWithCrop(int action, int x, int y, [[maybe_unused]] int flags)
+  void infer_with_crop(int action, int x, int y, [[maybe_unused]] int flags)
   {
     // cspell: ignore LBUTTONDOWN, LBUTTONUP
     if (action == cv::EVENT_LBUTTONDOWN) {
@@ -132,8 +131,8 @@ private:
       cv::Scalar color;
       cv::Scalar text_color;
       for (const auto & element : traffic_signal->signals[0].elements) {
-        auto color_str = toString(element.color);
-        auto shape_str = toString(element.shape);
+        auto color_str = state_to_string(element.color);
+        auto shape_str = state_to_string(element.shape);
         auto confidence_str = std::to_string(element.confidence);
         if (shape_str == "circle") {
           if (color_str == "red") {

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
@@ -29,7 +29,7 @@
 
 namespace autoware::traffic_light
 {
-// ROS-free classification orchestration extracted from TrafficLightClassifierNodelet.
+// ROS-free classification orchestration extracted from TrafficLightClassifierNode.
 // Owns the classifier backend and the per-ROI filtering / exposure / UNKNOWN-handling
 // logic; the node remains a thin adapter that handles I/O (params, pub/sub, diagnostics).
 class TrafficLightClassifier

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -41,7 +41,7 @@ bool update_param(
 }
 }  // namespace
 
-TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeOptions & options)
+TrafficLightClassifierNode::TrafficLightClassifierNode(const rclcpp::NodeOptions & options)
 : Node("traffic_light_classifier_node", options)
 {
   const auto classify_traffic_light_type =
@@ -56,35 +56,38 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
   if (is_approximate_sync_) {
     approximate_sync_.reset(new ApproximateSync(ApproximateSyncPolicy(10), image_sub_, roi_sub_));
     approximate_sync_->registerCallback(
-      std::bind(&TrafficLightClassifierNodelet::imageRoiCallback, this, _1, _2));
+      std::bind(&TrafficLightClassifierNode::image_roi_callback, this, _1, _2));
   } else {
     sync_.reset(new Sync(SyncPolicy(10), image_sub_, roi_sub_));
     sync_->registerCallback(
-      std::bind(&TrafficLightClassifierNodelet::imageRoiCallback, this, _1, _2));
+      std::bind(&TrafficLightClassifierNode::image_roi_callback, this, _1, _2));
   }
 
   traffic_signal_array_pub_ = this->create_publisher<tier4_perception_msgs::msg::TrafficLightArray>(
     "~/output/traffic_signals", rclcpp::QoS{1});
 
-  using std::chrono_literals::operator""ms;
-  timer_ = rclcpp::create_timer(
-    this, get_clock(), 100ms, std::bind(&TrafficLightClassifierNodelet::connectCb, this));
+  // Subscribe unconditionally; message_filters delivers synchronized image + ROI pairs to
+  // image_roi_callback. (Previously a 100 ms timer-driven connectCb subscribed lazily, only while
+  // the output had subscribers; always-on is simpler, and the callback no-ops until classifier_
+  // is set.)
+  image_sub_.subscribe(this, "~/input/image", "raw", rmw_qos_profile_sensor_data);
+  roi_sub_.subscribe(this, "~/input/rois", rclcpp::QoS{1}.get_rmw_qos_profile());
 
   int classifier_type = this->declare_parameter<int>("classifier_type");
   std::shared_ptr<ClassifierInterface> classifier_ptr;
-  if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::HSVFilter) {
+  if (classifier_type == TrafficLightClassifierNode::ClassifierType::HSVFilter) {
     // Keep a typed handle so the node can drive the color backend's dynamic reconfigure.
     color_classifier_ = std::make_shared<ColorClassifier>(declare_hsv_config(this));
     set_param_res_ = this->add_on_set_parameters_callback(
-      std::bind(&TrafficLightClassifierNodelet::on_set_parameters_callback, this, _1));
+      std::bind(&TrafficLightClassifierNode::on_set_parameters_callback, this, _1));
     classifier_ptr = color_classifier_;
-  } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::CNN) {
+  } else if (classifier_type == TrafficLightClassifierNode::ClassifierType::CNN) {
 #if ENABLE_GPU
     classifier_ptr = std::make_shared<CNNClassifier>(declare_cnn_config(this));
 #else
     RCLCPP_ERROR(this->get_logger(), "please install CUDA, and TensorRT to use cnn classifier");
 #endif
-  } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::LampRecognizer) {
+  } else if (classifier_type == TrafficLightClassifierNode::ClassifierType::LampRecognizer) {
 #if ENABLE_GPU
     auto lamp_config = declare_lamp_config(this);
     // The recognizer needs its traffic-light type at construction (pedestrian lamps force CIRCLE);
@@ -114,21 +117,7 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
   }
 }
 
-void TrafficLightClassifierNodelet::connectCb()
-{
-  // set callbacks only when there are subscribers to this node
-  if (
-    traffic_signal_array_pub_->get_subscription_count() == 0 &&
-    traffic_signal_array_pub_->get_intra_process_subscription_count() == 0) {
-    image_sub_.unsubscribe();
-    roi_sub_.unsubscribe();
-  } else if (!image_sub_.getSubscriber()) {
-    image_sub_.subscribe(this, "~/input/image", "raw", rmw_qos_profile_sensor_data);
-    roi_sub_.subscribe(this, "~/input/rois", rclcpp::QoS{1}.get_rmw_qos_profile());
-  }
-}
-
-void TrafficLightClassifierNodelet::imageRoiCallback(
+void TrafficLightClassifierNode::image_roi_callback(
   const sensor_msgs::msg::Image::ConstSharedPtr & input_image_msg,
   const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_rois_msg)
 {
@@ -187,7 +176,7 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
   }
 }
 
-rcl_interfaces::msg::SetParametersResult TrafficLightClassifierNodelet::on_set_parameters_callback(
+rcl_interfaces::msg::SetParametersResult TrafficLightClassifierNode::on_set_parameters_callback(
   const std::vector<rclcpp::Parameter> & parameters)
 {
   HSVConfig config = color_classifier_->get_config();
@@ -222,4 +211,4 @@ rcl_interfaces::msg::SetParametersResult TrafficLightClassifierNodelet::on_set_p
 
 #include <rclcpp_components/register_node_macro.hpp>
 
-RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::TrafficLightClassifierNodelet)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::TrafficLightClassifierNode)

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
@@ -58,11 +58,11 @@
 
 namespace autoware::traffic_light
 {
-class TrafficLightClassifierNodelet : public rclcpp::Node
+class TrafficLightClassifierNode : public rclcpp::Node
 {
 public:
-  explicit TrafficLightClassifierNodelet(const rclcpp::NodeOptions & options);
-  void imageRoiCallback(
+  explicit TrafficLightClassifierNode(const rclcpp::NodeOptions & options);
+  void image_roi_callback(
     const sensor_msgs::msg::Image::ConstSharedPtr & input_image_msg,
     const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_rois_msg);
 
@@ -74,14 +74,11 @@ public:
   };
 
 private:
-  void connectCb();
-
   // Applies HSV threshold parameter updates to the color backend at runtime (dynamic reconfigure).
   // Registered only for the HSV backend; drives color_classifier_'s get_config / set_config.
   rcl_interfaces::msg::SetParametersResult on_set_parameters_callback(
     const std::vector<rclcpp::Parameter> & parameters);
 
-  rclcpp::TimerBase::SharedPtr timer_;
   image_transport::SubscriberFilter image_sub_;
   message_filters::Subscriber<tier4_perception_msgs::msg::TrafficLightRoiArray> roi_sub_;
   typedef message_filters::sync_policies::ExactTime<

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_process.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_process.cpp
@@ -62,33 +62,34 @@ const std::unordered_map<std::string, tier4_perception_msgs::msg::TrafficLightEl
      {"down_right", tier4_perception_msgs::msg::TrafficLightElement::DOWN_RIGHT_ARROW},
      {"cross", tier4_perception_msgs::msg::TrafficLightElement::CROSS}});
 
-tier4_perception_msgs::msg::TrafficLightElement::_color_type convertColorStringtoT4(
+tier4_perception_msgs::msg::TrafficLightElement::_color_type convert_color_string_to_t4(
   const std::string & label)
 {
   return at_or(string2color, label, tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN);
 }
 
-tier4_perception_msgs::msg::TrafficLightElement::_shape_type convertShapeStringtoT4(
+tier4_perception_msgs::msg::TrafficLightElement::_shape_type convert_shape_string_to_t4(
   const std::string & label)
 {
   return at_or(string2shape, label, tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN);
 }
 
-std::string convertColorT4toString(
+std::string convert_color_t4_to_string(
   const tier4_perception_msgs::msg::TrafficLightElement::_color_type & label)
 {
   return at_or(color2string, label, std::string("unknown"));
 }
 
-std::string convertShapeT4toString(
+std::string convert_shape_t4_to_string(
   const tier4_perception_msgs::msg::TrafficLightElement::_shape_type & label)
 {
   return at_or(shape2string, label, std::string("unknown"));
 }
 
-bool isColorLabel(const std::string & label)
+bool is_color_label(const std::string & label)
 {
-  return convertColorStringtoT4(label) != tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+  return convert_color_string_to_t4(label) !=
+         tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
 }
 
 double compute_brightness(const cv::Mat & img)

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_process.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_process.hpp
@@ -35,19 +35,19 @@ V at_or(const std::unordered_map<K, V> & map, const K & key, const V & value)
   return map.count(key) ? map.at(key) : value;
 }
 
-tier4_perception_msgs::msg::TrafficLightElement::_color_type convertColorStringtoT4(
+tier4_perception_msgs::msg::TrafficLightElement::_color_type convert_color_string_to_t4(
   const std::string & label);
 
-tier4_perception_msgs::msg::TrafficLightElement::_shape_type convertShapeStringtoT4(
+tier4_perception_msgs::msg::TrafficLightElement::_shape_type convert_shape_string_to_t4(
   const std::string & label);
 
-std::string convertColorT4toString(
+std::string convert_color_t4_to_string(
   const tier4_perception_msgs::msg::TrafficLightElement::_color_type & label);
 
-std::string convertShapeT4toString(
+std::string convert_shape_t4_to_string(
   const tier4_perception_msgs::msg::TrafficLightElement::_shape_type & label);
 
-bool isColorLabel(const std::string & label);
+bool is_color_label(const std::string & label);
 
 double compute_brightness(const cv::Mat & img);
 

--- a/perception/autoware_traffic_light_classifier/test/test_traffic_light_classifier_integration.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_traffic_light_classifier_integration.cpp
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 //
-// Integration tests for TrafficLightClassifierNodelet.
+// Integration tests for TrafficLightClassifierNode.
 //
 // These stand up the real node and drive it over its ROS interface: an Image and
-// a TrafficLightRoiArray are published on the input topics, the node's own
-// lazy-subscription (connectCb) and message_filters ExactTime sync wire them
-// through imageRoiCallback, and the test observes the published traffic_signals
+// a TrafficLightRoiArray are published on the input topics, the node's always-on
+// subscription and message_filters ExactTime sync wire them through
+// image_roi_callback, and the test observes the published traffic_signals
 // and /diagnostics topics. This exercises the full pub/sub + sync + diagnostics
 // path that a unit-level callback invocation would bypass.
 //
@@ -191,26 +191,26 @@ public:
 class IntegrationTest : public ::testing::Test
 {
 protected:
-  std::shared_ptr<tl::TrafficLightClassifierNodelet> make_node_under_test()
+  std::shared_ptr<tl::TrafficLightClassifierNode> make_node_under_test()
   {
     rclcpp::NodeOptions options;
     options.append_parameter_override(
       "classifier_type",
-      static_cast<int>(tl::TrafficLightClassifierNodelet::ClassifierType::HSVFilter));
+      static_cast<int>(tl::TrafficLightClassifierNode::ClassifierType::HSVFilter));
     options.append_parameter_override("traffic_light_type", static_cast<int>(car_type));
     options.append_parameter_override("approximate_sync", false);
     options.append_parameter_override("over_exposure_threshold", no_over_threshold);
     options.append_parameter_override("under_exposure_threshold", no_under_threshold);
     options.append_parameter_override("build_only", false);
-    node_ = std::make_shared<tl::TrafficLightClassifierNodelet>(options);
+    node_ = std::make_shared<tl::TrafficLightClassifierNode>(options);
     return node_;
   }
 
   // Publish (image, rois) on the input topics and capture the node's output. The
-  // inputs are re-published in a wait loop so the test is robust against the
-  // lazy connectCb subscription and pub/sub discovery latency; identical stamps
-  // make every pair an ExactTime match. A missing signal publish is a setup
-  // failure, surfaced by throwing (helpers stay free of gtest assertions).
+  // inputs are re-published in a wait loop so the test is robust against pub/sub
+  // discovery latency; identical stamps make every pair an ExactTime match. A
+  // missing signal publish is a setup failure, surfaced by throwing (helpers stay
+  // free of gtest assertions).
   Captured run(const Image & image, const TrafficLightRoiArray & rois)
   {
     OutputCapture capture;
@@ -248,7 +248,7 @@ protected:
     return capture.cap;
   }
 
-  std::shared_ptr<tl::TrafficLightClassifierNodelet> node_;
+  std::shared_ptr<tl::TrafficLightClassifierNode> node_;
 };
 
 // --------------------------------------------------------------------------

--- a/perception/autoware_traffic_light_classifier/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_utils.cpp
@@ -120,117 +120,131 @@ TEST(is_under_exposure, dimmed_strong)
   EXPECT_TRUE(result);
 }
 
-TEST(convertColorStringtoT4, normal)
+TEST(convert_color_string_to_t4, normal)
 {
   using tier4_perception_msgs::msg::TrafficLightElement;
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertColorStringtoT4("red"), TrafficLightElement::RED);
+    autoware::traffic_light::utils::convert_color_string_to_t4("red"), TrafficLightElement::RED);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertColorStringtoT4("yellow"), TrafficLightElement::AMBER);
+    autoware::traffic_light::utils::convert_color_string_to_t4("yellow"),
+    TrafficLightElement::AMBER);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertColorStringtoT4("green"), TrafficLightElement::GREEN);
+    autoware::traffic_light::utils::convert_color_string_to_t4("green"),
+    TrafficLightElement::GREEN);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertColorStringtoT4("white"), TrafficLightElement::WHITE);
+    autoware::traffic_light::utils::convert_color_string_to_t4("white"),
+    TrafficLightElement::WHITE);
   EXPECT_EQ(  // return UNKNOWN for unknown string
-    autoware::traffic_light::utils::convertColorStringtoT4("abcde"), TrafficLightElement::UNKNOWN);
+    autoware::traffic_light::utils::convert_color_string_to_t4("abcde"),
+    TrafficLightElement::UNKNOWN);
 }
 
-TEST(convertShapeStringtoT4, normal)
+TEST(convert_shape_string_to_t4, normal)
 {
   using tier4_perception_msgs::msg::TrafficLightElement;
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("circle"), TrafficLightElement::CIRCLE);
+    autoware::traffic_light::utils::convert_shape_string_to_t4("circle"),
+    TrafficLightElement::CIRCLE);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("left"),
+    autoware::traffic_light::utils::convert_shape_string_to_t4("left"),
     TrafficLightElement::LEFT_ARROW);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("right"),
+    autoware::traffic_light::utils::convert_shape_string_to_t4("right"),
     TrafficLightElement::RIGHT_ARROW);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("straight"),
+    autoware::traffic_light::utils::convert_shape_string_to_t4("straight"),
     TrafficLightElement::UP_ARROW);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("up_left"),
+    autoware::traffic_light::utils::convert_shape_string_to_t4("up_left"),
     TrafficLightElement::UP_LEFT_ARROW);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("up_right"),
+    autoware::traffic_light::utils::convert_shape_string_to_t4("up_right"),
     TrafficLightElement::UP_RIGHT_ARROW);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("down"),
+    autoware::traffic_light::utils::convert_shape_string_to_t4("down"),
     TrafficLightElement::DOWN_ARROW);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("down_left"),
+    autoware::traffic_light::utils::convert_shape_string_to_t4("down_left"),
     TrafficLightElement::DOWN_LEFT_ARROW);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("down_right"),
+    autoware::traffic_light::utils::convert_shape_string_to_t4("down_right"),
     TrafficLightElement::DOWN_RIGHT_ARROW);
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeStringtoT4("cross"), TrafficLightElement::CROSS);
+    autoware::traffic_light::utils::convert_shape_string_to_t4("cross"),
+    TrafficLightElement::CROSS);
   EXPECT_EQ(  // return UNKNOWN for unknown string
-    autoware::traffic_light::utils::convertShapeStringtoT4("abcde"), TrafficLightElement::UNKNOWN);
+    autoware::traffic_light::utils::convert_shape_string_to_t4("abcde"),
+    TrafficLightElement::UNKNOWN);
 }
 
-TEST(convertColorT4toString, normal)
+TEST(convert_color_t4_to_string, normal)
 {
   using tier4_perception_msgs::msg::TrafficLightElement;
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertColorT4toString(TrafficLightElement::RED), "red");
+    autoware::traffic_light::utils::convert_color_t4_to_string(TrafficLightElement::RED), "red");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertColorT4toString(TrafficLightElement::AMBER), "yellow");
+    autoware::traffic_light::utils::convert_color_t4_to_string(TrafficLightElement::AMBER),
+    "yellow");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertColorT4toString(TrafficLightElement::GREEN), "green");
+    autoware::traffic_light::utils::convert_color_t4_to_string(TrafficLightElement::GREEN),
+    "green");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertColorT4toString(TrafficLightElement::WHITE), "white");
+    autoware::traffic_light::utils::convert_color_t4_to_string(TrafficLightElement::WHITE),
+    "white");
   EXPECT_EQ(  // return "unknown" for unknown enum value
-    autoware::traffic_light::utils::convertColorT4toString(99),
+    autoware::traffic_light::utils::convert_color_t4_to_string(99),
     "unknown");
 }
 
-TEST(convertShapeT4toString, normal)
+TEST(convert_shape_t4_to_string, normal)
 {
   using tier4_perception_msgs::msg::TrafficLightElement;
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::CIRCLE), "circle");
+    autoware::traffic_light::utils::convert_shape_t4_to_string(TrafficLightElement::CIRCLE),
+    "circle");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::LEFT_ARROW),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(TrafficLightElement::LEFT_ARROW),
     "left");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::RIGHT_ARROW),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(TrafficLightElement::RIGHT_ARROW),
     "right");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::UP_ARROW),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(TrafficLightElement::UP_ARROW),
     "straight");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::UP_LEFT_ARROW),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(TrafficLightElement::UP_LEFT_ARROW),
     "up_left");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::UP_RIGHT_ARROW),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(TrafficLightElement::UP_RIGHT_ARROW),
     "up_right");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::DOWN_ARROW),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(TrafficLightElement::DOWN_ARROW),
     "down");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::DOWN_LEFT_ARROW),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(
+      TrafficLightElement::DOWN_LEFT_ARROW),
     "down_left");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::DOWN_RIGHT_ARROW),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(
+      TrafficLightElement::DOWN_RIGHT_ARROW),
     "down_right");
   EXPECT_EQ(
-    autoware::traffic_light::utils::convertShapeT4toString(TrafficLightElement::CROSS), "cross");
+    autoware::traffic_light::utils::convert_shape_t4_to_string(TrafficLightElement::CROSS),
+    "cross");
   EXPECT_EQ(  // return "unknown" for unknown enum value
-    autoware::traffic_light::utils::convertShapeT4toString(99),
+    autoware::traffic_light::utils::convert_shape_t4_to_string(99),
     "unknown");
 }
 
-TEST(isColorLabel, normal)
+TEST(is_color_label, normal)
 {
-  EXPECT_TRUE(autoware::traffic_light::utils::isColorLabel("red"));
-  EXPECT_TRUE(autoware::traffic_light::utils::isColorLabel("yellow"));
-  EXPECT_TRUE(autoware::traffic_light::utils::isColorLabel("green"));
-  EXPECT_TRUE(autoware::traffic_light::utils::isColorLabel("white"));
-  EXPECT_FALSE(autoware::traffic_light::utils::isColorLabel("circle"));
-  EXPECT_FALSE(autoware::traffic_light::utils::isColorLabel("right"));
-  EXPECT_FALSE(autoware::traffic_light::utils::isColorLabel("abcde"));
+  EXPECT_TRUE(autoware::traffic_light::utils::is_color_label("red"));
+  EXPECT_TRUE(autoware::traffic_light::utils::is_color_label("yellow"));
+  EXPECT_TRUE(autoware::traffic_light::utils::is_color_label("green"));
+  EXPECT_TRUE(autoware::traffic_light::utils::is_color_label("white"));
+  EXPECT_FALSE(autoware::traffic_light::utils::is_color_label("circle"));
+  EXPECT_FALSE(autoware::traffic_light::utils::is_color_label("right"));
+  EXPECT_FALSE(autoware::traffic_light::utils::is_color_label("abcde"));
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

Follow-up to the by-concern de-Node refactor of `autoware_traffic_light_classifier`. Now that all classification logic lives in the ROS-free cores/wrapper, the node is a thin I/O shell; this PR tidies up the node layer.

- **Always-on subscription.** Subscribe to the image / ROI inputs unconditionally in the constructor, removing the 100 ms timer and its `connectCb`. `connectCb` was a lazy-subscribe optimization that unsubscribed the inputs (and thus stopped inference) whenever `~/output/traffic_signals` had no subscribers. Always-on is simpler, and the callback already no-ops until the classifier is constructed.
- **Drop the stale `Nodelet` suffix.** Rename `TrafficLightClassifierNodelet` → `TrafficLightClassifierNode`: it is a `rclcpp` component, not a (long-removed) nodelet.
- **snake_case the remaining camelCase names** (ROS 2 style): the node callback `imageRoiCallback` → `image_roi_callback`; the `utils` helpers `convertColorStringtoT4` / `convertShapeStringtoT4` / `convertColorT4toString` / `convertShapeT4toString` / `isColorLabel` → `convert_color_string_to_t4` / `convert_shape_string_to_t4` / `convert_color_t4_to_string` / `convert_shape_t4_to_string` / `is_color_label`; and the single-image debug tool's `onMouse` / `inferWithCrop` / `toString` → `on_mouse` / `infer_with_crop` / `state_to_string`.

## Related links

- Builds on #13081 (return-based `classify`, merged), the preceding PR in the series.
- Prior PRs: #13041, #13047, #13056, #13070, #13081.

## How was this PR tested?

`colcon build` and `colcon test` on an RTX 5080:

```bash
colcon build --packages-select autoware_traffic_light_classifier
colcon test --packages-select autoware_traffic_light_classifier && colcon test-result --verbose
```

All tests pass (82 tests, 0 failures, 0 skipped). The topic-driven integration test (`test_traffic_light_classifier_integration`) exercises the always-on subscription end to end.

## Notes for reviewers

The only behavior change is the always-on subscription: the node now runs the message_filters sync + classify on every synchronized input pair regardless of whether `~/output/traffic_signals` has subscribers (the debug image stays gated on its own subscriber count). In steady operation a downstream always subscribes, so this matters only for partial / bag / development runs. Everything else is a mechanical rename.

The class rename is fully in-package: the executable name (`traffic_light_classifier_node`) and the launch files are unchanged (they reference the executable, not the class), and no other package references the plugin string.

## Interface changes

No topic / parameter changes. Internal C++ only: `TrafficLightClassifierNodelet` → `TrafficLightClassifierNode` (and the plugin string in `CMakeLists.txt` / the design `*.node.yaml`); the callback and `utils` helper names are snake_cased.

<details><summary>Topic changes</summary>

### Added / Removed topics

None.

</details>

## Effects on system behavior

None to the published output. The node's input subscription is now always-on rather than lazily gated on output subscribers (see Notes).
