### PR TITLE
refactor(autoware_mission_planner_universe): decouple planner plugin from the node type

### DIFF
--- a/planning/autoware_mission_planner_universe/include/autoware/mission_planner_universe/mission_planner_plugin.hpp
+++ b/planning/autoware_mission_planner_universe/include/autoware/mission_planner_universe/mission_planner_plugin.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__MISSION_PLANNER_UNIVERSE__MISSION_PLANNER_PLUGIN_HPP_
 
 #include <autoware/route_handler/route_handler.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -23,6 +24,7 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <functional>
 #include <vector>
 
 namespace autoware::mission_planner_universe
@@ -36,9 +38,21 @@ public:
   using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
   using MarkerArray = visualization_msgs::msg::MarkerArray;
 
+  /// @brief Everything a planner plugin needs from the node that hosts it. Holding the node
+  /// interfaces instead of the node itself keeps this interface independent of the node type, so
+  /// that a plugin can be hosted by any node that provides them.
+  struct Context
+  {
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr parameters;
+    rclcpp::Logger logger{rclcpp::get_logger("mission_planner_plugin")};
+    rclcpp::Clock::SharedPtr clock;
+    std::function<void(const MarkerArray &)> publish_debug_marker;
+    autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+  };
+
   virtual ~PlannerPlugin() = default;
-  virtual void initialize(rclcpp::Node * node) = 0;
-  virtual void initialize(rclcpp::Node * node, const LaneletMapBin::ConstSharedPtr msg) = 0;
+  virtual void initialize(const Context & context) = 0;
+  virtual void set_map(const LaneletMapBin & map) = 0;
   virtual bool ready() const = 0;
   virtual LaneletRoute plan(const RoutePoints & points) = 0;
   virtual MarkerArray visualize(
@@ -46,6 +60,35 @@ public:
   virtual void updateRoute(const LaneletRoute & route) = 0;
   virtual void clearRoute() = 0;
   virtual const autoware::route_handler::RouteHandler & getRouteHandler() const = 0;
+
+  /// @brief Build a context from a node. Works with any node type that provides the rclcpp node
+  /// interfaces and create_publisher (rclcpp::Node, autoware::agnocast_wrapper::Node, ...).
+  template <typename NodeT>
+  static Context make_context(NodeT & node)
+  {
+    const auto durable_qos = rclcpp::QoS(1).transient_local();
+    auto debug_marker_publisher =
+      node.template create_publisher<MarkerArray>("~/debug/goal_footprint", durable_qos);
+
+    Context context;
+    context.parameters = node.get_node_parameters_interface();
+    context.logger = node.get_logger();
+    context.clock = node.get_clock();
+    // The publisher is owned by this callback, so it lives as long as the plugin keeps the context.
+    context.publish_debug_marker = [debug_marker_publisher](const MarkerArray & markers) {
+      debug_marker_publisher->publish(markers);
+    };
+    context.vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
+    return context;
+  }
+
+  /// @brief Convenience entry point for callers that own a node and already have the map.
+  template <typename NodeT>
+  void initialize(NodeT * node, const LaneletMapBin::ConstSharedPtr msg)
+  {
+    initialize(make_context(*node));
+    set_map(*msg);
+  }
 };
 
 }  // namespace autoware::mission_planner_universe

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -86,39 +86,41 @@ bool hasDirectionChangeTag(const lanelet::ConstLanelet & lanelet)
   const std::string direction_change_tag = lanelet.attributeOr("direction_change", "none");
   return direction_change_tag == "yes";
 }
+
+/// @brief Declare a parameter without a default value, i.e. an override must be provided.
+template <typename T>
+T declare_parameter(
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & parameters,
+  const std::string & name)
+{
+  return parameters->declare_parameter(name, rclcpp::ParameterValue{T{}}.get_type()).get<T>();
+}
+
+template <typename T>
+T declare_parameter(
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & parameters,
+  const std::string & name, const T & default_value)
+{
+  return parameters->declare_parameter(name, rclcpp::ParameterValue{default_value}).get<T>();
+}
 }  // namespace
 
-void DefaultPlanner::initialize_common(rclcpp::Node * node)
+void DefaultPlanner::initialize(const Context & context)
 {
   is_graph_ready_ = false;
-  node_ = node;
+  context_ = context;
+  vehicle_info_ = context_.vehicle_info;
 
-  const auto durable_qos = rclcpp::QoS(1).transient_local();
-  pub_goal_footprint_marker_ =
-    node_->create_publisher<MarkerArray>("~/debug/goal_footprint", durable_qos);
-
-  vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*node_).getVehicleInfo();
-  param_.goal_angle_threshold_deg = node_->declare_parameter<double>("goal_angle_threshold_deg");
-  param_.enable_correct_goal_pose = node_->declare_parameter<bool>("enable_correct_goal_pose");
-  param_.consider_no_drivable_lanes = node_->declare_parameter<bool>("consider_no_drivable_lanes");
+  const auto & parameters = context_.parameters;
+  param_.goal_angle_threshold_deg =
+    declare_parameter<double>(parameters, "goal_angle_threshold_deg");
+  param_.enable_correct_goal_pose = declare_parameter<bool>(parameters, "enable_correct_goal_pose");
+  param_.consider_no_drivable_lanes =
+    declare_parameter<bool>(parameters, "consider_no_drivable_lanes");
   param_.check_footprint_inside_lanes =
-    node_->declare_parameter<bool>("check_footprint_inside_lanes");
-  param_.allow_area = node_->declare_parameter<bool>("allow_area", false);
+    declare_parameter<bool>(parameters, "check_footprint_inside_lanes");
+  param_.allow_area = declare_parameter<bool>(parameters, "allow_area", false);
   route_handler_.setAllowArea(param_.allow_area);
-}
-
-void DefaultPlanner::initialize(rclcpp::Node * node)
-{
-  initialize_common(node);
-  map_subscriber_ = node_->create_subscription<LaneletMapBin>(
-    "~/input/vector_map", rclcpp::QoS{10}.transient_local(),
-    std::bind(&DefaultPlanner::map_callback, this, std::placeholders::_1));
-}
-
-void DefaultPlanner::initialize(rclcpp::Node * node, const LaneletMapBin::ConstSharedPtr msg)
-{
-  initialize_common(node);
-  map_callback(msg);
 }
 
 bool DefaultPlanner::ready() const
@@ -126,9 +128,9 @@ bool DefaultPlanner::ready() const
   return is_graph_ready_;
 }
 
-void DefaultPlanner::map_callback(const LaneletMapBin::ConstSharedPtr msg)
+void DefaultPlanner::set_map(const LaneletMapBin & map)
 {
-  route_handler_.setMap(*msg);
+  route_handler_.setMap(map);
   is_graph_ready_ = true;
 }
 
@@ -152,7 +154,7 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
         const auto area = route_handler_.getAreaFromId(prim.id);
         visualization_msgs::msg::Marker m;
         m.header.frame_id = "map";
-        m.header.stamp = node_->now();
+        m.header.stamp = context_.clock->now();
         m.ns = "route_areas";
         m.id = area_id++;
         m.action = visualization_msgs::msg::Marker::ADD;
@@ -280,7 +282,7 @@ bool DefaultPlanner::check_goal_footprint_inside_lanes(
 
 bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
 {
-  const auto logger = node_->get_logger();
+  const auto logger = context_.logger;
 
   const auto goal_lanelet_pt = experimental::lanelet2_utils::from_ros(goal.position);
 
@@ -346,7 +348,7 @@ bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
   lanelets_near_goal.insert(lanelets_near_goal.end(), next_lanelets.begin(), next_lanelets.end());
 
   const autoware_utils::LinearRing2d goal_footprint = vehicle_info_.createFootprint(0.0, goal);
-  pub_goal_footprint_marker_->publish(visualize_debug_footprint(goal_footprint));
+  context_.publish_debug_marker(visualize_debug_footprint(goal_footprint));
   const auto polygon_footprint = convert_linear_ring_to_polygon(goal_footprint);
 
   // check if goal footprint exceeds lane when the goal isn't in parking_lot
@@ -396,7 +398,7 @@ bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
 
 PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
 {
-  const auto logger = node_->get_logger();
+  const auto logger = context_.logger;
 
   std::stringstream log_ss;
   for (const auto & point : points) {
@@ -513,14 +515,14 @@ geometry_msgs::msg::Pose DefaultPlanner::refine_goal_height(
     const auto area = route_handler_.getAreaFromId(pref.id);
     goal_height = project_goal_to_area(area, goal_pt);
     RCLCPP_DEBUG(
-      node_->get_logger(), "[DefaultPlanner] refine_goal_height: goal on area id=%ld z=%.3f",
-      pref.id, goal_height);
+      context_.logger, "[DefaultPlanner] refine_goal_height: goal on area id=%ld z=%.3f", pref.id,
+      goal_height);
   } else {
     const auto goal_lanelet = route_handler_.getLaneletsFromId(pref.id);
     goal_height = project_goal_to_map(goal_lanelet, goal_pt);
     RCLCPP_DEBUG(
-      node_->get_logger(), "[DefaultPlanner] refine_goal_height: goal on lane id=%ld z=%.3f",
-      pref.id, goal_height);
+      context_.logger, "[DefaultPlanner] refine_goal_height: goal on lane id=%ld z=%.3f", pref.id,
+      goal_height);
   }
 
   Pose refined_goal = goal;

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.hpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.hpp
@@ -45,10 +45,13 @@ struct DefaultPlannerParameters
 class DefaultPlanner : public mission_planner_universe::PlannerPlugin
 {
 public:
-  DefaultPlanner() : vehicle_info_(), is_graph_ready_(false), param_(), node_(nullptr) {}
+  DefaultPlanner() : vehicle_info_(), is_graph_ready_(false), param_() {}
 
-  void initialize(rclcpp::Node * node) override;
-  void initialize(rclcpp::Node * node, const LaneletMapBin::ConstSharedPtr msg) override;
+  // Keep the node-based convenience overload of the base class visible.
+  using mission_planner_universe::PlannerPlugin::initialize;
+
+  void initialize(const Context & context) override;
+  void set_map(const LaneletMapBin & map) override;
   [[nodiscard]] bool ready() const override;
   LaneletRoute plan(const RoutePoints & points) override;
   void updateRoute(const PlannerPlugin::LaneletRoute & route) override;
@@ -71,12 +74,7 @@ protected:
 
   DefaultPlannerParameters param_;
 
-  rclcpp::Node * node_;
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr map_subscriber_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_goal_footprint_marker_;
-
-  void initialize_common(rclcpp::Node * node);
-  void map_callback(const LaneletMapBin::ConstSharedPtr msg);
+  Context context_;
 
   /**
    * @brief check if the goal_footprint is within the lanelets closest to the goal plus the

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -90,7 +90,7 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   goal_lanelet_transparency_ = declare_parameter<float>("goal_lanelet_transparency");
   planner_ = plugin_loader_.createSharedInstance(
     "autoware::mission_planner_universe::lanelet2::DefaultPlanner");
-  planner_->initialize(this);
+  planner_->initialize(PlannerPlugin::make_context(*this));
 
   const auto durable_qos = rclcpp::QoS(1).transient_local();
   sub_odometry_ = create_subscription<Odometry>(
@@ -207,6 +207,7 @@ void MissionPlanner::on_map(const LaneletMapBin::ConstSharedPtr msg)
   map_ptr_ = msg;
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*map_ptr_));
+  planner_->set_map(*map_ptr_);
 }
 
 Pose MissionPlanner::transform_pose(const Pose & pose, const Header & header)

--- a/planning/autoware_mission_planner_universe/test/test_lanelet2_plugins_default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/test/test_lanelet2_plugins_default_planner.cpp
@@ -86,7 +86,7 @@ protected:
     // vehicle_width: 1.83, vehicle_length: 4.77
 
     node_ = std::make_shared<rclcpp::Node>("test_node", options);
-    planner_.initialize(node_.get());
+    planner_.initialize(autoware::mission_planner_universe::PlannerPlugin::make_context(*node_));
   }
 
   ~DefaultPlannerTest() override { rclcpp::shutdown(); }


### PR DESCRIPTION
## Description

The plugin is loaded through pluginlib, so a node type in the virtual boundary is part of the plugin ABI. This replaces the node pointer with a node-free `Context`:

- `initialize(const Context &)` and `set_map(const LaneletMapBin &)` are the new virtual entry points. `Context` carries the parameters interface, logger, clock, a debug-marker publish callback and the vehicle info.
- `make_context(node)` builds one from any node that provides `get_node_parameters_interface()`, `get_logger()`, `get_clock()` and `create_publisher()`. It is a non-virtual template instantiated in the caller's translation unit, so the node type stays out of the plugin.
- `initialize(node, map)` is kept so existing callers compile unchanged. Once they move to `make_context()` + `set_map()`, that overload can be removed and `make_context()` moved out of this header, leaving the interface free of node-shaped code altogether.
- `DefaultPlanner` no longer subscribes to `~/input/vector_map`. `MissionPlanner` already subscribes to it and now forwards the map via `set_map()` from `on_map()`, removing a duplicated subscription to the same topic in the same process.

This keeps one pluginlib base class whatever the host node type is, and is the prerequisite for making the plugin fully node-independent (a follow-up can replace the parameters interface with a parameter-source abstraction without touching any caller).

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7007

## How was this PR tested?

- `colcon build` + `colcon test`: 82 tests, 0 failures (`DefaultPlannerTest` now initializes through `make_context()`).
- The out-of-repo caller of this interface (`autoware_static_centerline_generator` in `autoware_tools`) compiles unchanged against the new header.
- `make_context()` + `initialize()` + `set_map()` also compile with `autoware::agnocast_wrapper::Node` as the host node type.
- planning_simulator: set the ego pose, cleared the route and requested a new one via `/planning/set_waypoint_route`. The planner produced the same route as before this change (12 segments over lanelets 106..127), `/planning/mission_planning/route` was published and the route state reached `SET`.

## Notes for reviewers

`Context::publish_debug_marker` owns the `~/debug/goal_footprint` publisher (it is captured by the callback), so the publisher lives as long as the plugin keeps its context. Topic name and QoS are unchanged.

## Interface changes

- Removed: `initialize(rclcpp::Node *)`, the variant in which the plugin subscribed to `~/input/vector_map` itself. Its only user was `MissionPlanner`.
- Added: `initialize(const Context &)`, `set_map()`, `make_context()`.
- Unchanged: `initialize(node, map)`, the other virtual methods, the pluginlib base class name and the plugin lookup name.

## Effects on system behavior

None. The map now reaches the plugin through `MissionPlanner::on_map()` instead of the plugin's own subscription to the same topic.
