### PR TITLE
fix(trajectory_validator): manual cherry-pick planning factor

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/trajectory_validator_report.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/trajectory_validator_report.hpp
@@ -18,6 +18,7 @@
 #include <autoware_trajectory_validator/msg/validation_report.hpp>
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
+#include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
 
 #include <algorithm>
 #include <string>
@@ -65,6 +66,7 @@ struct TrajectoryValidatorReport
   autoware_internal_planning_msgs::msg::CandidateTrajectories valid_trajectories;
   std::vector<EvaluationTable> evaluation_tables;
   std::vector<autoware_trajectory_validator::msg::ValidationReport> validation_reports;
+  autoware_internal_planning_msgs::msg::PlanningFactorArray planning_factors;
   size_t num_feasible_trajectories{0};
 
   std::unordered_map<std::string, double> processing_time_ms;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_wrapper.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_wrapper.hpp
@@ -20,6 +20,7 @@
 #include "autoware/trajectory_validator/detail/validator_context.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
+#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_trajectory_validator/msg/metric_report.hpp>
 #include <autoware_trajectory_validator/msg/validation_report.hpp>
 #include <autoware_trajectory_validator/msg/validation_report_array.hpp>
@@ -32,6 +33,7 @@
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
+#include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
@@ -150,6 +152,11 @@ private:
   void publish_processing_time_text(
     const std::unordered_map<std::string, double> & processing_time);
 
+  void add_planning_factors(
+    const autoware_internal_planning_msgs::msg::PlanningFactorArray & planning_factors);
+  void publish_planning_factor(
+    const autoware_internal_planning_msgs::msg::PlanningFactorArray & planning_factors);
+
   rclcpp::Node * node_ptr_{nullptr};
   std::string interface_name_{"trajectory_validator"};
   rclcpp::Logger logger_;
@@ -164,6 +171,8 @@ private:
 
   // Publishers
   std::shared_ptr<autoware_utils_debug::DebugPublisher> pub_debug_;
+  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+    planning_factor_interface_;
 
   // Internal state
   std::unique_ptr<DiagnosticsInterface> diagnostics_interface_ptr_;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -23,6 +23,7 @@
 #include <tl_expected/expected.hpp>
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
+#include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -37,6 +38,7 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using VehicleInfo = autoware::vehicle_info_utils::VehicleInfo;
 using autoware_internal_planning_msgs::msg::CandidateTrajectory;
+using autoware_internal_planning_msgs::msg::PlanningFactorArray;
 using autoware_trajectory_validator::msg::MetricReport;
 using autoware_trajectory_validator::msg::RiskLevel;
 

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -29,6 +29,7 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_traffic_light_compliance_checker</depend>
   <depend>autoware_traffic_light_utils</depend>

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_wrapper.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_wrapper.cpp
@@ -70,6 +70,9 @@ TrajectoryValidatorWrapper::TrajectoryValidatorWrapper(
   });
   publishers();
 
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      &node, "trajectory_validator");
   validator_ptr_ = std::make_unique<TrajectoryValidator>(plugins_);
   diagnostics_interface_ptr_ = std::make_unique<DiagnosticsInterface>(node_ptr_, interface_name_);
 }
@@ -157,6 +160,7 @@ CandidateTrajectories TrajectoryValidatorWrapper::validate_trajectories(
   update_diagnostic(input_trajectories, report.num_feasible_trajectories);
 
   publish_validation_reports(report.validation_reports);
+  publish_planning_factor(report.planning_factors);
 
   // Wire up the debug publishers using the opaque report data
   publish_debug(report.evaluation_tables, report.processing_time_ms, context.odometry->pose.pose);
@@ -315,4 +319,38 @@ void TrajectoryValidatorWrapper::publish_processing_time_text(
   pub_debug_->publish<autoware_internal_debug_msgs::msg::StringStamped>(
     "processing_time_text", fmt::to_string(out));
 }
+
+void TrajectoryValidatorWrapper::add_planning_factors(
+  const autoware_internal_planning_msgs::msg::PlanningFactorArray & planning_factors)
+{
+  for (const auto & factor : planning_factors.factors) {
+    if (factor.control_points.empty()) {
+      continue;
+    }
+
+    const auto & control_point = factor.control_points.front();
+    if (factor.control_points.size() == 1) {
+      planning_factor_interface_->add(
+        control_point.distance, control_point.pose, factor.behavior, factor.safety_factors,
+        factor.is_driving_forward, control_point.velocity, control_point.shift_length,
+        factor.detail);
+      continue;
+    }
+
+    const auto & end_control_point = factor.control_points.back();
+    planning_factor_interface_->add(
+      control_point.distance, end_control_point.distance, control_point.pose,
+      end_control_point.pose, factor.behavior, factor.safety_factors, factor.is_driving_forward,
+      control_point.velocity, end_control_point.velocity, control_point.shift_length,
+      end_control_point.shift_length, factor.detail);
+  }
+}
+
+void TrajectoryValidatorWrapper::publish_planning_factor(
+  const autoware_internal_planning_msgs::msg::PlanningFactorArray & planning_factors)
+{
+  add_planning_factors(planning_factors);
+  planning_factor_interface_->publish();
+}
+
 }  // namespace autoware::trajectory_validator


### PR DESCRIPTION
## Description

Manual cherry-pick of the planning factor support into `autoware_trajectory_validator`.

This adds the plumbing for the trajectory validator to report planning factors, so that
validator plugins can surface *why* a candidate trajectory was rejected / constrained in the
same way the rest of the planning stack does (RViz planning factor markers, `/planning/planning_factors/*`).

Changes:

- `TrajectoryValidatorReport` gains a `planning_factors` field
  (`autoware_internal_planning_msgs::msg::PlanningFactorArray`), so plugins can attach planning
  factors to the validation result.
- `TrajectoryValidatorWrapper` owns a `PlanningFactorInterface` instance, constructed with the
  module name `trajectory_validator`.
- New private helpers `add_planning_factors()` / `publish_planning_factor()`:
  - factors with no control points are skipped,
  - a factor with a single control point is forwarded through the single-pose `add()` overload,
  - a factor with multiple control points is forwarded through the start/end-pose `add()` overload
    using the first and last control points.
- `validate_trajectories()` publishes the accumulated planning factors on every cycle, alongside
  the existing validation reports.
- `validator_interface.hpp` exposes a `PlanningFactorArray` alias for plugin authors.
- `package.xml` adds a dependency on `autoware_planning_factor_interface`.

Note: this change is plumbing only — no validator plugin populates `report.planning_factors` yet,
so the new publisher emits an empty `PlanningFactorArray` until a plugin starts filling it.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Built the package:
  `compile pilot-auto -rl -j 16 -s autoware_trajectory_validator`
- Existing package tests still pass:
  `colcon test --event-handlers console_cohesion+ --packages-select autoware_trajectory_validator`
- Confirmed `/planning/planning_factors/trajectory_validator` is advertised when the node is
  running, and that it publishes an empty array (expected, since no plugin populates factors yet).

## Notes for reviewers

- The two-control-point path intentionally uses only `front()` and `back()`; intermediate control
  points of a factor are dropped, which matches how the `PlanningFactorInterface` start/end
  overload is used elsewhere in the planning stack.
- Publishing happens unconditionally each validation cycle, which keeps the topic alive with empty
  messages rather than going silent when there is nothing to report.

## Interface changes

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name                                       | Message Type                                            | Description                                    |
| :---------- | :--------- | :----------------------------------------------- | :------------------------------------------------------ | :--------------------------------------------- |
| Added       | Pub        | `/planning/planning_factors/trajectory_validator` | `autoware_internal_planning_msgs/msg/PlanningFactorArray` | Planning factors reported by trajectory validator |

### ROS Parameter Changes

None.

## Effects on system behavior

A new planning factor topic is published by the trajectory validator node. No existing topic,
parameter, or validation logic is changed, and trajectory selection behavior is unaffected.
The topic currently carries empty arrays until a validator plugin populates
`TrajectoryValidatorReport::planning_factors`.
