### PR TITLE
feat(autoware_system_monitor): fallback to CUDA stub to look for libnvidia-ml.so

### DIFF
--- a/system/autoware_system_monitor/cmake/FindNVML.cmake
+++ b/system/autoware_system_monitor/cmake/FindNVML.cmake
@@ -24,7 +24,12 @@ if(NOT NVML_INCLUDE_DIRS)
 endif()
 
 if(NOT NVML_LIBRARIES)
-  find_library(NVML_LIBRARIES NAMES nvidia-ml)
+  # Fall back to the CUDA stub (SONAME is libnvidia-ml.so.1) when only the runtime driver is available.
+  set(NVML_STUB_PATHS "")
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    list(APPEND NVML_STUB_PATHS /usr/local/cuda/lib64/stubs)
+  endif()
+  find_library(NVML_LIBRARIES NAMES nvidia-ml PATHS ${NVML_STUB_PATHS})
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/system/autoware_system_monitor/cmake/FindNVML.cmake
+++ b/system/autoware_system_monitor/cmake/FindNVML.cmake
@@ -24,7 +24,7 @@ if(NOT NVML_INCLUDE_DIRS)
 endif()
 
 if(NOT NVML_LIBRARIES)
-  # Fall back to the CUDA stub (SONAME is libnvidia-ml.so.1) when only the runtime driver is available.
+  # Fall back to the CUDA stub (libnvidia-ml.so.1) when only the runtime driver is available.
   set(NVML_STUB_PATHS "")
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     list(APPEND NVML_STUB_PATHS /usr/local/cuda/lib64/stubs)


### PR DESCRIPTION
## Description

FindNVML.cmake currently locates NVML only via find_library(NVML_LIBRARIES NAMES nvidia-ml), which requires the unversioned libnvidia-ml.so symlink provided by the NVIDIA driver development packages. In environments where only the runtime driver is available (e.g. Docker build stages without the driver installed), only libnvidia-ml.so.1 exists, so find_library fails and autoware_system_monitor is built without GPU monitoring support.

This PR adds a fallback search path to the NVML stub library shipped with the CUDA Toolkit (/usr/local/cuda/lib64/stubs). The stub is intended exactly for this link-time use case: its SONAME is libnvidia-ml.so.1, so at runtime the dynamic linker resolves the real NVML library provided by the installed NVIDIA driver instead of the stub.

The fallback path is only appended on x86_64, since the stub path layout (lib64) is specific to that architecture.

## Related links

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
* install autoware dependencies with cuda dependencies:
```
cd autoware
bash ansible/scripts/install-ansible.sh
ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
ansible-playbook autoware.dev_env.install_dev_env
```

* Built autoware_system_monitor and confirmed that CMake now finds NVML.
```
colcon build --event-handlers console_direct+ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release  --continue-on-error --packages-up-to autoware_system_monitor
```

**Before:** build log outputs
```
-- Could NOT find NVML (missing: NVML_LIBRARIES)              
-- NVML include dir: /usr/local/cuda/include
-- NVML library : NVML_LIBRARIES-NOTFOUND

```

**After:**
```
-- Found NVML: /usr/local/cuda/lib64/stubs/libnvidia-ml.so  
-- NVML include dir: /usr/local/cuda/include
-- NVML library : /usr/local/cuda/lib64/stubs/libnvidia-ml.so
```


## Notes for reviewers

The system-default search paths are still searched first; the stub directory is only an additional PATHS hint used when the driver library is not found there.
No behavior change on systems where libnvidia-ml.so is already discoverable.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
