### PR TITLE
feat(autoware_pointcloud_preprocessor): templatize Filter into FilterBase<NodeT>

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
@@ -35,6 +35,7 @@ target_include_directories(pointcloud_preprocessor_filter_base PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   ${autoware_point_types_INCLUDE_DIRS}
+  ${autoware_agnocast_wrapper_INCLUDE_DIRS}
 )
 
 ament_target_dependencies(pointcloud_preprocessor_filter_base
@@ -48,7 +49,10 @@ ament_target_dependencies(pointcloud_preprocessor_filter_base
   pcl_ros
   autoware_point_types
   managed_transform_buffer
+  autoware_agnocast_wrapper
 )
+
+autoware_agnocast_wrapper_setup(pointcloud_preprocessor_filter_base)
 
 add_library(faster_voxel_grid_downsample_filter SHARED
   src/downsample_filter/faster_voxel_grid_downsample_filter.cpp

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/filter.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/filter.hpp
@@ -70,12 +70,17 @@
 #include <sensor_msgs/msg/point_cloud2.h>
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 // Autoware utils
+#include <autoware/agnocast_wrapper/message_filters.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
@@ -85,6 +90,7 @@
 namespace autoware::pointcloud_preprocessor
 {
 namespace sync_policies = message_filters::sync_policies;
+namespace agnocast_mf = autoware::agnocast_wrapper::message_filters;
 
 /** \brief For parameter service callback */
 template <typename T>
@@ -100,10 +106,11 @@ bool get_param(const std::vector<rclcpp::Parameter> & p, const std::string & nam
   return false;
 }
 
-/** \brief @b Filter represents the base filter class. Some generic 3D operations that are
+/** \brief @b FilterBase represents the base filter class. Some generic 3D operations that are
  * applicable to all filters are defined here as static methods. \author Radu Bogdan Rusu
  */
-class Filter : public rclcpp::Node
+template <typename NodeT = rclcpp::Node>
+class FilterBase : public NodeT
 {
 public:
   using PointCloud2 = sensor_msgs::msg::PointCloud2;
@@ -124,28 +131,57 @@ public:
   using IndicesPtr = pcl::IndicesPtr;
   using IndicesConstPtr = pcl::IndicesConstPtr;
 
+  using PublisherPtr = decltype(std::declval<NodeT *>()->template create_publisher<PointCloud2>(
+    std::string{}, rclcpp::QoS(1)));
+
+  // True only for the real, USE_AGNOCAST_ENABLED-compiled agnocast_wrapper::Node.
+  static constexpr bool kIsAgnocastNode =
+    !std::is_same_v<PublisherPtr, typename rclcpp::Publisher<PointCloud2>::SharedPtr>;
+
+  template <typename MessageT>
+  using MessageFiltersSubscriber = std::conditional_t<
+    kIsAgnocastNode, agnocast_mf::Subscriber<MessageT>,
+    message_filters::Subscriber<MessageT, NodeT>>;
+
+  template <template <typename...> class Policy, template <typename...> class AgnocastPolicy>
+  using SyncPolicy = std::conditional_t<
+    kIsAgnocastNode, agnocast_mf::Synchronizer<AgnocastPolicy<PointCloud2, PointIndices>>,
+    message_filters::Synchronizer<Policy<PointCloud2, PointIndices>>>;
+
   using ExactTimeSyncPolicy =
-    message_filters::Synchronizer<sync_policies::ExactTime<PointCloud2, PointIndices>>;
+    SyncPolicy<sync_policies::ExactTime, agnocast_mf::sync_policies::ExactTime>;
   using ApproximateTimeSyncPolicy =
-    message_filters::Synchronizer<sync_policies::ApproximateTime<PointCloud2, PointIndices>>;
+    SyncPolicy<sync_policies::ApproximateTime, agnocast_mf::sync_policies::ApproximateTime>;
 
   PCL_MAKE_ALIGNED_OPERATOR_NEW
-  explicit Filter(
+  explicit FilterBase(
     const std::string & filter_name = "pointcloud_preprocessor_filter",
     const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
 protected:
+  using SubscriptionPtr =
+    decltype(std::declval<NodeT *>()->template create_subscription<PointCloud2>(
+      std::string{}, rclcpp::QoS(1), std::function<void(const PointCloud2ConstPtr)>{}));
+
+  // The output message, owned either on the heap (rclcpp) or on loan from pub_output_
+  // (agnocast). Publishing it always moves this handle, so the loan is never copied.
+  using OutputMessagePtr = std::conditional_t<
+    kIsAgnocastNode, AUTOWARE_MESSAGE_UNIQUE_PTR(PointCloud2), std::unique_ptr<PointCloud2>>;
+
+  // Allocates output on loan from pub_output_ (agnocast) or on the heap (rclcpp).
+  OutputMessagePtr allocate_output_message();
+
   /** \brief The input PointCloud2 subscriber. */
-  rclcpp::Subscription<PointCloud2>::SharedPtr sub_input_;
+  SubscriptionPtr sub_input_;
 
   /** \brief The output PointCloud2 publisher. */
-  rclcpp::Publisher<PointCloud2>::SharedPtr pub_output_;
+  PublisherPtr pub_output_;
 
   /** \brief The message filter subscriber for PointCloud2. */
-  message_filters::Subscriber<PointCloud2> sub_input_filter_;
+  MessageFiltersSubscriber<PointCloud2> sub_input_filter_;
 
   /** \brief The message filter subscriber for PointIndices. */
-  message_filters::Subscriber<PointIndices> sub_indices_filter_;
+  MessageFiltersSubscriber<PointIndices> sub_indices_filter_;
 
   /** \brief The desired user filter field name. */
   std::string filter_field_name_;
@@ -175,12 +211,12 @@ protected:
   std::mutex mutex_;
 
   /** \brief The diagnostic message */
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_;
+  std::unique_ptr<autoware_utils::BasicDiagnosticsInterface<NodeT>> diagnostics_interface_;
 
   /** \brief processing time publisher. **/
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
-  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_;
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<autoware_utils::BasicDebugPublisher<NodeT>> debug_publisher_;
+  std::unique_ptr<autoware_utils::BasicPublishedTimePublisher<NodeT>> published_time_publisher_;
 
   /** \brief Virtual abstract filter method. To be implemented by every child.
    * \param input the input point cloud dataset.
@@ -212,7 +248,7 @@ protected:
   /** \brief PointCloud2 + Indices data callback. */
   virtual void input_indices_callback(
     const PointCloud2ConstPtr cloud, const PointIndicesConstPtr indices);
-  virtual bool convert_output_costly(std::unique_ptr<PointCloud2> & output);
+  virtual bool convert_output_costly(OutputMessagePtr & output);
 
   //////////////////////
   // from PCLNodelet //
@@ -446,12 +482,13 @@ private:
   std::shared_ptr<ExactTimeSyncPolicy> sync_input_indices_e_;
   std::shared_ptr<ApproximateTimeSyncPolicy> sync_input_indices_a_;
 
-  // Builds a Policy<PointCloud2, PointIndices> synchronizer over sub_input_filter_ /
+  // Builds a SyncPolicy<Policy, AgnocastPolicy> synchronizer over sub_input_filter_ /
   // sub_indices_filter_ and registers callback on it. Shared by the exact- and
-  // approximate-time branches of subscribe(), which otherwise only differ in this type.
-  template <template <typename...> class Policy, typename Callback>
-  std::shared_ptr<message_filters::Synchronizer<Policy<PointCloud2, PointIndices>>> make_sync(
-    Callback callback);
+  // approximate-time branches of subscribe(), which otherwise only differ in this policy pair.
+  template <
+    template <typename...> class Policy, template <typename...> class AgnocastPolicy,
+    typename Callback>
+  std::shared_ptr<SyncPolicy<Policy, AgnocastPolicy>> make_sync(Callback callback);
 
   /** \brief Get a matrix for conversion from the original frame to the target frame */
   bool calculate_transform_matrix(
@@ -465,6 +502,18 @@ private:
 
   void setup_tf();
 };
+
+/// The `rclcpp::Node` instantiation used by every existing filter node.
+///
+/// A real class, not `using Filter = FilterBase<>;`: downstream nodes in other namespaces
+/// (e.g. autoware_ground_segmentation) write bare `: Filter(...)` in their mem-initializer
+/// list, relying on the base's injected class name — which a type alias doesn't provide.
+class Filter : public FilterBase<>
+{
+public:
+  using FilterBase::FilterBase;
+};
+
 }  // namespace autoware::pointcloud_preprocessor
 
 #endif  // AUTOWARE__POINTCLOUD_PREPROCESSOR__FILTER_HPP_

--- a/sensing/autoware_pointcloud_preprocessor/src/filter.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/filter.cpp
@@ -60,13 +60,15 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-autoware::pointcloud_preprocessor::Filter::Filter(
+template <typename NodeT>
+autoware::pointcloud_preprocessor::FilterBase<NodeT>::FilterBase(
   const std::string & filter_name, const rclcpp::NodeOptions & options)
-: Node(filter_name, options), filter_field_name_(filter_name)
+: NodeT(filter_name, options), filter_field_name_(filter_name)
 {
   // Set parameters (moved from NodeletLazy onInit)
   {
@@ -91,9 +93,14 @@ autoware::pointcloud_preprocessor::Filter::Filter(
 
   // Set publisher
   {
-    rclcpp::PublisherOptions pub_options;
+    // kIsAgnocastNode is exactly "NodeT::create_publisher takes agnocast options", so this
+    // picks rclcpp::PublisherOptions for a plain node and for the wrapper node in a build
+    // without USE_AGNOCAST_ENABLED.
+    using PublisherOptionsT =
+      std::conditional_t<kIsAgnocastNode, AUTOWARE_PUBLISHER_OPTIONS, rclcpp::PublisherOptions>;
+    PublisherOptionsT pub_options;
     pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-    pub_output_ = this->create_publisher<PointCloud2>(
+    pub_output_ = this->template create_publisher<PointCloud2>(
       "output", rclcpp::SensorDataQoS().keep_last(max_queue_size_), pub_options);
   }
 
@@ -104,37 +111,55 @@ autoware::pointcloud_preprocessor::Filter::Filter(
 
   // Set parameter service callback
   set_param_res_filter_ = this->add_on_set_parameters_callback(
-    std::bind(&Filter::filter_param_callback, this, std::placeholders::_1));
+    std::bind(&FilterBase::filter_param_callback, this, std::placeholders::_1));
 
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ =
+    std::make_unique<autoware_utils::BasicPublishedTimePublisher<NodeT>>(this);
   RCLCPP_DEBUG(this->get_logger(), "[Filter Constructor] successfully created.");
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void autoware::pointcloud_preprocessor::Filter::setup_tf()
+template <typename NodeT>
+void autoware::pointcloud_preprocessor::FilterBase<NodeT>::setup_tf()
 {
   managed_tf_buffer_ = std::make_unique<managed_transform_buffer::ManagedTransformBuffer>();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void autoware::pointcloud_preprocessor::Filter::subscribe()
+template <typename NodeT>
+void autoware::pointcloud_preprocessor::FilterBase<NodeT>::subscribe()
 {
   std::string filter_name = "";
   subscribe(filter_name);
 }
 
-template <template <typename...> class Policy, typename Callback>
-auto autoware::pointcloud_preprocessor::Filter::make_sync(Callback callback)
-  -> std::shared_ptr<message_filters::Synchronizer<Policy<PointCloud2, PointIndices>>>
+template <typename NodeT>
+template <
+  template <typename...> class Policy, template <typename...> class AgnocastPolicy,
+  typename Callback>
+auto autoware::pointcloud_preprocessor::FilterBase<NodeT>::make_sync(Callback callback)
+  -> std::shared_ptr<SyncPolicy<Policy, AgnocastPolicy>>
 {
-  auto sync = std::make_shared<message_filters::Synchronizer<Policy<PointCloud2, PointIndices>>>(
-    max_queue_size_);
-  sync->connectInput(sub_input_filter_, sub_indices_filter_);
-  sync->registerCallback(std::bind(callback, this, std::placeholders::_1, std::placeholders::_2));
-  return sync;
+  // The wrapper Synchronizer takes its subscribers through the constructor rather than
+  // connectInput(); the callback itself is the same on both paths, since the wrapper delivers
+  // plain PointCloud2::ConstSharedPtr / PointIndices::ConstSharedPtr.
+  if constexpr (kIsAgnocastNode) {
+    auto sync = std::make_shared<SyncPolicy<Policy, AgnocastPolicy>>(
+      AgnocastPolicy<PointCloud2, PointIndices>(max_queue_size_), sub_input_filter_,
+      sub_indices_filter_);
+    sync->registerCallback(callback, this);
+    return sync;
+  } else {
+    auto sync = std::make_shared<SyncPolicy<Policy, AgnocastPolicy>>(max_queue_size_);
+    sync->connectInput(sub_input_filter_, sub_indices_filter_);
+    sync->registerCallback(std::bind(callback, this, std::placeholders::_1, std::placeholders::_2));
+    return sync;
+  }
 }
 
-void autoware::pointcloud_preprocessor::Filter::subscribe(const std::string & filter_name)
+template <typename NodeT>
+void autoware::pointcloud_preprocessor::FilterBase<NodeT>::subscribe(
+  const std::string & filter_name)
 {
   // TODO(sykwer): Change the corresponding node to subscribe to `faster_input_indices_callback`
   // each time a child class supports the faster version.
@@ -143,8 +168,8 @@ void autoware::pointcloud_preprocessor::Filter::subscribe(const std::string & fi
     "CropBoxFilter", "RingOutlierFilter", "VoxelGridDownsampleFilter", "ScanGroundFilter",
     "PointCloudDensifier"};
   auto callback = supported_nodes.find(filter_name) != supported_nodes.end()
-                    ? &Filter::faster_input_indices_callback
-                    : &Filter::input_indices_callback;
+                    ? &FilterBase::faster_input_indices_callback
+                    : &FilterBase::input_indices_callback;
 
   if (use_indices_) {
     // Subscribe to the input using a filter
@@ -154,22 +179,26 @@ void autoware::pointcloud_preprocessor::Filter::subscribe(const std::string & fi
       this, "indices", rclcpp::SensorDataQoS().keep_last(max_queue_size_).get_rmw_qos_profile());
 
     if (approximate_sync_) {
-      sync_input_indices_a_ = make_sync<sync_policies::ApproximateTime>(callback);
+      sync_input_indices_a_ =
+        make_sync<sync_policies::ApproximateTime, agnocast_mf::sync_policies::ApproximateTime>(
+          callback);
     } else {
-      sync_input_indices_e_ = make_sync<sync_policies::ExactTime>(callback);
+      sync_input_indices_e_ =
+        make_sync<sync_policies::ExactTime, agnocast_mf::sync_policies::ExactTime>(callback);
     }
   } else {
     // Subscribe in an old fashion to input only (no filters)
     // CAN'T use auto-type here.
-    std::function<void(const PointCloud2ConstPtr msg)> cb =
+    std::function<void(const PointCloud2ConstPtr)> cb =
       std::bind(callback, this, std::placeholders::_1, PointIndicesConstPtr());
-    sub_input_ = this->create_subscription<PointCloud2>(
+    sub_input_ = this->template create_subscription<PointCloud2>(
       "input", rclcpp::SensorDataQoS().keep_last(max_queue_size_), cb);
   }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void autoware::pointcloud_preprocessor::Filter::unsubscribe()
+template <typename NodeT>
+void autoware::pointcloud_preprocessor::FilterBase<NodeT>::unsubscribe()
 {
   if (use_indices_) {
     sub_input_filter_.unsubscribe();
@@ -187,10 +216,23 @@ void autoware::pointcloud_preprocessor::Filter::unsubscribe()
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TODO(sykwer): Temporary Implementation: Delete this function definition when all the filter nodes
 // conform to new API.
-void autoware::pointcloud_preprocessor::Filter::compute_publish(
+template <typename NodeT>
+typename autoware::pointcloud_preprocessor::FilterBase<NodeT>::OutputMessagePtr
+autoware::pointcloud_preprocessor::FilterBase<NodeT>::allocate_output_message()
+{
+  if constexpr (kIsAgnocastNode) {
+    // Loaned from pub_output_'s shm queue; publish() below moves it out without copying.
+    return ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_output_);
+  } else {
+    return std::make_unique<PointCloud2>();
+  }
+}
+
+template <typename NodeT>
+void autoware::pointcloud_preprocessor::FilterBase<NodeT>::compute_publish(
   const PointCloud2ConstPtr & input, const IndicesPtr & indices)
 {
-  auto output = std::make_unique<PointCloud2>();
+  auto output = allocate_output_message();
 
   // Call the virtual method in the child
   filter(input, indices, *output);
@@ -206,8 +248,9 @@ void autoware::pointcloud_preprocessor::Filter::compute_publish(
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
+template <typename NodeT>
 rcl_interfaces::msg::SetParametersResult
-autoware::pointcloud_preprocessor::Filter::filter_param_callback(
+autoware::pointcloud_preprocessor::FilterBase<NodeT>::filter_param_callback(
   const std::vector<rclcpp::Parameter> & p)
 {
   std::scoped_lock lock(mutex_);
@@ -230,7 +273,8 @@ autoware::pointcloud_preprocessor::Filter::filter_param_callback(
 //////////////////////////////////////////////////////////////////////////////////////////////
 // TODO(sykwer): Temporary Implementation: Delete this function definition when all the filter nodes
 // conform to new API.
-void autoware::pointcloud_preprocessor::Filter::input_indices_callback(
+template <typename NodeT>
+void autoware::pointcloud_preprocessor::FilterBase<NodeT>::input_indices_callback(
   const PointCloud2ConstPtr cloud, const PointIndicesConstPtr indices)
 {
   if (!is_valid(cloud, this->get_logger(), *this->get_clock())) {
@@ -291,7 +335,8 @@ void autoware::pointcloud_preprocessor::Filter::input_indices_callback(
 }
 
 // Returns false in error cases
-bool autoware::pointcloud_preprocessor::Filter::calculate_transform_matrix(
+template <typename NodeT>
+bool autoware::pointcloud_preprocessor::FilterBase<NodeT>::calculate_transform_matrix(
   const std::string & target_frame, const sensor_msgs::msg::PointCloud2 & from,
   TransformInfo & transform_info /*output*/)
 {
@@ -314,7 +359,8 @@ bool autoware::pointcloud_preprocessor::Filter::calculate_transform_matrix(
   return true;
 }
 
-bool autoware::pointcloud_preprocessor::Filter::transform_pointcloud(
+template <typename NodeT>
+bool autoware::pointcloud_preprocessor::FilterBase<NodeT>::transform_pointcloud(
   const std::string & target_frame, const sensor_msgs::msg::PointCloud2 & in,
   sensor_msgs::msg::PointCloud2 & out)
 {
@@ -323,7 +369,9 @@ bool autoware::pointcloud_preprocessor::Filter::transform_pointcloud(
     this->get_logger());
 }
 
-std::optional<Eigen::Matrix4f> autoware::pointcloud_preprocessor::Filter::lookup_transform_matrix(
+template <typename NodeT>
+std::optional<Eigen::Matrix4f>
+autoware::pointcloud_preprocessor::FilterBase<NodeT>::lookup_transform_matrix(
   const std::string & target_frame, const std::string & source_frame, const rclcpp::Time & stamp)
 {
   return managed_tf_buffer_->getTransform<Eigen::Matrix4f>(
@@ -331,8 +379,9 @@ std::optional<Eigen::Matrix4f> autoware::pointcloud_preprocessor::Filter::lookup
 }
 
 // Returns false in error cases
-bool autoware::pointcloud_preprocessor::Filter::convert_output_costly(
-  std::unique_ptr<PointCloud2> & output)
+template <typename NodeT>
+bool autoware::pointcloud_preprocessor::FilterBase<NodeT>::convert_output_costly(
+  OutputMessagePtr & output)
 {
   // In terms of performance, we should avoid using pcl_ros library function,
   // but this code path isn't reached in the main use case of Autoware, so it's left as is for now.
@@ -342,7 +391,7 @@ bool autoware::pointcloud_preprocessor::Filter::convert_output_costly(
       output->header.frame_id.c_str(), tf_output_frame_.c_str());
 
     // Convert the cloud into the different frame
-    auto cloud_transformed = std::make_unique<PointCloud2>();
+    auto cloud_transformed = allocate_output_message();
 
     if (!transform_pointcloud(tf_output_frame_, *output, *cloud_transformed)) {
       RCLCPP_ERROR(
@@ -362,7 +411,7 @@ bool autoware::pointcloud_preprocessor::Filter::convert_output_costly(
       this->get_logger(), "[convert_output_costly] Transforming output dataset from %s back to %s.",
       output->header.frame_id.c_str(), tf_input_orig_frame_.c_str());
 
-    auto cloud_transformed = std::make_unique<PointCloud2>();
+    auto cloud_transformed = allocate_output_message();
 
     if (!transform_pointcloud(tf_input_orig_frame_, *output, *cloud_transformed)) {
       return false;
@@ -377,7 +426,8 @@ bool autoware::pointcloud_preprocessor::Filter::convert_output_costly(
 // TODO(sykwer): Temporary Implementation: Rename this function to `input_indices_callback()` when
 // all the filter nodes conform to new API. Then delete the old `input_indices_callback()` defined
 // above.
-void autoware::pointcloud_preprocessor::Filter::faster_input_indices_callback(
+template <typename NodeT>
+void autoware::pointcloud_preprocessor::FilterBase<NodeT>::faster_input_indices_callback(
   const PointCloud2ConstPtr cloud, const PointIndicesConstPtr indices)
 {
   if (
@@ -445,7 +495,7 @@ void autoware::pointcloud_preprocessor::Filter::faster_input_indices_callback(
     vindices.reset(new std::vector<int>(indices->indices));
   }
 
-  auto output = std::make_unique<PointCloud2>();
+  auto output = allocate_output_message();
 
   // TODO(sykwer): Change to `filter()` call after when the filter nodes conform to new API.
   faster_filter(cloud, vindices, *output, transform_info);
@@ -460,7 +510,8 @@ void autoware::pointcloud_preprocessor::Filter::faster_input_indices_callback(
 // TODO(sykwer): Temporary Implementation: Remove this interface when all the filter nodes conform
 // to new API. It's not a pure virtual function so that a child class does not have to implement
 // this function.
-void autoware::pointcloud_preprocessor::Filter::faster_filter(
+template <typename NodeT>
+void autoware::pointcloud_preprocessor::FilterBase<NodeT>::faster_filter(
   const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output,
   const TransformInfo & transform_info)
 {
@@ -469,3 +520,6 @@ void autoware::pointcloud_preprocessor::Filter::faster_filter(
   (void)output;
   (void)transform_info;
 }
+
+template class autoware::pointcloud_preprocessor::FilterBase<rclcpp::Node>;
+template class autoware::pointcloud_preprocessor::FilterBase<autoware::agnocast_wrapper::Node>;

--- a/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/polar_voxel_outlier_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/polar_voxel_outlier_filter_node.cpp
@@ -226,18 +226,15 @@ PolarVoxelOutlierFilterComponent::PolarVoxelOutlierFilterComponent(
   set_param_res_ = this->add_on_set_parameters_callback(
     [this](const std::vector<rclcpp::Parameter> & p) { return param_callback(p); });
 
-  // TODO(Koichi98): Remove this override once Filter base class supports agnocast_wrapper.
-  // The aliasing shared_ptr bridge is needed because Filter::sub_input_ uses raw rclcpp types.
+  // TODO(Koichi98): Remove this override once this node is instantiated on
+  // FilterBase<agnocast_wrapper::Node>, which subscribes through agnocast itself.
+  // Needed because FilterBase<rclcpp::Node>::sub_input_ is a plain rclcpp subscription.
   sub_input_.reset();
   // cppcheck-suppress unknownMacro
   agnocast_sub_input_ = AUTOWARE_CREATE_SUBSCRIPTION(
     PointCloud2, "input", rclcpp::SensorDataQoS().keep_last(max_queue_size_),
-    // cppcheck-suppress unknownMacro
-    [this](AUTOWARE_MESSAGE_CONST_SHARED_PTR(PointCloud2) msg) {
-      auto holder =
-        std::make_shared<AUTOWARE_MESSAGE_CONST_SHARED_PTR(PointCloud2)>(std::move(msg));
-      PointCloud2ConstPtr bridge(holder, holder->get());
-      input_indices_callback(bridge, PointIndicesConstPtr());
+    [this](const PointCloud2ConstPtr & msg) {
+      input_indices_callback(msg, PointIndicesConstPtr());
     },
     AUTOWARE_SUBSCRIPTION_OPTIONS{});
 


### PR DESCRIPTION
## Description

Templatizes `pointcloud_preprocessor::Filter` into `FilterBase<NodeT>` (default `NodeT = rclcpp::Node`), so a filter node can be instantiated on `autoware::agnocast_wrapper::Node`.

`Filter` is kept as a real (non-alias) class inheriting `FilterBase<>`, so every existing node deriving from `Filter` — in this package and in others such as `autoware_ground_segmentation` and `autoware_compare_map_segmentation` — compiles unchanged. It must be a class rather than `using Filter = FilterBase<>;` because downstream nodes in other namespaces write a bare `: Filter(...)` in their mem-initializer list, relying on the base's injected class name.

Nothing instantiates `FilterBase<agnocast_wrapper::Node>` yet. The bottom of `filter.cpp` explicitly instantiates it purely as a compile check; adopting it in a concrete node is a separate PR.

### How the two backends are selected

A single trait, `kIsAgnocastNode`, derives from `create_publisher`'s return type — no preprocessor needed for the trait itself. It is true exactly when `NodeT`'s pub/sub API is the Agnocast one, which is false for `rclcpp::Node` in any build and false for the wrapper node in a build without `USE_AGNOCAST_ENABLED`.

It drives `NodeT`-dependent aliases (`PublisherPtr`, `SubscriptionPtr`, `MessageFiltersSubscriber<MessageT>`, `SyncPolicy<Policy, AgnocastPolicy>`, `OutputMessagePtr`), the publisher-options type, and `if constexpr` branches in the handful of call sites that actually differ. `diagnostics_interface_` / `debug_publisher_` / `published_time_publisher_` move from the fixed `rclcpp::Node` aliases to their `Basic*<NodeT>` template form.

Because #13073 already extracted `transform_pointcloud()` / `lookup_transform_matrix()`, deduped the sync setup behind `make_sync<Policy>()`, and added the `this->`-qualification, the rest of the diff is mostly the `template <typename NodeT>` / `FilterBase<NodeT>::` boilerplate on out-of-class definitions.

### Zero-copy on both directions

Output: a new `OutputMessagePtr` alias (`std::unique_ptr<PointCloud2>` for rclcpp, `AUTOWARE_MESSAGE_UNIQUE_PTR(PointCloud2)` for agnocast) and an `allocate_output_message()` helper replace `std::make_unique<PointCloud2>()` in `compute_publish()`, `convert_output_costly()` and `faster_input_indices_callback()`. `pub_output_->publish(std::move(output))` needs no branch — both publishers accept the same move call. `convert_output_costly()`'s signature changes accordingly; it is not overridden by any derived filter node.

Input: the callbacks are fixed to `PointCloud2ConstPtr` because derived nodes override them. The wrapper hands subscription callbacks exactly that type (autowarefoundation/autoware_core#1314), aliasing the payload out of the agnocast message without copying it, so `subscribe()` and `make_sync()` pass the very same callback on both node types — the `if constexpr` split on the input path disappears rather than moving. The hand-rolled copy of that aliasing pattern in `PolarVoxelOutlierFilterComponent` goes away with it: its subscription override now just takes a `PointCloud2ConstPtr` and forwards it.

## Related links

- Depends on autowarefoundation/autoware_core#1314 (`MessageT::ConstSharedPtr` subscription callbacks).
- Follows up #13073, which prepared `Filter` for this change.

## How was this PR tested?

Built with `ENABLE_AGNOCAST` unset and with `ENABLE_AGNOCAST=1` (the latter with `--cmake-force-configure`). Both instantiations, including the `FilterBase<agnocast_wrapper::Node>` explicit instantiation, compile in both builds.

Run at `ENABLE_AGNOCAST=0` against a synthetic 10 Hz / 11520-point cloud, to confirm the templatization is behavior-neutral for the nodes that go through it:

| node | rate | points out |
| --- | --- | --- |
| `polar_voxel_outlier_filter` | 9.98 Hz | 1376 |
| `voxel_grid_downsample_filter` | 9.98 Hz | 7958 |

`test_polar_voxel_outlier_filter_node`: 4/4 passed.

No runtime behavior change is expected: every existing filter node still uses `Filter` = `FilterBase<rclcpp::Node>`, and the agnocast instantiation is not reachable at runtime from this PR.

Not verified at runtime here: the `ENABLE_AGNOCAST=1` input path of `PolarVoxelOutlierFilterComponent`, whose subscription override this PR touches. It is verified in the stacked follow-up that puts the node on `agnocast_wrapper::Node` (9.90 Hz, 1376 points — identical output to `=0`).

## Notes for reviewers

`ManagedTransformBuffer` is deliberately left as the tf backend for both instantiations. It is unusable only under an *AgnocastOnly* executor, where `node_main_switchable` skips `rclcpp::init()` and its internal `rclcpp::Node` cannot be built. That is a runtime property of the executable; `is_same_v<NodeT, agnocast_wrapper::Node>` does not describe it, being equally true at `ENABLE_AGNOCAST=0` and in mixed mode, where `ManagedTransformBuffer` works and its process-wide singleton and static-TF fast path are worth keeping. Since nothing instantiates the wrapper variant here, a swap could not be exercised either — it belongs to the follow-up PR that adopts the instantiation and can verify it end to end.

## Interface changes

None.

## Effects on system behavior

None.
