### PR TITLE
perf(cuda_pointcloud_preprocessor): allocate fixed GPU buffers at startup

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
@@ -8,6 +8,9 @@
     processing_time_threshold_sec: 0.01
     timestamp_mismatch_fraction_threshold: 0.01
     enable_ring_outlier_filter: true
+    max_input_point_count: 691200  # Hesai OT128, dual return, high resolution mode
+    max_twist_frequency_hz: 200.0
+    max_imu_frequency_hz: 200.0
 
     crop_box.min_x: [0.0]
     crop_box.min_y: [0.0]

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
@@ -9,6 +9,8 @@
     timestamp_mismatch_fraction_threshold: 0.01
     enable_ring_outlier_filter: true
     max_input_point_count: 691200  # Hesai OT128, dual return, high resolution mode
+    max_ring_count: 128
+    max_points_per_ring: 7200
     max_twist_frequency_hz: 200.0
     max_imu_frequency_hz: 200.0
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -30,6 +30,7 @@
 
 #include <thrust/device_vector.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <deque>
 #include <memory>
@@ -56,6 +57,7 @@ public:
   void setRingOutlierFilterParameters(const RingOutlierFilterParameters & ring_outlier_parameters);
   void setRingOutlierFilterActive(const bool enable_filter);
   void setUndistortionType(const UndistortionType & undistortion_type);
+  void setMaxInputPointCount(const std::size_t max_input_point_count);
 
   void preallocateOutput();
   [[nodiscard]] ProcessingStats getProcessingStats() const { return stats_; }
@@ -80,8 +82,9 @@ private:
 
   int num_rings_{};
   int max_points_per_ring_{};
-  size_t num_raw_points_{};
-  size_t num_organized_points_{};
+  std::size_t num_raw_points_{};
+  std::size_t num_organized_points_{};
+  std::size_t max_input_point_count_{};
 
   std::vector<sensor_msgs::msg::PointField> point_fields_;
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> output_pointcloud_ptr_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -39,11 +39,20 @@
 namespace autoware::cuda_pointcloud_preprocessor
 {
 
+struct PreprocessorCapacity
+{
+  std::size_t max_input_point_count{0};
+  int max_ring_count{0};
+  int max_points_per_ring{0};
+  std::size_t max_twist_struct_count{0};
+};
+
 struct ProcessingStats
 {
   int mismatch_count{0};
   int num_crop_box_passed_points{0};
   int num_nan_points{0};
+  bool ring_overflow{false};
 };
 
 class CudaPointcloudPreprocessor
@@ -51,13 +60,12 @@ class CudaPointcloudPreprocessor
 public:
   enum class UndistortionType { Invalid, Undistortion2D, Undistortion3D };
 
-  CudaPointcloudPreprocessor();
+  explicit CudaPointcloudPreprocessor(const PreprocessorCapacity & capacity);
 
   void setCropBoxParameters(const std::vector<CropBoxParameters> & crop_box_parameters);
   void setRingOutlierFilterParameters(const RingOutlierFilterParameters & ring_outlier_parameters);
   void setRingOutlierFilterActive(const bool enable_filter);
   void setUndistortionType(const UndistortionType & undistortion_type);
-  void setMaxInputPointCount(const std::size_t max_input_point_count);
 
   void preallocateOutput();
   [[nodiscard]] ProcessingStats getProcessingStats() const { return stats_; }
@@ -72,6 +80,7 @@ public:
 private:
   static cudaStream_t initialize_stream();
 
+  void initializeBuffers();
   void organizePointcloud();
 
   CropBoxParameters self_crop_box_parameters_{};
@@ -84,7 +93,7 @@ private:
   int max_points_per_ring_{};
   std::size_t num_raw_points_{};
   std::size_t num_organized_points_{};
-  std::size_t max_input_point_count_{};
+  PreprocessorCapacity capacity_{};
 
   std::vector<sensor_msgs::msg::PointField> point_fields_;
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> output_pointcloud_ptr_;
@@ -119,6 +128,8 @@ private:
   thrust::device_vector<std::uint32_t> device_indices_;
   thrust::device_vector<TwistStruct2D> device_twist_2d_structs_;
   thrust::device_vector<TwistStruct3D> device_twist_3d_structs_;
+  std::size_t active_twist_2d_struct_count_{};
+  std::size_t active_twist_3d_struct_count_{};
   thrust::device_vector<CropBoxParameters> device_crop_box_structs_;
 };
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -39,11 +39,20 @@
 namespace autoware::cuda_pointcloud_preprocessor
 {
 
+struct PreprocessorCapacity
+{
+  std::size_t max_input_point_count{0};
+  int max_ring_count{0};
+  int max_points_per_ring{0};
+  std::size_t max_twist_struct_count{0};
+};
+
 struct ProcessingStats
 {
   int mismatch_count{0};
   int num_crop_box_passed_points{0};
   int num_nan_points{0};
+  bool ring_overflow{false};
 };
 
 class CudaPointcloudPreprocessor
@@ -51,13 +60,12 @@ class CudaPointcloudPreprocessor
 public:
   enum class UndistortionType { Invalid, Undistortion2D, Undistortion3D };
 
-  CudaPointcloudPreprocessor();
+  explicit CudaPointcloudPreprocessor(const PreprocessorCapacity & capacity);
 
   void setCropBoxParameters(const std::vector<CropBoxParameters> & crop_box_parameters);
   void setRingOutlierFilterParameters(const RingOutlierFilterParameters & ring_outlier_parameters);
   void setRingOutlierFilterActive(const bool enable_filter);
   void setUndistortionType(const UndistortionType & undistortion_type);
-  void setMaxInputPointCount(const std::size_t max_input_point_count);
 
   void preallocateOutput();
   [[nodiscard]] ProcessingStats getProcessingStats() const { return stats_; }
@@ -72,6 +80,7 @@ public:
 private:
   static cudaStream_t initialize_stream();
 
+  void initializeBuffers();
   void organizePointcloud();
 
   CropBoxParameters self_crop_box_parameters_{};
@@ -84,7 +93,7 @@ private:
   int max_points_per_ring_{};
   std::size_t num_raw_points_{};
   std::size_t num_organized_points_{};
-  std::size_t max_input_point_count_{};
+  PreprocessorCapacity capacity_{};
 
   std::vector<sensor_msgs::msg::PointField> point_fields_;
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> output_pointcloud_ptr_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -89,11 +89,11 @@ private:
   UndistortionType undistortion_type_{UndistortionType::Invalid};
   bool enable_ring_outlier_filter_{true};
 
+  PreprocessorCapacity capacity_{};
   int num_rings_{};
   int max_points_per_ring_{};
-  std::size_t num_raw_points_{};
   std::size_t num_organized_points_{};
-  PreprocessorCapacity capacity_{};
+  std::size_t num_raw_points_{};
 
   std::vector<sensor_msgs::msg::PointField> point_fields_;
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> output_pointcloud_ptr_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -39,6 +39,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <cstddef>
 #include <deque>
 #include <memory>
 #include <string>
@@ -73,6 +74,23 @@ CHECK_OFFSET(OutputPointType, autoware::point_types::PointXYZIRCAEDT, intensity)
 CHECK_OFFSET(OutputPointType, autoware::point_types::PointXYZIRCAEDT, return_type);
 CHECK_OFFSET(OutputPointType, autoware::point_types::PointXYZIRCAEDT, channel);
 
+struct InputBoundsParams
+{
+  std::size_t max_input_point_count{};
+  std::size_t max_twist_subscriber_queue_size{};
+  std::size_t max_imu_subscriber_queue_size{};
+  std::size_t max_twist_queue_size{};
+  std::size_t max_imu_queue_size{};
+};
+
+struct InputBoundsStatus
+{
+  std::size_t input_point_count{};
+  std::size_t truncated_point_count{};
+  std::size_t dropped_twist_count{};
+  std::size_t dropped_imu_count{};
+};
+
 class CudaPointcloudPreprocessorNode : public rclcpp::Node
 {
 public:
@@ -97,6 +115,8 @@ private:
 
   void updateTwistQueue(std::uint64_t first_point_stamp);
   void updateImuQueue(std::uint64_t first_point_stamp);
+  void boundTwistQueue();
+  void boundImuQueue();
   std::optional<geometry_msgs::msg::TransformStamped> lookupTransformToBase(
     const std::string & source_frame);
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> processPointcloud(
@@ -119,6 +139,8 @@ private:
   bool use_imu_;
   double processing_time_threshold_sec_;
   double timestamp_mismatch_fraction_threshold_;
+  InputBoundsParams input_bounds_params_{};
+  InputBoundsStatus latest_input_bounds_status_{};
 
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> twist_queue_;
   std::deque<geometry_msgs::msg::Vector3Stamped> angular_velocity_queue_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -77,6 +77,8 @@ CHECK_OFFSET(OutputPointType, autoware::point_types::PointXYZIRCAEDT, channel);
 struct InputBoundsParams
 {
   std::size_t max_input_point_count{};
+  int max_ring_count{};
+  int max_points_per_ring{};
   std::size_t max_twist_subscriber_queue_size{};
   std::size_t max_imu_subscriber_queue_size{};
   std::size_t max_twist_queue_size{};

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
@@ -24,6 +24,7 @@
 #include <cuda_runtime.h>
 #include <thrust/device_vector.h>
 
+#include <cstddef>
 #include <deque>
 
 namespace autoware::cuda_pointcloud_preprocessor
@@ -38,13 +39,13 @@ void undistort3DLaunch(
   std::uint8_t * output_mismatch_mask, int threads_per_block, int blocks_per_grid,
   cudaStream_t & stream);
 
-void setupTwist2DStructs(
+std::size_t setupTwist2DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
   const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
   const std::uint64_t pointcloud_stamp_nsec, const std::uint32_t first_point_rel_stamp_nsec,
   thrust::device_vector<TwistStruct2D> & device_twist_2d_structs, cudaStream_t & stream);
 
-void setupTwist3DStructs(
+std::size_t setupTwist3DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
   const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
   const std::uint64_t pointcloud_stamp_nsec, const std::uint32_t first_point_rel_stamp_nsec,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
@@ -48,6 +48,24 @@
           "description": "Enable/disable ring outlier filter in the cuda_pointcloud_preprocessor pipeline.",
           "default": "true"
         },
+        "max_input_point_count": {
+          "type": "integer",
+          "description": "Maximum number of input points processed per cloud. Larger inputs are reported as errors and truncated to the first N points.",
+          "default": 691200,
+          "minimum": 1
+        },
+        "max_twist_frequency_hz": {
+          "type": "number",
+          "description": "Maximum expected twist input frequency. Used with twist_imu_queue_window_sec to bound the twist queue.",
+          "default": 200.0,
+          "exclusiveMinimum": 0.0
+        },
+        "max_imu_frequency_hz": {
+          "type": "number",
+          "description": "Maximum expected IMU input frequency. Used with twist_imu_queue_window_sec to bound the IMU queue.",
+          "default": 200.0,
+          "exclusiveMinimum": 0.0
+        },
         "crop_box.min_x": {
           "type": "array",
           "description": "An array in which each element is the minimum x value in a crop box",
@@ -92,6 +110,9 @@
         "object_length_threshold",
         "processing_time_threshold_sec",
         "timestamp_mismatch_fraction_threshold",
+        "max_input_point_count",
+        "max_twist_frequency_hz",
+        "max_imu_frequency_hz",
         "crop_box.min_x",
         "crop_box.min_y",
         "crop_box.min_z",

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
@@ -54,15 +54,27 @@
           "default": 691200,
           "minimum": 1
         },
+        "max_ring_count": {
+          "type": "integer",
+          "description": "Maximum number of LiDAR rings used for startup allocation of ring outlier filter CUDA buffers.",
+          "default": 128,
+          "minimum": 1
+        },
+        "max_points_per_ring": {
+          "type": "integer",
+          "description": "Maximum number of points per ring used for startup allocation of ring outlier filter CUDA buffers.",
+          "default": 7200,
+          "minimum": 1
+        },
         "max_twist_frequency_hz": {
           "type": "number",
-          "description": "Maximum expected twist input frequency. Used with twist_imu_queue_window_sec to bound the twist queue.",
+          "description": "Maximum expected twist input frequency. Used to bound the twist queue.",
           "default": 200.0,
           "exclusiveMinimum": 0.0
         },
         "max_imu_frequency_hz": {
           "type": "number",
-          "description": "Maximum expected IMU input frequency. Used with twist_imu_queue_window_sec to bound the IMU queue.",
+          "description": "Maximum expected IMU input frequency. Used to bound the IMU queue.",
           "default": 200.0,
           "exclusiveMinimum": 0.0
         },
@@ -111,6 +123,8 @@
         "processing_time_threshold_sec",
         "timestamp_mismatch_fraction_threshold",
         "max_input_point_count",
+        "max_ring_count",
+        "max_points_per_ring",
         "max_twist_frequency_hz",
         "max_imu_frequency_hz",
         "crop_box.min_x",

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -36,7 +36,9 @@
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <stdexcept>
 
 namespace autoware::cuda_pointcloud_preprocessor
 {
@@ -140,6 +142,14 @@ void CudaPointcloudPreprocessor::setUndistortionType(const UndistortionType & un
   }
 
   undistortion_type_ = undistortion_type;
+}
+
+void CudaPointcloudPreprocessor::setMaxInputPointCount(const std::size_t max_input_point_count)
+{
+  if (max_input_point_count == 0) {
+    throw std::runtime_error("max_input_point_count must be positive");
+  }
+  max_input_point_count_ = max_input_point_count;
 }
 
 void CudaPointcloudPreprocessor::preallocateOutput()
@@ -281,8 +291,10 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   const std::uint32_t first_point_rel_stamp_nsec)
 {
   auto frame_id = input_pointcloud_msg.header.frame_id;
-  num_raw_points_ = static_cast<int>(input_pointcloud_msg.width * input_pointcloud_msg.height);
-  num_organized_points_ = num_rings_ * max_points_per_ring_;
+  const auto input_point_count =
+    static_cast<std::size_t>(input_pointcloud_msg.width) * input_pointcloud_msg.height;
+  num_raw_points_ = std::min(input_point_count, max_input_point_count_);
+  num_organized_points_ = static_cast<std::size_t>(num_rings_) * max_points_per_ring_;
 
   if (num_raw_points_ == 0) {
     output_pointcloud_ptr_->row_step = 0;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -45,8 +45,15 @@ namespace autoware::cuda_pointcloud_preprocessor
 
 namespace thrust_stream = cuda_utils::thrust_stream;
 
-CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_stream())
+CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(const PreprocessorCapacity & capacity)
+: stream_(initialize_stream()), capacity_(capacity)
 {
+  if (
+    capacity_.max_input_point_count == 0 || capacity_.max_ring_count <= 0 ||
+    capacity_.max_points_per_ring <= 0 || capacity_.max_twist_struct_count == 0) {
+    throw std::runtime_error("CudaPointcloudPreprocessor capacities must be positive");
+  }
+
   using sensor_msgs::msg::PointField;
 
   auto make_point_field = [](
@@ -74,43 +81,8 @@ CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_st
   CHECK_CUDA_ERROR(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, 0));
   max_blocks_per_grid_ = 4 * num_sm;  // used for strided loops
 
-  num_rings_ = 1;
-  max_points_per_ring_ = 1;
-  num_organized_points_ = num_rings_ * max_points_per_ring_;
-  device_ring_index_.resize(num_rings_);
-
-  device_indexes_tensor_.resize(num_organized_points_);
-  device_sorted_indexes_tensor_.resize(num_organized_points_);
-
-  device_segment_offsets_.resize(num_rings_ + 1);
-  device_segment_offsets_[0] = 0;
-  device_segment_offsets_[1] = 1;
-
-  device_max_ring_.resize(1);
-  device_max_points_per_ring_.resize(1);
-
-  device_organized_points_.resize(num_organized_points_);
-
-  thrust_stream::fill(device_max_ring_, 0, stream_);
-  thrust_stream::fill(device_max_points_per_ring_, 0, stream_);
-  thrust_stream::fill(device_indexes_tensor_, UINT32_MAX, stream_);
-
-  sort_workspace_bytes_ = querySortWorkspace(
-    num_rings_ * max_points_per_ring_, num_rings_,
-    thrust::raw_pointer_cast(device_segment_offsets_.data()),
-    thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-    thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
-
-  device_transformed_points_.resize(num_organized_points_);
-  device_crop_mask_.resize(num_organized_points_);
-  device_nan_mask_.resize(num_organized_points_);
-  device_mismatch_mask_.resize(num_organized_points_);
-  device_ring_outlier_mask_.resize(num_organized_points_);
-  device_indices_.resize(num_organized_points_);
-
-  preallocateOutput();
+  initializeBuffers();
 }
-
 cudaStream_t CudaPointcloudPreprocessor::initialize_stream()
 {
   cudaStream_t stream{};
@@ -144,12 +116,48 @@ void CudaPointcloudPreprocessor::setUndistortionType(const UndistortionType & un
   undistortion_type_ = undistortion_type;
 }
 
-void CudaPointcloudPreprocessor::setMaxInputPointCount(const std::size_t max_input_point_count)
+void CudaPointcloudPreprocessor::initializeBuffers()
 {
-  if (max_input_point_count == 0) {
-    throw std::runtime_error("max_input_point_count must be positive");
+  num_rings_ = capacity_.max_ring_count;
+  max_points_per_ring_ = capacity_.max_points_per_ring;
+  num_organized_points_ = static_cast<std::size_t>(num_rings_) * max_points_per_ring_;
+
+  device_input_points_.resize(capacity_.max_input_point_count);
+  device_ring_index_.resize(num_rings_);
+  device_indexes_tensor_.resize(num_organized_points_);
+  device_sorted_indexes_tensor_.resize(num_organized_points_);
+  device_segment_offsets_.resize(num_rings_ + 1);
+  device_max_ring_.resize(1);
+  device_max_points_per_ring_.resize(1);
+  device_organized_points_.resize(num_organized_points_);
+  device_transformed_points_.resize(num_organized_points_);
+  device_crop_mask_.resize(num_organized_points_);
+  device_nan_mask_.resize(num_organized_points_);
+  device_mismatch_mask_.resize(num_organized_points_);
+  device_ring_outlier_mask_.resize(num_organized_points_);
+  device_indices_.resize(num_organized_points_);
+  device_twist_2d_structs_.resize(capacity_.max_twist_struct_count);
+  device_twist_3d_structs_.resize(capacity_.max_twist_struct_count);
+
+  std::vector<std::int32_t> segment_offsets_host(num_rings_ + 1);
+  for (int i = 0; i < num_rings_ + 1; i++) {
+    segment_offsets_host[i] = i * max_points_per_ring_;
   }
-  max_input_point_count_ = max_input_point_count;
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    thrust::raw_pointer_cast(device_segment_offsets_.data()), segment_offsets_host.data(),
+    segment_offsets_host.size() * sizeof(std::int32_t), cudaMemcpyHostToDevice, stream_));
+
+  thrust_stream::fill(device_max_ring_, 0, stream_);
+  thrust_stream::fill(device_max_points_per_ring_, 0, stream_);
+  thrust_stream::fill(device_indexes_tensor_, UINT32_MAX, stream_);
+
+  sort_workspace_bytes_ = querySortWorkspace(
+    num_organized_points_, num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
+    thrust::raw_pointer_cast(device_indexes_tensor_.data()),
+    thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
+  device_sort_workspace_.resize(sort_workspace_bytes_);
+
+  preallocateOutput();
 }
 
 void CudaPointcloudPreprocessor::preallocateOutput()
@@ -165,9 +173,10 @@ void CudaPointcloudPreprocessor::organizePointcloud()
   thrust_stream::fill_n(
     device_indexes_tensor_, num_organized_points_, static_cast<std::uint32_t>(num_raw_points_),
     stream_);
+  thrust_stream::fill(device_max_ring_, 0, stream_);
+  thrust_stream::fill(device_max_points_per_ring_, 0, stream_);
 
   if (num_raw_points_ == 0) {
-    output_pointcloud_ptr_->data.reset();
     return;
   }
 
@@ -182,92 +191,13 @@ void CudaPointcloudPreprocessor::organizePointcloud()
     thrust::raw_pointer_cast(device_max_points_per_ring_.data()), num_raw_points_,
     threads_per_block_, raw_points_blocks_per_grid, stream_);
 
-  std::int32_t max_ring_value{};
-  std::int32_t max_points_per_ring{};
-
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    &max_ring_value, thrust::raw_pointer_cast(device_max_ring_.data()), sizeof(std::int32_t),
-    cudaMemcpyDeviceToHost, stream_));
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    &max_points_per_ring, thrust::raw_pointer_cast(device_max_points_per_ring_.data()),
-    sizeof(std::int32_t), cudaMemcpyDeviceToHost, stream_));
-  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
-
-  if (max_ring_value >= num_rings_ || max_points_per_ring > max_points_per_ring_) {
-    num_rings_ = max_ring_value + 1;
-    max_points_per_ring_ = std::max((max_points_per_ring + 511) / 512 * 512, 512);
-    num_organized_points_ = num_rings_ * max_points_per_ring_;
-
-    device_ring_index_.resize(num_rings_);
-    thrust_stream::fill(device_ring_index_, 0, stream_);
-    device_indexes_tensor_.resize(num_organized_points_);
-    thrust_stream::fill<uint32_t>(device_indexes_tensor_, num_raw_points_, stream_);
-    device_sorted_indexes_tensor_.resize(num_organized_points_);
-    thrust_stream::fill<uint32_t>(device_sorted_indexes_tensor_, num_raw_points_, stream_);
-    device_segment_offsets_.resize(num_rings_ + 1);
-    device_organized_points_.resize(num_organized_points_);
-    thrust_stream::fill(device_organized_points_, InputPointType{}, stream_);
-
-    device_transformed_points_.resize(num_organized_points_);
-    thrust_stream::fill(device_transformed_points_, InputPointType{}, stream_);
-    device_crop_mask_.resize(num_organized_points_);
-    thrust_stream::fill(device_crop_mask_, 0U, stream_);
-    device_nan_mask_.resize(num_organized_points_);
-    thrust_stream::fill<uint8_t>(device_nan_mask_, 0, stream_);
-    device_mismatch_mask_.resize(num_organized_points_);
-    thrust_stream::fill<uint8_t>(device_mismatch_mask_, 0, stream_);
-    device_ring_outlier_mask_.resize(num_organized_points_);
-    thrust_stream::fill(device_ring_outlier_mask_, 0U, stream_);
-    device_indices_.resize(num_organized_points_);
-    thrust_stream::fill(device_indices_, 0U, stream_);
-
-    preallocateOutput();
-
-    std::vector<std::int32_t> segment_offsets_host(num_rings_ + 1);
-    for (int i = 0; i < num_rings_ + 1; i++) {
-      segment_offsets_host[i] = i * max_points_per_ring_;
-    }
-
-    CHECK_CUDA_ERROR(cudaMemcpyAsync(
-      thrust::raw_pointer_cast(device_segment_offsets_.data()), segment_offsets_host.data(),
-      (num_rings_ + 1) * sizeof(std::int32_t), cudaMemcpyHostToDevice, stream_));
-
-    CHECK_CUDA_ERROR(cudaMemsetAsync(
-      thrust::raw_pointer_cast(device_ring_index_.data()), 0, num_rings_ * sizeof(std::int32_t),
-      stream_));
-    CHECK_CUDA_ERROR(cudaMemsetAsync(
-      thrust::raw_pointer_cast(device_indexes_tensor_.data()), 0xFF,
-      num_organized_points_ * sizeof(std::int32_t), stream_));
-
-    sort_workspace_bytes_ = querySortWorkspace(
-      num_organized_points_, num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
-      thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
-    device_sort_workspace_.resize(sort_workspace_bytes_);
-
-    organizeLaunch(
-      thrust::raw_pointer_cast(device_input_points_.data()),
-      thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_ring_index_.data()), num_rings_,
-      thrust::raw_pointer_cast(device_max_ring_.data()), max_points_per_ring_,
-      thrust::raw_pointer_cast(device_max_points_per_ring_.data()), num_raw_points_,
-      threads_per_block_, raw_points_blocks_per_grid, stream_);
-  }
-
-  if (num_organized_points_ == num_rings_) {
-    CHECK_CUDA_ERROR(cudaMemcpyAsync(
-      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      num_organized_points_ * sizeof(std::uint32_t), cudaMemcpyDeviceToDevice, stream_));
-  } else {
-    cub::DeviceSegmentedRadixSort::SortKeys(
-      reinterpret_cast<void *>(thrust::raw_pointer_cast(device_sort_workspace_.data())),  // NOLINT
-      sort_workspace_bytes_, thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), num_organized_points_,
-      num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
-      thrust::raw_pointer_cast(device_segment_offsets_.data()) + 1, 0, sizeof(std::uint32_t) * 8,
-      stream_);
-  }
+  cub::DeviceSegmentedRadixSort::SortKeys(
+    reinterpret_cast<void *>(thrust::raw_pointer_cast(device_sort_workspace_.data())),  // NOLINT
+    sort_workspace_bytes_, thrust::raw_pointer_cast(device_indexes_tensor_.data()),
+    thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), num_organized_points_,
+    num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
+    thrust::raw_pointer_cast(device_segment_offsets_.data()) + 1, 0, sizeof(std::uint32_t) * 8,
+    stream_);
 
   // reuse device_indexes_tensor_ to store valid point location
   thrust_stream::fill(device_indexes_tensor_, 0U, stream_);
@@ -293,7 +223,7 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   auto frame_id = input_pointcloud_msg.header.frame_id;
   const auto input_point_count =
     static_cast<std::size_t>(input_pointcloud_msg.width) * input_pointcloud_msg.height;
-  num_raw_points_ = std::min(input_point_count, max_input_point_count_);
+  num_raw_points_ = std::min(input_point_count, capacity_.max_input_point_count);
   num_organized_points_ = static_cast<std::size_t>(num_rings_) * max_points_per_ring_;
 
   if (num_raw_points_ == 0) {
@@ -308,11 +238,6 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     output_pointcloud_ptr_->header.stamp = input_pointcloud_msg.header.stamp;
 
     return std::move(output_pointcloud_ptr_);
-  }
-
-  if (num_raw_points_ > device_input_points_.size()) {
-    std::size_t new_capacity = (num_raw_points_ + 1024) / 1024 * 1024;
-    device_input_points_.resize(new_capacity);
   }
 
   // Reset all contents in the device vector
@@ -360,11 +285,11 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     input_pointcloud_msg.header.stamp.nanosec;
 
   if (undistortion_type_ == UndistortionType::Undistortion3D) {
-    setupTwist3DStructs(
+    active_twist_3d_struct_count_ = setupTwist3DStructs(
       twist_queue, angular_velocity_queue, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
       device_twist_3d_structs_, stream_);
   } else if (undistortion_type_ == UndistortionType::Undistortion2D) {
-    setupTwist2DStructs(
+    active_twist_2d_struct_count_ = setupTwist2DStructs(
       twist_queue, angular_velocity_queue, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
       device_twist_2d_structs_, stream_);
   } else {
@@ -405,17 +330,16 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   }
 
   // Undistortion
-  if (
-    undistortion_type_ == UndistortionType::Undistortion3D && device_twist_3d_structs_.size() > 0) {
+  if (undistortion_type_ == UndistortionType::Undistortion3D && active_twist_3d_struct_count_ > 0) {
     undistort3DLaunch(
       device_transformed_points, num_organized_points_, device_twist_3d_structs,
-      static_cast<int>(device_twist_3d_structs_.size()), device_mismatch_mask, threads_per_block_,
+      static_cast<int>(active_twist_3d_struct_count_), device_mismatch_mask, threads_per_block_,
       blocks_per_grid, stream_);
   } else if (
-    undistortion_type_ == UndistortionType::Undistortion2D && device_twist_2d_structs_.size() > 0) {
+    undistortion_type_ == UndistortionType::Undistortion2D && active_twist_2d_struct_count_ > 0) {
     undistort2DLaunch(
       device_transformed_points, num_organized_points_, device_twist_2d_structs,
-      static_cast<int>(device_twist_2d_structs_.size()), device_mismatch_mask, threads_per_block_,
+      static_cast<int>(active_twist_2d_struct_count_), device_mismatch_mask, threads_per_block_,
       blocks_per_grid, stream_);
   }
 
@@ -447,11 +371,21 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     device_ring_outlier_mask + num_organized_points_, device_indices);
 
   int num_output_points{};
+  std::int32_t max_ring_value{};
+  std::int32_t max_points_per_ring_value{};
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     &num_output_points, device_indices + num_organized_points_ - 1, sizeof(int),
     cudaMemcpyDeviceToHost, stream_));
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    &max_ring_value, thrust::raw_pointer_cast(device_max_ring_.data()), sizeof(std::int32_t),
+    cudaMemcpyDeviceToHost, stream_));
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    &max_points_per_ring_value, thrust::raw_pointer_cast(device_max_points_per_ring_.data()),
+    sizeof(std::int32_t), cudaMemcpyDeviceToHost, stream_));
 
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+  stats_.ring_overflow =
+    max_ring_value >= num_rings_ || max_points_per_ring_value >= max_points_per_ring_;
 
   // Get information and extract points after filters
   size_t num_crop_box_passed_points = thrust_stream::count(device_crop_mask_, 1U, stream_);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -225,7 +225,6 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   const auto input_point_count =
     static_cast<std::size_t>(input_pointcloud_msg.width) * input_pointcloud_msg.height;
   num_raw_points_ = std::min(input_point_count, capacity_.max_input_point_count);
-  num_organized_points_ = static_cast<std::size_t>(num_rings_) * max_points_per_ring_;
 
   if (num_raw_points_ == 0) {
     output_pointcloud_ptr_->row_step = 0;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -45,15 +45,28 @@ namespace autoware::cuda_pointcloud_preprocessor
 
 namespace thrust_stream = cuda_utils::thrust_stream;
 
-CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(const PreprocessorCapacity & capacity)
-: stream_(initialize_stream()), capacity_(capacity)
+namespace
+{
+
+PreprocessorCapacity validate_capacity(const PreprocessorCapacity & capacity)
 {
   if (
-    capacity_.max_input_point_count == 0 || capacity_.max_ring_count <= 0 ||
-    capacity_.max_points_per_ring <= 0 || capacity_.max_twist_struct_count == 0) {
+    capacity.max_input_point_count == 0 || capacity.max_ring_count <= 0 ||
+    capacity.max_points_per_ring <= 0 || capacity.max_twist_struct_count == 0) {
     throw std::runtime_error("CudaPointcloudPreprocessor capacities must be positive");
   }
+  return capacity;
+}
 
+}  // namespace
+
+CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(const PreprocessorCapacity & capacity)
+: capacity_(validate_capacity(capacity)),
+  num_rings_(capacity_.max_ring_count),
+  max_points_per_ring_(capacity_.max_points_per_ring),
+  num_organized_points_(static_cast<std::size_t>(num_rings_) * max_points_per_ring_),
+  stream_(initialize_stream())
+{
   using sensor_msgs::msg::PointField;
 
   auto make_point_field = [](
@@ -118,10 +131,6 @@ void CudaPointcloudPreprocessor::setUndistortionType(const UndistortionType & un
 
 void CudaPointcloudPreprocessor::initializeBuffers()
 {
-  num_rings_ = capacity_.max_ring_count;
-  max_points_per_ring_ = capacity_.max_points_per_ring;
-  num_organized_points_ = static_cast<std::size_t>(num_rings_) * max_points_per_ring_;
-
   device_input_points_.resize(capacity_.max_input_point_count);
   device_ring_index_.resize(num_rings_);
   device_indexes_tensor_.resize(num_organized_points_);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -45,8 +45,15 @@ namespace autoware::cuda_pointcloud_preprocessor
 
 namespace thrust_stream = cuda_utils::thrust_stream;
 
-CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_stream())
+CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(const PreprocessorCapacity & capacity)
+: stream_(initialize_stream()), capacity_(capacity)
 {
+  if (
+    capacity_.max_input_point_count == 0 || capacity_.max_ring_count <= 0 ||
+    capacity_.max_points_per_ring <= 0 || capacity_.max_twist_struct_count == 0) {
+    throw std::runtime_error("CudaPointcloudPreprocessor capacities must be positive");
+  }
+
   using sensor_msgs::msg::PointField;
 
   auto make_point_field = [](
@@ -74,43 +81,8 @@ CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_st
   CHECK_CUDA_ERROR(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, 0));
   max_blocks_per_grid_ = 4 * num_sm;  // used for strided loops
 
-  num_rings_ = 1;
-  max_points_per_ring_ = 1;
-  num_organized_points_ = num_rings_ * max_points_per_ring_;
-  device_ring_index_.resize(num_rings_);
-
-  device_indexes_tensor_.resize(num_organized_points_);
-  device_sorted_indexes_tensor_.resize(num_organized_points_);
-
-  device_segment_offsets_.resize(num_rings_ + 1);
-  device_segment_offsets_[0] = 0;
-  device_segment_offsets_[1] = 1;
-
-  device_max_ring_.resize(1);
-  device_max_points_per_ring_.resize(1);
-
-  device_organized_points_.resize(num_organized_points_);
-
-  thrust_stream::fill(device_max_ring_, 0, stream_);
-  thrust_stream::fill(device_max_points_per_ring_, 0, stream_);
-  thrust_stream::fill(device_indexes_tensor_, UINT32_MAX, stream_);
-
-  sort_workspace_bytes_ = querySortWorkspace(
-    num_rings_ * max_points_per_ring_, num_rings_,
-    thrust::raw_pointer_cast(device_segment_offsets_.data()),
-    thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-    thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
-
-  device_transformed_points_.resize(num_organized_points_);
-  device_crop_mask_.resize(num_organized_points_);
-  device_nan_mask_.resize(num_organized_points_);
-  device_mismatch_mask_.resize(num_organized_points_);
-  device_ring_outlier_mask_.resize(num_organized_points_);
-  device_indices_.resize(num_organized_points_);
-
-  preallocateOutput();
+  initializeBuffers();
 }
-
 cudaStream_t CudaPointcloudPreprocessor::initialize_stream()
 {
   cudaStream_t stream{};
@@ -144,12 +116,48 @@ void CudaPointcloudPreprocessor::setUndistortionType(const UndistortionType & un
   undistortion_type_ = undistortion_type;
 }
 
-void CudaPointcloudPreprocessor::setMaxInputPointCount(const std::size_t max_input_point_count)
+void CudaPointcloudPreprocessor::initializeBuffers()
 {
-  if (max_input_point_count == 0) {
-    throw std::runtime_error("max_input_point_count must be positive");
+  num_rings_ = capacity_.max_ring_count;
+  max_points_per_ring_ = capacity_.max_points_per_ring;
+  num_organized_points_ = static_cast<std::size_t>(num_rings_) * max_points_per_ring_;
+
+  device_input_points_.resize(capacity_.max_input_point_count);
+  device_ring_index_.resize(num_rings_);
+  device_indexes_tensor_.resize(num_organized_points_);
+  device_sorted_indexes_tensor_.resize(num_organized_points_);
+  device_segment_offsets_.resize(num_rings_ + 1);
+  device_max_ring_.resize(1);
+  device_max_points_per_ring_.resize(1);
+  device_organized_points_.resize(num_organized_points_);
+  device_transformed_points_.resize(num_organized_points_);
+  device_crop_mask_.resize(num_organized_points_);
+  device_nan_mask_.resize(num_organized_points_);
+  device_mismatch_mask_.resize(num_organized_points_);
+  device_ring_outlier_mask_.resize(num_organized_points_);
+  device_indices_.resize(num_organized_points_);
+  device_twist_2d_structs_.resize(capacity_.max_twist_struct_count);
+  device_twist_3d_structs_.resize(capacity_.max_twist_struct_count);
+
+  std::vector<std::int32_t> segment_offsets_host(num_rings_ + 1);
+  for (int i = 0; i < num_rings_ + 1; i++) {
+    segment_offsets_host[i] = i * max_points_per_ring_;
   }
-  max_input_point_count_ = max_input_point_count;
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    thrust::raw_pointer_cast(device_segment_offsets_.data()), segment_offsets_host.data(),
+    segment_offsets_host.size() * sizeof(std::int32_t), cudaMemcpyHostToDevice, stream_));
+
+  thrust_stream::fill(device_max_ring_, 0, stream_);
+  thrust_stream::fill(device_max_points_per_ring_, 0, stream_);
+  thrust_stream::fill(device_indexes_tensor_, UINT32_MAX, stream_);
+
+  sort_workspace_bytes_ = querySortWorkspace(
+    num_organized_points_, num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
+    thrust::raw_pointer_cast(device_indexes_tensor_.data()),
+    thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
+  device_sort_workspace_.resize(sort_workspace_bytes_);
+
+  preallocateOutput();
 }
 
 void CudaPointcloudPreprocessor::preallocateOutput()
@@ -165,9 +173,10 @@ void CudaPointcloudPreprocessor::organizePointcloud()
   thrust_stream::fill_n(
     device_indexes_tensor_, num_organized_points_, static_cast<std::uint32_t>(num_raw_points_),
     stream_);
+  thrust_stream::fill(device_max_ring_, 0, stream_);
+  thrust_stream::fill(device_max_points_per_ring_, 0, stream_);
 
   if (num_raw_points_ == 0) {
-    output_pointcloud_ptr_->data.reset();
     return;
   }
 
@@ -182,94 +191,14 @@ void CudaPointcloudPreprocessor::organizePointcloud()
     thrust::raw_pointer_cast(device_max_points_per_ring_.data()), num_raw_points_,
     threads_per_block_, raw_points_blocks_per_grid, stream_);
 
-  std::int32_t max_ring_value{};
-  std::int32_t max_points_per_ring{};
-
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    &max_ring_value, thrust::raw_pointer_cast(device_max_ring_.data()), sizeof(std::int32_t),
-    cudaMemcpyDeviceToHost, stream_));
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    &max_points_per_ring, thrust::raw_pointer_cast(device_max_points_per_ring_.data()),
-    sizeof(std::int32_t), cudaMemcpyDeviceToHost, stream_));
-  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
-
-  if (max_ring_value >= num_rings_ || max_points_per_ring > max_points_per_ring_) {
-    num_rings_ = max_ring_value + 1;
-    max_points_per_ring_ = std::max((max_points_per_ring + 511) / 512 * 512, 512);
-    num_organized_points_ = num_rings_ * max_points_per_ring_;
-
-    device_ring_index_.resize(num_rings_);
-    thrust_stream::fill(device_ring_index_, 0, stream_);
-    device_indexes_tensor_.resize(num_organized_points_);
-    thrust_stream::fill<uint32_t>(device_indexes_tensor_, num_raw_points_, stream_);
-    device_sorted_indexes_tensor_.resize(num_organized_points_);
-    thrust_stream::fill<uint32_t>(device_sorted_indexes_tensor_, num_raw_points_, stream_);
-    device_segment_offsets_.resize(num_rings_ + 1);
-    device_organized_points_.resize(num_organized_points_);
-    thrust_stream::fill(device_organized_points_, InputPointType{}, stream_);
-
-    device_transformed_points_.resize(num_organized_points_);
-    thrust_stream::fill(device_transformed_points_, InputPointType{}, stream_);
-    device_crop_mask_.resize(num_organized_points_);
-    thrust_stream::fill(device_crop_mask_, 0U, stream_);
-    device_nan_mask_.resize(num_organized_points_);
-    thrust_stream::fill<uint8_t>(device_nan_mask_, 0, stream_);
-    device_mismatch_mask_.resize(num_organized_points_);
-    thrust_stream::fill<uint8_t>(device_mismatch_mask_, 0, stream_);
-    device_ring_outlier_mask_.resize(num_organized_points_);
-    thrust_stream::fill(device_ring_outlier_mask_, 0U, stream_);
-    device_indices_.resize(num_organized_points_);
-    thrust_stream::fill(device_indices_, 0U, stream_);
-
-    preallocateOutput();
-
-    std::vector<std::int32_t> segment_offsets_host(num_rings_ + 1);
-    for (int i = 0; i < num_rings_ + 1; i++) {
-      segment_offsets_host[i] = i * max_points_per_ring_;
-    }
-
-    CHECK_CUDA_ERROR(cudaMemcpyAsync(
-      thrust::raw_pointer_cast(device_segment_offsets_.data()), segment_offsets_host.data(),
-      (num_rings_ + 1) * sizeof(std::int32_t), cudaMemcpyHostToDevice, stream_));
-
-    CHECK_CUDA_ERROR(cudaMemsetAsync(
-      thrust::raw_pointer_cast(device_ring_index_.data()), 0, num_rings_ * sizeof(std::int32_t),
+  CHECK_CUDA_ERROR(
+    cub::DeviceSegmentedRadixSort::SortKeys(
+      reinterpret_cast<void *>(thrust::raw_pointer_cast(device_sort_workspace_.data())),  // NOLINT
+      sort_workspace_bytes_, thrust::raw_pointer_cast(device_indexes_tensor_.data()),
+      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), num_organized_points_,
+      num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
+      thrust::raw_pointer_cast(device_segment_offsets_.data()) + 1, 0, sizeof(std::uint32_t) * 8,
       stream_));
-    CHECK_CUDA_ERROR(cudaMemsetAsync(
-      thrust::raw_pointer_cast(device_indexes_tensor_.data()), 0xFF,
-      num_organized_points_ * sizeof(std::int32_t), stream_));
-
-    sort_workspace_bytes_ = querySortWorkspace(
-      num_organized_points_, num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
-      thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), stream_);
-    device_sort_workspace_.resize(sort_workspace_bytes_);
-
-    organizeLaunch(
-      thrust::raw_pointer_cast(device_input_points_.data()),
-      thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_ring_index_.data()), num_rings_,
-      thrust::raw_pointer_cast(device_max_ring_.data()), max_points_per_ring_,
-      thrust::raw_pointer_cast(device_max_points_per_ring_.data()), num_raw_points_,
-      threads_per_block_, raw_points_blocks_per_grid, stream_);
-  }
-
-  if (num_organized_points_ == num_rings_) {
-    CHECK_CUDA_ERROR(cudaMemcpyAsync(
-      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      num_organized_points_ * sizeof(std::uint32_t), cudaMemcpyDeviceToDevice, stream_));
-  } else {
-    CHECK_CUDA_ERROR(
-      cub::DeviceSegmentedRadixSort::SortKeys(
-        reinterpret_cast<void *>(
-          thrust::raw_pointer_cast(device_sort_workspace_.data())),  // NOLINT
-        sort_workspace_bytes_, thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-        thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), num_organized_points_,
-        num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
-        thrust::raw_pointer_cast(device_segment_offsets_.data()) + 1, 0, sizeof(std::uint32_t) * 8,
-        stream_));
-  }
 
   // reuse device_indexes_tensor_ to store valid point location
   thrust_stream::fill(device_indexes_tensor_, 0U, stream_);
@@ -295,7 +224,7 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   auto frame_id = input_pointcloud_msg.header.frame_id;
   const auto input_point_count =
     static_cast<std::size_t>(input_pointcloud_msg.width) * input_pointcloud_msg.height;
-  num_raw_points_ = std::min(input_point_count, max_input_point_count_);
+  num_raw_points_ = std::min(input_point_count, capacity_.max_input_point_count);
   num_organized_points_ = static_cast<std::size_t>(num_rings_) * max_points_per_ring_;
 
   if (num_raw_points_ == 0) {
@@ -310,11 +239,6 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     output_pointcloud_ptr_->header.stamp = input_pointcloud_msg.header.stamp;
 
     return std::move(output_pointcloud_ptr_);
-  }
-
-  if (num_raw_points_ > device_input_points_.size()) {
-    std::size_t new_capacity = (num_raw_points_ + 1024) / 1024 * 1024;
-    device_input_points_.resize(new_capacity);
   }
 
   // Reset all contents in the device vector
@@ -362,11 +286,11 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     input_pointcloud_msg.header.stamp.nanosec;
 
   if (undistortion_type_ == UndistortionType::Undistortion3D) {
-    setupTwist3DStructs(
+    active_twist_3d_struct_count_ = setupTwist3DStructs(
       twist_queue, angular_velocity_queue, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
       device_twist_3d_structs_, stream_);
   } else if (undistortion_type_ == UndistortionType::Undistortion2D) {
-    setupTwist2DStructs(
+    active_twist_2d_struct_count_ = setupTwist2DStructs(
       twist_queue, angular_velocity_queue, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
       device_twist_2d_structs_, stream_);
   } else {
@@ -407,17 +331,16 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   }
 
   // Undistortion
-  if (
-    undistortion_type_ == UndistortionType::Undistortion3D && device_twist_3d_structs_.size() > 0) {
+  if (undistortion_type_ == UndistortionType::Undistortion3D && active_twist_3d_struct_count_ > 0) {
     undistort3DLaunch(
       device_transformed_points, num_organized_points_, device_twist_3d_structs,
-      static_cast<int>(device_twist_3d_structs_.size()), device_mismatch_mask, threads_per_block_,
+      static_cast<int>(active_twist_3d_struct_count_), device_mismatch_mask, threads_per_block_,
       blocks_per_grid, stream_);
   } else if (
-    undistortion_type_ == UndistortionType::Undistortion2D && device_twist_2d_structs_.size() > 0) {
+    undistortion_type_ == UndistortionType::Undistortion2D && active_twist_2d_struct_count_ > 0) {
     undistort2DLaunch(
       device_transformed_points, num_organized_points_, device_twist_2d_structs,
-      static_cast<int>(device_twist_2d_structs_.size()), device_mismatch_mask, threads_per_block_,
+      static_cast<int>(active_twist_2d_struct_count_), device_mismatch_mask, threads_per_block_,
       blocks_per_grid, stream_);
   }
 
@@ -449,11 +372,21 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     device_ring_outlier_mask + num_organized_points_, device_indices);
 
   int num_output_points{};
+  std::int32_t max_ring_value{};
+  std::int32_t max_points_per_ring_value{};
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     &num_output_points, device_indices + num_organized_points_ - 1, sizeof(int),
     cudaMemcpyDeviceToHost, stream_));
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    &max_ring_value, thrust::raw_pointer_cast(device_max_ring_.data()), sizeof(std::int32_t),
+    cudaMemcpyDeviceToHost, stream_));
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    &max_points_per_ring_value, thrust::raw_pointer_cast(device_max_points_per_ring_.data()),
+    sizeof(std::int32_t), cudaMemcpyDeviceToHost, stream_));
 
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+  stats_.ring_overflow =
+    max_ring_value >= num_rings_ || max_points_per_ring_value >= max_points_per_ring_;
 
   // Get information and extract points after filters
   size_t num_crop_box_passed_points = thrust_stream::count(device_crop_mask_, 1U, stream_);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -146,6 +146,7 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
     queue_size_from_frequency(max_twist_frequency_hz);
   input_bounds_params_.max_imu_subscriber_queue_size =
     queue_size_from_frequency(max_imu_frequency_hz);
+  // TODO(mojomex): equates to 1s of messages, should be made tighter in the future
   input_bounds_params_.max_twist_queue_size =
     static_cast<std::size_t>(std::ceil(max_twist_frequency_hz));
   input_bounds_params_.max_imu_queue_size =

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -103,8 +103,8 @@ public:
       return std::make_pair(
         diagnostic_msgs::msg::DiagnosticStatus::ERROR,
         "[ERROR]: input bounds exceeded; truncated_points=" + std::to_string(truncated_points_) +
-          ", dropped_twists=" + std::to_string(dropped_twists_) +
-          ", dropped_imus=" + std::to_string(dropped_imus_));
+          ", dropped_twists=" + std::to_string(dropped_twists_) + ", dropped_imus=" +
+          std::to_string(dropped_imus_) + ", ring_overflow=" + (ring_overflow_ ? "true" : "false"));
     }
     return std::nullopt;
   }

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -17,6 +17,7 @@
 #include "autoware/cuda_pointcloud_preprocessor/memory.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/crop_box_diagnostics.hpp"
+#include "autoware/pointcloud_preprocessor/diagnostics/diagnostics_base.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/distortion_corrector_diagnostics.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/latency_diagnostics.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/pass_rate_diagnostics.hpp"
@@ -34,7 +35,9 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <deque>
 #include <memory>
 #include <string>
@@ -44,6 +47,79 @@
 namespace autoware::cuda_pointcloud_preprocessor
 {
 using sensor_msgs::msg::PointCloud2;
+namespace
+{
+
+std::size_t queue_size_from_frequency(const double max_frequency_hz)
+{
+  // TODO(mojomex): derive from a future pointcloud_frequency param instead of assuming 10 Hz.
+  constexpr double assumed_pointcloud_frequency_hz = 10.0;
+  if (max_frequency_hz <= 0.0) {
+    throw std::runtime_error("Queue frequency parameters must be positive");
+  }
+  return static_cast<std::size_t>(std::ceil(max_frequency_hz / assumed_pointcloud_frequency_hz)) +
+         1U;
+}
+
+class InputBoundsDiagnostics : public autoware::pointcloud_preprocessor::DiagnosticsBase
+{
+public:
+  InputBoundsDiagnostics(
+    const std::size_t input_points, const std::size_t max_input_points,
+    const std::size_t truncated_points, const std::size_t twist_queue_size,
+    const std::size_t max_twist_queue_size, const std::size_t dropped_twists,
+    const std::size_t imu_queue_size, const std::size_t max_imu_queue_size,
+    const std::size_t dropped_imus)
+  : input_points_(input_points),
+    max_input_points_(max_input_points),
+    truncated_points_(truncated_points),
+    twist_queue_size_(twist_queue_size),
+    max_twist_queue_size_(max_twist_queue_size),
+    dropped_twists_(dropped_twists),
+    imu_queue_size_(imu_queue_size),
+    max_imu_queue_size_(max_imu_queue_size),
+    dropped_imus_(dropped_imus)
+  {
+  }
+
+  void add_to_interface(autoware_utils::DiagnosticsInterface & interface) const override
+  {
+    interface.add_key_value("Input point count", input_points_);
+    interface.add_key_value("Maximum input point count", max_input_points_);
+    interface.add_key_value("Truncated input point count", truncated_points_);
+    interface.add_key_value("Twist queue size", twist_queue_size_);
+    interface.add_key_value("Maximum twist queue size", max_twist_queue_size_);
+    interface.add_key_value("Dropped twist count", dropped_twists_);
+    interface.add_key_value("IMU queue size", imu_queue_size_);
+    interface.add_key_value("Maximum IMU queue size", max_imu_queue_size_);
+    interface.add_key_value("Dropped IMU count", dropped_imus_);
+  }
+
+  [[nodiscard]] std::optional<std::pair<int, std::string>> evaluate_status() const override
+  {
+    if (truncated_points_ > 0 || dropped_twists_ > 0 || dropped_imus_ > 0) {
+      return std::make_pair(
+        diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+        "[ERROR]: input bounds exceeded; truncated_points=" + std::to_string(truncated_points_) +
+          ", dropped_twists=" + std::to_string(dropped_twists_) +
+          ", dropped_imus=" + std::to_string(dropped_imus_));
+    }
+    return std::nullopt;
+  }
+
+private:
+  std::size_t input_points_;
+  std::size_t max_input_points_;
+  std::size_t truncated_points_;
+  std::size_t twist_queue_size_;
+  std::size_t max_twist_queue_size_;
+  std::size_t dropped_twists_;
+  std::size_t imu_queue_size_;
+  std::size_t max_imu_queue_size_;
+  std::size_t dropped_imus_;
+};
+
+}  // namespace
 
 CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   const rclcpp::NodeOptions & node_options)
@@ -62,6 +138,22 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   use_3d_undistortion_ = declare_parameter<bool>("use_3d_distortion_correction");
   use_imu_ = declare_parameter<bool>("use_imu");
   bool enable_ring_outlier_filter = declare_parameter<bool>("enable_ring_outlier_filter");
+  input_bounds_params_.max_input_point_count =
+    static_cast<std::size_t>(declare_parameter<int64_t>("max_input_point_count"));
+  const auto max_twist_frequency_hz = declare_parameter<double>("max_twist_frequency_hz");
+  const auto max_imu_frequency_hz = declare_parameter<double>("max_imu_frequency_hz");
+  input_bounds_params_.max_twist_subscriber_queue_size =
+    queue_size_from_frequency(max_twist_frequency_hz);
+  input_bounds_params_.max_imu_subscriber_queue_size =
+    queue_size_from_frequency(max_imu_frequency_hz);
+  input_bounds_params_.max_twist_queue_size =
+    static_cast<std::size_t>(std::ceil(max_twist_frequency_hz));
+  input_bounds_params_.max_imu_queue_size =
+    static_cast<std::size_t>(std::ceil(max_imu_frequency_hz));
+
+  if (input_bounds_params_.max_input_point_count == 0) {
+    throw std::runtime_error("max_input_point_count must be positive");
+  }
 
   RingOutlierFilterParameters ring_outlier_filter_parameters;
   ring_outlier_filter_parameters.distance_ratio =
@@ -133,18 +225,16 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
     std::bind(&CudaPointcloudPreprocessorNode::pointcloudCallback, this, std::placeholders::_1),
     sub_options);
 
-  // Twist queue size needs to be larger than 'twist frequency' / 'pointcloud frequency'.
-  // To avoid individual tuning, a sufficiently large value is hard-coded.
-  // With 100, it can handle twist updates up to 1000Hz if the pointcloud is 10Hz.
-  const uint16_t TWIST_QUEUE_SIZE = 100;
   twist_sub_ = autoware_utils::InterProcessPollingSubscriber<
     geometry_msgs::msg::TwistWithCovarianceStamped, autoware_utils::polling_policy::All>::
-    create_subscription(this, "~/input/twist", rclcpp::QoS(TWIST_QUEUE_SIZE));
+    create_subscription(
+      this, "~/input/twist", rclcpp::QoS(input_bounds_params_.max_twist_subscriber_queue_size));
 
   if (use_imu_) {
     imu_sub_ = autoware_utils::InterProcessPollingSubscriber<
       sensor_msgs::msg::Imu, autoware_utils::polling_policy::All>::
-      create_subscription(this, "~/input/imu", rclcpp::QoS(TWIST_QUEUE_SIZE));
+      create_subscription(
+        this, "~/input/imu", rclcpp::QoS(input_bounds_params_.max_imu_subscriber_queue_size));
   }
 
   CudaPointcloudPreprocessor::UndistortionType undistortion_type =
@@ -152,6 +242,7 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
                          : CudaPointcloudPreprocessor::UndistortionType::Undistortion2D;
 
   cuda_pointcloud_preprocessor_ = std::make_unique<CudaPointcloudPreprocessor>();
+  cuda_pointcloud_preprocessor_->setMaxInputPointCount(input_bounds_params_.max_input_point_count);
   cuda_pointcloud_preprocessor_->setRingOutlierFilterParameters(ring_outlier_filter_parameters);
   cuda_pointcloud_preprocessor_->setRingOutlierFilterActive(enable_ring_outlier_filter);
   cuda_pointcloud_preprocessor_->setCropBoxParameters(crop_box_parameters);
@@ -220,6 +311,7 @@ void CudaPointcloudPreprocessorNode::twistCallback(
       return rclcpp::Time(twist.header.stamp) < stamp;
     });
   twist_queue_.insert(it, twist_msg);
+  boundTwistQueue();
 }
 
 void CudaPointcloudPreprocessorNode::imuCallback(const sensor_msgs::msg::Imu & imu_msg)
@@ -260,6 +352,7 @@ void CudaPointcloudPreprocessorNode::imuCallback(const sensor_msgs::msg::Imu & i
       return rclcpp::Time(angular_velocity.header.stamp) < stamp;
     });
   angular_velocity_queue_.insert(it, transformed_angular_velocity);
+  boundImuQueue();
 }
 
 void CudaPointcloudPreprocessorNode::pointcloudCallback(
@@ -267,6 +360,13 @@ void CudaPointcloudPreprocessorNode::pointcloudCallback(
   AUTOWARE_MESSAGE_UNIQUE_PTR(sensor_msgs::msg::PointCloud2) input_pointcloud_msg_ptr)
 {
   const auto & input_pointcloud_msg = *input_pointcloud_msg_ptr;
+  latest_input_bounds_status_ = {};
+  latest_input_bounds_status_.input_point_count =
+    static_cast<std::size_t>(input_pointcloud_msg.width) * input_pointcloud_msg.height;
+  latest_input_bounds_status_.truncated_point_count =
+    latest_input_bounds_status_.input_point_count > input_bounds_params_.max_input_point_count
+      ? latest_input_bounds_status_.input_point_count - input_bounds_params_.max_input_point_count
+      : 0U;
 
   if (!validatePointcloudLayout(input_pointcloud_msg)) {
     return;
@@ -338,20 +438,32 @@ void CudaPointcloudPreprocessorNode::updateTwistQueue(std::uint64_t first_point_
 {
   std::vector<geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr> twist_msgs =
     twist_sub_->take_data();
-  for (const auto & msg : twist_msgs) {
-    twistCallback(*msg);
-  }
 
-  // Find the last twist message that is before the first point's timestamp
-  // and remove all older messages.
   auto it = std::lower_bound(
     twist_queue_.begin(), twist_queue_.end(), first_point_stamp,
     [](const auto & twist, const std::uint64_t stamp) {
       // To prevent potential precision loss, use nanoseconds
-      return rclcpp::Time(twist.header.stamp).nanoseconds() < stamp;
+      return static_cast<std::uint64_t>(rclcpp::Time(twist.header.stamp).nanoseconds()) < stamp;
     });
-
   twist_queue_.erase(twist_queue_.begin(), it);
+
+  twist_msgs.erase(
+    std::remove_if(
+      twist_msgs.begin(), twist_msgs.end(),
+      [first_point_stamp](const auto & twist) {
+        return static_cast<std::uint64_t>(rclcpp::Time(twist->header.stamp).nanoseconds()) <
+               first_point_stamp;
+      }),
+    twist_msgs.end());
+
+  const auto free_capacity = input_bounds_params_.max_twist_queue_size - twist_queue_.size();
+  if (twist_msgs.size() > free_capacity) {
+    latest_input_bounds_status_.dropped_twist_count += twist_msgs.size() - free_capacity;
+    twist_msgs.erase(twist_msgs.begin(), twist_msgs.end() - free_capacity);
+  }
+  for (const auto & msg : twist_msgs) {
+    twistCallback(*msg);
+  }
 }
 
 void CudaPointcloudPreprocessorNode::updateImuQueue(std::uint64_t first_point_stamp)
@@ -359,20 +471,50 @@ void CudaPointcloudPreprocessorNode::updateImuQueue(std::uint64_t first_point_st
   if (!imu_sub_) return;
 
   std::vector<sensor_msgs::msg::Imu::ConstSharedPtr> imu_msgs = imu_sub_->take_data();
-  for (const auto & msg : imu_msgs) {
-    imuCallback(*msg);
-  }
 
-  // Find the last angular velocity message that is before the first point's timestamp
-  // and remove all older messages.
   auto it = std::lower_bound(
     angular_velocity_queue_.begin(), angular_velocity_queue_.end(), first_point_stamp,
     [](const auto & angular_velocity, const std::uint64_t stamp) {
       //  To prevent potential precision loss, use nanoseconds
-      return rclcpp::Time(angular_velocity.header.stamp).nanoseconds() < stamp;
+      return static_cast<std::uint64_t>(rclcpp::Time(angular_velocity.header.stamp).nanoseconds()) <
+             stamp;
     });
-
   angular_velocity_queue_.erase(angular_velocity_queue_.begin(), it);
+
+  imu_msgs.erase(
+    std::remove_if(
+      imu_msgs.begin(), imu_msgs.end(),
+      [first_point_stamp](const auto & imu) {
+        return static_cast<std::uint64_t>(rclcpp::Time(imu->header.stamp).nanoseconds()) <
+               first_point_stamp;
+      }),
+    imu_msgs.end());
+
+  const auto free_capacity =
+    input_bounds_params_.max_imu_queue_size - angular_velocity_queue_.size();
+  if (imu_msgs.size() > free_capacity) {
+    latest_input_bounds_status_.dropped_imu_count += imu_msgs.size() - free_capacity;
+    imu_msgs.erase(imu_msgs.begin(), imu_msgs.end() - free_capacity);
+  }
+  for (const auto & msg : imu_msgs) {
+    imuCallback(*msg);
+  }
+}
+
+void CudaPointcloudPreprocessorNode::boundTwistQueue()
+{
+  while (twist_queue_.size() > input_bounds_params_.max_twist_queue_size) {
+    twist_queue_.pop_front();
+    ++latest_input_bounds_status_.dropped_twist_count;
+  }
+}
+
+void CudaPointcloudPreprocessorNode::boundImuQueue()
+{
+  while (angular_velocity_queue_.size() > input_bounds_params_.max_imu_queue_size) {
+    angular_velocity_queue_.pop_front();
+    ++latest_input_bounds_status_.dropped_imu_count;
+  }
 }
 
 std::optional<geometry_msgs::msg::TransformStamped>
@@ -435,11 +577,18 @@ void CudaPointcloudPreprocessorNode::publishDiagnostics(
 
   auto crop_box_diag =
     std::make_shared<autoware::pointcloud_preprocessor::CropBoxDiagnostics>(skipped_nan_count);
+  auto input_bounds_diag = std::make_shared<InputBoundsDiagnostics>(
+    latest_input_bounds_status_.input_point_count, input_bounds_params_.max_input_point_count,
+    latest_input_bounds_status_.truncated_point_count, twist_queue_.size(),
+    input_bounds_params_.max_twist_queue_size, latest_input_bounds_status_.dropped_twist_count,
+    angular_velocity_queue_.size(), input_bounds_params_.max_imu_queue_size,
+    latest_input_bounds_status_.dropped_imu_count);
 
   diagnostics_interface_->clear();
 
   std::vector<std::shared_ptr<const autoware::pointcloud_preprocessor::DiagnosticsBase>>
-    diagnostics = {latency_diag, pass_rate_diag, crop_box_diag, distortion_corrector_diag};
+    diagnostics = {
+      latency_diag, pass_rate_diag, crop_box_diag, distortion_corrector_diag, input_bounds_diag};
 
   int worst_level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   std::string message;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -69,7 +69,7 @@ public:
     const std::size_t truncated_points, const std::size_t twist_queue_size,
     const std::size_t max_twist_queue_size, const std::size_t dropped_twists,
     const std::size_t imu_queue_size, const std::size_t max_imu_queue_size,
-    const std::size_t dropped_imus)
+    const std::size_t dropped_imus, const bool ring_overflow)
   : input_points_(input_points),
     max_input_points_(max_input_points),
     truncated_points_(truncated_points),
@@ -78,7 +78,8 @@ public:
     dropped_twists_(dropped_twists),
     imu_queue_size_(imu_queue_size),
     max_imu_queue_size_(max_imu_queue_size),
-    dropped_imus_(dropped_imus)
+    dropped_imus_(dropped_imus),
+    ring_overflow_(ring_overflow)
   {
   }
 
@@ -93,11 +94,12 @@ public:
     interface.add_key_value("IMU queue size", imu_queue_size_);
     interface.add_key_value("Maximum IMU queue size", max_imu_queue_size_);
     interface.add_key_value("Dropped IMU count", dropped_imus_);
+    interface.add_key_value("Ring organization overflow", ring_overflow_);
   }
 
   [[nodiscard]] std::optional<std::pair<int, std::string>> evaluate_status() const override
   {
-    if (truncated_points_ > 0 || dropped_twists_ > 0 || dropped_imus_ > 0) {
+    if (truncated_points_ > 0 || dropped_twists_ > 0 || dropped_imus_ > 0 || ring_overflow_) {
       return std::make_pair(
         diagnostic_msgs::msg::DiagnosticStatus::ERROR,
         "[ERROR]: input bounds exceeded; truncated_points=" + std::to_string(truncated_points_) +
@@ -117,6 +119,7 @@ private:
   std::size_t imu_queue_size_;
   std::size_t max_imu_queue_size_;
   std::size_t dropped_imus_;
+  bool ring_overflow_;
 };
 
 }  // namespace
@@ -140,6 +143,10 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   bool enable_ring_outlier_filter = declare_parameter<bool>("enable_ring_outlier_filter");
   input_bounds_params_.max_input_point_count =
     static_cast<std::size_t>(declare_parameter<int64_t>("max_input_point_count"));
+  input_bounds_params_.max_ring_count =
+    static_cast<int>(declare_parameter<int64_t>("max_ring_count"));
+  input_bounds_params_.max_points_per_ring =
+    static_cast<int>(declare_parameter<int64_t>("max_points_per_ring"));
   const auto max_twist_frequency_hz = declare_parameter<double>("max_twist_frequency_hz");
   const auto max_imu_frequency_hz = declare_parameter<double>("max_imu_frequency_hz");
   input_bounds_params_.max_twist_subscriber_queue_size =
@@ -152,8 +159,10 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   input_bounds_params_.max_imu_queue_size =
     static_cast<std::size_t>(std::ceil(max_imu_frequency_hz));
 
-  if (input_bounds_params_.max_input_point_count == 0) {
-    throw std::runtime_error("max_input_point_count must be positive");
+  if (
+    input_bounds_params_.max_input_point_count == 0 || input_bounds_params_.max_ring_count <= 0 ||
+    input_bounds_params_.max_points_per_ring <= 0) {
+    throw std::runtime_error("Pointcloud preprocessor capacity parameters must be positive");
   }
 
   RingOutlierFilterParameters ring_outlier_filter_parameters;
@@ -242,8 +251,12 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
     use_3d_undistortion_ ? CudaPointcloudPreprocessor::UndistortionType::Undistortion3D
                          : CudaPointcloudPreprocessor::UndistortionType::Undistortion2D;
 
-  cuda_pointcloud_preprocessor_ = std::make_unique<CudaPointcloudPreprocessor>();
-  cuda_pointcloud_preprocessor_->setMaxInputPointCount(input_bounds_params_.max_input_point_count);
+  const PreprocessorCapacity preprocessor_capacity{
+    input_bounds_params_.max_input_point_count, input_bounds_params_.max_ring_count,
+    input_bounds_params_.max_points_per_ring,
+    input_bounds_params_.max_twist_queue_size + input_bounds_params_.max_imu_queue_size};
+  cuda_pointcloud_preprocessor_ =
+    std::make_unique<CudaPointcloudPreprocessor>(preprocessor_capacity);
   cuda_pointcloud_preprocessor_->setRingOutlierFilterParameters(ring_outlier_filter_parameters);
   cuda_pointcloud_preprocessor_->setRingOutlierFilterActive(enable_ring_outlier_filter);
   cuda_pointcloud_preprocessor_->setCropBoxParameters(crop_box_parameters);
@@ -583,7 +596,7 @@ void CudaPointcloudPreprocessorNode::publishDiagnostics(
     latest_input_bounds_status_.truncated_point_count, twist_queue_.size(),
     input_bounds_params_.max_twist_queue_size, latest_input_bounds_status_.dropped_twist_count,
     angular_velocity_queue_.size(), input_bounds_params_.max_imu_queue_size,
-    latest_input_bounds_status_.dropped_imu_count);
+    latest_input_bounds_status_.dropped_imu_count, stats.ring_overflow);
 
   diagnostics_interface_->clear();
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/undistort_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/undistort_kernels.cu
@@ -21,6 +21,9 @@
 #include <Eigen/Geometry>
 #include <autoware/cuda_utils/cuda_check_error.hpp>
 
+#include <cassert>
+#include <stdexcept>
+
 namespace autoware::cuda_pointcloud_preprocessor
 {
 
@@ -165,12 +168,13 @@ void undistort3DLaunch(
   CHECK_CUDA_ERROR(cudaGetLastError());
 }
 
-void setupTwist2DStructs(
+std::size_t setupTwist2DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
   const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
   const std::uint64_t pointcloud_stamp_nsec, const std::uint32_t first_point_rel_stamp_nsec,
   thrust::device_vector<TwistStruct2D> & device_twist_2d_structs, cudaStream_t & stream)
 {
+  assert(twist_queue.size() + angular_velocity_queue.size() <= device_twist_2d_structs.size());
   std::vector<TwistStruct2D> host_twist_2d_structs;
   host_twist_2d_structs.reserve(twist_queue.size() + angular_velocity_queue.size());
 
@@ -246,19 +250,24 @@ void setupTwist2DStructs(
     cum_y += d * sin(cum_theta);
   }
 
-  // Copy to device
-  device_twist_2d_structs.resize(host_twist_2d_structs.size());
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    thrust::raw_pointer_cast(device_twist_2d_structs.data()), host_twist_2d_structs.data(),
-    host_twist_2d_structs.size() * sizeof(TwistStruct2D), cudaMemcpyHostToDevice, stream));
+  if (host_twist_2d_structs.size() > device_twist_2d_structs.size()) {
+    throw std::runtime_error("Twist2D struct capacity exceeded");
+  }
+  if (!host_twist_2d_structs.empty()) {
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      thrust::raw_pointer_cast(device_twist_2d_structs.data()), host_twist_2d_structs.data(),
+      host_twist_2d_structs.size() * sizeof(TwistStruct2D), cudaMemcpyHostToDevice, stream));
+  }
+  return host_twist_2d_structs.size();
 }
 
-void setupTwist3DStructs(
+std::size_t setupTwist3DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
   const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
   const std::uint64_t pointcloud_stamp_nsec, const std::uint32_t first_point_rel_stamp_nsec,
   thrust::device_vector<TwistStruct3D> & device_twist_3d_structs, cudaStream_t & stream)
 {
+  assert(twist_queue.size() + angular_velocity_queue.size() <= device_twist_3d_structs.size());
   std::vector<TwistStruct3D> host_twist_3d_structs;
   host_twist_3d_structs.reserve(twist_queue.size() + angular_velocity_queue.size());
 
@@ -339,11 +348,15 @@ void setupTwist3DStructs(
     cum_transform = cum_transform * delta_transform;
   }
 
-  // Copy to device
-  device_twist_3d_structs.resize(host_twist_3d_structs.size());
-  CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    thrust::raw_pointer_cast(device_twist_3d_structs.data()), host_twist_3d_structs.data(),
-    host_twist_3d_structs.size() * sizeof(TwistStruct3D), cudaMemcpyHostToDevice, stream));
+  if (host_twist_3d_structs.size() > device_twist_3d_structs.size()) {
+    throw std::runtime_error("Twist3D struct capacity exceeded");
+  }
+  if (!host_twist_3d_structs.empty()) {
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      thrust::raw_pointer_cast(device_twist_3d_structs.data()), host_twist_3d_structs.data(),
+      host_twist_3d_structs.size() * sizeof(TwistStruct3D), cudaMemcpyHostToDevice, stream));
+  }
+  return host_twist_3d_structs.size();
 }
 
 }  // namespace autoware::cuda_pointcloud_preprocessor


### PR DESCRIPTION
## Description

Use the configured input bounds from the previous PR to allocate the CUDA pointcloud preprocessor working buffers during startup.

This PR:

- introduces `PreprocessorCapacity`
- adds `max_ring_count` and `max_points_per_ring` parameters
- allocates input, organized, transformed, mask, index, sort workspace, and twist struct buffers during construction
- removes dynamic resizing from the pointcloud callback path
- reports ring/per-ring overflow through diagnostics instead of reallocating
- keeps the existing cuda blackboard output ownership/allocation path unchanged

## Stack

This is PR 2 of 5 in a stack. Every PR targets `autowarefoundation:main` (GitHub does not allow cross-repository stacks, and the branches live on a fork), so each **Files changed** tab shows the *cumulative* diff of the stack up to that PR.

**To review only one PR's own changes, use its Own diff link below.**

| # | PR | Own diff |
| --- | --- | --- |
| 1 | #13106 feat: add input bounds diagnostics | [Files changed](https://github.com/autowarefoundation/autoware_universe/pull/13106/files) (bottom of stack) |
| 2 | #13134 perf: allocate fixed GPU buffers at startup **← this PR** | [preproc-bounds-diagnostics → preproc-startup-capacity](https://github.com/mojomex/autoware_universe/compare/preproc-bounds-diagnostics...preproc-startup-capacity) |
| 3 | #13135 perf: avoid runtime thrust allocations | [preproc-startup-capacity → preproc-remove-runtime-thrust-allocs](https://github.com/mojomex/autoware_universe/compare/preproc-startup-capacity...preproc-remove-runtime-thrust-allocs) |
| 4 | #13136 refactor: clarify queue update flow | [preproc-remove-runtime-thrust-allocs → preproc-queue-update-cleanup](https://github.com/mojomex/autoware_universe/compare/preproc-remove-runtime-thrust-allocs...preproc-queue-update-cleanup) |
| 5 | #13137 test: cover capacity bounds behavior | [preproc-queue-update-cleanup → preproc-behavior-tests](https://github.com/mojomex/autoware_universe/compare/preproc-queue-update-cleanup...preproc-behavior-tests) |

Merge in stack order (1 → 5); each PR depends on the one below it. The whole stack is meant as one unit: tests are added at the top to keep the individual PRs small, so please review in stack order but test with the full stack applied (`preproc-behavior-tests`).

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `max_ring_count` | `integer` | `128` | Maximum number of LiDAR rings used for startup allocation of ring outlier filter CUDA buffers. |
| Added | `max_points_per_ring` | `integer` | `7200` | Maximum number of points per ring used for startup allocation of ring outlier filter CUDA buffers. |

Both defaults are taken from the beefiest sensor any of our users are using to the best of our knowledge (Hesai OT128 in dual-return high-resolution mode).

### Diagnostics Changes

#### Additions and removals

| Change type | DiagnosticStatus name | Diagnostic field / status | Level | Description |
|:------------|:----------------------|:--------------------------|:------|:------------|
| Added | Node fully-qualified name from `this->get_fully_qualified_name()` | `Ring organization overflow` | ERROR when true | Reports when the observed ring count or points per ring exceeds the configured startup allocation capacity. |

## Effects on system behavior

- CUDA pointcloud preprocessor working buffers are allocated from configured capacities during startup instead of growing dynamically during pointcloud processing.
- Ring or per-ring capacity overflow is reported through diagnostics instead of triggering runtime reallocation.
- Invalid non-positive capacity parameters fail during startup.

## Validation

Validated as part of the full stack with:

```bash
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF --packages-up-to autoware_cuda_pointcloud_preprocessor
```

The build passed on `sensing-bench`; stderr contained existing CMake/NVCC warnings from the mixed underlay.
