### PR TITLE
fix(autoware_pointcloud_preprocessor): fix azimuth_diff 1deg threshold math

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_node.cpp
@@ -154,7 +154,7 @@ void RingOutlierFilterComponent::faster_filter(
       if (
         std::max(current_distance, next_distance) <
           std::min(current_distance, next_distance) * distance_ratio_ &&
-        azimuth_diff < 1.0 * (180.0 / M_PI)) {  // one degree
+        azimuth_diff < 1.0 * (M_PI / 180.0)) {  // one degree
         continue;                               // Determined to be included in the same walk
       }
 


### PR DESCRIPTION
## Description

Fixes #13146.

`azimuth_diff` is in radians, and a `1deg` threshold was being converted incorrectly, leading to a `3283deg` threshold instead.

This brings us closer to behavior parity with `autoware_cuda_pointcloud_preprocessor`, but not quite: CUDA ring outlier filter has an upper bound on its run length (11 points, hard-coded) while the CPU version does not. So, as seen below, point counts are still not 1:1 the same :smiling_face_with_tear: 

## Related links

## How was this PR tested?

### Ran before (`/a/`) & after (`/b/`) fix side-by-side comparison 
Ran using [TIER IV INTERNAL](https://github.com/tier4/pa-tools). Reproduce: [TIER IV INTERNAL](https://drive.google.com/file/d/1cSFbxkT2VqFh2y5QWFmX2xx4ITXwyOC9/view?usp=sharing):

<img width="3840" height="2160" alt="Screenshot from 2026-08-04 18-54-46" src="https://github.com/user-attachments/assets/cfc6d22e-f1cd-4965-aaad-aa3b3d69908e" />

**~12k point difference.**

### Ran CUDA preprocessor (`/a/`) vs. fix (`/b/`) side-by-side comparison. 
Reproduce: [TIER IV INTERNAL](https://drive.google.com/file/d/1IZ_fe4sJGQjJXvTMDUX6kSXCvxjsW6Zd/view?usp=sharing):

<img width="3840" height="2160" alt="Screenshot from 2026-08-04 19-11-03" src="https://github.com/user-attachments/assets/f5ac6b27-dbb5-47d0-a64e-3bbb8dce9388" />

**700 point difference.**


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

CPU ring outlier filter now produces correct (to-spec) results.
