### PR TITLE
fix(autoware_carla_interface): stop dropping frames when the publish rate matches the sensor rate

### DIFF
--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/sensor_manager.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/sensor_manager.py
@@ -197,7 +197,13 @@ class SensorRegistry:
             return True
 
         time_diff = current_time - sensor.last_publish_time
-        return time_diff >= (1.0 / sensor.frequency_hz)
+        # A sensor producing at exactly the publish rate lands on time_diff
+        # values that fall a float rounding step short of the period, and
+        # those frames are dropped. The next frame then arrives a whole period
+        # late, so the sensor publishes at a fraction of the rate it was
+        # configured for. The tolerance is orders of magnitude below any
+        # simulation step, so it cannot let a genuinely early frame through.
+        return time_diff >= (1.0 / sensor.frequency_hz) - 1e-9
 
     def get_all_sensors(self) -> Dict[str, SensorConfig]:
         """


### PR DESCRIPTION
## Description

`SensorRegistry.should_publish` compared the elapsed time against the publication period exactly:

```python
time_diff = current_time - sensor.last_publish_time
return time_diff >= (1.0 / sensor.frequency_hz)
```

A sensor whose `sensor_tick` equals the configured publish period lands on `time_diff` values that fall a floating point rounding step short of that period. Those frames are dropped, and because `last_publish_time` is only advanced on a publication, the next frame arrives a whole period late. The sensor then publishes at a fraction of the rate it was configured for.

Counting publications over 200 source frames, with timestamps accumulated the way a simulation clock accumulates them:

| `fixed_delta_seconds` | `frequency_hz` | published before | published after |
| --------------------- | -------------- | ---------------- | --------------- |
| 0.05                  | 20             | 134              | 200             |
| 0.1                   | 10             | 134              | 200             |
| 0.02                  | 50             | 193              | 200             |
| 1/30                  | 30             | 115              | 200             |

The fix compares against the period less a tolerance of 1e-9 s, which is orders of magnitude below any simulation step and so cannot admit a genuinely early frame.

This may also be why `config/sensor_mapping.yaml` carries `frequency_hz: 11` for sensors that are not 11 Hz devices — setting the throttle above the sensor rate sidesteps the comparison. With this change the throttle can be set to the rate actually wanted.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

- The table above is from a standalone reproduction of `should_publish`'s arithmetic, run before and after the change.
- `isort`, `black` and `flake8-ros` pre-commit hooks pass on the changed file.
- Not run against a live CARLA server on this branch.

## Notes for reviewers

The tolerance is absolute rather than relative. At the frequencies this registry deals with (single digits to a few hundred Hz, so periods no smaller than milliseconds) 1e-9 s is at least six orders of magnitude below the period, so a relative epsilon would not behave differently.

## Interface changes

None.

## Effects on system behavior

Sensors configured with a publish rate equal to their production rate now publish every frame instead of a fraction of them. Any configuration where the publish rate was already above the sensor rate is unaffected.
