### PR TITLE
refactor(autoware_ptv3): replace voxelization hashing with serialized codes

### DIFF
--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -46,12 +46,44 @@ public:
   PreprocessCuda(const PTv3Config & config, cudaStream_t stream);
   ~PreprocessCuda();
 
+  /**
+   * @brief Crops, voxelizes and deduplicates the input cloud.
+   *
+   * The emitted voxels are sorted by their order-0 serialized code.
+   *
+   * @param input_data Input cloud in `input_format` layout.
+   * @param input_format Point layout of `input_data`.
+   * @param num_points Number of points in `input_data`.
+   * @param voxel_features Output feature vector (x, y, z, intensity) per voxel.
+   * @param voxel_coords Output grid coordinates, laid out [num_voxels, 3].
+   * @param serialized_code Output serialized codes, laid out [num_orders, num_voxels].
+   * @param compact_points Output representative input point per voxel, in `input_format` layout.
+   * @param reconstruction_features Optional output feature vectors of every input point (FULL
+   * reconstruction) or of the in-range ones (PARTIAL). Skipped if nullptr.
+   * @param cropped_source_points Optional output of the in-range input points, in `input_format`
+   * layout. Skipped if nullptr.
+   * @param inverse_map Optional output mapping each in-range point to its voxel index. Skipped if
+   * nullptr.
+   * @param num_cropped_points Output number of in-range points.
+   * @return Number of unique voxels. May exceed max_num_voxels, in which case only the first
+   * max_num_voxels voxels were written to the outputs.
+   */
   std::size_t generateFeatures(
     const void * input_data, CloudFormat input_format, unsigned int num_points,
-    float * voxel_features, std::int32_t * voxel_coords, std::int64_t * voxel_hashes,
+    float * voxel_features, std::int32_t * voxel_coords, std::int64_t * serialized_code,
     void * compact_points, float * reconstruction_features, void * cropped_source_points,
     std::int64_t * inverse_map, std::size_t * num_cropped_points);
 
+  /**
+   * @brief Builds the per-stage pooling metadata the encoder graph consumes.
+   *
+   * @param grid_coord Grid coordinates of the input voxels, laid out [num_voxels, 3].
+   * @param serialized_code Codes of the input voxels, laid out [num_orders, num_voxels].
+   * @param num_voxels Number of input voxels.
+   * @param stages Output device buffers to fill, one per pooling stage.
+   * @param stage_counts Output voxel count per level, laid out [num_stages + 1]; entry 0 is the
+   * input count.
+   */
   void generateSerializedPoolingMetadata(
     const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
     const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts);
@@ -69,28 +101,21 @@ private:
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> crop_mask_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> crop_indices_d_{nullptr};
 
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> hashes64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> sorted_hashes64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> hash_indexes64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> sorted_hash_indexes64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> unique_mask64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> unique_indices64_d_{nullptr};
-
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> hashes32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> sorted_hashes32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> hash_indexes32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> sorted_hash_indexes32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> unique_mask32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> unique_indices32_d_{nullptr};
+  // Voxelization keys: order-0 serialized (Morton) codes, unique per grid cell, so sorting by them
+  // both deduplicates voxels and puts them in order-0 serialization order.
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> codes_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> sorted_codes_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> code_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> sorted_code_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> unique_mask_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> unique_indices_d_{nullptr};
 
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> generate_feature_workspace_d_{nullptr};
   std::size_t generate_feature_workspace_size_{0};
   autoware::cuda_utils::CudaUniquePtrHost<std::uint32_t> num_cropped_points_;
-  autoware::cuda_utils::CudaUniquePtrHost<std::uint32_t> num_unique_points32_;
-  autoware::cuda_utils::CudaUniquePtrHost<std::uint64_t> num_unique_points64_;
+  autoware::cuda_utils::CudaUniquePtrHost<std::uint32_t> num_unique_points_;
   cudaEvent_t num_cropped_points_copy_event_;
-  cudaEvent_t num_unique_points32_copy_event_;
-  cudaEvent_t num_unique_points64_copy_event_;
+  cudaEvent_t num_unique_points_copy_event_;
 
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_keys_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_keys_d_{nullptr};
@@ -100,6 +125,7 @@ private:
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_ids_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> pooling_workspace_d_{nullptr};
   std::size_t pooling_workspace_size_{0};
+  int code_sort_end_bit_{64};
 };
 }  // namespace autoware::ptv3
 

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -46,12 +46,22 @@ public:
   PreprocessCuda(const PTv3Config & config, cudaStream_t stream);
   ~PreprocessCuda();
 
+  // Crops, voxelizes and deduplicates the input cloud. The emitted voxels are ordered by their
+  // order-0 serialized code, which generateSerializedPoolingMetadata requires (see below).
   std::size_t generateFeatures(
     const void * input_data, CloudFormat input_format, unsigned int num_points,
     float * voxel_features, std::int32_t * voxel_coords, std::int64_t * voxel_hashes,
     void * compact_points, float * reconstruction_features, void * cropped_source_points,
     std::int64_t * inverse_map, std::size_t * num_cropped_points);
 
+  // Builds the per-stage pooling metadata the encoder graph consumes.
+  //
+  // PRECONDITION: `serialized_code` row 0 must be ascending, i.e. the voxels must be stored in
+  // order-0 serialization order. generateFeatures guarantees this. The whole hierarchy is then
+  // derived with prefix scans instead of sorts: right-shifting a serialized code yields its
+  // parent's code, which is monotone, so pooling preserves the ordering and every coarser level
+  // stays sorted by construction. Feeding an arbitrarily ordered level here silently produces wrong
+  // metadata.
   void generateSerializedPoolingMetadata(
     const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
     const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts);
@@ -69,37 +79,35 @@ private:
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> crop_mask_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> crop_indices_d_{nullptr};
 
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> hashes64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> sorted_hashes64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> hash_indexes64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> sorted_hash_indexes64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> unique_mask64_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint64_t[]> unique_indices64_d_{nullptr};
-
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> hashes32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> sorted_hashes32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> hash_indexes32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> sorted_hash_indexes32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> unique_mask32_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> unique_indices32_d_{nullptr};
+  // Voxelization keys are order-0 serialized (Morton) codes, not hashes: they are an injective
+  // function of the grid coordinate, so sorting by them both deduplicates voxels and leaves the
+  // voxel array in order-0 serialization order (see generateFeatures).
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> codes_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> sorted_codes_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> code_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> sorted_code_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> unique_mask_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> unique_indices_d_{nullptr};
 
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> generate_feature_workspace_d_{nullptr};
   std::size_t generate_feature_workspace_size_{0};
   autoware::cuda_utils::CudaUniquePtrHost<std::uint32_t> num_cropped_points_;
-  autoware::cuda_utils::CudaUniquePtrHost<std::uint32_t> num_unique_points32_;
-  autoware::cuda_utils::CudaUniquePtrHost<std::uint64_t> num_unique_points64_;
+  autoware::cuda_utils::CudaUniquePtrHost<std::uint32_t> num_unique_points_;
   cudaEvent_t num_cropped_points_copy_event_;
-  cudaEvent_t num_unique_points32_copy_event_;
-  cudaEvent_t num_unique_points64_copy_event_;
+  cudaEvent_t num_unique_points_copy_event_;
 
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_keys_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_keys_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_indices_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_indices_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_flags_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_ids_d_{nullptr};
+  // Level-0 serialization order, laid out [num_orders, num_voxels]. Row 0 is the identity because
+  // generateFeatures already sorted the voxels by their order-0 code; the remaining rows are the
+  // only genuine sorts left in the pooling-metadata path.
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> level0_order_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_sorted_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_flags_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_ids_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> pooling_workspace_d_{nullptr};
   std::size_t pooling_workspace_size_{0};
+  int code_sort_end_bit_{64};
 };
 }  // namespace autoware::ptv3
 

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -56,12 +56,9 @@ public:
 
   // Builds the per-stage pooling metadata the encoder graph consumes.
   //
-  // PRECONDITION: `serialized_code` row 0 must be ascending, i.e. the voxels must be stored in
-  // order-0 serialization order. generateFeatures guarantees this. The whole hierarchy is then
-  // derived with prefix scans instead of sorts: right-shifting a serialized code yields its
-  // parent's code, which is monotone, so pooling preserves the ordering and every coarser level
-  // stays sorted by construction. Feeding an arbitrarily ordered level here silently produces wrong
-  // metadata.
+  // PRECONDITION: the voxels must be sorted by their order-0 serialized code, as generateFeatures
+  // emits them. The coarser levels are derived with prefix scans that rely on this ordering; an
+  // unsorted input silently produces wrong metadata.
   void generateSerializedPoolingMetadata(
     const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
     const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts);
@@ -79,9 +76,8 @@ private:
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> crop_mask_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> crop_indices_d_{nullptr};
 
-  // Voxelization keys are order-0 serialized (Morton) codes, not hashes: they are an injective
-  // function of the grid coordinate, so sorting by them both deduplicates voxels and leaves the
-  // voxel array in order-0 serialization order (see generateFeatures).
+  // Voxelization keys: order-0 serialized (Morton) codes, unique per grid cell, so sorting by them
+  // both deduplicates voxels and puts them in order-0 serialization order.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> codes_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> sorted_codes_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint32_t[]> code_indices_d_{nullptr};
@@ -96,9 +92,8 @@ private:
   cudaEvent_t num_cropped_points_copy_event_;
   cudaEvent_t num_unique_points_copy_event_;
 
-  // Level-0 serialization order, laid out [num_orders, num_voxels]. Row 0 is the identity because
-  // generateFeatures already sorted the voxels by their order-0 code; the remaining rows are the
-  // only genuine sorts left in the pooling-metadata path.
+  // Level-0 serialization order, laid out [num_orders, num_voxels]. Row 0 is the identity; the
+  // remaining rows are the only sorts left in the pooling-metadata path.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> level0_order_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_keys_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_sorted_keys_d_{nullptr};

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -21,7 +21,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -104,9 +103,6 @@ public:
     if (serialization_depth_ * 3 + max_voxels_depth >= 64) {
       throw std::runtime_error("Serialization depth is too large");
     }
-
-    use_64bit_hash_ =
-      grid_x_size_ * grid_y_size_ * grid_z_size_ > std::numeric_limits<std::uint32_t>::max();
 
     serialization_orders_ = validate_serialization_orders(serialization_orders);
     pooling_strides_ = validate_pooling_strides(pooling_strides);
@@ -379,7 +375,6 @@ public:
   bool use_det3d_head_;
 
   // Preprocess parameters
-  bool use_64bit_hash_{};
   std::int32_t serialization_depth_{};
 
   ///// NETWORK PARAMETERS /////

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -95,9 +95,26 @@ public:
     grid_x_size_ = grid_cells(min_x_range_, max_x_range_, voxel_x_size_);
     grid_y_size_ = grid_cells(min_y_range_, max_y_range_, voxel_y_size_);
     grid_z_size_ = grid_cells(min_z_range_, max_z_range_, voxel_z_size_);
-    auto max_grid_size = std::max({grid_x_size_, grid_y_size_, grid_z_size_});
+
+    // The serialization depth must cover every coordinate the device-side grid mapping
+    // (floor(p / size) - floor(min_range / size), see gridCoord) can emit. That is one more than
+    // the rounded cell count above when a range boundary is not voxel-aligned: [0.5, 16.5) with
+    // unit voxels emits 0..16. Sizing the depth from the rounded count would then drop the extra
+    // coordinate's top Morton bit and silently merge its voxels with coordinate 0's. The largest
+    // coordinate is attained at the largest float below max_range, since the crop accepts
+    // min_range <= p < max_range and float division is monotonic.
+    const auto effective_grid_cells =
+      [](const float min_range, const float max_range, const float size) {
+        const float min_coord = std::floor(min_range / size);
+        const float max_coord = std::floor(std::nextafter(max_range, min_range) / size);
+        return static_cast<std::int64_t>(max_coord - min_coord) + 1;
+      };
+    const auto max_effective_cells = std::max(
+      {effective_grid_cells(min_x_range_, max_x_range_, voxel_x_size_),
+       effective_grid_cells(min_y_range_, max_y_range_, voxel_y_size_),
+       effective_grid_cells(min_z_range_, max_z_range_, voxel_z_size_)});
     serialization_depth_ =
-      static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_grid_size))));
+      static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_effective_cells))));
     auto max_voxels_depth =
       static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_num_voxels_))));
     if (serialization_depth_ * 3 + max_voxels_depth >= 64) {

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -96,23 +96,25 @@ public:
     grid_y_size_ = grid_cells(min_y_range_, max_y_range_, voxel_y_size_);
     grid_z_size_ = grid_cells(min_z_range_, max_z_range_, voxel_z_size_);
 
-    // The serialization depth must cover every coordinate the device-side grid mapping
-    // (floor(p / size) - floor(min_range / size), see gridCoord) can emit. That is one more than
-    // the rounded cell count above when a range boundary is not voxel-aligned: [0.5, 16.5) with
-    // unit voxels emits 0..16. Sizing the depth from the rounded count would then drop the extra
-    // coordinate's top Morton bit and silently merge its voxels with coordinate 0's. The largest
-    // coordinate is attained at the largest float below max_range, since the crop accepts
-    // min_range <= p < max_range and float division is monotonic.
+    // The serialization depth and the per-stage voxel capacities must cover every coordinate the
+    // device-side grid mapping (floor(p / size) - floor(min_range / size), see gridCoord) can
+    // emit. That is one more than the rounded cell count above when a range boundary is not
+    // voxel-aligned: [0.5, 16.5) with unit voxels emits 0..16. Sizing the depth from the rounded
+    // count would then drop the extra coordinate's top Morton bit and silently merge its voxels
+    // with coordinate 0's. The largest coordinate is attained at the largest float below
+    // max_range, since the crop accepts min_range <= p < max_range and float division is
+    // monotonic.
     const auto effective_grid_cells =
       [](const float min_range, const float max_range, const float size) {
         const float min_coord = std::floor(min_range / size);
         const float max_coord = std::floor(std::nextafter(max_range, min_range) / size);
         return static_cast<std::int64_t>(max_coord - min_coord) + 1;
       };
-    const auto max_effective_cells = std::max(
-      {effective_grid_cells(min_x_range_, max_x_range_, voxel_x_size_),
-       effective_grid_cells(min_y_range_, max_y_range_, voxel_y_size_),
-       effective_grid_cells(min_z_range_, max_z_range_, voxel_z_size_)});
+    effective_grid_x_size_ = effective_grid_cells(min_x_range_, max_x_range_, voxel_x_size_);
+    effective_grid_y_size_ = effective_grid_cells(min_y_range_, max_y_range_, voxel_y_size_);
+    effective_grid_z_size_ = effective_grid_cells(min_z_range_, max_z_range_, voxel_z_size_);
+    const auto max_effective_cells =
+      std::max({effective_grid_x_size_, effective_grid_y_size_, effective_grid_z_size_});
     serialization_depth_ =
       static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_effective_cells))));
     auto max_voxels_depth =
@@ -364,7 +366,10 @@ public:
 
   // Hard geometric voxel-count bound for one encoder stage: a stage cannot hold more voxels
   // than the sparse grid has cells at its cumulative pooling depth, and pooling never grows
-  // the voxel count, so min(max_num_voxels_, grid cells) is safe for any input.
+  // the voxel count, so min(max_num_voxels_, grid cells) is safe for any input. The cell counts
+  // must be the effective ones (the coordinates the grid mapping can actually emit, see the
+  // constructor); the rounded counts fall one cell per unaligned axis short, and this bound sizes
+  // the encoder stage buffers and TensorRT profiles.
   [[nodiscard]] std::int64_t stage_voxel_capacity(const std::size_t stage_index) const
   {
     std::int64_t cumulative_depth = 0;
@@ -376,8 +381,8 @@ public:
     const auto ceil_shift = [cumulative_depth](const std::int64_t size) {
       return (size + (std::int64_t{1} << cumulative_depth) - 1) >> cumulative_depth;
     };
-    const auto grid_cells =
-      ceil_shift(grid_x_size_) * ceil_shift(grid_y_size_) * ceil_shift(grid_z_size_);
+    const auto grid_cells = ceil_shift(effective_grid_x_size_) *
+                            ceil_shift(effective_grid_y_size_) * ceil_shift(effective_grid_z_size_);
     return std::min(max_num_voxels_, grid_cells);
   }
 
@@ -442,10 +447,17 @@ public:
   float voxel_y_size_{};
   float voxel_z_size_{};
 
-  // Grid size
+  // Grid size (rounded from the range extents)
   std::int64_t grid_x_size_{};
   std::int64_t grid_y_size_{};
   std::int64_t grid_z_size_{};
+
+  // Cell counts the device grid mapping can actually emit: one more than grid_*_size_ on each
+  // axis whose range boundary is not voxel-aligned. Size serialization_depth_ and the per-stage
+  // voxel capacities.
+  std::int64_t effective_grid_x_size_{};
+  std::int64_t effective_grid_y_size_{};
+  std::int64_t effective_grid_z_size_{};
 
   ///// RUNTIME DIMENSIONS /////
   std::array<std::int64_t, 3> voxels_num_{};

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -89,34 +89,20 @@ public:
       voxel_z_size_ = voxel_size[2];
     }
 
+    // Cells the device grid mapping (see gridCoord) can emit per axis - one more than
+    // round(extent / size) when a range border is not voxel-aligned. The largest coordinate comes
+    // from the largest float below max_range: the crop is strict and float division is monotonic.
     const auto grid_cells = [](const float min_range, const float max_range, const float size) {
-      return static_cast<std::int64_t>(std::round((max_range - min_range) / size));
+      const float min_coord = std::floor(min_range / size);
+      const float max_coord = std::floor(std::nextafter(max_range, min_range) / size);
+      return static_cast<std::int64_t>(max_coord - min_coord) + 1;
     };
     grid_x_size_ = grid_cells(min_x_range_, max_x_range_, voxel_x_size_);
     grid_y_size_ = grid_cells(min_y_range_, max_y_range_, voxel_y_size_);
     grid_z_size_ = grid_cells(min_z_range_, max_z_range_, voxel_z_size_);
-
-    // The serialization depth and the per-stage voxel capacities must cover every coordinate the
-    // device-side grid mapping (floor(p / size) - floor(min_range / size), see gridCoord) can
-    // emit. That is one more than the rounded cell count above when a range boundary is not
-    // voxel-aligned: [0.5, 16.5) with unit voxels emits 0..16. Sizing the depth from the rounded
-    // count would then drop the extra coordinate's top Morton bit and silently merge its voxels
-    // with coordinate 0's. The largest coordinate is attained at the largest float below
-    // max_range, since the crop accepts min_range <= p < max_range and float division is
-    // monotonic.
-    const auto effective_grid_cells =
-      [](const float min_range, const float max_range, const float size) {
-        const float min_coord = std::floor(min_range / size);
-        const float max_coord = std::floor(std::nextafter(max_range, min_range) / size);
-        return static_cast<std::int64_t>(max_coord - min_coord) + 1;
-      };
-    effective_grid_x_size_ = effective_grid_cells(min_x_range_, max_x_range_, voxel_x_size_);
-    effective_grid_y_size_ = effective_grid_cells(min_y_range_, max_y_range_, voxel_y_size_);
-    effective_grid_z_size_ = effective_grid_cells(min_z_range_, max_z_range_, voxel_z_size_);
-    const auto max_effective_cells =
-      std::max({effective_grid_x_size_, effective_grid_y_size_, effective_grid_z_size_});
+    const auto max_grid_size = std::max({grid_x_size_, grid_y_size_, grid_z_size_});
     serialization_depth_ =
-      static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_effective_cells))));
+      static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_grid_size))));
     auto max_voxels_depth =
       static_cast<std::int32_t>(std::ceil(std::log2(static_cast<float>(max_num_voxels_))));
     if (serialization_depth_ * 3 + max_voxels_depth >= 64) {
@@ -364,12 +350,9 @@ public:
     return enc_channels;
   }
 
-  // Hard geometric voxel-count bound for one encoder stage: a stage cannot hold more voxels
-  // than the sparse grid has cells at its cumulative pooling depth, and pooling never grows
-  // the voxel count, so min(max_num_voxels_, grid cells) is safe for any input. The cell counts
-  // must be the effective ones (the coordinates the grid mapping can actually emit, see the
-  // constructor); the rounded counts fall one cell per unaligned axis short, and this bound sizes
-  // the encoder stage buffers and TensorRT profiles.
+  // Hard voxel-count bound for one encoder stage: a stage cannot hold more voxels than the grid
+  // has cells at its cumulative pooling depth, and pooling never grows the voxel count. Sizes the
+  // encoder stage buffers and TensorRT profiles.
   [[nodiscard]] std::int64_t stage_voxel_capacity(const std::size_t stage_index) const
   {
     std::int64_t cumulative_depth = 0;
@@ -381,8 +364,8 @@ public:
     const auto ceil_shift = [cumulative_depth](const std::int64_t size) {
       return (size + (std::int64_t{1} << cumulative_depth) - 1) >> cumulative_depth;
     };
-    const auto grid_cells = ceil_shift(effective_grid_x_size_) *
-                            ceil_shift(effective_grid_y_size_) * ceil_shift(effective_grid_z_size_);
+    const auto grid_cells =
+      ceil_shift(grid_x_size_) * ceil_shift(grid_y_size_) * ceil_shift(grid_z_size_);
     return std::min(max_num_voxels_, grid_cells);
   }
 
@@ -447,17 +430,10 @@ public:
   float voxel_y_size_{};
   float voxel_z_size_{};
 
-  // Grid size (rounded from the range extents)
+  // Grid size (cells the device grid mapping can emit, see the constructor)
   std::int64_t grid_x_size_{};
   std::int64_t grid_y_size_{};
   std::int64_t grid_z_size_{};
-
-  // Cell counts the device grid mapping can actually emit: one more than grid_*_size_ on each
-  // axis whose range boundary is not voxel-aligned. Size serialization_depth_ and the per-stage
-  // voxel capacities.
-  std::int64_t effective_grid_x_size_{};
-  std::int64_t effective_grid_y_size_{};
-  std::int64_t effective_grid_z_size_{};
 
   ///// RUNTIME DIMENSIONS /////
   std::array<std::int64_t, 3> voxels_num_{};

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -56,37 +56,24 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   auto policy = thrust::cuda::par.on(stream_);
 
-  if (config_.use_64bit_hash_) {
-    hashes64_d_ = autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    sorted_hashes64_d_ =
-      autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    hash_indexes64_d_ = autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    sorted_hash_indexes64_d_ =
-      autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    unique_mask64_d_ = autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    unique_indices64_d_ =
-      autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
+  codes_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.cloud_capacity_);
+  sorted_codes_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.cloud_capacity_);
+  code_indices_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
+  sorted_code_indices_d_ =
+    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
+  unique_mask_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
+  unique_indices_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
 
-    thrust::device_ptr<std::uint64_t> idx_ptr(hash_indexes64_d_.get());
+  thrust::device_ptr<std::uint32_t> idx_ptr(code_indices_d_.get());
+  thrust::sequence(policy, idx_ptr, idx_ptr + config_.cloud_capacity_, 0);
 
-    thrust::sequence(policy, idx_ptr, idx_ptr + config_.cloud_capacity_, 0);
-  } else {
-    hashes32_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    sorted_hashes32_d_ =
-      autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    hash_indexes32_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    sorted_hash_indexes32_d_ =
-      autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    unique_mask32_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    unique_indices32_d_ =
-      autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
+  // Serialized codes occupy 3 * serialization_depth_ bits. std::max guards
+  // serialization_depth_ == 0 (CUB requires end_bit > begin_bit). The workspace query below uses
+  // the full 64 bits, which upper-bounds the scratch needed for any narrower range.
+  code_sort_end_bit_ = std::max(1, 3 * config_.serialization_depth_);
 
-    thrust::device_ptr<std::uint32_t> idx_ptr(hash_indexes32_d_.get());
-
-    thrust::sequence(policy, idx_ptr, idx_ptr + config_.cloud_capacity_, 0);
-  }
-
-  std::uint64_t * uint64_nullptr = nullptr;
+  std::int64_t * int64_nullptr = nullptr;
+  std::uint32_t * uint32_nullptr = nullptr;
 
   std::size_t sort_pair_workspace_size = 0;
   std::size_t inclusive_sum_workspace_size = 0;
@@ -94,15 +81,15 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   CHECK_CUDA_ERROR(
     cub::DeviceRadixSort::SortPairs(
-      nullptr, sort_pair_workspace_size, uint64_nullptr, uint64_nullptr, uint64_nullptr,
-      uint64_nullptr, config_.cloud_capacity_, 0, 64, nullptr));
+      nullptr, sort_pair_workspace_size, int64_nullptr, int64_nullptr, uint32_nullptr,
+      uint32_nullptr, config_.cloud_capacity_, 0, 64, nullptr));
   CHECK_CUDA_ERROR(
     cub::DeviceScan::InclusiveSum(
-      nullptr, inclusive_sum_workspace_size, uint64_nullptr, uint64_nullptr,
+      nullptr, inclusive_sum_workspace_size, uint32_nullptr, uint32_nullptr,
       config_.cloud_capacity_));
   CHECK_CUDA_ERROR(
     cub::DeviceAdjacentDifference::SubtractLeftCopy(
-      nullptr, adjacent_difference_workspace_size, uint64_nullptr, uint64_nullptr,
+      nullptr, adjacent_difference_workspace_size, int64_nullptr, uint32_nullptr,
       config_.cloud_capacity_, NotEqual{}));
 
   generate_feature_workspace_size_ = std::max(
@@ -111,8 +98,7 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
     autoware::cuda_utils::make_unique<std::uint8_t[]>(generate_feature_workspace_size_);
 
   num_cropped_points_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
-  num_unique_points32_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
-  num_unique_points64_ = autoware::cuda_utils::make_unique_host<std::uint64_t>();
+  num_unique_points_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
 
   pooling_keys_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
   pooling_sorted_keys_d_ =
@@ -125,7 +111,6 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   std::size_t pooling_sort_workspace_size = 0;
   std::size_t pooling_scan_workspace_size = 0;
-  std::int64_t * int64_nullptr = nullptr;
   cub::DeviceRadixSort::SortPairs(
     nullptr, pooling_sort_workspace_size, int64_nullptr, int64_nullptr, int64_nullptr,
     int64_nullptr, config_.max_num_voxels_, 0, 63, nullptr);
@@ -138,9 +123,7 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
   CHECK_CUDA_ERROR(
     cudaEventCreateWithFlags(&num_cropped_points_copy_event_, cudaEventDisableTiming));
   CHECK_CUDA_ERROR(
-    cudaEventCreateWithFlags(&num_unique_points32_copy_event_, cudaEventDisableTiming));
-  CHECK_CUDA_ERROR(
-    cudaEventCreateWithFlags(&num_unique_points64_copy_event_, cudaEventDisableTiming));
+    cudaEventCreateWithFlags(&num_unique_points_copy_event_, cudaEventDisableTiming));
 
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 }
@@ -150,11 +133,8 @@ PreprocessCuda::~PreprocessCuda()
   if (num_cropped_points_copy_event_) {
     cudaEventDestroy(num_cropped_points_copy_event_);
   }
-  if (num_unique_points32_copy_event_) {
-    cudaEventDestroy(num_unique_points32_copy_event_);
-  }
-  if (num_unique_points64_copy_event_) {
-    cudaEventDestroy(num_unique_points64_copy_event_);
+  if (num_unique_points_copy_event_) {
+    cudaEventDestroy(num_unique_points_copy_event_);
   }
 }
 
@@ -258,7 +238,7 @@ __global__ void extractIndicesKernel(
 
 template <typename mask_t>
 __global__ void scatterInverseMapKernel(
-  const mask_t * __restrict__ unique_indices, const mask_t * __restrict__ sorted_hash_indexes,
+  const mask_t * __restrict__ unique_indices, const mask_t * __restrict__ sorted_code_indices,
   std::int64_t * __restrict__ inverse_map, int num_points)
 {
   const auto idx = static_cast<std::uint32_t>(blockIdx.x * blockDim.x + threadIdx.x);
@@ -266,60 +246,99 @@ __global__ void scatterInverseMapKernel(
     return;
   }
 
-  inverse_map[sorted_hash_indexes[idx]] = static_cast<std::int64_t>(unique_indices[idx] - 1);
+  inverse_map[sorted_code_indices[idx]] = static_cast<std::int64_t>(unique_indices[idx] - 1);
 }
 
-__global__ void voxelizationHash64Kernel(
-  const float4 * __restrict__ points, std::uint64_t * __restrict__ hashes, int num_points,
+/**
+ * @brief Interleaves the three grid coordinates into a serialized (Morton / Z-order) code,
+ * `depth` bits per axis.
+ *
+ * The bit layout must match autoware-ml's z_order_encode, which the model was trained against.
+ *
+ * @param x Grid coordinate on the x axis.
+ * @param y Grid coordinate on the y axis.
+ * @param z Grid coordinate on the z axis.
+ * @param depth Number of bits consumed per axis.
+ * @param transposed Swap x and y ("z-trans" order).
+ * @return The serialized code.
+ */
+__device__ inline std::int64_t serializeCoord(
+  const std::int32_t x, const std::int32_t y, const std::int32_t z, const int depth,
+  const bool transposed)
+{
+  const std::int32_t major = transposed ? y : x;
+  const std::int32_t minor = transposed ? x : y;
+
+  std::int64_t code = 0;
+  for (int i = 0; i < depth; ++i) {
+    const std::int64_t mask = 1 << i;
+    code |= ((major & mask) << (2 * i + 2));
+    code |= ((minor & mask) << (2 * i + 1));
+    code |= ((z & mask) << (2 * i + 0));
+  }
+  return code;
+}
+
+/**
+ * @brief Maps a point to its grid coordinate. Single helper so the voxelization key and the
+ * serialization codes always place a point in the same cell.
+ *
+ * @param point Point position; only x, y and z are read.
+ * @param voxel_size_x Voxel edge length on the x axis.
+ * @param voxel_size_y Voxel edge length on the y axis.
+ * @param voxel_size_z Voxel edge length on the z axis.
+ * @param min_x Grid origin on the x axis, in cells.
+ * @param min_y Grid origin on the y axis, in cells.
+ * @param min_z Grid origin on the z axis, in cells.
+ * @return The grid coordinate.
+ */
+__device__ inline int3 gridCoord(
+  const float4 & point, const float voxel_size_x, const float voxel_size_y,
+  const float voxel_size_z, const std::int32_t min_x, const std::int32_t min_y,
+  const std::int32_t min_z)
+{
+  return make_int3(
+    static_cast<std::int32_t>(std::floor(point.x / voxel_size_x) - min_x),
+    static_cast<std::int32_t>(std::floor(point.y / voxel_size_y) - min_y),
+    static_cast<std::int32_t>(std::floor(point.z / voxel_size_z) - min_z));
+}
+
+/**
+ * @brief Produces the voxelization key: the order-0 serialized code.
+ *
+ * The code is unique per grid cell, so sorting by it deduplicates voxels and leaves them in
+ * order-0 serialization order.
+ *
+ * @param points Input points.
+ * @param codes Output code per point.
+ * @param num_points Number of points.
+ * @param voxel_size_x Voxel edge length on the x axis.
+ * @param voxel_size_y Voxel edge length on the y axis.
+ * @param voxel_size_z Voxel edge length on the z axis.
+ * @param min_x Grid origin on the x axis, in cells.
+ * @param min_y Grid origin on the y axis, in cells.
+ * @param min_z Grid origin on the z axis, in cells.
+ * @param depth Serialization depth: bits per axis in the code.
+ */
+__global__ void voxelizationCodeKernel(
+  const float4 * __restrict__ points, std::int64_t * __restrict__ codes, int num_points,
   float voxel_size_x, float voxel_size_y, float voxel_size_z, std::int32_t min_x,
-  std::int32_t min_y, std::int32_t min_z)
-{
-  // FNV64-1A
-  auto idx = static_cast<std::uint32_t>(blockIdx.x * blockDim.x + threadIdx.x);
-  if (idx >= num_points) {
-    return;
-  }
-
-  const float4 & point = points[idx];
-  const auto x = static_cast<std::int32_t>(std::floor(point.x / voxel_size_x));
-  const auto y = static_cast<std::int32_t>(std::floor(point.y / voxel_size_y));
-  const auto z = static_cast<std::int32_t>(std::floor(point.z / voxel_size_z));
-
-  std::uint64_t hash = 14695981039346656037ULL;
-  hash *= 1099511628211ULL;
-  hash ^= static_cast<std::uint64_t>(x - min_x);
-  hash *= 1099511628211ULL;
-  hash ^= static_cast<std::uint64_t>(y - min_y);
-  hash *= 1099511628211ULL;
-  hash ^= static_cast<std::uint64_t>(z - min_z);
-
-  hashes[idx] = hash;
-}
-
-__global__ void voxelizationHash32Kernel(
-  const float4 * __restrict__ points, std::uint32_t * __restrict__ hashes, int num_points,
-  float voxel_size_x, float voxel_size_y, float voxel_size_z, float min_x, float min_y, float min_z,
-  std::uint32_t grid_x_size, std::uint32_t grid_xy_size)
+  std::int32_t min_y, std::int32_t min_z, int depth)
 {
   auto idx = static_cast<std::uint32_t>(blockIdx.x * blockDim.x + threadIdx.x);
   if (idx >= num_points) {
     return;
   }
 
-  const float4 & point = points[idx];
-  const std::uint32_t x =
-    static_cast<std::uint32_t>(std::max<float>((point.x - min_x) / voxel_size_x, 0.f));
-  const std::uint32_t y =
-    static_cast<std::uint32_t>(std::max<float>((point.y - min_y) / voxel_size_y, 0.f));
-  const std::uint32_t z =
-    static_cast<std::uint32_t>(std::max<float>((point.z - min_z) / voxel_size_z, 0.f));
-  hashes[idx] = z * grid_xy_size + y * grid_x_size + x;
+  const auto coord =
+    gridCoord(points[idx], voxel_size_x, voxel_size_y, voxel_size_z, min_x, min_y, min_z);
+  codes[idx] = serializeCoord(coord.x, coord.y, coord.z, depth, false);
 }
 
 __global__ void computeGridCoordsAndSerializationKernel(
-  const float4 * __restrict__ points, int3 * __restrict__ coords,
-  std::int64_t * __restrict__ hashes, int num_points, float voxel_size_x, float voxel_size_y,
-  float voxel_size_z, std::int32_t min_x, std::int32_t min_y, std::int32_t min_z, int depth)
+  const float4 * __restrict__ points, int3 * __restrict__ coords, std::int64_t * __restrict__ codes,
+  int num_points, float voxel_size_x, float voxel_size_y, float voxel_size_z, std::int32_t min_x,
+  std::int32_t min_y, std::int32_t min_z, int depth)
 {
   static_assert(sizeof(int3) == sizeof(std::int32_t) * 3, "int3 must be 12 bytes");
   auto idx = static_cast<std::uint32_t>(blockIdx.x * blockDim.x + threadIdx.x);
@@ -327,29 +346,12 @@ __global__ void computeGridCoordsAndSerializationKernel(
     return;
   }
 
-  const float4 & point = points[idx];
-  const auto x = static_cast<std::int32_t>(std::floor(point.x / voxel_size_x) - min_x);
-  const auto y = static_cast<std::int32_t>(std::floor(point.y / voxel_size_y) - min_y);
-  const auto z = static_cast<std::int32_t>(std::floor(point.z / voxel_size_z) - min_z);
+  const auto coord =
+    gridCoord(points[idx], voxel_size_x, voxel_size_y, voxel_size_z, min_x, min_y, min_z);
+  coords[idx] = coord;
 
-  coords[idx] = make_int3(x, y, z);
-
-  std::int64_t key1 = 0;
-  std::int64_t key2 = 0;
-
-  for (int i = 0; i < depth; ++i) {
-    std::int64_t mask = 1 << i;
-    key1 |= ((x & mask) << (2 * i + 2));
-    key1 |= ((y & mask) << (2 * i + 1));
-    key1 |= ((z & mask) << (2 * i + 0));
-
-    key2 |= ((y & mask) << (2 * i + 2));
-    key2 |= ((x & mask) << (2 * i + 1));
-    key2 |= ((z & mask) << (2 * i + 0));
-  }
-
-  hashes[idx] = key1;
-  hashes[idx + num_points] = key2;
+  codes[idx] = serializeCoord(coord.x, coord.y, coord.z, depth, false);
+  codes[idx + num_points] = serializeCoord(coord.x, coord.y, coord.z, depth, true);
 }
 
 constexpr std::int64_t kInvalidPoolingKey = std::numeric_limits<std::int64_t>::max();
@@ -570,7 +572,7 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
 
 std::size_t PreprocessCuda::generateFeatures(
   const void * input_data, CloudFormat input_format, unsigned int num_points,
-  float * voxel_features, std::int32_t * voxel_coords, std::int64_t * voxel_hashes,
+  float * voxel_features, std::int32_t * voxel_coords, std::int64_t * serialized_code,
   void * compact_points, float * reconstruction_features, void * cropped_source_points,
   std::int64_t * inverse_map, std::size_t * output_num_cropped_points)
 {
@@ -711,179 +713,91 @@ std::size_t PreprocessCuda::generateFeatures(
 
   const auto num_cropped_blocks = divup(*num_cropped_points_, config_.threads_per_block_);
 
-  std::uint64_t num_unique_points;
+  voxelizationCodeKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+    reinterpret_cast<float4 *>(cropped_points_d_.get()), codes_d_.get(), *num_cropped_points_,
+    config_.voxel_x_size_, config_.voxel_y_size_, config_.voxel_z_size_, coord_min_x, coord_min_y,
+    coord_min_z, config_.serialization_depth_);
 
-  if (config_.use_64bit_hash_) {
-    voxelizationHash64Kernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-      reinterpret_cast<float4 *>(cropped_points_d_.get()), hashes64_d_.get(), *num_cropped_points_,
-      config_.voxel_x_size_, config_.voxel_y_size_, config_.voxel_z_size_, coord_min_x, coord_min_y,
-      coord_min_z);
+  // This sort both groups duplicates for the compaction below and leaves the voxels in order-0
+  // serialization order.
+  CHECK_CUDA_ERROR(
+    cub::DeviceRadixSort::SortPairs(
+      reinterpret_cast<void *>(generate_feature_workspace_d_.get()),
+      generate_feature_workspace_size_, codes_d_.get(), sorted_codes_d_.get(),
+      code_indices_d_.get(), sorted_code_indices_d_.get(), *num_cropped_points_, 0,
+      code_sort_end_bit_, stream_));
 
-    // Keys are FNV-1a hashes spread pseudo-randomly across the full 64-bit range, so there is no
-    // usable upper bound below 2^64; sort all 64 bits.
-    CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        reinterpret_cast<void *>(generate_feature_workspace_d_.get()),
-        generate_feature_workspace_size_, hashes64_d_.get(), sorted_hashes64_d_.get(),
-        hash_indexes64_d_.get(), sorted_hash_indexes64_d_.get(), *num_cropped_points_, 0, 64,
-        stream_));
+  CHECK_CUDA_ERROR(
+    cub::DeviceAdjacentDifference::SubtractLeftCopy(
+      generate_feature_workspace_d_.get(), generate_feature_workspace_size_, sorted_codes_d_.get(),
+      unique_mask_d_.get(), *num_cropped_points_, NotEqual{}, stream_));
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceAdjacentDifference::SubtractLeftCopy(
-        generate_feature_workspace_d_.get(), generate_feature_workspace_size_,
-        sorted_hashes64_d_.get(), unique_mask64_d_.get(), *num_cropped_points_, NotEqual{},
-        stream_));
+  std::uint32_t one = 1;
+  cudaMemcpyAsync(
+    unique_mask_d_.get(), &one, sizeof(std::uint32_t), cudaMemcpyHostToDevice, stream_);
 
-    std::uint64_t one = 1;
-    cudaMemcpyAsync(
-      unique_mask64_d_.get(), &one, sizeof(std::uint64_t), cudaMemcpyHostToDevice, stream_);
+  CHECK_CUDA_ERROR(
+    cub::DeviceScan::InclusiveSum(
+      generate_feature_workspace_d_.get(), generate_feature_workspace_size_, unique_mask_d_.get(),
+      unique_indices_d_.get(), *num_cropped_points_, stream_));
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceScan::InclusiveSum(
-        generate_feature_workspace_d_.get(), generate_feature_workspace_size_,
-        unique_mask64_d_.get(), unique_indices64_d_.get(), *num_cropped_points_, stream_));
+  *num_unique_points_ = 0;
+  cudaMemcpyAsync(
+    num_unique_points_.get(), unique_indices_d_.get() + *num_cropped_points_ - 1,
+    sizeof(std::uint32_t), cudaMemcpyDeviceToHost, stream_);
+  CHECK_CUDA_ERROR(
+    cudaEventRecord(num_unique_points_copy_event_, stream_));  // Lazy sync. use later
 
-    *num_unique_points64_ = 0;
-    cudaMemcpyAsync(
-      num_unique_points64_.get(), unique_indices64_d_.get() + *num_cropped_points_ - 1,
-      sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream_);
-    CHECK_CUDA_ERROR(cudaEventRecord(num_unique_points64_copy_event_, stream_));
-
-    extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-      reinterpret_cast<float4 *>(cropped_points_d_.get()), unique_mask64_d_.get(),
-      unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-      reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_,
-      static_cast<int>(config_.max_num_voxels_));
-    if (inverse_map != nullptr) {
-      scatterInverseMapKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-        unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(), inverse_map,
-        *num_cropped_points_);
-    }
-
-    switch (input_format) {
-      case CloudFormat::XYZIRCAEDT:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(cropped_input_points_d_.get()),
-          unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZIRADRT:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(cropped_input_points_d_.get()),
-          unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZIRC:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRC *>(cropped_input_points_d_.get()),
-          unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZI:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZI *>(cropped_input_points_d_.get()),
-          unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      default:
-        throw std::runtime_error("Unsupported input point cloud format.");
-    }
-
-    CHECK_CUDA_ERROR(cudaEventSynchronize(num_unique_points64_copy_event_));
-    num_unique_points = *num_unique_points64_;
-
-  } else {
-    voxelizationHash32Kernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-      reinterpret_cast<float4 *>(cropped_points_d_.get()), hashes32_d_.get(), *num_cropped_points_,
-      config_.voxel_x_size_, config_.voxel_y_size_, config_.voxel_z_size_, config_.min_x_range_,
-      config_.min_y_range_, config_.min_z_range_, static_cast<std::uint32_t>(config_.grid_x_size_),
-      static_cast<std::uint32_t>(config_.grid_x_size_ * config_.grid_y_size_));
-
-    CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        reinterpret_cast<void *>(generate_feature_workspace_d_.get()),
-        generate_feature_workspace_size_, hashes32_d_.get(), sorted_hashes32_d_.get(),
-        hash_indexes32_d_.get(), sorted_hash_indexes32_d_.get(), *num_cropped_points_, 0, 32,
-        stream_));
-
-    CHECK_CUDA_ERROR(
-      cub::DeviceAdjacentDifference::SubtractLeftCopy(
-        generate_feature_workspace_d_.get(), generate_feature_workspace_size_,
-        sorted_hashes32_d_.get(), unique_mask32_d_.get(), *num_cropped_points_, NotEqual{},
-        stream_));
-
-    std::uint32_t one = 1;
-    cudaMemcpyAsync(
-      unique_mask32_d_.get(), &one, sizeof(std::uint32_t), cudaMemcpyHostToDevice, stream_);
-
-    CHECK_CUDA_ERROR(
-      cub::DeviceScan::InclusiveSum(
-        generate_feature_workspace_d_.get(), generate_feature_workspace_size_,
-        unique_mask32_d_.get(), unique_indices32_d_.get(), *num_cropped_points_, stream_));
-
-    *num_unique_points32_ = 0;
-    cudaMemcpyAsync(
-      num_unique_points32_.get(), unique_indices32_d_.get() + *num_cropped_points_ - 1,
-      sizeof(std::uint32_t), cudaMemcpyDeviceToHost, stream_);
-    CHECK_CUDA_ERROR(
-      cudaEventRecord(num_unique_points32_copy_event_, stream_));  // Lazy sync. use later
-
-    extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-      reinterpret_cast<float4 *>(cropped_points_d_.get()), unique_mask32_d_.get(),
-      unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-      reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_,
-      static_cast<int>(config_.max_num_voxels_));
-    if (inverse_map != nullptr) {
-      scatterInverseMapKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-        unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(), inverse_map,
-        *num_cropped_points_);
-    }
-
-    switch (input_format) {
-      case CloudFormat::XYZIRCAEDT:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(cropped_input_points_d_.get()),
-          unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZIRADRT:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(cropped_input_points_d_.get()),
-          unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZIRC:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRC *>(cropped_input_points_d_.get()),
-          unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZI:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZI *>(cropped_input_points_d_.get()),
-          unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      default:
-        throw std::runtime_error("Unsupported input point cloud format.");
-    }
-
-    CHECK_CUDA_ERROR(cudaEventSynchronize(num_unique_points32_copy_event_));
-    num_unique_points = static_cast<std::uint64_t>(*num_unique_points32_);
+  extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+    reinterpret_cast<float4 *>(cropped_points_d_.get()), unique_mask_d_.get(),
+    unique_indices_d_.get(), sorted_code_indices_d_.get(),
+    reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_,
+    static_cast<int>(config_.max_num_voxels_));
+  if (inverse_map != nullptr) {
+    scatterInverseMapKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+      unique_indices_d_.get(), sorted_code_indices_d_.get(), inverse_map, *num_cropped_points_);
   }
 
+  switch (input_format) {
+    case CloudFormat::XYZIRCAEDT:
+      extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+        reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(cropped_input_points_d_.get()),
+        unique_mask_d_.get(), unique_indices_d_.get(), sorted_code_indices_d_.get(),
+        reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_,
+        static_cast<int>(config_.max_num_voxels_));
+      break;
+    case CloudFormat::XYZIRADRT:
+      extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+        reinterpret_cast<CloudPointTypeXYZIRADRT *>(cropped_input_points_d_.get()),
+        unique_mask_d_.get(), unique_indices_d_.get(), sorted_code_indices_d_.get(),
+        reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_,
+        static_cast<int>(config_.max_num_voxels_));
+      break;
+    case CloudFormat::XYZIRC:
+      extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+        reinterpret_cast<CloudPointTypeXYZIRC *>(cropped_input_points_d_.get()),
+        unique_mask_d_.get(), unique_indices_d_.get(), sorted_code_indices_d_.get(),
+        reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_,
+        static_cast<int>(config_.max_num_voxels_));
+      break;
+    case CloudFormat::XYZI:
+      extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+        reinterpret_cast<CloudPointTypeXYZI *>(cropped_input_points_d_.get()), unique_mask_d_.get(),
+        unique_indices_d_.get(), sorted_code_indices_d_.get(),
+        reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_,
+        static_cast<int>(config_.max_num_voxels_));
+      break;
+    default:
+      throw std::runtime_error("Unsupported input point cloud format.");
+  }
+
+  CHECK_CUDA_ERROR(cudaEventSynchronize(num_unique_points_copy_event_));
+  const auto num_unique_points = static_cast<std::uint64_t>(*num_unique_points_);
+
   // The extract kernels above dropped any voxels beyond max_num_voxels, so only the first
-  // max_num_voxels entries of voxel_features/voxel_coords/voxel_hashes are valid. Cap the count fed
-  // to the grid-coord kernel to that same limit; writing more would overrun those buffers (which
-  // are sized max_num_voxels) exactly as the unguarded extract did. The true count is still
+  // max_num_voxels entries of voxel_features/voxel_coords/serialized_code are valid. Cap the count
+  // fed to the grid-coord kernel to that same limit; writing more would overrun those buffers
+  // (which are sized max_num_voxels) exactly as the unguarded extract did. The true count is still
   // returned so the caller logs the "over the limit" warning and clips consistently.
   const auto max_num_voxels_u = static_cast<std::uint64_t>(config_.max_num_voxels_);
   const auto num_voxels_capped =
@@ -892,8 +806,9 @@ std::size_t PreprocessCuda::generateFeatures(
   computeGridCoordsAndSerializationKernel<<<
     num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
     reinterpret_cast<float4 *>(voxel_features), reinterpret_cast<int3 *>(voxel_coords),
-    voxel_hashes, static_cast<int>(num_voxels_capped), config_.voxel_x_size_, config_.voxel_y_size_,
-    config_.voxel_z_size_, coord_min_x, coord_min_y, coord_min_z, config_.serialization_depth_);
+    serialized_code, static_cast<int>(num_voxels_capped), config_.voxel_x_size_,
+    config_.voxel_y_size_, config_.voxel_z_size_, coord_min_x, coord_min_y, coord_min_z,
+    config_.serialization_depth_);
 
   return num_unique_points;
 }

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -25,7 +25,6 @@
 #include <thrust/sequence.h>
 
 #include <algorithm>
-#include <limits>
 #include <stdexcept>
 
 namespace autoware::ptv3
@@ -56,37 +55,26 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   auto policy = thrust::cuda::par.on(stream_);
 
-  if (config_.use_64bit_hash_) {
-    hashes64_d_ = autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    sorted_hashes64_d_ =
-      autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    hash_indexes64_d_ = autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    sorted_hash_indexes64_d_ =
-      autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    unique_mask64_d_ = autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
-    unique_indices64_d_ =
-      autoware::cuda_utils::make_unique<std::uint64_t[]>(config_.cloud_capacity_);
+  codes_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.cloud_capacity_);
+  sorted_codes_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.cloud_capacity_);
+  code_indices_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
+  sorted_code_indices_d_ =
+    autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
+  unique_mask_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
+  unique_indices_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
 
-    thrust::device_ptr<std::uint64_t> idx_ptr(hash_indexes64_d_.get());
+  thrust::device_ptr<std::uint32_t> idx_ptr(code_indices_d_.get());
+  thrust::sequence(policy, idx_ptr, idx_ptr + config_.cloud_capacity_, 0);
 
-    thrust::sequence(policy, idx_ptr, idx_ptr + config_.cloud_capacity_, 0);
-  } else {
-    hashes32_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    sorted_hashes32_d_ =
-      autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    hash_indexes32_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    sorted_hash_indexes32_d_ =
-      autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    unique_mask32_d_ = autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
-    unique_indices32_d_ =
-      autoware::cuda_utils::make_unique<std::uint32_t[]>(config_.cloud_capacity_);
+  // Serialized codes interleave 3 grid coordinates of serialization_depth_ bits each, so their MSB
+  // sits at 3 * serialization_depth_ - 1. Pooling only right-shifts codes, which can never raise
+  // the MSB, so this bound holds for every stage. std::max guards a degenerate single-cell grid
+  // (serialization_depth_ == 0), since CUB requires end_bit > begin_bit. Workspace queries below
+  // deliberately use the full 64 bits: a wider key range can only need at least as much scratch.
+  code_sort_end_bit_ = std::max(1, 3 * config_.serialization_depth_);
 
-    thrust::device_ptr<std::uint32_t> idx_ptr(hash_indexes32_d_.get());
-
-    thrust::sequence(policy, idx_ptr, idx_ptr + config_.cloud_capacity_, 0);
-  }
-
-  std::uint64_t * uint64_nullptr = nullptr;
+  std::int64_t * int64_nullptr = nullptr;
+  std::uint32_t * uint32_nullptr = nullptr;
 
   std::size_t sort_pair_workspace_size = 0;
   std::size_t inclusive_sum_workspace_size = 0;
@@ -94,15 +82,15 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   CHECK_CUDA_ERROR(
     cub::DeviceRadixSort::SortPairs(
-      nullptr, sort_pair_workspace_size, uint64_nullptr, uint64_nullptr, uint64_nullptr,
-      uint64_nullptr, config_.cloud_capacity_, 0, 64, nullptr));
+      nullptr, sort_pair_workspace_size, int64_nullptr, int64_nullptr, uint32_nullptr,
+      uint32_nullptr, config_.cloud_capacity_, 0, 64, nullptr));
   CHECK_CUDA_ERROR(
     cub::DeviceScan::InclusiveSum(
-      nullptr, inclusive_sum_workspace_size, uint64_nullptr, uint64_nullptr,
+      nullptr, inclusive_sum_workspace_size, uint32_nullptr, uint32_nullptr,
       config_.cloud_capacity_));
   CHECK_CUDA_ERROR(
     cub::DeviceAdjacentDifference::SubtractLeftCopy(
-      nullptr, adjacent_difference_workspace_size, uint64_nullptr, uint64_nullptr,
+      nullptr, adjacent_difference_workspace_size, int64_nullptr, uint32_nullptr,
       config_.cloud_capacity_, NotEqual{}));
 
   generate_feature_workspace_size_ = std::max(
@@ -111,24 +99,24 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
     autoware::cuda_utils::make_unique<std::uint8_t[]>(generate_feature_workspace_size_);
 
   num_cropped_points_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
-  num_unique_points32_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
-  num_unique_points64_ = autoware::cuda_utils::make_unique_host<std::uint64_t>();
+  num_unique_points_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
 
-  pooling_keys_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_sorted_keys_d_ =
+  const auto num_orders = static_cast<std::int64_t>(config_.serialization_orders_.size());
+  level0_order_d_ =
+    autoware::cuda_utils::make_unique<std::int64_t[]>(num_orders * config_.max_num_voxels_);
+  order_sort_keys_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  order_sort_sorted_keys_d_ =
     autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_indices_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_sorted_indices_d_ =
+  order_sort_indices_d_ =
     autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_run_flags_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_run_ids_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  run_flags_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  run_ids_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
 
   std::size_t pooling_sort_workspace_size = 0;
   std::size_t pooling_scan_workspace_size = 0;
-  std::int64_t * int64_nullptr = nullptr;
   cub::DeviceRadixSort::SortPairs(
     nullptr, pooling_sort_workspace_size, int64_nullptr, int64_nullptr, int64_nullptr,
-    int64_nullptr, config_.max_num_voxels_, 0, 63, nullptr);
+    int64_nullptr, config_.max_num_voxels_, 0, 64, nullptr);
   cub::DeviceScan::InclusiveSum(
     nullptr, pooling_scan_workspace_size, int64_nullptr, int64_nullptr, config_.max_num_voxels_,
     nullptr);
@@ -138,9 +126,7 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
   CHECK_CUDA_ERROR(
     cudaEventCreateWithFlags(&num_cropped_points_copy_event_, cudaEventDisableTiming));
   CHECK_CUDA_ERROR(
-    cudaEventCreateWithFlags(&num_unique_points32_copy_event_, cudaEventDisableTiming));
-  CHECK_CUDA_ERROR(
-    cudaEventCreateWithFlags(&num_unique_points64_copy_event_, cudaEventDisableTiming));
+    cudaEventCreateWithFlags(&num_unique_points_copy_event_, cudaEventDisableTiming));
 
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 }
@@ -150,11 +136,8 @@ PreprocessCuda::~PreprocessCuda()
   if (num_cropped_points_copy_event_) {
     cudaEventDestroy(num_cropped_points_copy_event_);
   }
-  if (num_unique_points32_copy_event_) {
-    cudaEventDestroy(num_unique_points32_copy_event_);
-  }
-  if (num_unique_points64_copy_event_) {
-    cudaEventDestroy(num_unique_points64_copy_event_);
+  if (num_unique_points_copy_event_) {
+    cudaEventDestroy(num_unique_points_copy_event_);
   }
 }
 
@@ -269,57 +252,64 @@ __global__ void scatterInverseMapKernel(
   inverse_map[sorted_hash_indexes[idx]] = static_cast<std::int64_t>(unique_indices[idx] - 1);
 }
 
-__global__ void voxelizationHash64Kernel(
-  const float4 * __restrict__ points, std::uint64_t * __restrict__ hashes, int num_points,
-  float voxel_size_x, float voxel_size_y, float voxel_size_z, std::int32_t min_x,
-  std::int32_t min_y, std::int32_t min_z)
+// Interleaves the three grid coordinates into one serialized (Morton / Z-order) code, consuming
+// `depth` bits per axis. `transposed` swaps the roles of x and y, which is the "z-trans" order.
+// The bit layout matches autoware-ml's z_order_encode, so the codes index the same space-filling
+// curve the model was trained and exported against.
+__device__ inline std::int64_t serializeCoord(
+  const std::int32_t x, const std::int32_t y, const std::int32_t z, const int depth,
+  const bool transposed)
 {
-  // FNV64-1A
-  auto idx = static_cast<std::uint32_t>(blockIdx.x * blockDim.x + threadIdx.x);
-  if (idx >= num_points) {
-    return;
+  const std::int32_t major = transposed ? y : x;
+  const std::int32_t minor = transposed ? x : y;
+
+  std::int64_t code = 0;
+  for (int i = 0; i < depth; ++i) {
+    const std::int64_t mask = 1 << i;
+    code |= ((major & mask) << (2 * i + 2));
+    code |= ((minor & mask) << (2 * i + 1));
+    code |= ((z & mask) << (2 * i + 0));
   }
-
-  const float4 & point = points[idx];
-  const auto x = static_cast<std::int32_t>(std::floor(point.x / voxel_size_x));
-  const auto y = static_cast<std::int32_t>(std::floor(point.y / voxel_size_y));
-  const auto z = static_cast<std::int32_t>(std::floor(point.z / voxel_size_z));
-
-  std::uint64_t hash = 14695981039346656037ULL;
-  hash *= 1099511628211ULL;
-  hash ^= static_cast<std::uint64_t>(x - min_x);
-  hash *= 1099511628211ULL;
-  hash ^= static_cast<std::uint64_t>(y - min_y);
-  hash *= 1099511628211ULL;
-  hash ^= static_cast<std::uint64_t>(z - min_z);
-
-  hashes[idx] = hash;
+  return code;
 }
 
-__global__ void voxelizationHash32Kernel(
-  const float4 * __restrict__ points, std::uint32_t * __restrict__ hashes, int num_points,
-  float voxel_size_x, float voxel_size_y, float voxel_size_z, float min_x, float min_y, float min_z,
-  std::uint32_t grid_x_size, std::uint32_t grid_xy_size)
+// Maps a point to its grid coordinate. Kept as one helper so the voxelization key and the
+// serialization codes are guaranteed to describe the same grid: the two used to be computed with
+// different arithmetic, which let boundary points fall into different cells in each.
+__device__ inline int3 gridCoord(
+  const float4 & point, const float voxel_size_x, const float voxel_size_y,
+  const float voxel_size_z, const std::int32_t min_x, const std::int32_t min_y,
+  const std::int32_t min_z)
+{
+  return make_int3(
+    static_cast<std::int32_t>(std::floor(point.x / voxel_size_x) - min_x),
+    static_cast<std::int32_t>(std::floor(point.y / voxel_size_y) - min_y),
+    static_cast<std::int32_t>(std::floor(point.z / voxel_size_z) - min_z));
+}
+
+// Produces the voxelization key: the order-0 serialized code. Unlike the FNV / raster hashes this
+// replaced, the code is an injective function of the grid coordinate, so sorting by it cannot merge
+// two distinct voxels, and it additionally leaves the deduplicated voxels in order-0 serialization
+// order - which is what lets the rest of the pipeline avoid re-sorting.
+__global__ void voxelizationCodeKernel(
+  const float4 * __restrict__ points, std::int64_t * __restrict__ codes, int num_points,
+  float voxel_size_x, float voxel_size_y, float voxel_size_z, std::int32_t min_x,
+  std::int32_t min_y, std::int32_t min_z, int depth)
 {
   auto idx = static_cast<std::uint32_t>(blockIdx.x * blockDim.x + threadIdx.x);
   if (idx >= num_points) {
     return;
   }
 
-  const float4 & point = points[idx];
-  const std::uint32_t x =
-    static_cast<std::uint32_t>(std::max<float>((point.x - min_x) / voxel_size_x, 0.f));
-  const std::uint32_t y =
-    static_cast<std::uint32_t>(std::max<float>((point.y - min_y) / voxel_size_y, 0.f));
-  const std::uint32_t z =
-    static_cast<std::uint32_t>(std::max<float>((point.z - min_z) / voxel_size_z, 0.f));
-  hashes[idx] = z * grid_xy_size + y * grid_x_size + x;
+  const auto coord =
+    gridCoord(points[idx], voxel_size_x, voxel_size_y, voxel_size_z, min_x, min_y, min_z);
+  codes[idx] = serializeCoord(coord.x, coord.y, coord.z, depth, false);
 }
 
 __global__ void computeGridCoordsAndSerializationKernel(
-  const float4 * __restrict__ points, int3 * __restrict__ coords,
-  std::int64_t * __restrict__ hashes, int num_points, float voxel_size_x, float voxel_size_y,
-  float voxel_size_z, std::int32_t min_x, std::int32_t min_y, std::int32_t min_z, int depth)
+  const float4 * __restrict__ points, int3 * __restrict__ coords, std::int64_t * __restrict__ codes,
+  int num_points, float voxel_size_x, float voxel_size_y, float voxel_size_z, std::int32_t min_x,
+  std::int32_t min_y, std::int32_t min_z, int depth)
 {
   static_assert(sizeof(int3) == sizeof(std::int32_t) * 3, "int3 must be 12 bytes");
   auto idx = static_cast<std::uint32_t>(blockIdx.x * blockDim.x + threadIdx.x);
@@ -327,32 +317,13 @@ __global__ void computeGridCoordsAndSerializationKernel(
     return;
   }
 
-  const float4 & point = points[idx];
-  const auto x = static_cast<std::int32_t>(std::floor(point.x / voxel_size_x) - min_x);
-  const auto y = static_cast<std::int32_t>(std::floor(point.y / voxel_size_y) - min_y);
-  const auto z = static_cast<std::int32_t>(std::floor(point.z / voxel_size_z) - min_z);
+  const auto coord =
+    gridCoord(points[idx], voxel_size_x, voxel_size_y, voxel_size_z, min_x, min_y, min_z);
+  coords[idx] = coord;
 
-  coords[idx] = make_int3(x, y, z);
-
-  std::int64_t key1 = 0;
-  std::int64_t key2 = 0;
-
-  for (int i = 0; i < depth; ++i) {
-    std::int64_t mask = 1 << i;
-    key1 |= ((x & mask) << (2 * i + 2));
-    key1 |= ((y & mask) << (2 * i + 1));
-    key1 |= ((z & mask) << (2 * i + 0));
-
-    key2 |= ((y & mask) << (2 * i + 2));
-    key2 |= ((x & mask) << (2 * i + 1));
-    key2 |= ((z & mask) << (2 * i + 0));
-  }
-
-  hashes[idx] = key1;
-  hashes[idx + num_points] = key2;
+  codes[idx] = serializeCoord(coord.x, coord.y, coord.z, depth, false);
+  codes[idx + num_points] = serializeCoord(coord.x, coord.y, coord.z, depth, true);
 }
-
-constexpr std::int64_t kInvalidPoolingKey = std::numeric_limits<std::int64_t>::max();
 
 __global__ void setInitialStageCountKernel(
   std::int64_t * __restrict__ stage_counts, std::int64_t num_voxels)
@@ -360,10 +331,39 @@ __global__ void setInitialStageCountKernel(
   *stage_counts = num_voxels;
 }
 
-__global__ void preparePoolingSortInputKernel(
-  const std::int64_t * __restrict__ serialized_code, const std::int64_t * __restrict__ stage_counts,
-  std::int64_t * __restrict__ keys, std::int64_t * __restrict__ indices, std::int32_t stage_index,
-  std::int32_t pooling_depth, std::int64_t capacity)
+__global__ void fillIdentityKernel(std::int64_t * __restrict__ out, std::int64_t count)
+{
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= count) {
+    return;
+  }
+  out[idx] = idx;
+}
+
+__global__ void prepareLevel0OrderSortKernel(
+  const std::int64_t * __restrict__ serialized_code, std::int64_t * __restrict__ keys,
+  std::int64_t * __restrict__ indices, std::int64_t num_voxels, std::int32_t order_index)
+{
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= num_voxels) {
+    return;
+  }
+
+  // serialized_code is laid out densely as [num_orders, num_voxels].
+  keys[idx] = serialized_code[order_index * num_voxels + idx];
+  indices[idx] = idx;
+}
+
+// Marks the first element of every parent run in the input level's own storage order.
+//
+// The input level is stored in ascending order-0 code, so `code >> 3 * pooling_depth` - which is
+// exactly the parent cell's order-0 code - is non-decreasing across the array and all children of a
+// parent are contiguous. Detecting a change against the previous element is therefore sufficient to
+// find the run starts, and no sort is required.
+__global__ void markPoolingRunsKernel(
+  const std::int64_t * __restrict__ serialized_code_in,
+  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
+  std::int32_t stage_index, std::int32_t pooling_depth, std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
@@ -371,33 +371,26 @@ __global__ void preparePoolingSortInputKernel(
   }
 
   const auto input_count = stage_counts[stage_index];
-  keys[idx] = idx < input_count ? serialized_code[idx] >> (pooling_depth * 3) : kInvalidPoolingKey;
-  indices[idx] = idx;
-}
-
-__global__ void markPoolingRunsKernel(
-  const std::int64_t * __restrict__ sorted_keys, std::int64_t * __restrict__ run_flags,
-  std::int64_t capacity)
-{
-  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (idx >= capacity) {
+  if (idx >= input_count) {
+    run_flags[idx] = 0;
     return;
   }
 
-  const auto key = sorted_keys[idx];
-  run_flags[idx] = key != kInvalidPoolingKey && (idx == 0 || key != sorted_keys[idx - 1]) ? 1 : 0;
+  const auto shift = pooling_depth * 3;
+  const auto key = serialized_code_in[idx] >> shift;
+  run_flags[idx] = (idx == 0 || key != (serialized_code_in[idx - 1] >> shift)) ? 1 : 0;
 }
 
 __global__ void fillPoolingStageKernel(
   const std::int32_t * __restrict__ grid_coord_in,
-  const std::int64_t * __restrict__ serialized_code_in,
-  const std::int64_t * __restrict__ sorted_keys, const std::int64_t * __restrict__ sorted_indices,
-  const std::int64_t * __restrict__ run_flags, const std::int64_t * __restrict__ run_ids,
-  std::int64_t * __restrict__ indices_out, std::int64_t * __restrict__ indptr_out,
-  std::int64_t * __restrict__ head_indices_out, std::int64_t * __restrict__ cluster_out,
-  std::int32_t * __restrict__ grid_coord_out, std::int64_t * __restrict__ serialized_code_out,
-  std::int64_t * __restrict__ stage_counts, std::int32_t stage_index, std::int32_t pooling_depth,
-  std::int32_t num_orders, std::int64_t capacity)
+  const std::int64_t * __restrict__ serialized_code_in, const std::int64_t * __restrict__ run_flags,
+  const std::int64_t * __restrict__ run_ids, std::int64_t * __restrict__ indices_out,
+  std::int64_t * __restrict__ indptr_out, std::int64_t * __restrict__ head_indices_out,
+  std::int64_t * __restrict__ cluster_out, std::int32_t * __restrict__ grid_coord_out,
+  std::int64_t * __restrict__ serialized_code_out, std::int64_t * __restrict__ order_out,
+  std::int64_t * __restrict__ inverse_out, std::int64_t * __restrict__ stage_counts,
+  std::int32_t stage_index, std::int32_t pooling_depth, std::int32_t num_orders,
+  std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
@@ -416,64 +409,92 @@ __global__ void fillPoolingStageKernel(
     indptr_out[next_count] = input_count;
   }
 
-  if (sorted_keys[idx] == kInvalidPoolingKey) {
+  if (idx >= input_count) {
     return;
   }
 
-  const auto input_index = sorted_indices[idx];
+  // The input level is already grouped by parent (see markPoolingRunsKernel), so the gather order
+  // that collects each parent's children into a contiguous run is the identity.
+  indices_out[idx] = idx;
   const auto segment_index = run_ids[idx] - 1;
-  indices_out[idx] = input_index;
-  cluster_out[input_index] = segment_index;
+  cluster_out[idx] = segment_index;
 
   if (run_flags[idx] == 0) {
     return;
   }
 
   indptr_out[segment_index] = idx;
-  head_indices_out[segment_index] = input_index;
+  head_indices_out[segment_index] = idx;
   for (std::int32_t coord_index = 0; coord_index < 3; ++coord_index) {
     grid_coord_out[segment_index * 3 + coord_index] =
-      grid_coord_in[input_index * 3 + coord_index] >> pooling_depth;
+      grid_coord_in[idx * 3 + coord_index] >> pooling_depth;
   }
   for (std::int32_t order_index = 0; order_index < num_orders; ++order_index) {
     serialized_code_out[order_index * next_count + segment_index] =
-      serialized_code_in[order_index * input_count + input_index] >> (pooling_depth * 3);
+      serialized_code_in[order_index * input_count + idx] >> (pooling_depth * 3);
   }
+
+  // Order 0 of the pooled level is the identity: segments are emitted in increasing input index,
+  // and the input was ascending in order-0 code, so the pooled order-0 codes come out ascending in
+  // segment index too. This is what keeps markPoolingRunsKernel's precondition true for the next
+  // stage, and it is why no sort is needed for order 0 at any level.
+  order_out[segment_index] = segment_index;
+  inverse_out[segment_index] = segment_index;
 }
 
-__global__ void prepareOrderSortInputKernel(
-  const std::int64_t * __restrict__ serialized_code, const std::int64_t * __restrict__ stage_counts,
-  std::int64_t * __restrict__ keys, std::int64_t * __restrict__ indices, std::int32_t stage_index,
-  std::int32_t order_index, std::int64_t capacity)
+// Marks where the pooled voxel changes while walking the input level in order-`order_index` rank
+// order.
+//
+// Every serialization order right-shifts to the same parent partition (the low 3 * pooling_depth
+// bits locate a child inside its parent, whichever axis permutation the order uses), so walking the
+// input level in order-o rank order also visits each parent's children contiguously. The parents
+// are therefore encountered in ascending pooled order-o code, and compacting the run heads yields
+// the pooled level's order-o ranking directly - again without sorting.
+__global__ void markOrderRunsKernel(
+  const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster,
+  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
+  std::int32_t stage_index, std::int32_t order_index, std::int64_t capacity)
 {
-  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (idx >= capacity) {
+  const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (rank >= capacity) {
     return;
   }
 
   const auto input_count = stage_counts[stage_index];
-  // serialized_code is stored densely as [num_orders, input_count] (see fillPoolingStageKernel).
-  keys[idx] =
-    idx < input_count ? serialized_code[order_index * input_count + idx] : kInvalidPoolingKey;
-  indices[idx] = idx;
+  if (rank >= input_count) {
+    run_flags[rank] = 0;
+    return;
+  }
+
+  // order_in is laid out densely as [num_orders, input_count].
+  const auto segment_index = cluster[order_in[order_index * input_count + rank]];
+  run_flags[rank] =
+    (rank == 0 || segment_index != cluster[order_in[order_index * input_count + rank - 1]]) ? 1 : 0;
 }
 
 __global__ void fillOrderAndInverseKernel(
-  const std::int64_t * __restrict__ sorted_keys, const std::int64_t * __restrict__ sorted_indices,
+  const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster,
+  const std::int64_t * __restrict__ run_flags, const std::int64_t * __restrict__ run_ids,
   const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ order_out,
   std::int64_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
   std::int64_t capacity)
 {
-  const auto count = stage_counts[stage_index];
   const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (rank >= capacity || rank >= count || sorted_keys[rank] == kInvalidPoolingKey) {
+  if (rank >= capacity) {
     return;
   }
 
-  // order/inverse are stored densely as [num_orders, count] to match the engine input layout.
-  const auto input_index = sorted_indices[rank];
-  order_out[order_index * count + rank] = input_index;
-  inverse_out[order_index * count + input_index] = rank;
+  const auto input_count = stage_counts[stage_index];
+  if (rank >= input_count || run_flags[rank] == 0) {
+    return;
+  }
+
+  // order/inverse are stored densely as [num_orders, out_count] to match the engine input layout.
+  const auto out_count = stage_counts[stage_index + 1];
+  const auto out_rank = run_ids[rank] - 1;
+  const auto segment_index = cluster[order_in[order_index * input_count + rank]];
+  order_out[order_index * out_count + out_rank] = segment_index;
+  inverse_out[order_index * out_count + segment_index] = out_rank;
 }
 
 std::int32_t poolingDepth(const std::int64_t stride)
@@ -496,75 +517,83 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
   const auto capacity = config_.max_num_voxels_;
   const auto num_orders = static_cast<std::int32_t>(config_.serialization_orders_.size());
   const auto num_blocks = divup(static_cast<std::size_t>(capacity), config_.threads_per_block_);
+  const auto clamped_num_voxels = std::min(num_voxels, capacity);
+  const auto voxel_blocks = divup(
+    static_cast<std::size_t>(std::max<std::int64_t>(clamped_num_voxels, 1)),
+    config_.threads_per_block_);
 
-  // The sort keys are serialized (Morton/Z-order) codes interleaving 3 grid coordinates of
-  // serialization_depth_ bits each, so they occupy at most 3 * serialization_depth_ bits (the MSB
-  // sits at 3 * serialization_depth_ - 1). Pooling stages only right-shift the codes, which can
-  // never raise the MSB, so this is a valid upper bound for every stage. The INT64_MAX padding
-  // sentinel still sorts last because its low bits are all set, and the full key value is preserved
-  // by the radix sort, so exact-equality sentinel checks remain valid. std::max guards a degenerate
-  // single-voxel grid (serialization_depth_ == 0), since CUB requires end_bit > begin_bit.
-  const int pooling_end_bit = std::max(1, 3 * config_.serialization_depth_);
-
-  setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, num_voxels);
+  setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, clamped_num_voxels);
   CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+  // Level 0 is already stored in ascending order-0 code (generateFeatures deduplicated the voxels
+  // by that very code), so its order-0 ranking is the identity. The remaining orders are unrelated
+  // axis permutations of the curve and cannot be derived from order 0, so they need one real sort
+  // each - the only sorts in this function, and the only ones that run at the finest granularity.
+  fillIdentityKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
+    level0_order_d_.get(), clamped_num_voxels);
+  CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+  for (std::int32_t order_index = 1; order_index < num_orders; ++order_index) {
+    prepareLevel0OrderSortKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
+      serialized_code, order_sort_keys_d_.get(), order_sort_indices_d_.get(), clamped_num_voxels,
+      order_index);
+    CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+    CHECK_CUDA_ERROR(
+      cub::DeviceRadixSort::SortPairs(
+        pooling_workspace_d_.get(), pooling_workspace_size_, order_sort_keys_d_.get(),
+        order_sort_sorted_keys_d_.get(), order_sort_indices_d_.get(),
+        level0_order_d_.get() + order_index * clamped_num_voxels, clamped_num_voxels, 0,
+        code_sort_end_bit_, stream_));
+  }
 
   const std::int32_t * current_grid_coord = grid_coord;
   const std::int64_t * current_serialized_code = serialized_code;
+  const std::int64_t * current_order = level0_order_d_.get();
 
   for (std::size_t stage_index = 0; stage_index < stages.size(); ++stage_index) {
     const auto & stage = stages[stage_index];
     const auto pooling_depth = poolingDepth(config_.pooling_strides_[stage_index]);
 
-    preparePoolingSortInputKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-      current_serialized_code, stage_counts, pooling_keys_d_.get(), pooling_indices_d_.get(),
+    markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+      current_serialized_code, stage_counts, run_flags_d_.get(),
       static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
     CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-        capacity, 0, pooling_end_bit, stream_));
-
-    markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-      pooling_sorted_keys_d_.get(), pooling_run_flags_d_.get(), capacity);
-    CHECK_CUDA_ERROR(cudaPeekAtLastError());
-
-    CHECK_CUDA_ERROR(
       cub::DeviceScan::InclusiveSum(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
-        pooling_run_ids_d_.get(), capacity, stream_));
+        pooling_workspace_d_.get(), pooling_workspace_size_, run_flags_d_.get(), run_ids_d_.get(),
+        capacity, stream_));
 
     fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-      current_grid_coord, current_serialized_code, pooling_sorted_keys_d_.get(),
-      pooling_sorted_indices_d_.get(), pooling_run_flags_d_.get(), pooling_run_ids_d_.get(),
+      current_grid_coord, current_serialized_code, run_flags_d_.get(), run_ids_d_.get(),
       stage.indices, stage.indptr, stage.head_indices, stage.cluster, stage.grid_coord,
-      stage.serialized_code, stage_counts, static_cast<std::int32_t>(stage_index), pooling_depth,
-      num_orders, capacity);
+      stage.serialized_code, stage.serialized_order, stage.serialized_inverse, stage_counts,
+      static_cast<std::int32_t>(stage_index), pooling_depth, num_orders, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    for (std::int32_t order_index = 0; order_index < num_orders; ++order_index) {
-      prepareOrderSortInputKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-        stage.serialized_code, stage_counts, pooling_keys_d_.get(), pooling_indices_d_.get(),
-        static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
+    // Order 0 was already written as the identity by fillPoolingStageKernel above.
+    for (std::int32_t order_index = 1; order_index < num_orders; ++order_index) {
+      markOrderRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+        current_order, stage.cluster, stage_counts, run_flags_d_.get(),
+        static_cast<std::int32_t>(stage_index), order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
       CHECK_CUDA_ERROR(
-        cub::DeviceRadixSort::SortPairs(
-          pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-          pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-          capacity, 0, pooling_end_bit, stream_));
+        cub::DeviceScan::InclusiveSum(
+          pooling_workspace_d_.get(), pooling_workspace_size_, run_flags_d_.get(), run_ids_d_.get(),
+          capacity, stream_));
 
       fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-        pooling_sorted_keys_d_.get(), pooling_sorted_indices_d_.get(), stage_counts,
-        stage.serialized_order, stage.serialized_inverse,
-        static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
+        current_order, stage.cluster, run_flags_d_.get(), run_ids_d_.get(), stage_counts,
+        stage.serialized_order, stage.serialized_inverse, static_cast<std::int32_t>(stage_index),
+        order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
     }
 
     current_grid_coord = stage.grid_coord;
     current_serialized_code = stage.serialized_code;
+    current_order = stage.serialized_order;
   }
 }
 
@@ -711,174 +740,89 @@ std::size_t PreprocessCuda::generateFeatures(
 
   const auto num_cropped_blocks = divup(*num_cropped_points_, config_.threads_per_block_);
 
-  std::uint64_t num_unique_points;
+  voxelizationCodeKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+    reinterpret_cast<float4 *>(cropped_points_d_.get()), codes_d_.get(), *num_cropped_points_,
+    config_.voxel_x_size_, config_.voxel_y_size_, config_.voxel_z_size_, coord_min_x, coord_min_y,
+    coord_min_z, config_.serialization_depth_);
 
-  if (config_.use_64bit_hash_) {
-    voxelizationHash64Kernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-      reinterpret_cast<float4 *>(cropped_points_d_.get()), hashes64_d_.get(), *num_cropped_points_,
-      config_.voxel_x_size_, config_.voxel_y_size_, config_.voxel_z_size_, coord_min_x, coord_min_y,
-      coord_min_z);
+  // Sorting by the order-0 serialized code does double duty: it groups duplicate voxels for the
+  // compaction below, and it leaves the surviving voxels in ascending order-0 code, i.e. already in
+  // serialization order for the first curve. generateSerializedPoolingMetadata relies on that
+  // ordering to derive every coarser level without sorting again, so this ordering is part of this
+  // function's contract, not an incidental side effect.
+  CHECK_CUDA_ERROR(
+    cub::DeviceRadixSort::SortPairs(
+      reinterpret_cast<void *>(generate_feature_workspace_d_.get()),
+      generate_feature_workspace_size_, codes_d_.get(), sorted_codes_d_.get(),
+      code_indices_d_.get(), sorted_code_indices_d_.get(), *num_cropped_points_, 0,
+      code_sort_end_bit_, stream_));
 
-    // Keys are FNV-1a hashes spread pseudo-randomly across the full 64-bit range, so there is no
-    // usable upper bound below 2^64; sort all 64 bits.
-    CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        reinterpret_cast<void *>(generate_feature_workspace_d_.get()),
-        generate_feature_workspace_size_, hashes64_d_.get(), sorted_hashes64_d_.get(),
-        hash_indexes64_d_.get(), sorted_hash_indexes64_d_.get(), *num_cropped_points_, 0, 64,
-        stream_));
+  CHECK_CUDA_ERROR(
+    cub::DeviceAdjacentDifference::SubtractLeftCopy(
+      generate_feature_workspace_d_.get(), generate_feature_workspace_size_, sorted_codes_d_.get(),
+      unique_mask_d_.get(), *num_cropped_points_, NotEqual{}, stream_));
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceAdjacentDifference::SubtractLeftCopy(
-        generate_feature_workspace_d_.get(), generate_feature_workspace_size_,
-        sorted_hashes64_d_.get(), unique_mask64_d_.get(), *num_cropped_points_, NotEqual{},
-        stream_));
+  std::uint32_t one = 1;
+  cudaMemcpyAsync(
+    unique_mask_d_.get(), &one, sizeof(std::uint32_t), cudaMemcpyHostToDevice, stream_);
 
-    std::uint64_t one = 1;
-    cudaMemcpyAsync(
-      unique_mask64_d_.get(), &one, sizeof(std::uint64_t), cudaMemcpyHostToDevice, stream_);
+  CHECK_CUDA_ERROR(
+    cub::DeviceScan::InclusiveSum(
+      generate_feature_workspace_d_.get(), generate_feature_workspace_size_, unique_mask_d_.get(),
+      unique_indices_d_.get(), *num_cropped_points_, stream_));
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceScan::InclusiveSum(
-        generate_feature_workspace_d_.get(), generate_feature_workspace_size_,
-        unique_mask64_d_.get(), unique_indices64_d_.get(), *num_cropped_points_, stream_));
+  *num_unique_points_ = 0;
+  cudaMemcpyAsync(
+    num_unique_points_.get(), unique_indices_d_.get() + *num_cropped_points_ - 1,
+    sizeof(std::uint32_t), cudaMemcpyDeviceToHost, stream_);
+  CHECK_CUDA_ERROR(
+    cudaEventRecord(num_unique_points_copy_event_, stream_));  // Lazy sync. use later
 
-    *num_unique_points64_ = 0;
-    cudaMemcpyAsync(
-      num_unique_points64_.get(), unique_indices64_d_.get() + *num_cropped_points_ - 1,
-      sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream_);
-    CHECK_CUDA_ERROR(cudaEventRecord(num_unique_points64_copy_event_, stream_));
-
-    extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-      reinterpret_cast<float4 *>(cropped_points_d_.get()), unique_mask64_d_.get(),
-      unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-      reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_,
-      static_cast<int>(config_.max_num_voxels_));
-    if (inverse_map != nullptr) {
-      scatterInverseMapKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-        unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(), inverse_map,
-        *num_cropped_points_);
-    }
-
-    switch (input_format) {
-      case CloudFormat::XYZIRCAEDT:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(cropped_input_points_d_.get()),
-          unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZIRADRT:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(cropped_input_points_d_.get()),
-          unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZIRC:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRC *>(cropped_input_points_d_.get()),
-          unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZI:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZI *>(cropped_input_points_d_.get()),
-          unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      default:
-        throw std::runtime_error("Unsupported input point cloud format.");
-    }
-
-    CHECK_CUDA_ERROR(cudaEventSynchronize(num_unique_points64_copy_event_));
-    num_unique_points = *num_unique_points64_;
-
-  } else {
-    voxelizationHash32Kernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-      reinterpret_cast<float4 *>(cropped_points_d_.get()), hashes32_d_.get(), *num_cropped_points_,
-      config_.voxel_x_size_, config_.voxel_y_size_, config_.voxel_z_size_, config_.min_x_range_,
-      config_.min_y_range_, config_.min_z_range_, static_cast<std::uint32_t>(config_.grid_x_size_),
-      static_cast<std::uint32_t>(config_.grid_x_size_ * config_.grid_y_size_));
-
-    CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        reinterpret_cast<void *>(generate_feature_workspace_d_.get()),
-        generate_feature_workspace_size_, hashes32_d_.get(), sorted_hashes32_d_.get(),
-        hash_indexes32_d_.get(), sorted_hash_indexes32_d_.get(), *num_cropped_points_, 0, 32,
-        stream_));
-
-    CHECK_CUDA_ERROR(
-      cub::DeviceAdjacentDifference::SubtractLeftCopy(
-        generate_feature_workspace_d_.get(), generate_feature_workspace_size_,
-        sorted_hashes32_d_.get(), unique_mask32_d_.get(), *num_cropped_points_, NotEqual{},
-        stream_));
-
-    std::uint32_t one = 1;
-    cudaMemcpyAsync(
-      unique_mask32_d_.get(), &one, sizeof(std::uint32_t), cudaMemcpyHostToDevice, stream_);
-
-    CHECK_CUDA_ERROR(
-      cub::DeviceScan::InclusiveSum(
-        generate_feature_workspace_d_.get(), generate_feature_workspace_size_,
-        unique_mask32_d_.get(), unique_indices32_d_.get(), *num_cropped_points_, stream_));
-
-    *num_unique_points32_ = 0;
-    cudaMemcpyAsync(
-      num_unique_points32_.get(), unique_indices32_d_.get() + *num_cropped_points_ - 1,
-      sizeof(std::uint32_t), cudaMemcpyDeviceToHost, stream_);
-    CHECK_CUDA_ERROR(
-      cudaEventRecord(num_unique_points32_copy_event_, stream_));  // Lazy sync. use later
-
-    extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-      reinterpret_cast<float4 *>(cropped_points_d_.get()), unique_mask32_d_.get(),
-      unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-      reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_,
-      static_cast<int>(config_.max_num_voxels_));
-    if (inverse_map != nullptr) {
-      scatterInverseMapKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-        unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(), inverse_map,
-        *num_cropped_points_);
-    }
-
-    switch (input_format) {
-      case CloudFormat::XYZIRCAEDT:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(cropped_input_points_d_.get()),
-          unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZIRADRT:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(cropped_input_points_d_.get()),
-          unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZIRC:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZIRC *>(cropped_input_points_d_.get()),
-          unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      case CloudFormat::XYZI:
-        extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
-          reinterpret_cast<CloudPointTypeXYZI *>(cropped_input_points_d_.get()),
-          unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_,
-          static_cast<int>(config_.max_num_voxels_));
-        break;
-      default:
-        throw std::runtime_error("Unsupported input point cloud format.");
-    }
-
-    CHECK_CUDA_ERROR(cudaEventSynchronize(num_unique_points32_copy_event_));
-    num_unique_points = static_cast<std::uint64_t>(*num_unique_points32_);
+  extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+    reinterpret_cast<float4 *>(cropped_points_d_.get()), unique_mask_d_.get(),
+    unique_indices_d_.get(), sorted_code_indices_d_.get(),
+    reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_,
+    static_cast<int>(config_.max_num_voxels_));
+  if (inverse_map != nullptr) {
+    scatterInverseMapKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+      unique_indices_d_.get(), sorted_code_indices_d_.get(), inverse_map, *num_cropped_points_);
   }
+
+  switch (input_format) {
+    case CloudFormat::XYZIRCAEDT:
+      extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+        reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(cropped_input_points_d_.get()),
+        unique_mask_d_.get(), unique_indices_d_.get(), sorted_code_indices_d_.get(),
+        reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_,
+        static_cast<int>(config_.max_num_voxels_));
+      break;
+    case CloudFormat::XYZIRADRT:
+      extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+        reinterpret_cast<CloudPointTypeXYZIRADRT *>(cropped_input_points_d_.get()),
+        unique_mask_d_.get(), unique_indices_d_.get(), sorted_code_indices_d_.get(),
+        reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_,
+        static_cast<int>(config_.max_num_voxels_));
+      break;
+    case CloudFormat::XYZIRC:
+      extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+        reinterpret_cast<CloudPointTypeXYZIRC *>(cropped_input_points_d_.get()),
+        unique_mask_d_.get(), unique_indices_d_.get(), sorted_code_indices_d_.get(),
+        reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_,
+        static_cast<int>(config_.max_num_voxels_));
+      break;
+    case CloudFormat::XYZI:
+      extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
+        reinterpret_cast<CloudPointTypeXYZI *>(cropped_input_points_d_.get()), unique_mask_d_.get(),
+        unique_indices_d_.get(), sorted_code_indices_d_.get(),
+        reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_,
+        static_cast<int>(config_.max_num_voxels_));
+      break;
+    default:
+      throw std::runtime_error("Unsupported input point cloud format.");
+  }
+
+  CHECK_CUDA_ERROR(cudaEventSynchronize(num_unique_points_copy_event_));
+  const auto num_unique_points = static_cast<std::uint64_t>(*num_unique_points_);
 
   // The extract kernels above dropped any voxels beyond max_num_voxels, so only the first
   // max_num_voxels entries of voxel_features/voxel_coords/voxel_hashes are valid. Cap the count fed

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -66,11 +66,10 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
   thrust::device_ptr<std::uint32_t> idx_ptr(code_indices_d_.get());
   thrust::sequence(policy, idx_ptr, idx_ptr + config_.cloud_capacity_, 0);
 
-  // Serialized codes interleave 3 grid coordinates of serialization_depth_ bits each, so their MSB
-  // sits at 3 * serialization_depth_ - 1. Pooling only right-shifts codes, which can never raise
-  // the MSB, so this bound holds for every stage. std::max guards a degenerate single-cell grid
-  // (serialization_depth_ == 0), since CUB requires end_bit > begin_bit. Workspace queries below
-  // deliberately use the full 64 bits: a wider key range can only need at least as much scratch.
+  // Serialized codes occupy 3 * serialization_depth_ bits, and pooling only right-shifts them, so
+  // this bound holds for every stage. std::max guards serialization_depth_ == 0 (CUB requires
+  // end_bit > begin_bit). Workspace queries below use the full 64 bits, which upper-bounds the
+  // scratch needed for any narrower range.
   code_sort_end_bit_ = std::max(1, 3 * config_.serialization_depth_);
 
   std::int64_t * int64_nullptr = nullptr;
@@ -252,10 +251,9 @@ __global__ void scatterInverseMapKernel(
   inverse_map[sorted_hash_indexes[idx]] = static_cast<std::int64_t>(unique_indices[idx] - 1);
 }
 
-// Interleaves the three grid coordinates into one serialized (Morton / Z-order) code, consuming
-// `depth` bits per axis. `transposed` swaps the roles of x and y, which is the "z-trans" order.
-// The bit layout matches autoware-ml's z_order_encode, so the codes index the same space-filling
-// curve the model was trained and exported against.
+// Interleaves the three grid coordinates into a serialized (Morton / Z-order) code, `depth` bits
+// per axis. `transposed` swaps x and y ("z-trans" order). The bit layout must match autoware-ml's
+// z_order_encode, which the model was trained against.
 __device__ inline std::int64_t serializeCoord(
   const std::int32_t x, const std::int32_t y, const std::int32_t z, const int depth,
   const bool transposed)
@@ -273,9 +271,8 @@ __device__ inline std::int64_t serializeCoord(
   return code;
 }
 
-// Maps a point to its grid coordinate. Kept as one helper so the voxelization key and the
-// serialization codes are guaranteed to describe the same grid: the two used to be computed with
-// different arithmetic, which let boundary points fall into different cells in each.
+// Single helper so the voxelization key and the serialization codes always place a point in the
+// same cell.
 __device__ inline int3 gridCoord(
   const float4 & point, const float voxel_size_x, const float voxel_size_y,
   const float voxel_size_z, const std::int32_t min_x, const std::int32_t min_y,
@@ -287,10 +284,8 @@ __device__ inline int3 gridCoord(
     static_cast<std::int32_t>(std::floor(point.z / voxel_size_z) - min_z));
 }
 
-// Produces the voxelization key: the order-0 serialized code. Unlike the FNV / raster hashes this
-// replaced, the code is an injective function of the grid coordinate, so sorting by it cannot merge
-// two distinct voxels, and it additionally leaves the deduplicated voxels in order-0 serialization
-// order - which is what lets the rest of the pipeline avoid re-sorting.
+// Produces the voxelization key: the order-0 serialized code. It is unique per grid cell, so
+// sorting by it deduplicates voxels and leaves them in order-0 serialization order.
 __global__ void voxelizationCodeKernel(
   const float4 * __restrict__ points, std::int64_t * __restrict__ codes, int num_points,
   float voxel_size_x, float voxel_size_y, float voxel_size_z, std::int32_t min_x,
@@ -354,12 +349,9 @@ __global__ void prepareLevel0OrderSortKernel(
   indices[idx] = idx;
 }
 
-// Marks the first element of every parent run in the input level's own storage order.
-//
-// The input level is stored in ascending order-0 code, so `code >> 3 * pooling_depth` - which is
-// exactly the parent cell's order-0 code - is non-decreasing across the array and all children of a
-// parent are contiguous. Detecting a change against the previous element is therefore sufficient to
-// find the run starts, and no sort is required.
+// Marks the first child of every parent run. The input level is ascending in order-0 code, so the
+// parent code (code >> 3 * pooling_depth) is non-decreasing and each parent's children are already
+// contiguous; comparing against the previous element finds the run starts without sorting.
 __global__ void markPoolingRunsKernel(
   const std::int64_t * __restrict__ serialized_code_in,
   const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
@@ -413,8 +405,8 @@ __global__ void fillPoolingStageKernel(
     return;
   }
 
-  // The input level is already grouped by parent (see markPoolingRunsKernel), so the gather order
-  // that collects each parent's children into a contiguous run is the identity.
+  // The input is already grouped by parent (see markPoolingRunsKernel), so the gather order is the
+  // identity.
   indices_out[idx] = idx;
   const auto segment_index = run_ids[idx] - 1;
   cluster_out[idx] = segment_index;
@@ -434,22 +426,16 @@ __global__ void fillPoolingStageKernel(
       serialized_code_in[order_index * input_count + idx] >> (pooling_depth * 3);
   }
 
-  // Order 0 of the pooled level is the identity: segments are emitted in increasing input index,
-  // and the input was ascending in order-0 code, so the pooled order-0 codes come out ascending in
-  // segment index too. This is what keeps markPoolingRunsKernel's precondition true for the next
-  // stage, and it is why no sort is needed for order 0 at any level.
+  // Segments are emitted in ascending order-0 code, so the pooled level's order-0 ranking is the
+  // identity and markPoolingRunsKernel's precondition holds for the next stage.
   order_out[segment_index] = segment_index;
   inverse_out[segment_index] = segment_index;
 }
 
-// Marks where the pooled voxel changes while walking the input level in order-`order_index` rank
-// order.
-//
-// Every serialization order right-shifts to the same parent partition (the low 3 * pooling_depth
-// bits locate a child inside its parent, whichever axis permutation the order uses), so walking the
-// input level in order-o rank order also visits each parent's children contiguously. The parents
-// are therefore encountered in ascending pooled order-o code, and compacting the run heads yields
-// the pooled level's order-o ranking directly - again without sorting.
+// Marks where the parent voxel changes while walking the input level in order-`order_index` rank
+// order. Every serialization order visits each parent's children contiguously and the parents in
+// ascending pooled code, so compacting the run heads yields the pooled level's order-`order_index`
+// ranking without sorting.
 __global__ void markOrderRunsKernel(
   const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster,
   const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
@@ -525,26 +511,27 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
   setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, clamped_num_voxels);
   CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-  // Level 0 is already stored in ascending order-0 code (generateFeatures deduplicated the voxels
-  // by that very code), so its order-0 ranking is the identity. The remaining orders are unrelated
-  // axis permutations of the curve and cannot be derived from order 0, so they need one real sort
-  // each - the only sorts in this function, and the only ones that run at the finest granularity.
-  fillIdentityKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
-    level0_order_d_.get(), clamped_num_voxels);
-  CHECK_CUDA_ERROR(cudaPeekAtLastError());
-
-  for (std::int32_t order_index = 1; order_index < num_orders; ++order_index) {
-    prepareLevel0OrderSortKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
-      serialized_code, order_sort_keys_d_.get(), order_sort_indices_d_.get(), clamped_num_voxels,
-      order_index);
+  // Level 0 is already stored in ascending order-0 code, so its order-0 ranking is the identity.
+  // The remaining orders cannot be derived from it and need one real sort each - the only sorts in
+  // this function.
+  if (clamped_num_voxels > 0) {
+    fillIdentityKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
+      level0_order_d_.get(), clamped_num_voxels);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        pooling_workspace_d_.get(), pooling_workspace_size_, order_sort_keys_d_.get(),
-        order_sort_sorted_keys_d_.get(), order_sort_indices_d_.get(),
-        level0_order_d_.get() + order_index * clamped_num_voxels, clamped_num_voxels, 0,
-        code_sort_end_bit_, stream_));
+    for (std::int32_t order_index = 1; order_index < num_orders; ++order_index) {
+      prepareLevel0OrderSortKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
+        serialized_code, order_sort_keys_d_.get(), order_sort_indices_d_.get(), clamped_num_voxels,
+        order_index);
+      CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+      CHECK_CUDA_ERROR(
+        cub::DeviceRadixSort::SortPairs(
+          pooling_workspace_d_.get(), pooling_workspace_size_, order_sort_keys_d_.get(),
+          order_sort_sorted_keys_d_.get(), order_sort_indices_d_.get(),
+          level0_order_d_.get() + order_index * clamped_num_voxels, clamped_num_voxels, 0,
+          code_sort_end_bit_, stream_));
+    }
   }
 
   const std::int32_t * current_grid_coord = grid_coord;
@@ -745,11 +732,8 @@ std::size_t PreprocessCuda::generateFeatures(
     config_.voxel_x_size_, config_.voxel_y_size_, config_.voxel_z_size_, coord_min_x, coord_min_y,
     coord_min_z, config_.serialization_depth_);
 
-  // Sorting by the order-0 serialized code does double duty: it groups duplicate voxels for the
-  // compaction below, and it leaves the surviving voxels in ascending order-0 code, i.e. already in
-  // serialization order for the first curve. generateSerializedPoolingMetadata relies on that
-  // ordering to derive every coarser level without sorting again, so this ordering is part of this
-  // function's contract, not an incidental side effect.
+  // This sort both groups duplicates for the compaction below and leaves the voxels in order-0
+  // serialization order, which generateSerializedPoolingMetadata requires.
   CHECK_CUDA_ERROR(
     cub::DeviceRadixSort::SortPairs(
       reinterpret_cast<void *>(generate_feature_workspace_d_.get()),

--- a/perception/autoware_ptv3/test/ptv3_config_test.cpp
+++ b/perception/autoware_ptv3/test/ptv3_config_test.cpp
@@ -29,10 +29,11 @@ PTv3Config makeDetectionConfig(
   const std::vector<float> & bbox_voxel_size = {8.0F, 8.0F, 4.0F},
   const std::vector<float> & distance_bin_upper_limits = {10.0F, 20.0F},
   const std::vector<float> & detection_score_thresholds = {0.1F, 0.2F, 0.3F, 0.4F},
-  const std::vector<float> & yaw_norm_thresholds = {0.1F, 0.2F})
+  const std::vector<float> & yaw_norm_thresholds = {0.1F, 0.2F},
+  const std::vector<float> & voxel_size = {1.0F, 1.0F, 1.0F})
 {
   return PTv3Config(
-    false, true, "", 8, {1, 4, 8}, point_cloud_range, {1.0F, 1.0F, 1.0F}, {}, {"z", "z-trans"},
+    false, true, "", 8, {1, 4, 8}, point_cloud_range, voxel_size, {}, {"z", "z-trans"},
     {2, 2, 2, 2}, {8, 16, 32, 64, 128}, {}, {}, "", false, "", {}, {"CAR", "PEDESTRIAN"},
     bbox_voxel_size, distance_bin_upper_limits, detection_score_thresholds, yaw_norm_thresholds,
     true, 8, {-2.0F, -2.0F, -2.0F, 4.0F, 4.0F, 4.0F});
@@ -84,6 +85,18 @@ TEST(PTv3ConfigTest, SerializationDepthCoversUnalignedRangeBoundary)
 
   const auto unaligned = makeDetectionConfig({0.5F, 0.5F, 0.5F, 16.5F, 16.5F, 4.5F});
   EXPECT_EQ(unaligned.serialization_depth_, 5);
+}
+
+// Borders that are voxel-aligned in decimal but not exactly representable in binary (neither 102.4
+// nor 0.1 is a binary float) must not gain a spurious extra coordinate from rounding: the depth is
+// derived from the same float division and floor the device mapping executes, which lands exactly
+// on the 2048 aligned cells here.
+TEST(PTv3ConfigTest, SerializationDepthStaysExactForBase10AlignedRanges)
+{
+  const auto config = makeDetectionConfig(
+    {-102.4F, -102.4F, -0.4F, 102.4F, 102.4F, 0.4F}, {0.8F, 0.8F, 4.0F}, {10.0F, 20.0F},
+    {0.1F, 0.2F, 0.3F, 0.4F}, {0.1F, 0.2F}, {0.1F, 0.1F, 0.1F});
+  EXPECT_EQ(config.serialization_depth_, 11);
 }
 
 }  // namespace test

--- a/perception/autoware_ptv3/test/ptv3_config_test.cpp
+++ b/perception/autoware_ptv3/test/ptv3_config_test.cpp
@@ -75,10 +75,8 @@ TEST(PTv3ConfigTest, RejectsInvalidDetectionThresholdTables)
     std::runtime_error);
 }
 
-// A range boundary that is not voxel-aligned makes the floor-based grid mapping emit one more
-// coordinate than the rounded cell count suggests ([0.5, 16.5) with unit voxels emits 0..16), and
-// the serialization depth must cover it; a 4-bit depth would drop the extra coordinate's top
-// Morton bit and merge its voxels with coordinate 0's.
+// [0.5, 16.5) with unit voxels emits coordinates 0..16; a depth sized for 16 cells would drop the
+// boundary coordinate's top Morton bit and merge its voxels with coordinate 0's.
 TEST(PTv3ConfigTest, SerializationDepthCoversUnalignedRangeBoundary)
 {
   const auto aligned = makeDetectionConfig();
@@ -88,11 +86,9 @@ TEST(PTv3ConfigTest, SerializationDepthCoversUnalignedRangeBoundary)
   EXPECT_EQ(unaligned.serialization_depth_, 5);
 }
 
-// The per-stage voxel-count bound must also be derived from the coordinates the grid mapping can
-// emit: [0.5, 16.5) x [0.5, 16.5) x [0.5, 4.5) with unit voxels emits 17 x 17 x 5 coordinates, so
-// stage 0 can hold up to 1445 distinct voxels and a stride-2 stage ceil(17/2)^2 * ceil(5/2) = 243.
-// Bounding by the rounded 16 x 16 x 4 grid would under-allocate the encoder stage buffers and the
-// TensorRT profiles sized from this capacity.
+// The same boundary coordinates count toward the per-stage voxel bound: 17 x 17 x 5 cells at
+// stage 0, ceil'd per stride-2 stage. A 16 x 16 x 4 bound would under-size the encoder stage
+// buffers and TensorRT profiles.
 TEST(PTv3ConfigTest, StageVoxelCapacityCoversUnalignedRangeBoundary)
 {
   const auto config = makeDetectionConfig(

--- a/perception/autoware_ptv3/test/ptv3_config_test.cpp
+++ b/perception/autoware_ptv3/test/ptv3_config_test.cpp
@@ -73,5 +73,18 @@ TEST(PTv3ConfigTest, RejectsInvalidDetectionThresholdTables)
     std::runtime_error);
 }
 
+// A range boundary that is not voxel-aligned makes the floor-based grid mapping emit one more
+// coordinate than the rounded cell count suggests ([0.5, 16.5) with unit voxels emits 0..16), and
+// the serialization depth must cover it; a 4-bit depth would drop the extra coordinate's top
+// Morton bit and merge its voxels with coordinate 0's.
+TEST(PTv3ConfigTest, SerializationDepthCoversUnalignedRangeBoundary)
+{
+  const auto aligned = makeDetectionConfig();
+  EXPECT_EQ(aligned.serialization_depth_, 4);
+
+  const auto unaligned = makeDetectionConfig({0.5F, 0.5F, 0.5F, 16.5F, 16.5F, 4.5F});
+  EXPECT_EQ(unaligned.serialization_depth_, 5);
+}
+
 }  // namespace test
 }  // namespace autoware::ptv3

--- a/perception/autoware_ptv3/test/ptv3_config_test.cpp
+++ b/perception/autoware_ptv3/test/ptv3_config_test.cpp
@@ -88,9 +88,7 @@ TEST(PTv3ConfigTest, SerializationDepthCoversUnalignedRangeBoundary)
 }
 
 // Borders that are voxel-aligned in decimal but not exactly representable in binary (neither 102.4
-// nor 0.1 is a binary float) must not gain a spurious extra coordinate from rounding: the depth is
-// derived from the same float division and floor the device mapping executes, which lands exactly
-// on the 2048 aligned cells here.
+// nor 0.1 is a binary float) must not gain a spurious extra coordinate from rounding.
 TEST(PTv3ConfigTest, SerializationDepthStaysExactForBase10AlignedRanges)
 {
   const auto config = makeDetectionConfig(

--- a/perception/autoware_ptv3/test/ptv3_config_test.cpp
+++ b/perception/autoware_ptv3/test/ptv3_config_test.cpp
@@ -30,10 +30,11 @@ PTv3Config makeDetectionConfig(
   const std::vector<float> & distance_bin_upper_limits = {10.0F, 20.0F},
   const std::vector<float> & detection_score_thresholds = {0.1F, 0.2F, 0.3F, 0.4F},
   const std::vector<float> & yaw_norm_thresholds = {0.1F, 0.2F},
-  const std::vector<float> & voxel_size = {1.0F, 1.0F, 1.0F})
+  const std::vector<float> & voxel_size = {1.0F, 1.0F, 1.0F},
+  const std::vector<std::int64_t> & voxels_num = {1, 4, 8})
 {
   return PTv3Config(
-    false, true, "", 8, {1, 4, 8}, point_cloud_range, voxel_size, {}, {"z", "z-trans"},
+    false, true, "", 8, voxels_num, point_cloud_range, voxel_size, {}, {"z", "z-trans"},
     {2, 2, 2, 2}, {8, 16, 32, 64, 128}, {}, {}, "", false, "", {}, {"CAR", "PEDESTRIAN"},
     bbox_voxel_size, distance_bin_upper_limits, detection_score_thresholds, yaw_norm_thresholds,
     true, 8, {-2.0F, -2.0F, -2.0F, 4.0F, 4.0F, 4.0F});
@@ -85,6 +86,21 @@ TEST(PTv3ConfigTest, SerializationDepthCoversUnalignedRangeBoundary)
 
   const auto unaligned = makeDetectionConfig({0.5F, 0.5F, 0.5F, 16.5F, 16.5F, 4.5F});
   EXPECT_EQ(unaligned.serialization_depth_, 5);
+}
+
+// The per-stage voxel-count bound must also be derived from the coordinates the grid mapping can
+// emit: [0.5, 16.5) x [0.5, 16.5) x [0.5, 4.5) with unit voxels emits 17 x 17 x 5 coordinates, so
+// stage 0 can hold up to 1445 distinct voxels and a stride-2 stage ceil(17/2)^2 * ceil(5/2) = 243.
+// Bounding by the rounded 16 x 16 x 4 grid would under-allocate the encoder stage buffers and the
+// TensorRT profiles sized from this capacity.
+TEST(PTv3ConfigTest, StageVoxelCapacityCoversUnalignedRangeBoundary)
+{
+  const auto config = makeDetectionConfig(
+    {0.5F, 0.5F, 0.5F, 16.5F, 16.5F, 4.5F}, {8.0F, 8.0F, 4.0F}, {10.0F, 20.0F},
+    {0.1F, 0.2F, 0.3F, 0.4F}, {0.1F, 0.2F}, {1.0F, 1.0F, 1.0F}, {1, 1024, 4096});
+  EXPECT_EQ(config.stage_voxel_capacity(0), 17 * 17 * 5);
+  EXPECT_EQ(config.stage_voxel_capacity(1), 9 * 9 * 3);
+  EXPECT_EQ(config.stage_voxel_capacity(4), 2 * 2 * 1);
 }
 
 // Borders that are voxel-aligned in decimal but not exactly representable in binary (neither 102.4

--- a/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
+++ b/perception/autoware_ptv3/test/ptv3_test_fixture.hpp
@@ -64,6 +64,22 @@ struct PTv3ConfigParams
   std::vector<float> post_center_range = {-2.0F, -2.0F, -2.0F, 4.0F, 4.0F, 4.0F};
 };
 
+// Host reimplementation of the device-side serialized (Morton / Z-order) encoding. `transposed`
+// selects the "z-trans" order, which swaps the x and y planes.
+inline std::int64_t serialize_coord(
+  const std::int64_t x, const std::int64_t y, const std::int64_t z, const std::int32_t depth,
+  const bool transposed)
+{
+  std::int64_t code = 0;
+  for (std::int32_t bit = 0; bit < depth; ++bit) {
+    const std::int64_t mask = 1LL << bit;
+    code |= (((transposed ? y : x) & mask) << (2 * bit + 2));
+    code |= (((transposed ? x : y) & mask) << (2 * bit + 1));
+    code |= ((z & mask) << (2 * bit));
+  }
+  return code;
+}
+
 inline PTv3Config makeConfig(const PTv3ConfigParams & params = {})
 {
   return PTv3Config(

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -79,25 +79,6 @@ std::int32_t pooling_depth(const std::int64_t stride)
   return depth;
 }
 
-std::int64_t serialize_coord(
-  const std::int64_t x, const std::int64_t y, const std::int64_t z, const std::int32_t depth,
-  const bool transposed)
-{
-  std::int64_t code = 0;
-  for (std::int32_t bit = 0; bit < depth; ++bit) {
-    const std::int64_t mask = 1LL << bit;
-    if (transposed) {
-      code |= ((y & mask) << (2 * bit + 2));
-      code |= ((x & mask) << (2 * bit + 1));
-    } else {
-      code |= ((x & mask) << (2 * bit + 2));
-      code |= ((y & mask) << (2 * bit + 1));
-    }
-    code |= ((z & mask) << (2 * bit));
-  }
-  return code;
-}
-
 std::vector<std::int64_t> make_serialized_code(
   const std::vector<std::int32_t> & grid_coord, const std::int32_t depth)
 {

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -97,9 +97,8 @@ std::vector<std::int64_t> make_serialized_code(
   return code;
 }
 
-// generateSerializedPoolingMetadata requires its input level to be stored in order-0 serialization
-// order, which is what generateFeatures produces. Tests that hand-build a level must therefore sort
-// it the same way before feeding it in.
+// generateSerializedPoolingMetadata requires its input sorted by order-0 serialized code (as
+// generateFeatures emits it), so hand-built levels must be sorted the same way.
 std::vector<std::int32_t> sort_grid_coord_by_order0(
   const std::vector<std::int32_t> & grid_coord, const std::int32_t depth)
 {
@@ -258,10 +257,8 @@ void expect_permutation(const std::vector<std::int64_t> & values, const std::str
   EXPECT_EQ(sorted, expected) << name;
 }
 
-// Guards a fixture's discriminating power: if two serialization orders rank a level identically,
-// then comparing that level's serialized_order against the reference cannot distinguish a correct
-// per-order derivation from one that returns the same order for every curve. Any fixture used to
-// check serialized_order/serialized_inverse must therefore make the orders disagree.
+// A fixture whose serialization orders rank a level identically cannot detect an implementation
+// that returns the same ranking for every order, so require the orders to disagree.
 void expect_orders_diverge(
   const std::vector<std::int64_t> & order, const std::size_t count, const std::size_t num_orders,
   const std::string & name)
@@ -332,9 +329,8 @@ TEST_F(SerializedPoolingMetadataTest, DetectionGridCoord3StaysInsideBevGrid)
   }
 }
 
-// Randomized sweep against the same CPU reference. The metadata is now derived with prefix scans
-// that assume pooling preserves the serialization order, so this exercises the assumption across
-// many occupancy patterns rather than one hand-picked level.
+// Randomized sweep against the CPU reference: the scan-based derivation assumes pooling preserves
+// the serialization order, so exercise that across many occupancy patterns.
 TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForRandomizedClouds)
 {
   const auto config = make_test_config();
@@ -440,11 +436,8 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
 {
   const auto config = make_test_config();
   constexpr std::size_t kNumOrders = 2;
-  // This level is chosen so that "z" and "z-trans" rank the voxels *differently* at every level,
-  // and so that pooling genuinely merges voxels at every stage (10 -> 6 -> 4). Both properties
-  // matter: the previous fixture was almost entirely y=0, which left it nearly invariant under
-  // transposing x and y, so a implementation that returned order 0 for every serialization order
-  // still passed. expect_orders_diverge below enforces the first property rather than assuming it.
+  // Chosen so that "z" and "z-trans" rank the voxels differently at every level (enforced by
+  // expect_orders_diverge below) and pooling merges voxels at every stage (10 -> 6 -> 4).
   const auto grid_coord = sort_grid_coord_by_order0(
     {3, 0, 2, 3, 1, 3, 0, 5, 2, 4, 2, 0, 5, 2, 1, 5, 3, 0, 4, 3, 3, 5, 4, 1, 4, 4, 2, 5, 4, 2},
     config.serialization_depth_);

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -22,10 +22,13 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <map>
 #include <numeric>
+#include <random>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -79,25 +82,6 @@ std::int32_t pooling_depth(const std::int64_t stride)
   return depth;
 }
 
-std::int64_t serialize_coord(
-  const std::int64_t x, const std::int64_t y, const std::int64_t z, const std::int32_t depth,
-  const bool transposed)
-{
-  std::int64_t code = 0;
-  for (std::int32_t bit = 0; bit < depth; ++bit) {
-    const std::int64_t mask = 1LL << bit;
-    if (transposed) {
-      code |= ((y & mask) << (2 * bit + 2));
-      code |= ((x & mask) << (2 * bit + 1));
-    } else {
-      code |= ((x & mask) << (2 * bit + 2));
-      code |= ((y & mask) << (2 * bit + 1));
-    }
-    code |= ((z & mask) << (2 * bit));
-  }
-  return code;
-}
-
 std::vector<std::int64_t> make_serialized_code(
   const std::vector<std::int32_t> & grid_coord, const std::int32_t depth)
 {
@@ -111,6 +95,33 @@ std::vector<std::int64_t> make_serialized_code(
     code[count + index] = serialize_coord(x, y, z, depth, true);
   }
   return code;
+}
+
+// generateSerializedPoolingMetadata requires its input level to be stored in order-0 serialization
+// order, which is what generateFeatures produces. Tests that hand-build a level must therefore sort
+// it the same way before feeding it in.
+std::vector<std::int32_t> sort_grid_coord_by_order0(
+  const std::vector<std::int32_t> & grid_coord, const std::int32_t depth)
+{
+  const auto count = grid_coord.size() / 3;
+  std::vector<std::size_t> order(count);
+  std::iota(order.begin(), order.end(), 0);
+  const auto code_of = [&grid_coord, depth](const std::size_t index) {
+    return serialize_coord(
+      grid_coord[index * 3 + 0], grid_coord[index * 3 + 1], grid_coord[index * 3 + 2], depth,
+      false);
+  };
+  std::stable_sort(order.begin(), order.end(), [&code_of](const auto lhs, const auto rhs) {
+    return code_of(lhs) < code_of(rhs);
+  });
+
+  std::vector<std::int32_t> sorted(grid_coord.size());
+  for (std::size_t rank = 0; rank < count; ++rank) {
+    for (std::size_t coord = 0; coord < 3; ++coord) {
+      sorted[rank * 3 + coord] = grid_coord[order[rank] * 3 + coord];
+    }
+  }
+  return sorted;
 }
 
 std::vector<std::int64_t> stable_argsort(const std::vector<std::int64_t> & values)
@@ -247,6 +258,29 @@ void expect_permutation(const std::vector<std::int64_t> & values, const std::str
   EXPECT_EQ(sorted, expected) << name;
 }
 
+// Guards a fixture's discriminating power: if two serialization orders rank a level identically,
+// then comparing that level's serialized_order against the reference cannot distinguish a correct
+// per-order derivation from one that returns the same order for every curve. Any fixture used to
+// check serialized_order/serialized_inverse must therefore make the orders disagree.
+void expect_orders_diverge(
+  const std::vector<std::int64_t> & order, const std::size_t count, const std::size_t num_orders,
+  const std::string & name)
+{
+  ASSERT_GE(num_orders, 2u) << name;
+  const auto row = [&order, count](const std::size_t index) {
+    const auto begin = static_cast<std::ptrdiff_t>(index * count);
+    return std::vector<std::int64_t>(
+      order.begin() + begin, order.begin() + begin + static_cast<std::ptrdiff_t>(count));
+  };
+  const auto first = row(0);
+  for (std::size_t index = 1; index < num_orders; ++index) {
+    EXPECT_NE(first, row(index))
+      << name << ": serialization orders 0 and " << index << " rank this level identically, so the "
+      << "fixture cannot detect a wrong per-order derivation. Pick coordinates that vary in both x "
+      << "and y.";
+  }
+}
+
 class SerializedPoolingMetadataTest : public PTv3CudaTest
 {
 };
@@ -255,7 +289,8 @@ TEST_F(SerializedPoolingMetadataTest, DetectionGridCoord3StaysInsideBevGrid)
 {
   const auto config = make_detection_test_config();
   constexpr std::size_t kNumOrders = 2;
-  const std::vector<std::int32_t> grid_coord{0, 0, 0, 15, 15, 0};
+  const auto grid_coord =
+    sort_grid_coord_by_order0({0, 0, 0, 15, 15, 0}, config.serialization_depth_);
   const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
   const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
 
@@ -297,12 +332,122 @@ TEST_F(SerializedPoolingMetadataTest, DetectionGridCoord3StaysInsideBevGrid)
   }
 }
 
+// Randomized sweep against the same CPU reference. The metadata is now derived with prefix scans
+// that assume pooling preserves the serialization order, so this exercises the assumption across
+// many occupancy patterns rather than one hand-picked level.
+TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForRandomizedClouds)
+{
+  const auto config = make_test_config();
+  constexpr std::size_t kNumOrders = 2;
+  const auto stage_count = config.pooling_strides_.size();
+
+  PreprocessCuda preprocess(config, stream_);
+  auto grid_coord_d = makeDeviceBuffer<std::int32_t>(config.max_num_voxels_ * 3);
+  auto serialized_code_d = makeDeviceBuffer<std::int64_t>(config.max_num_voxels_ * kNumOrders);
+  auto stage_counts_d = makeDeviceBuffer<std::int64_t>(stage_count + 1);
+  std::vector<DeviceStage> device_stages;
+  std::vector<SerializedPoolingDeviceStageView> stage_views;
+  for (std::size_t stage = 0; stage < stage_count; ++stage) {
+    device_stages.emplace_back(config.max_num_voxels_, kNumOrders);
+  }
+  for (auto & stage : device_stages) {
+    stage_views.push_back(
+      SerializedPoolingDeviceStageView{
+        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+        stage.serialized_inverse.get()});
+  }
+
+  // The grid spans 2^serialization_depth_ cells per axis; draw from a sub-cube so that pooling
+  // actually merges cells instead of every voxel ending up in its own parent.
+  const std::int32_t extent = 1 << config.serialization_depth_;
+  std::mt19937 rng(20260805U);
+
+  for (int trial = 0; trial < 32; ++trial) {
+    const std::size_t requested =
+      1U + static_cast<std::size_t>(rng() % static_cast<unsigned>(config.max_num_voxels_));
+    std::uniform_int_distribution<std::int32_t> coord_dist(0, extent - 1);
+
+    // Deduplicate: the pipeline never feeds repeated voxels into the metadata builder.
+    std::set<std::array<std::int32_t, 3>> unique_coords;
+    for (std::size_t i = 0; i < requested; ++i) {
+      unique_coords.insert({coord_dist(rng), coord_dist(rng), coord_dist(rng)});
+    }
+    std::vector<std::int32_t> grid_coord;
+    grid_coord.reserve(unique_coords.size() * 3);
+    for (const auto & coord : unique_coords) {
+      grid_coord.insert(grid_coord.end(), coord.begin(), coord.end());
+    }
+    grid_coord = sort_grid_coord_by_order0(grid_coord, config.serialization_depth_);
+
+    const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
+    const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
+
+    copyToDevice(grid_coord_d.get(), grid_coord);
+    copyToDevice(serialized_code_d.get(), serialized_code);
+    preprocess.generateSerializedPoolingMetadata(
+      grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, stage_counts_d.get());
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    std::vector<CpuStage> references;
+    references.push_back(
+      make_stage_reference(grid_coord, serialized_code, kNumOrders, config.pooling_strides_[0]));
+    for (std::size_t stage = 1; stage < stage_count; ++stage) {
+      references.push_back(make_stage_reference(
+        references[stage - 1].grid_coord, references[stage - 1].serialized_code, kNumOrders,
+        config.pooling_strides_[stage]));
+    }
+
+    const auto stage_counts = copyToHost(stage_counts_d.get(), stage_count + 1);
+    const auto trial_prefix =
+      "trial " + std::to_string(trial) + " (" + std::to_string(num_voxels) + " voxels) ";
+    ASSERT_EQ(stage_counts[0], num_voxels) << trial_prefix;
+
+    for (std::size_t stage_index = 0; stage_index < references.size(); ++stage_index) {
+      const auto & expected = references[stage_index];
+      const auto & actual = device_stages[stage_index];
+      const auto in_count = static_cast<std::size_t>(stage_counts[stage_index]);
+      const auto out_count = static_cast<std::size_t>(stage_counts[stage_index + 1]);
+      const auto prefix = trial_prefix + "stage " + std::to_string(stage_index) + " ";
+
+      ASSERT_EQ(out_count, expected.head_indices.size()) << prefix + "out_count";
+      expect_equal(
+        copyToHost(actual.indices.get(), in_count), expected.indices, prefix + "indices");
+      expect_equal(
+        copyToHost(actual.indptr.get(), out_count + 1), expected.indptr, prefix + "indptr");
+      expect_equal(
+        copyToHost(actual.head_indices.get(), out_count), expected.head_indices,
+        prefix + "head_indices");
+      expect_equal(
+        copyToHost(actual.cluster.get(), in_count), expected.cluster, prefix + "cluster");
+      expect_equal(
+        copyToHost(actual.grid_coord.get(), out_count * 3), expected.grid_coord,
+        prefix + "grid_coord");
+      expect_equal(
+        copyToHost(actual.serialized_code.get(), out_count * kNumOrders), expected.serialized_code,
+        prefix + "serialized_code");
+      expect_equal(
+        copyToHost(actual.serialized_order.get(), out_count * kNumOrders),
+        expected.serialized_order, prefix + "serialized_order");
+      expect_equal(
+        copyToHost(actual.serialized_inverse.get(), out_count * kNumOrders),
+        expected.serialized_inverse, prefix + "serialized_inverse");
+    }
+  }
+}
+
 TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
 {
   const auto config = make_test_config();
   constexpr std::size_t kNumOrders = 2;
-  const std::vector<std::int32_t> grid_coord{5, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 3,  0, 1,
-                                             4, 4, 0, 5, 4, 1, 8, 0, 0, 9, 0, 0, 10, 2, 0};
+  // This level is chosen so that "z" and "z-trans" rank the voxels *differently* at every level,
+  // and so that pooling genuinely merges voxels at every stage (10 -> 6 -> 4). Both properties
+  // matter: the previous fixture was almost entirely y=0, which left it nearly invariant under
+  // transposing x and y, so a implementation that returned order 0 for every serialization order
+  // still passed. expect_orders_diverge below enforces the first property rather than assuming it.
+  const auto grid_coord = sort_grid_coord_by_order0(
+    {3, 0, 2, 3, 1, 3, 0, 5, 2, 4, 2, 0, 5, 2, 1, 5, 3, 0, 4, 3, 3, 5, 4, 1, 4, 4, 2, 5, 4, 2},
+    config.serialization_depth_);
   const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
   const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
 
@@ -370,6 +515,8 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     const auto serialized_order = copyToHost(actual.serialized_order.get(), out_count * kNumOrders);
     const auto serialized_inverse =
       copyToHost(actual.serialized_inverse.get(), out_count * kNumOrders);
+    expect_orders_diverge(
+      expected.serialized_order, out_count, kNumOrders, prefix + "reference serialized_order");
     expect_equal(serialized_order, expected.serialized_order, prefix + "serialized_order");
     expect_equal(serialized_inverse, expected.serialized_inverse, prefix + "serialized_inverse");
     for (std::size_t order = 0; order < kNumOrders; ++order) {

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -324,6 +325,40 @@ TEST_F(PreprocessKernelTest, UnalignedRangeBoundaryKeepsCornerVoxelsDistinct)
   EXPECT_EQ(voxel_coords, (std::vector<std::int32_t>{0, 0, 0, 16, 16, 16}));
   EXPECT_EQ(serialized_code[0], serialize_coord(0, 0, 0, depth, false));
   EXPECT_EQ(serialized_code[1], serialize_coord(16, 16, 16, depth, false));
+}
+
+// Borders that are voxel-aligned in decimal but not exactly representable in binary (102.4, 0.1)
+// rely on the config evaluating the same float arithmetic as the device grid mapping: the depth
+// must stay 11 (2048 cells, no spurious boundary coordinate), a point one ULP below the border
+// must land in the last cell, and a point exactly on the border must be cropped by the strict
+// upper bound - the very exclusion the config's nextafter maximization models.
+TEST_F(PreprocessKernelTest, Base10AlignedBordersStayWithinSerializationDepth)
+{
+  PTv3ConfigParams params;
+  params.cloud_capacity = 64;
+  params.voxels_num = {1, 32, 64};
+  params.point_cloud_range = {-102.4F, -102.4F, -102.4F, 102.4F, 102.4F, 102.4F};
+  params.voxel_size = {0.1F, 0.1F, 0.1F};
+
+  const float below_max = std::nextafter(102.4F, 0.0F);
+  const std::vector<CloudPointTypeXYZI> host_points{
+    {-102.4F, -102.4F, -102.4F, 1.0F},        // exactly on the min border: grid coord (0, 0, 0)
+    {below_max, below_max, below_max, 2.0F},  // last cell: grid coord (2047, 2047, 2047)
+    {102.4F, 102.4F, 102.4F, 3.0F},           // exactly on the max border: cropped
+  };
+
+  const auto result = runGenerateFeatures(params, host_points, true);
+  ASSERT_EQ(result.num_cropped_points, 2U);
+  ASSERT_EQ(result.num_voxels, 2U);
+
+  const auto depth = config_->serialization_depth_;
+  EXPECT_EQ(depth, 11);
+
+  const auto voxel_coords = copyToHost(result.voxel_coords_d.get(), result.num_voxels * 3);
+  const auto serialized_code = copyToHost(result.serialized_code_d.get(), result.num_voxels * 2);
+  EXPECT_EQ(voxel_coords, (std::vector<std::int32_t>{0, 0, 0, 2047, 2047, 2047}));
+  EXPECT_EQ(serialized_code[0], serialize_coord(0, 0, 0, depth, false));
+  EXPECT_EQ(serialized_code[1], serialize_coord(2047, 2047, 2047, depth, false));
 }
 
 TEST_F(PreprocessKernelTest, FullReconstructionKeepsAllInputFeaturesBeforeCrop)

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -295,6 +295,37 @@ TEST_F(PreprocessKernelTest, VoxelsAreOrderedByOrder0SerializedCode)
   }
 }
 
+// A range boundary that is not voxel-aligned makes the grid mapping emit one more coordinate than
+// max_range - min_range suggests: [0.5, 16.5) with unit voxels emits 0..16. The serialization
+// depth must cover that extra coordinate; with a 4-bit depth serializeCoord would drop bit 4 and
+// the two corner voxels below would deduplicate into one.
+TEST_F(PreprocessKernelTest, UnalignedRangeBoundaryKeepsCornerVoxelsDistinct)
+{
+  PTv3ConfigParams params;
+  params.cloud_capacity = 64;
+  params.voxels_num = {1, 32, 64};
+  params.point_cloud_range = {0.5F, 0.5F, 0.5F, 16.5F, 16.5F, 16.5F};
+  params.voxel_size = {1.0F, 1.0F, 1.0F};
+
+  const std::vector<CloudPointTypeXYZI> host_points{
+    {0.6F, 0.6F, 0.6F, 1.0F},     // grid coord (0, 0, 0)
+    {16.4F, 16.4F, 16.4F, 2.0F},  // grid coord (16, 16, 16): needs a fifth coordinate bit
+  };
+
+  const auto result = runGenerateFeatures(params, host_points, true);
+  ASSERT_EQ(result.num_cropped_points, 2U);
+  ASSERT_EQ(result.num_voxels, 2U);
+
+  const auto depth = config_->serialization_depth_;
+  EXPECT_EQ(depth, 5);
+
+  const auto voxel_coords = copyToHost(result.voxel_coords_d.get(), result.num_voxels * 3);
+  const auto serialized_code = copyToHost(result.serialized_code_d.get(), result.num_voxels * 2);
+  EXPECT_EQ(voxel_coords, (std::vector<std::int32_t>{0, 0, 0, 16, 16, 16}));
+  EXPECT_EQ(serialized_code[0], serialize_coord(0, 0, 0, depth, false));
+  EXPECT_EQ(serialized_code[1], serialize_coord(16, 16, 16, depth, false));
+}
+
 TEST_F(PreprocessKernelTest, FullReconstructionKeepsAllInputFeaturesBeforeCrop)
 {
   const std::vector<CloudPointTypeXYZI> host_points{

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -51,6 +51,7 @@ protected:
   {
     CudaUniquePtr<float[]> reconstruction_features_d;
     CudaUniquePtr<std::int32_t[]> voxel_coords_d;
+    CudaUniquePtr<std::int64_t[]> serialized_code_d;
     CudaUniquePtr<CloudPointTypeXYZI[]> cropped_source_points_d;
     CudaUniquePtr<std::int64_t[]> inverse_map_d;
     std::size_t num_cropped_points{};
@@ -119,7 +120,7 @@ protected:
     auto reconstruction_features_d =
       makeDeviceBuffer<float>(config.cloud_capacity_ * config.num_point_feature_size_);
     auto voxel_coords_d = makeDeviceBuffer<std::int32_t>(config.cloud_capacity_ * 3);
-    auto voxel_hashes_d = makeDeviceBuffer<std::int64_t>(config.cloud_capacity_ * 2);
+    auto serialized_code_d = makeDeviceBuffer<std::int64_t>(config.cloud_capacity_ * 2);
     auto compact_points_d = makeDeviceBuffer<CloudPointTypeXYZI>(config.cloud_capacity_);
     auto cropped_source_points_d = makeDeviceBuffer<CloudPointTypeXYZI>(config.cloud_capacity_);
     auto inverse_map_d = makeDeviceBuffer<std::int64_t>(config.cloud_capacity_);
@@ -127,7 +128,7 @@ protected:
     std::size_t num_cropped_points = 0;
     const auto num_voxels = preprocess_->generateFeatures(
       input_points_d.get(), CloudFormat::XYZI, host_points.size(), voxel_features_d.get(),
-      voxel_coords_d.get(), voxel_hashes_d.get(), compact_points_d.get(),
+      voxel_coords_d.get(), serialized_code_d.get(), compact_points_d.get(),
       reconstruction_features_d.get(),
       with_source_outputs ? cropped_source_points_d.get() : nullptr,
       with_source_outputs ? inverse_map_d.get() : nullptr, &num_cropped_points);
@@ -137,6 +138,7 @@ protected:
     return GenerateFeaturesResult{
       std::move(reconstruction_features_d),
       std::move(voxel_coords_d),
+      std::move(serialized_code_d),
       std::move(cropped_source_points_d),
       std::move(inverse_map_d),
       num_cropped_points,
@@ -248,6 +250,48 @@ TEST_F(PreprocessKernelTest, CroppedVoxelCoordsStayInsideGridBounds)
     EXPECT_LT(x, config.grid_x_size_);
     EXPECT_LT(y, config.grid_y_size_);
     EXPECT_LT(z, config.grid_z_size_);
+  }
+}
+
+// generateFeatures sorts the emitted voxels by their order-0 serialized code; this pins that
+// postcondition down at its source.
+TEST_F(PreprocessKernelTest, VoxelsAreOrderedByOrder0SerializedCode)
+{
+  PTv3ConfigParams params;
+  params.cloud_capacity = 64;
+  params.voxels_num = {1, 32, 64};
+  params.point_cloud_range = {0.0F, 0.0F, 0.0F, 8.0F, 8.0F, 8.0F};
+  params.voxel_size = {1.0F, 1.0F, 1.0F};
+
+  // Scrambled relative to the serialization curve, with one duplicated voxel, so that neither
+  // input order nor deduplication can accidentally satisfy the assertions below.
+  const std::vector<CloudPointTypeXYZI> host_points{
+    {7.5F, 7.5F, 7.5F, 1.0F}, {0.5F, 0.5F, 0.5F, 2.0F}, {3.5F, 1.5F, 0.5F, 3.0F},
+    {0.5F, 6.5F, 2.5F, 4.0F}, {3.5F, 1.5F, 0.5F, 5.0F}, {6.5F, 0.5F, 4.5F, 6.0F},
+  };
+
+  const auto result = runGenerateFeatures(params, host_points, true);
+  ASSERT_EQ(result.num_cropped_points, 6U);
+  ASSERT_EQ(result.num_voxels, 5U);
+
+  const auto depth = config_->serialization_depth_;
+  const auto voxel_coords = copyToHost(result.voxel_coords_d.get(), result.num_voxels * 3);
+  const auto serialized_code = copyToHost(result.serialized_code_d.get(), result.num_voxels * 2);
+
+  for (std::size_t voxel_idx = 1; voxel_idx < result.num_voxels; ++voxel_idx) {
+    EXPECT_LT(serialized_code[voxel_idx - 1], serialized_code[voxel_idx])
+      << "at voxel " << voxel_idx;
+  }
+
+  // The codes must describe the grid coordinates that were actually emitted.
+  for (std::size_t voxel_idx = 0; voxel_idx < result.num_voxels; ++voxel_idx) {
+    const auto x = voxel_coords[voxel_idx * 3 + 0];
+    const auto y = voxel_coords[voxel_idx * 3 + 1];
+    const auto z = voxel_coords[voxel_idx * 3 + 2];
+    EXPECT_EQ(serialized_code[voxel_idx], serialize_coord(x, y, z, depth, false))
+      << "order 0 at voxel " << voxel_idx;
+    EXPECT_EQ(serialized_code[result.num_voxels + voxel_idx], serialize_coord(x, y, z, depth, true))
+      << "order 1 at voxel " << voxel_idx;
   }
 }
 

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -51,6 +51,7 @@ protected:
   {
     CudaUniquePtr<float[]> reconstruction_features_d;
     CudaUniquePtr<std::int32_t[]> voxel_coords_d;
+    CudaUniquePtr<std::int64_t[]> voxel_hashes_d;
     CudaUniquePtr<CloudPointTypeXYZI[]> cropped_source_points_d;
     CudaUniquePtr<std::int64_t[]> inverse_map_d;
     std::size_t num_cropped_points{};
@@ -137,6 +138,7 @@ protected:
     return GenerateFeaturesResult{
       std::move(reconstruction_features_d),
       std::move(voxel_coords_d),
+      std::move(voxel_hashes_d),
       std::move(cropped_source_points_d),
       std::move(inverse_map_d),
       num_cropped_points,
@@ -248,6 +250,49 @@ TEST_F(PreprocessKernelTest, CroppedVoxelCoordsStayInsideGridBounds)
     EXPECT_LT(x, config.grid_x_size_);
     EXPECT_LT(y, config.grid_y_size_);
     EXPECT_LT(z, config.grid_z_size_);
+  }
+}
+
+// generateSerializedPoolingMetadata derives every coarser encoder level with prefix scans instead
+// of per-stage sorts, which is only valid because generateFeatures hands it voxels already ordered
+// by their order-0 serialized code. This pins that contract down at its source.
+TEST_F(PreprocessKernelTest, VoxelsAreOrderedByOrder0SerializedCode)
+{
+  PTv3ConfigParams params;
+  params.cloud_capacity = 64;
+  params.voxels_num = {1, 32, 64};
+  params.point_cloud_range = {0.0F, 0.0F, 0.0F, 8.0F, 8.0F, 8.0F};
+  params.voxel_size = {1.0F, 1.0F, 1.0F};
+
+  // Deliberately scrambled relative to the serialization curve, and with one duplicated voxel, so
+  // that neither input order nor deduplication can accidentally satisfy the assertions below.
+  const std::vector<CloudPointTypeXYZI> host_points{
+    {7.5F, 7.5F, 7.5F, 1.0F}, {0.5F, 0.5F, 0.5F, 2.0F}, {3.5F, 1.5F, 0.5F, 3.0F},
+    {0.5F, 6.5F, 2.5F, 4.0F}, {3.5F, 1.5F, 0.5F, 5.0F}, {6.5F, 0.5F, 4.5F, 6.0F},
+  };
+
+  const auto result = runGenerateFeatures(params, host_points, true);
+  ASSERT_EQ(result.num_cropped_points, 6U);
+  ASSERT_EQ(result.num_voxels, 5U);
+
+  const auto depth = config_->serialization_depth_;
+  const auto voxel_coords = copyToHost(result.voxel_coords_d.get(), result.num_voxels * 3);
+  const auto voxel_hashes = copyToHost(result.voxel_hashes_d.get(), result.num_voxels * 2);
+
+  for (std::size_t voxel_idx = 1; voxel_idx < result.num_voxels; ++voxel_idx) {
+    EXPECT_LT(voxel_hashes[voxel_idx - 1], voxel_hashes[voxel_idx]) << "at voxel " << voxel_idx;
+  }
+
+  // The codes must describe the grid coordinates that were actually emitted; otherwise the ordering
+  // above would be sorted with respect to a grid the encoder never sees.
+  for (std::size_t voxel_idx = 0; voxel_idx < result.num_voxels; ++voxel_idx) {
+    const auto x = voxel_coords[voxel_idx * 3 + 0];
+    const auto y = voxel_coords[voxel_idx * 3 + 1];
+    const auto z = voxel_coords[voxel_idx * 3 + 2];
+    EXPECT_EQ(voxel_hashes[voxel_idx], serialize_coord(x, y, z, depth, false))
+      << "order 0 at voxel " << voxel_idx;
+    EXPECT_EQ(voxel_hashes[result.num_voxels + voxel_idx], serialize_coord(x, y, z, depth, true))
+      << "order 1 at voxel " << voxel_idx;
   }
 }
 

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -253,9 +253,8 @@ TEST_F(PreprocessKernelTest, CroppedVoxelCoordsStayInsideGridBounds)
   }
 }
 
-// generateSerializedPoolingMetadata derives every coarser encoder level with prefix scans instead
-// of per-stage sorts, which is only valid because generateFeatures hands it voxels already ordered
-// by their order-0 serialized code. This pins that contract down at its source.
+// generateSerializedPoolingMetadata requires voxels ordered by their order-0 serialized code; this
+// pins that contract of generateFeatures down at its source.
 TEST_F(PreprocessKernelTest, VoxelsAreOrderedByOrder0SerializedCode)
 {
   PTv3ConfigParams params;
@@ -264,8 +263,8 @@ TEST_F(PreprocessKernelTest, VoxelsAreOrderedByOrder0SerializedCode)
   params.point_cloud_range = {0.0F, 0.0F, 0.0F, 8.0F, 8.0F, 8.0F};
   params.voxel_size = {1.0F, 1.0F, 1.0F};
 
-  // Deliberately scrambled relative to the serialization curve, and with one duplicated voxel, so
-  // that neither input order nor deduplication can accidentally satisfy the assertions below.
+  // Scrambled relative to the serialization curve, with one duplicated voxel, so that neither
+  // input order nor deduplication can accidentally satisfy the assertions below.
   const std::vector<CloudPointTypeXYZI> host_points{
     {7.5F, 7.5F, 7.5F, 1.0F}, {0.5F, 0.5F, 0.5F, 2.0F}, {3.5F, 1.5F, 0.5F, 3.0F},
     {0.5F, 6.5F, 2.5F, 4.0F}, {3.5F, 1.5F, 0.5F, 5.0F}, {6.5F, 0.5F, 4.5F, 6.0F},
@@ -283,8 +282,7 @@ TEST_F(PreprocessKernelTest, VoxelsAreOrderedByOrder0SerializedCode)
     EXPECT_LT(voxel_hashes[voxel_idx - 1], voxel_hashes[voxel_idx]) << "at voxel " << voxel_idx;
   }
 
-  // The codes must describe the grid coordinates that were actually emitted; otherwise the ordering
-  // above would be sorted with respect to a grid the encoder never sees.
+  // The codes must describe the grid coordinates that were actually emitted.
   for (std::size_t voxel_idx = 0; voxel_idx < result.num_voxels; ++voxel_idx) {
     const auto x = voxel_coords[voxel_idx * 3 + 0];
     const auto y = voxel_coords[voxel_idx * 3 + 1];

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -296,10 +296,8 @@ TEST_F(PreprocessKernelTest, VoxelsAreOrderedByOrder0SerializedCode)
   }
 }
 
-// A range boundary that is not voxel-aligned makes the grid mapping emit one more coordinate than
-// max_range - min_range suggests: [0.5, 16.5) with unit voxels emits 0..16. The serialization
-// depth must cover that extra coordinate; with a 4-bit depth serializeCoord would drop bit 4 and
-// the two corner voxels below would deduplicate into one.
+// End-to-end check of the unaligned-boundary depth handling: the corner voxel (16, 16, 16) needs
+// a fifth coordinate bit, without which it would deduplicate into (0, 0, 0).
 TEST_F(PreprocessKernelTest, UnalignedRangeBoundaryKeepsCornerVoxelsDistinct)
 {
   PTv3ConfigParams params;
@@ -327,11 +325,9 @@ TEST_F(PreprocessKernelTest, UnalignedRangeBoundaryKeepsCornerVoxelsDistinct)
   EXPECT_EQ(serialized_code[1], serialize_coord(16, 16, 16, depth, false));
 }
 
-// Borders that are voxel-aligned in decimal but not exactly representable in binary (102.4, 0.1)
-// rely on the config evaluating the same float arithmetic as the device grid mapping: the depth
-// must stay 11 (2048 cells, no spurious boundary coordinate), a point one ULP below the border
-// must land in the last cell, and a point exactly on the border must be cropped by the strict
-// upper bound - the very exclusion the config's nextafter maximization models.
+// Decimal-aligned borders (neither 102.4 nor 0.1 is a binary float) rely on the config using the
+// same float arithmetic as the device mapping: depth stays 11, a point one ULP below the border
+// lands in the last cell, and a point exactly on the border is cropped.
 TEST_F(PreprocessKernelTest, Base10AlignedBordersStayWithinSerializationDepth)
 {
   PTv3ConfigParams params;


### PR DESCRIPTION
> [!NOTE]
> This PR was originally the full "13 radix sorts -> 2" rework and has been split in two. This first half is the enabler: it changes *what* the voxelization key is; the sort-count reduction itself now lives in PR 2 (see **Stack** below).

## What this PR does

Voxel deduplication keyed on two hashes of the grid coordinate: an FNV-1a hash on grids larger than 2^32 cells and a raster index below that. This PR replaces both with the order-0 serialized ([Morton](https://en.wikipedia.org/wiki/Z-order_curve)) code that the serialization step computes anyway:

```python
# The 3 4-bit coordinates get interleaved into a 12-bit serialization code
(xxxx, yyyy, zzzz) -> xyzxyzxyzxyz
```

Because the deduplication sort now orders voxels by their order-0 serialized code, `generateFeatures` emits them in order-0 serialization order — the postcondition PR 2 builds on to derive all pooling metadata without further sorting. This PR on its own is perf-neutral (still one deduplication sort) and not breaking (no re-export needed).

## Fixes that fall out of this

- **The 64-bit deduplication path keyed on an FNV-1a hash, which is not injective**, so distinct voxels could silently merge. Dormant (grids under 2^32 cells take the injective raster path) but armed by a larger range or finer voxels. Serialized codes are injective by construction, so `use_64bit_hash_` and the whole dual 32/64-bit branch are gone.
- **The deduplication grid and the serialization grid used different arithmetic** (`(p - min_range) / size` vs `floor(p / size) - floor(min_range / size)`), so boundary points could land in different cells in each. Both now share one `gridCoord` helper.
- **`serialization_depth_` could be one bit too small** when a range boundary is not voxel-aligned (e.g. `[0.5, 16.5)` with unit voxels emits coordinates 0..16, one more than the rounded cell count), which would drop the extra coordinate's top Morton bit and merge its voxels with coordinate 0's. Found by Copilot and Codex on review. The depth is now derived from the coordinates the mapping can actually emit, evaluated with the same float arithmetic the kernel executes. No-op for the shipped configs.

## Code changes

Removed kernels: `voxelizationHash32Kernel`, `voxelizationHash64Kernel`.
Added: `voxelizationCodeKernel`, plus `serializeCoord` / `gridCoord` device helpers shared by the key and code kernels.
Buffers: the 12 hash/index buffers (32- and 64-bit variants) become 6 code/index buffers.

The pooling-metadata path (`generateSerializedPoolingMetadata` and its kernels) is untouched — zero diff against `main`.

## Tests

- `VoxelsAreOrderedByOrder0SerializedCode` pins the new ordering postcondition (and that the emitted codes describe the emitted grid coordinates) at its source, with scrambled input and a duplicated voxel.
- `SerializationDepthCoversUnalignedRangeBoundary` / `UnalignedRangeBoundaryKeepsCornerVoxelsDistinct` cover the depth fix at the config and device level; both verified to fail against the previous depth derivation.
- `SerializationDepthStaysExactForBase10AlignedRanges` / `Base10AlignedBordersStayWithinSerializationDepth` pin the float behavior of decimal-aligned borders (e.g. `±102.4` @ `0.1`), including that a point one ULP below the border lands in the last cell and a point exactly on the border is cropped.

## Validation

Full package test suite passes. The stack as a whole (this PR + PR 2) was validated with a before/after side-by-side comparison showing no visual discrepancies (see PR 2).

## Stack

- **PR 1 (this one)**: replaces voxelization hashing with serialized codes. Perf-neutral, not breaking, no re-export, independent.
- PR 2, #13170: derives the pooling metadata with prefix scans instead of sorts (13 radix sorts -> 2). Stacked on this PR, so its diff includes this PR's commits until this one merges; the isolated PR-2 diff is https://github.com/mojomex/autoware_universe/compare/feat/ptv3-scan-serialization...feat/ptv3-scan-pooling
- PR 3, autowarefoundation/autoware_universe#13155: replaces the encoder's `serialized_code` input with `serialized_order` / `serialized_inverse`. Breaking; depends on this stack.
