### PR TITLE
fix(autoware_cuda_pointcloud_preprocessor): check CUDA launch status so errors do not leak between nodes

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -17,6 +17,7 @@
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
 
+#include <autoware/cuda_utils/cuda_check_error.hpp>
 #include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
 
@@ -64,7 +65,7 @@ CombineCloudHandler<CudaPointCloud2Traits>::CombineCloudHandler(
 {
   for (const auto & topic : input_topics_) {
     CudaConcatStruct cuda_concat_struct;
-    cudaStreamCreate(&cuda_concat_struct.stream);
+    CHECK_CUDA_ERROR(cudaStreamCreate(&cuda_concat_struct.stream));
     cuda_concat_struct_map_[topic] = std::move(cuda_concat_struct);
   }
 }
@@ -256,9 +257,9 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
           reinterpret_cast<PointTypeStruct *>(output_cloud->data.get()), stream);
         output_cloud->header.frame_id = cloud->header.frame_id;
       } else {
-        cudaMemcpyAsync(
+        CHECK_CUDA_ERROR(cudaMemcpyAsync(
           output_cloud->data.get(), output_points + concatenated_start_index, data_size,
-          cudaMemcpyDeviceToDevice, stream);
+          cudaMemcpyDeviceToDevice, stream));
         output_cloud->header.frame_id = output_frame_;
       }
 
@@ -277,7 +278,7 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
 
   // Sync all streams
   for (const auto & [topic, cuda_concat_struct] : cuda_concat_struct_map_) {
-    cudaStreamSynchronize(cuda_concat_struct.stream);
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(cuda_concat_struct.stream));
   }
 
   concatenate_cloud_result.concatenate_cloud_ptr->header.stamp = oldest_stamp;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.cu
@@ -47,9 +47,8 @@ void transform_launch(
   const PointTypeStruct * input_points, int num_points, TransformStruct transform,
   PointTypeStruct * output_points, cudaStream_t & stream)
 {
-  // An empty cloud would give a zero-sized grid, which the launch rejects with
-  // cudaErrorInvalidConfiguration. That error would then stay pending on this host thread and be
-  // reported by the next unrelated CUDA call made from it (see also the launch status check below).
+  // `num_points <= 0` would result in an invalid number of `blocks_per_grid`,
+  // causing a `cudaErrorInvalidConfiguration`. Exit early instead.
   if (num_points <= 0) {
     return;
   }

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.cu
@@ -14,6 +14,8 @@
 
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp"
 
+#include <autoware/cuda_utils/cuda_check_error.hpp>
+
 #include <cuda_runtime.h>
 
 namespace autoware::pointcloud_preprocessor
@@ -45,11 +47,19 @@ void transform_launch(
   const PointTypeStruct * input_points, int num_points, TransformStruct transform,
   PointTypeStruct * output_points, cudaStream_t & stream)
 {
+  // An empty cloud would give a zero-sized grid, which the launch rejects with
+  // cudaErrorInvalidConfiguration. That error would then stay pending on this host thread and be
+  // reported by the next unrelated CUDA call made from it (see also the launch status check below).
+  if (num_points <= 0) {
+    return;
+  }
+
   constexpr int threads_per_block = 256;
   const int block_per_grid = (num_points + threads_per_block - 1) / threads_per_block;
 
   transform_kernel<<<block_per_grid, threads_per_block, 0, stream>>>(
     input_points, num_points, transform, output_points);
+  CHECK_CUDA_ERROR(cudaGetLastError());
 }
 
 }  // namespace autoware::pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
@@ -16,6 +16,8 @@
 #include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/types.hpp"
 
+#include <autoware/cuda_utils/cuda_check_error.hpp>
+
 namespace autoware::cuda_pointcloud_preprocessor
 {
 __global__ void transformPointsKernel(
@@ -116,6 +118,7 @@ void transformPointsLaunch(
 {
   transformPointsKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
     input_points, output_points, num_points, transform);
+  CHECK_CUDA_ERROR(cudaGetLastError());
 }
 
 void cropBoxLaunch(
@@ -126,6 +129,7 @@ void cropBoxLaunch(
   cropBoxKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
     d_points, output_crop_mask, output_nan_mask, num_points, crop_box_parameters_ptr,
     num_crop_boxes);
+  CHECK_CUDA_ERROR(cudaGetLastError());
 }
 
 void combineMasksLaunch(
@@ -134,6 +138,7 @@ void combineMasksLaunch(
 {
   combineMasksKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
     mask1, mask2, num_points, output_mask);
+  CHECK_CUDA_ERROR(cudaGetLastError());
 }
 
 void extractPointsLaunch(
@@ -143,6 +148,7 @@ void extractPointsLaunch(
 {
   extractPointsKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
     input_points, masks, indices, num_points, output_points);
+  CHECK_CUDA_ERROR(cudaGetLastError());
 }
 
 }  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -250,13 +250,15 @@ void CudaPointcloudPreprocessor::organizePointcloud()
       thrust::raw_pointer_cast(device_indexes_tensor_.data()),
       num_organized_points_ * sizeof(std::uint32_t), cudaMemcpyDeviceToDevice, stream_));
   } else {
-    cub::DeviceSegmentedRadixSort::SortKeys(
+    // The status has to be checked here: cub leaves a failure pending on this host thread, where
+    // the next CUDA call (e.g. the fill below) would report it as its own error instead.
+    CHECK_CUDA_ERROR(cub::DeviceSegmentedRadixSort::SortKeys(
       reinterpret_cast<void *>(thrust::raw_pointer_cast(device_sort_workspace_.data())),  // NOLINT
       sort_workspace_bytes_, thrust::raw_pointer_cast(device_indexes_tensor_.data()),
       thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), num_organized_points_,
       num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
       thrust::raw_pointer_cast(device_segment_offsets_.data()) + 1, 0, sizeof(std::uint32_t) * 8,
-      stream_);
+      stream_));
   }
 
   // reuse device_indexes_tensor_ to store valid point location

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -252,13 +252,15 @@ void CudaPointcloudPreprocessor::organizePointcloud()
   } else {
     // The status has to be checked here: cub leaves a failure pending on this host thread, where
     // the next CUDA call (e.g. the fill below) would report it as its own error instead.
-    CHECK_CUDA_ERROR(cub::DeviceSegmentedRadixSort::SortKeys(
-      reinterpret_cast<void *>(thrust::raw_pointer_cast(device_sort_workspace_.data())),  // NOLINT
-      sort_workspace_bytes_, thrust::raw_pointer_cast(device_indexes_tensor_.data()),
-      thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), num_organized_points_,
-      num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
-      thrust::raw_pointer_cast(device_segment_offsets_.data()) + 1, 0, sizeof(std::uint32_t) * 8,
-      stream_));
+    CHECK_CUDA_ERROR(
+      cub::DeviceSegmentedRadixSort::SortKeys(
+        reinterpret_cast<void *>(
+          thrust::raw_pointer_cast(device_sort_workspace_.data())),  // NOLINT
+        sort_workspace_bytes_, thrust::raw_pointer_cast(device_indexes_tensor_.data()),
+        thrust::raw_pointer_cast(device_sorted_indexes_tensor_.data()), num_organized_points_,
+        num_rings_, thrust::raw_pointer_cast(device_segment_offsets_.data()),
+        thrust::raw_pointer_cast(device_segment_offsets_.data()) + 1, 0, sizeof(std::uint32_t) * 8,
+        stream_));
   }
 
   // reuse device_indexes_tensor_ to store valid point location

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -250,8 +250,6 @@ void CudaPointcloudPreprocessor::organizePointcloud()
       thrust::raw_pointer_cast(device_indexes_tensor_.data()),
       num_organized_points_ * sizeof(std::uint32_t), cudaMemcpyDeviceToDevice, stream_));
   } else {
-    // The status has to be checked here: cub leaves a failure pending on this host thread, where
-    // the next CUDA call (e.g. the fill below) would report it as its own error instead.
     CHECK_CUDA_ERROR(
       cub::DeviceSegmentedRadixSort::SortKeys(
         reinterpret_cast<void *>(


### PR DESCRIPTION
## Description

A CUDA error raised by one node in the pointcloud container was reported — and fatally so — by a
different, innocent node.

`transform_launch()` in the CUDA concatenate handler computes its grid from the source cloud size:

```cpp
const int block_per_grid = (num_points + threads_per_block - 1) / threads_per_block;
transform_kernel<<<block_per_grid, threads_per_block, 0, stream>>>(...);   // status discarded
```

For an empty cloud that is a zero-sized grid, which the launch rejects with
`cudaErrorInvalidConfiguration`. Since the status is never checked, the error simply stays pending
on the calling host thread.

thrust's launcher then picks it up. `triple_chevron::doit_host()` returns `cudaPeekAtLastError()`,
i.e. *any* error pending on the thread, not just the one from its own launch:

```cpp
k<<<grid, block, shared_mem, stream>>>(args...);
return cudaPeekAtLastError();
```

So the next `thrust::fill` on that thread fails with someone else's error, thrust converts it to
`thrust::system_error`, nothing catches it, and `std::terminate` aborts the whole
`component_container_mt` — all eight `cuda_pointcloud_preprocessor` nodes plus the concatenator.
Because the concatenator and the preprocessors share the executor threads, the stack trace and the
error text both point at a node that did nothing wrong:

```
terminate called after throwing an instance of 'thrust::...::system::system_error'
  what():  parallel_for failed: cudaErrorInvalidDevice: invalid device ordinal
    @ autoware::cuda_utils::thrust_stream::fill<>()
    @ autoware::cuda_pointcloud_preprocessor::CudaPointcloudPreprocessor::process()
```

Changes:

- `transform_launch()`: an empty cloud is valid, empty data with nothing to launch, so return early
  rather than launching a zero-sized grid. Also check the launch status.
- `common_kernels.cu`: add the missing launch status checks to the four launch wrappers.
  `organize_kernels.cu`, `outlier_kernels.cu` and `undistort_kernels.cu` already do this; these four
  were the outliers.
- Check the status of `cub::DeviceSegmentedRadixSort::SortKeys`, which was discarded. cub leaves its
  failures pending too, so it had the same failure mode — and it sits immediately before a
  `thrust::fill`, which is what made the misattribution so convincing.
- Check the three remaining unchecked CUDA calls in the CUDA concatenate handler.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

### Minimal reproduction

Three components in one container plus ten dummy pointclouds. Download the linked files  to your autoware workspace first.

```bash
colcon build --packages-select autoware_cuda_pointcloud_preprocessor
source install/setup.bash

python3 make_bag.py /tmp/cuda_pp_empty_cloud_repro   # ~1 MB, 10 frames, one empty cloud
ros2 launch ./repro.launch.xml                       # leave running
ros2 bag play /tmp/cuda_pp_empty_cloud_repro --clock  # second shell
```

[README.md](https://github.com/user-attachments/files/30778243/README.md) · [make_bag.py](https://github.com/user-attachments/files/30778241/make_bag.py) · [repro.launch.xml](https://github.com/user-attachments/files/30778244/repro.launch.xml) · [repro.param.yaml](https://github.com/user-attachments/files/30778246/repro.param.yaml)

Why each piece is needed:

| Piece | Reason |
|---|---|
| 1 × `CudaPointCloudConcatenateDataSynchronizerComponent` | Leaks the error. |
| 2 × `CudaPointcloudPreprocessorNode` | Surfaces it — the concatenator makes no thrust calls itself. Two, because the concatenator rejects fewer than two `input_topics`. |
| All three in **one** container | The CUDA error state is per host thread, so leaker and victim must share a thread. |
| `component_container`, not `_mt` | Makes it deterministic. Under `component_container_mt` the same crash occurs only when the poisoned thread happens to run a preprocessor callback next, which is why it looks bag- and load-dependent in production. |
| One `width == 0` input cloud | The entire trigger. A lidar frame with no returns suffices. |

Before the fix, the container aborts within a frame of the empty cloud, with the same stack as
the field report:

```
[WARN] cuda_concatenate: Empty sensor points!
terminate called after throwing an instance of 'thrust::...::system::system_error'
  what():  parallel_for failed: cudaErrorInvalidDevice: invalid device ordinal
    @ autoware::cuda_utils::thrust_stream::fill<>()
    @ autoware::cuda_pointcloud_preprocessor::CudaPointcloudPreprocessor::process()
    @ ...::CudaPointcloudPreprocessorNode::pointcloudCallback()
[ERROR] [component_container-1]: process has died [exit code -6]
```

Worth noting the reported error is `cudaErrorInvalidDevice`, while the failed launch actually
produced `cudaErrorInvalidConfiguration`. thrust's `dispatch()` calls `cub::PtxVersion()` first,
which calls `cub::CurrentDevice()` → `cudaGetDevice()`; that returns the pending error, so
`CurrentDevice()` yields `-1` and CUB maps `device < 0` to `cudaErrorInvalidDevice`. A zero-sized
grid in the concatenator therefore gets reported as a bogus missing GPU inside an unrelated node.

After the fix, on the same bag: `Empty sensor points!` is still logged (the empty frame is still
processed as valid, empty data), no exception is thrown, and all three nodes are alive when the
bag ends.

### Real-vehicle bag

Also reproduced on `aip_x2_gen2` (8 × Hesai, dual return) replaying a logging simulation, on an
RTX PRO 6000 Blackwell with CUDA 12.8. There the abort is timing-dependent, so the measured
signal was the leaked error itself: the package was rebuilt with a probe reading
`cudaPeekAtLastError()` at the top of `CudaPointcloudPreprocessor::process()`, before it issues
any CUDA call of its own. Anything reported there was leaked by other code sharing the thread.

| | `Empty sensor points!` reached | leaked error at `process()` entry | container abort |
|---|---|---|---|
| before | 3/3 runs | **3/3 runs** (`cudaErrorInvalidConfiguration`) | reproduced |
| after  | 3/3 runs | **0/3 runs** | none |

The empty-cloud path is still exercised on every run after the fix, so the trigger fires and no
longer leaks. None of the newly added checks fired during those runs.

## Notes for reviewers

The new checks mean a genuine launch failure now throws where it previously continued silently. That
is the intended behaviour — an unchecked status corrupts an unrelated node instead — but it does turn
some previously invisible failures into loud ones, so it is worth a second opinion on whether any
caller wants to handle rather than propagate.

Two pre-existing issues in `organizePointcloud()` were left alone to keep this diff reviewable:

- `device_max_ring_` / `device_max_points_per_ring_` are never reset between frames, so they hold
  lifetime maxima. `num_rings_` visibly thrashes during startup (1 → 128, then 126 → 127 → 128),
  reallocating every buffer each time.
- `max_points_per_ring_ = std::max((max_points_per_ring + 511) / 512 * 512, 512)` is off by one:
  `max_points_per_ring` is the largest *offset*, so the capacity needs `+ 1`. At an exact multiple of
  512 the resize condition can never become true again and points are silently dropped from then on.

## Interface changes

None.

## Effects on system behavior

Empty pointclouds pass through the concatenator as valid empty data instead of leaving a CUDA error
behind. Otherwise no behavioural change on the success path; failing CUDA calls are now reported at
their origin.
