### PR TITLE
fix(autoware_tensorrt_plugins): make spconv plugins safe under CUDA graph capture

### DIFF
--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -108,6 +108,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     src/unique_ops/unique.cu
     src/multi_scale_deform_attn_ops/ms_deform_attn_kernel.cu
     src/rotate_ops/rotate_kernel.cu
+    src/scalar_ops/fill_scalar.cu
     src/select_and_pad_ops/select_and_pad_kernel.cu
   )
 

--- a/perception/autoware_tensorrt_plugins/include/autoware/scalar_ops/fill_scalar.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/scalar_ops/fill_scalar.hpp
@@ -1,0 +1,31 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__SCALAR_OPS__FILL_SCALAR_HPP_
+#define AUTOWARE__SCALAR_OPS__FILL_SCALAR_HPP_
+
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+
+/// \brief Write a single host-known ``std::int32_t`` into device memory.
+///
+/// This exists so that plugins can publish a scalar they computed on the host without issuing a
+/// host-to-device ``cudaMemcpyAsync`` from pageable memory. Such a copy has synchronous behaviour
+/// and is rejected with ``cudaErrorStreamCaptureUnsupported`` while a stream is capturing, which
+/// TensorRT does when it times tactics during engine build. A kernel launch carries its arguments
+/// by value, so it is legal both during capture and during ordinary execution.
+cudaError_t fill_scalar_int32(std::int32_t * output, std::int32_t value, cudaStream_t stream);
+
+#endif  // AUTOWARE__SCALAR_OPS__FILL_SCALAR_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
@@ -139,6 +139,10 @@ private:
   GetIndicesPairsImplicitGemmParameters params_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
+
+  // Set once the zero-output CUDA-graph-capture path has been reported, so engine builds do not
+  // repeat the warning for every timed tactic.
+  bool stream_capture_warned_{false};
 };
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp
@@ -127,6 +127,10 @@ private:
   GetIndicesPairsParameters params_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
+
+  // Set once the zero-output CUDA-graph-capture path has been reported, so engine builds do not
+  // repeat the warning for every timed tactic.
+  bool stream_capture_warned_{false};
 };
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -140,6 +140,10 @@ private:
 
   // Pre-allocated CPU mask tensor to avoid heap allocation during CUDA graph capture.
   tv::Tensor mask_tensor_;
+
+  // Set once the zero-output CUDA-graph-capture path has been reported, so engine builds do not
+  // repeat the warning for every timed tactic.
+  bool stream_capture_warned_{false};
 };
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/indice_conv_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/indice_conv_plugin.hpp
@@ -18,6 +18,8 @@
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
 #include <cuda_runtime.h>
+#include <spconvlib/spconv/csrc/sparse/alloc/StaticAllocator.h>
+#include <spconvlib/spconv/csrc/sparse/convops/SimpleExternalSpconvMatmul.h>
 #include <spconvlib/spconv/csrc/sparse/convops/gemmops/GemmTunerSimple.h>  // cSpell:ignore spconvlib
 #include <spconvlib/spconv/csrc/sparse/convops/spops/ConvGemmOps.h>
 
@@ -48,6 +50,9 @@ class IndiceConvPlugin : public IPluginV3,
 {
 public:
   using GemmTunerSimple = spconvlib::spconv::csrc::sparse::convops::spops::GemmTuner;
+  using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
+  using SimpleExternalSpconvMatmul =
+    spconvlib::spconv::csrc::sparse::convops::SimpleExternalSpconvMatmul;
   IndiceConvPlugin(const std::string & name, IndiceConvParameters const & params);
 
   ~IndiceConvPlugin() override = default;
@@ -124,6 +129,18 @@ private:
 
   std::unique_ptr<GemmTunerSimple> tuner_fp32_ptr_{};
   std::unique_ptr<GemmTunerSimple> tuner_fp16_ptr_{};
+
+  // The matmul helper owns a cuBLASLt handle, whose creation allocates and is therefore rejected
+  // while TensorRT captures the stream to time tactics during engine build. Keeping it alive for
+  // the lifetime of the plugin moves that creation out of enqueue(), which also spares every
+  // inference call a cublasLtCreate()/cublasLtDestroy() pair. The allocator it references is
+  // retargeted at the current bindings on each call via set_new_tensor_dict().
+  std::unique_ptr<StaticAllocator> matmul_allocator_ptr_{};
+  std::unique_ptr<SimpleExternalSpconvMatmul> matmul_ptr_{};
+
+  // Set once the zero-output CUDA-graph-capture path has been reported, so engine builds do not
+  // repeat the warning for every timed tactic.
+  bool stream_capture_warned_{false};
 };
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -30,6 +30,24 @@ void logWarning(char const * msg);
 cudaError_t reportCudaStatus(
   cudaError_t status, char const * msg, char const * file, std::int32_t line);
 
+/// \brief Whether \p stream is currently being captured into a CUDA graph.
+bool isStreamCapturing(cudaStream_t stream);
+
+/// \brief Zero every output of a plugin, for use when its real work cannot run.
+///
+/// The spconv-backed plugins compute their output extents on the host, which forces host
+/// synchronization and library handle creation that CUDA rejects while a stream is capturing.
+/// TensorRT captures the stream when it times tactics during engine build, so those plugins
+/// cannot execute there. Writing deterministic zeros lets the build proceed; the tactic timing it
+/// produces for these layers is meaningless, which is harmless because they expose a single
+/// tactic. Callers must only use this while \ref isStreamCapturing is true.
+cudaError_t zeroPluginOutputs(
+  nvinfer1::PluginTensorDesc const * output_desc, std::int32_t num_outputs, void * const * outputs,
+  cudaStream_t stream);
+
+/// \brief Log, at most once per plugin instance, that capture forced the zero-output path.
+void warnOnceStreamCaptureUnsupported(char const * plugin_name, bool & already_warned);
+
 #define PLUGIN_CUDA_CHECK(val) reportCudaStatus((val), #val, __FILE__, __LINE__)
 
 #define PLUGIN_ASSERT(val) reportAssertion((val), #val, __FILE__, __LINE__)

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp"
 
+#include "autoware/scalar_ops/fill_scalar.hpp"
 #include "autoware/tensorrt_plugins/plugin_utils.hpp"
 
 #include <NvInferRuntime.h>
@@ -286,12 +287,18 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::getOutputShapes(
 // =========================================================================
 
 std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
-  PluginTensorDesc const * input_desc, [[maybe_unused]] PluginTensorDesc const * output_desc,
+  PluginTensorDesc const * input_desc, PluginTensorDesc const * output_desc,
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
   using SpconvOps = spconvlib::spconv::csrc::sparse::all::SpconvOps;
   using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
+
+  if (isStreamCapturing(stream)) {
+    warnOnceStreamCaptureUnsupported(
+      kGET_INDICES_PAIRS_IMPLICIT_GEMM_PLUGIN_NAME, stream_capture_warned_);
+    return zeroPluginOutputs(output_desc, getNbOutputs(), outputs, stream) == cudaSuccess ? 0 : -1;
+  }
 
   const bool is_subm = params_.subm;
   const bool direct_table = true;
@@ -439,10 +446,9 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
   std::int32_t num_act_out_real = std::get<1>(pair_res);
   std::int32_t * num_act_out_data = static_cast<std::int32_t *>(outputs[4]);
 
-  cudaError_t const status = cudaMemcpyAsync(
-    num_act_out_data, &num_act_out_real, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
-
-  return status;
+  // See GetIndicesPairsPlugin::enqueue: a pageable host-to-device copy is rejected while
+  // TensorRT captures the stream to time tactics, so publish the count with a kernel instead.
+  return fill_scalar_int32(num_act_out_data, num_act_out_real, stream);
 }
 
 std::int32_t GetIndicesPairsImplicitGemmPlugin::onShapeChange(

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp"
 
+#include "autoware/scalar_ops/fill_scalar.hpp"
 #include "autoware/tensorrt_plugins/plugin_utils.hpp"
 
 #include <NvInferRuntime.h>
@@ -229,12 +230,17 @@ std::int32_t GetIndicesPairsPlugin::getOutputShapes(
 }
 
 std::int32_t GetIndicesPairsPlugin::enqueue(
-  PluginTensorDesc const * input_desc, [[maybe_unused]] PluginTensorDesc const * output_desc,
+  PluginTensorDesc const * input_desc, PluginTensorDesc const * output_desc,
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
   using SpconvOps = spconvlib::spconv::csrc::sparse::all::SpconvOps;
   using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
+
+  if (isStreamCapturing(stream)) {
+    warnOnceStreamCaptureUnsupported(kGET_INDICES_PAIRS_PLUGIN_NAME, stream_capture_warned_);
+    return zeroPluginOutputs(output_desc, getNbOutputs(), outputs, stream) == cudaSuccess ? 0 : -1;
+  }
 
   const bool is_subm = params_.subm;
   const int num_act_in = input_desc[0].dims.d[0];
@@ -291,12 +297,10 @@ std::int32_t GetIndicesPairsPlugin::enqueue(
 
   std::int32_t * num_act_out_data = static_cast<std::int32_t *>(outputs[3]);
 
-  cudaError_t const status = cudaMemcpyAsync(
-    num_act_out_data, &num_act_out_real, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
-
-  cudaStreamSynchronize(stream);
-
-  return status;
+  // Publish the count with a kernel rather than a host-to-device copy: the source is a stack
+  // variable, so a pageable copy would be rejected while TensorRT captures the stream to time
+  // tactics during engine build. The launch is stream-ordered, so no synchronization is needed.
+  return fill_scalar_int32(num_act_out_data, num_act_out_real, stream);
 }
 
 std::int32_t GetIndicesPairsPlugin::onShapeChange(

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -285,12 +285,17 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
 }
 
 std::int32_t ImplicitGemmPlugin::enqueue(
-  PluginTensorDesc const * input_desc, [[maybe_unused]] PluginTensorDesc const * output_desc,
+  PluginTensorDesc const * input_desc, PluginTensorDesc const * output_desc,
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
   using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
   using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
+
+  if (isStreamCapturing(stream)) {
+    warnOnceStreamCaptureUnsupported(kIMPLICIT_GEMM_PLUGIN_NAME, stream_capture_warned_);
+    return zeroPluginOutputs(output_desc, getNbOutputs(), outputs, stream) == cudaSuccess ? 0 : -1;
+  }
 
   PLUGIN_ASSERT(
     num_plugin_inputs_ == NUM_PLUGIN_INPUTS_NO_BIAS ||

--- a/perception/autoware_tensorrt_plugins/src/indice_conv_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/indice_conv_plugin.cpp
@@ -49,6 +49,12 @@ IndiceConvPlugin::IndiceConvPlugin(const std::string & name, IndiceConvParameter
   tuner_fp16_ptr_ =
     std::make_unique<GemmTunerSimple>(GemmMain::get_all_algo_desp());  // cSpell:ignore desp
   tuner_fp32_ptr_ = std::make_unique<GemmTunerSimple>(GemmMain::get_all_algo_desp());
+
+  // Create the cuBLASLt-backed matmul helper here rather than in enqueue(); see the member
+  // declaration for why it must not be created while the stream is capturing.
+  matmul_allocator_ptr_ =
+    std::make_unique<StaticAllocator>(std::unordered_map<std::string, tv::Tensor>{});
+  matmul_ptr_ = std::make_unique<SimpleExternalSpconvMatmul>(*matmul_allocator_ptr_);
 }
 
 void IndiceConvPlugin::initFieldsToSerialize()
@@ -196,14 +202,16 @@ std::int32_t IndiceConvPlugin::getOutputShapes(
 }
 
 std::int32_t IndiceConvPlugin::enqueue(
-  PluginTensorDesc const * input_desc, [[maybe_unused]] PluginTensorDesc const * output_desc,
+  PluginTensorDesc const * input_desc, PluginTensorDesc const * output_desc,
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
-  using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
   using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
-  using SimpleExternalSpconvMatmul =
-    spconvlib::spconv::csrc::sparse::convops::SimpleExternalSpconvMatmul;
+
+  if (isStreamCapturing(stream)) {
+    warnOnceStreamCaptureUnsupported(kINDICE_CONV_PLUGIN_NAME, stream_capture_warned_);
+    return zeroPluginOutputs(output_desc, getNbOutputs(), outputs, stream) == cudaSuccess ? 0 : -1;
+  }
 
   std::int64_t num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
   std::int64_t num_in_features = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];
@@ -250,9 +258,12 @@ std::int32_t IndiceConvPlugin::enqueue(
     {SPCONV_ALLOC_FEATURES, input_features},
     {SPCONV_ALLOC_FILTERS, weights},
     {SPCONV_ALLOC_OUT_FEATURES, out_features}};
-  StaticAllocator alloc2(tensor_dict);
 
-  SimpleExternalSpconvMatmul ext_mm(alloc2);
+  // Retarget the long-lived allocator at this call's bindings. matmul_ptr_ holds a reference to
+  // it, so the cuBLASLt handle created in the constructor is reused instead of rebuilt here.
+  auto & alloc2 = *matmul_allocator_ptr_;
+  alloc2.set_new_tensor_dict(tensor_dict);
+  auto & ext_mm = *matmul_ptr_;
 
   ConvGemmOps::indice_conv(
     alloc2, ext_mm, *tuner_ptr, true, false, input_features, weights, pairs, pairs_num, arch_,

--- a/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
+++ b/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
@@ -16,6 +16,8 @@
 
 #include <NvInferRuntime.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <sstream>
@@ -104,5 +106,73 @@ void reportValidationMsg(
 {
   if (!success) {
     logValidationFailure(msg, detail, file, line);
+  }
+}
+
+bool isStreamCapturing(cudaStream_t stream)
+{
+  cudaStreamCaptureStatus capture_status{cudaStreamCaptureStatusNone};
+  if (cudaStreamIsCapturing(stream, &capture_status) != cudaSuccess) {
+    return false;
+  }
+  return capture_status != cudaStreamCaptureStatusNone;
+}
+
+cudaError_t zeroPluginOutputs(
+  nvinfer1::PluginTensorDesc const * output_desc, std::int32_t num_outputs, void * const * outputs,
+  cudaStream_t stream)
+{
+  for (std::int32_t output_index = 0; output_index < num_outputs; ++output_index) {
+    auto const & desc = output_desc[output_index];
+    std::size_t num_elements = 1;
+    for (std::int32_t dim = 0; dim < desc.dims.nbDims; ++dim) {
+      num_elements *= static_cast<std::size_t>(std::max<std::int64_t>(desc.dims.d[dim], 0));
+    }
+    if (num_elements == 0) {
+      continue;
+    }
+    std::size_t element_size = 0;
+    switch (desc.type) {
+      case nvinfer1::DataType::kINT64:
+        element_size = 8;
+        break;
+      case nvinfer1::DataType::kFLOAT:
+      case nvinfer1::DataType::kINT32:
+        element_size = 4;
+        break;
+      case nvinfer1::DataType::kHALF:
+      case nvinfer1::DataType::kBF16:
+        element_size = 2;
+        break;
+      default:
+        element_size = 1;
+        break;
+    }
+    if (
+      auto const status =
+        cudaMemsetAsync(outputs[output_index], 0, num_elements * element_size, stream);
+      status != cudaSuccess) {
+      return status;
+    }
+  }
+  return cudaSuccess;
+}
+
+void warnOnceStreamCaptureUnsupported(char const * plugin_name, bool & already_warned)
+{
+  if (already_warned) {
+    return;
+  }
+  already_warned = true;
+  std::ostringstream stream;
+  stream << plugin_name
+         << ": the stream is being captured into a CUDA graph, which this plugin cannot support "
+            "because it derives its output extents on the host. Writing zero outputs instead. "
+            "This is expected while TensorRT times tactics during engine build; if it appears "
+            "during inference, the CUDA graph result is not valid.";
+  // getLogger() yields null until TensorRT hands the library a logger finder, which does not
+  // happen when the plugin library is loaded directly rather than through the plugin registry.
+  if (auto * logger = getLogger(); logger != nullptr) {
+    logger->log(nvinfer1::ILogger::Severity::kWARNING, stream.str().c_str());
   }
 }

--- a/perception/autoware_tensorrt_plugins/src/scalar_ops/fill_scalar.cu
+++ b/perception/autoware_tensorrt_plugins/src/scalar_ops/fill_scalar.cu
@@ -1,0 +1,31 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/scalar_ops/fill_scalar.hpp"
+
+namespace
+{
+
+__global__ void fill_scalar_int32_kernel(std::int32_t * output_out, const std::int32_t value_in)
+{
+  *output_out = value_in;
+}
+
+}  // namespace
+
+cudaError_t fill_scalar_int32(std::int32_t * output, std::int32_t value, cudaStream_t stream)
+{
+  fill_scalar_int32_kernel<<<1, 1, 0, stream>>>(output, value);
+  return cudaPeekAtLastError();
+}


### PR DESCRIPTION
## Description

The PTv3 encoder engine cannot be built on DRIVE Thor (TensorRT 10.10). TensorRT captures the stream into a CUDA graph while it times tactics during engine build, and the spconv-backed plugins issue CUDA calls that are illegal while a stream is capturing. The plugins return `cudaErrorStreamCaptureUnsupported` (900) or `cudaErrorStreamCaptureInvalidated` (901), TensorRT then reports `Could not find any implementation for node {ForeignNode[...]}`, and spconv aborts the process outright (`CUB error: invalid device ordinal`, later `cuBLAS API failed`).

The same ONNX, optimization profile and plugin sources build without complaint on x86 (TensorRT 10.8), which is why this went unnoticed.

Three distinct violations are fixed:

| Location | Violation |
|:---|:---|
| `GetIndicesPairsPlugin::enqueue` | `cudaStreamSynchronize` on every call, plus a host-to-device `cudaMemcpyAsync` whose source is a stack variable — a pageable copy has synchronous behaviour and is rejected during capture |
| `GetIndicesPairsImplicitGemmPlugin::enqueue` | the same pageable host-to-device copy |
| `IndiceConvPlugin::enqueue` | constructs `SimpleExternalSpconvMatmul` per call, whose constructor calls `cublasLtCreate` |

Both counts are now published with a one-element kernel (`fill_scalar_int32`). Kernel arguments are passed by value, so no synchronization is needed and the source value's lifetime is no longer a concern. The cuBLASLt handle now lives for the lifetime of the plugin, with the allocator it references retargeted at the current bindings via `set_new_tensor_dict`.

Removing the per-call stream synchronization and the `cublasLtCreate`/`cublasLtDestroy` pair also takes work off the inference path, which runs once per frame.

Those fixes are necessary but not sufficient: further capture-illegal calls remain inside spconv itself, and fixing them one at a time does not converge. The four spconv-backed plugins therefore also detect capture and emit zeroed outputs instead of running. Plugin output shapes come from `getOutputShapes` rather than from data, so only tactic timing is affected, and these plugins expose a single tactic, so that timing is not used to choose between alternatives.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

Built and run on a DRIVE Thor board and on an x86 workstation, using a standalone TensorRT builder that loads the plugin library, parses the ONNX and applies the same optimization profile as `PTv3TRT::initEncoderTrt`, so ROS is not in the loop.

- **DRIVE Thor (TensorRT 10.10.10), before:** the process aborts during builder tactic timing, inside spconv.
- **DRIVE Thor, after:** `ENGINE BUILD SUCCEEDED after 39 s`. The resulting engine deserializes and creates an execution context on the device.
- **x86 (TensorRT 10.8), before and after:** engine builds successfully, so the previously working platform does not regress.
- **Inference:** `enqueueV3` on the built engine returns `cudaSuccess` on both a cold and a warm run, and `cudaStreamIsCapturing` reports no capture around it, confirming the capture path is build-only and never taken during ordinary inference.

Verified against a submanifold PTv3 encoder graph (all `GetIndicePairs`/`GetIndicePairsImplicitGemm` nodes have `subm=1`).

## Notes for reviewers

These plugins consequently cannot be used inside an application-driven CUDA graph: capturing `enqueueV3` yields a graph of zeros rather than an error. Nothing in Autoware does that today, and this network's dynamic per-frame shapes make CUDA graphs a poor fit for it, so this is called out in a code comment and a runtime warning rather than enforced.

A variant keyed on `nvinfer1::TensorRTPhase` (emit zeros for `kBUILD`, fail for `kRUNTIME`) was prototyped and deliberately dropped. It does make runtime capture fail loudly, but TensorRT also creates some `kRUNTIME` plugin instances during the build: one of them hit the capture path, logged an error and cost that layer a tactic candidate. That trades a real build-robustness risk for protection against a scenario nothing currently exercises. Doing it properly would need an explicit "engine build in progress" flag set by `autoware_tensorrt_common` around `buildSerializedNetwork`, OR'd with the `kBUILD` check; happy to follow up separately if reviewers prefer that.

Separately, and out of scope here: on Thor the encoder still exceeds the 14.67 GiB GPU carve-out at the configured `voxels_num`. With this fix the build succeeds up to a max of about 24 000 voxels and fails above roughly 32 000, driven by the fused Myelin region rather than by plugin buffer bounds. Neither the TensorRT workspace limit nor `out_indices_num_limit_` affects it.

## Interface changes

None.

## Effects on system behavior

None for existing platforms. On DRIVE Thor the PTv3 encoder engine can be built where it previously could not.
