### PR TITLE
feat(autoware_tensorrt_common): support strongly typed network builds

### DIFF
--- a/perception/autoware_tensorrt_common/CMakeLists.txt
+++ b/perception/autoware_tensorrt_common/CMakeLists.txt
@@ -14,8 +14,8 @@ if(NOT (CUDAToolkit_FOUND AND TENSORRT_FOUND))
   return()
 endif()
 
-if(TENSORRT_VERSION VERSION_LESS 8.5)
-  message(WARNING "Unsupported version TensorRT ${TENSORRT_VERSION} detected. This package requires TensorRT 8.5 or later.")
+if(TENSORRT_VERSION VERSION_LESS 10.0)
+  message(WARNING "Unsupported version TensorRT ${TENSORRT_VERSION} detected. This package requires TensorRT 10.0 or later.")
   return()
 endif()
 

--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -316,6 +316,14 @@ public:
    */
   void printProfiling() const;
 
+  /**
+   * @brief Whether the network is built strongly typed (precision "as-is"): tensor precisions
+   * are taken from the model itself.
+   *
+   * @return Whether the network is strongly typed.
+   */
+  [[nodiscard]] bool isStronglyTyped() const;
+
 private:
   /**
    * @brief Initialize TensorRT common.

--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
@@ -40,7 +40,7 @@ namespace autoware
 {
 namespace tensorrt_common
 {
-constexpr std::array<std::string_view, 3> valid_precisions = {"fp32", "fp16", "int8"};
+constexpr std::array<std::string_view, 4> valid_precisions = {"fp32", "fp16", "int8", "as-is"};
 
 /**
  * @brief Return a human-readable name for a TensorRT DataType.
@@ -81,7 +81,9 @@ struct TrtCommonConfig
   /** @brief Construct TrtCommonConfig, ONNX model path is mandatory.
    *
    * @param[in] onnx_path ONNX model path
-   * @param[in] precision precision for inference
+   * @param[in] precision precision requested for the weakly typed build ("fp32", "fp16",
+   *            "int8"), or "as-is" to build a strongly typed network where every tensor
+   *            precision is taken from the model itself.
    * @param[in] engine_path TensorRT engine path
    * @param[in] max_workspace_size maximum workspace size for TensorRT
    * @param[in] dla_core_id DLA core ID
@@ -129,7 +131,8 @@ struct TrtCommonConfig
   //!< @brief ONNX model path.
   const fs::path onnx_path;
 
-  //!< @brief Precision for inference.
+  //!< @brief Precision requested for the weakly typed build, or "as-is" for a strongly typed
+  //!< network with tensor precisions taken from the model itself.
   const std::string precision;
 
   //!< @brief TensorRT engine path.

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -516,10 +516,6 @@ bool TrtCommon::initialize()
       nvinfer1::ILogger::Severity::kINFO,
       "Building a strongly typed network; tensor precisions are taken from the model itself");
   }
-#if (NV_TENSORRT_MAJOR * 10000) + (NV_TENSORRT_MINOR * 100) + NV_TENSORRT_PATCH < 100000
-  network_flags |=
-    1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
-#endif
   network_ = TrtUniquePtr<nvinfer1::INetworkDefinition>(builder_->createNetworkV2(network_flags));
 
   if (!network_) {

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -109,8 +109,14 @@ bool TrtCommon::setup(ProfileDimsPtr profile_dims, NetworkIOPtr network_io)
     builder_config_->addOptimizationProfile(profile);
   }
 
-  // Apply dtype overrides from NetworkIO to the parsed network inputs and outputs.
-  if (network_io_) {
+  // Apply dtype overrides from NetworkIO to the parsed network inputs and outputs. Strongly
+  // typed networks do not allow overrides; requested dtypes are still validated by
+  // validateNetworkIO.
+  if (network_io_ && isStronglyTyped()) {
+    logger_->log(
+      nvinfer1::ILogger::Severity::kINFO,
+      "Strongly typed network: NetworkIO dtype overrides are not applied");
+  } else if (network_io_) {
     const auto apply_dtype = [&](nvinfer1::ITensor * tensor, const char * io_type) {
       if (!tensor) return;
       const auto it = std::find_if(network_io_->begin(), network_io_->end(), [&](const auto & io) {
@@ -502,13 +508,19 @@ bool TrtCommon::initialize()
     return false;
   }
 
+  uint32_t network_flags = 0;
+  if (isStronglyTyped()) {
+    network_flags |=
+      1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kSTRONGLY_TYPED);
+    logger_->log(
+      nvinfer1::ILogger::Severity::kINFO,
+      "Building a strongly typed network; tensor precisions are taken from the model itself");
+  }
 #if (NV_TENSORRT_MAJOR * 10000) + (NV_TENSORRT_MINOR * 100) + NV_TENSORRT_PATCH < 100000
-  const auto explicit_batch =
+  network_flags |=
     1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
-  network_ = TrtUniquePtr<nvinfer1::INetworkDefinition>(builder_->createNetworkV2(explicit_batch));
-#else
-  network_ = TrtUniquePtr<nvinfer1::INetworkDefinition>(builder_->createNetworkV2(0));
 #endif
+  network_ = TrtUniquePtr<nvinfer1::INetworkDefinition>(builder_->createNetworkV2(network_flags));
 
   if (!network_) {
     logger_->log(nvinfer1::ILogger::Severity::kERROR, "Fail to create network");
@@ -527,7 +539,9 @@ bool TrtCommon::initialize()
       nvinfer1::ILogger::Severity::kINFO, "Number of DLAs supported: %d", num_available_dla);
     builder_config_->setDefaultDeviceType(nvinfer1::DeviceType::kDLA);
     builder_config_->setDLACore(trt_config_->dla_core_id);
-    builder_config_->setFlag(nvinfer1::BuilderFlag::kPREFER_PRECISION_CONSTRAINTS);
+    if (!isStronglyTyped()) {
+      builder_config_->setFlag(nvinfer1::BuilderFlag::kPREFER_PRECISION_CONSTRAINTS);
+    }
     builder_config_->setFlag(nvinfer1::BuilderFlag::kGPU_FALLBACK);
   }
   if (trt_config_->precision == "fp16") {
@@ -550,6 +564,11 @@ bool TrtCommon::initialize()
   }
 
   return true;
+}
+
+bool TrtCommon::isStronglyTyped() const
+{
+  return trt_config_->precision == "as-is";
 }
 
 bool TrtCommon::buildEngineFromOnnx()

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -615,7 +615,6 @@ bool TrtCommon::buildEngineFromOnnx()
 
 bool TrtCommon::validateEngine()
 {
-#if (NV_TENSORRT_MAJOR * 10000) + (NV_TENSORRT_MINOR * 100) + NV_TENSORRT_PATCH >= 80600
   std::ifstream engine_file(trt_config_->engine_path);
   std::stringstream engine_buffer;
   engine_buffer << engine_file.rdbuf();
@@ -637,7 +636,6 @@ bool TrtCommon::validateEngine()
       NV_TENSORRT_MAJOR, NV_TENSORRT_MINOR, NV_TENSORRT_PATCH);
     return false;
   }
-#endif
   return true;
 }
 


### PR DESCRIPTION
## Description

Strong typing becomes a [hard requirement in TensorRT 11](https://docs.nvidia.com/deeplearning/tensorrt/latest/api/migration/tensorrt-10x-to-11x.html#strongly-typed-networks-are-now-required) and is a de-facto requirement for some layers on DriveOS 7 (TensorRT 10.10.10).

This PR adds opt-in support for **strongly typed** TensorRT network builds: `TrtCommonConfig` now accepts `"as-is"` as a `precision` value. Fully backward compatible: the existing precision values are unchanged and no current consumer changes behavior; there are no API signature changes.

With `precision: "as-is"`:

- the network is created with `NetworkDefinitionCreationFlag::kSTRONGLY_TYPED`: every tensor precision is taken from the model itself instead of being requested via builder precision flags
- precision constraints and `NetworkIO` dtype overrides are skipped (TensorRT rejects them for strongly typed networks); dtypes requested via `NetworkIO` are still validated against the built engine;
- a new `isStronglyTyped()` accessor exposes the mode.

Strong typing is independent of the model's precision: any export — fp32 or reduced precision — can be built as-is. 

First adopter: `autoware_ptv3`, in the stacked PR #13159.

## Related links

- Stacked adoption PR: #13159
- Related, independent: #13158

## How was this PR tested?

- **Backward compatibility**: the PTv3 node built weakly typed fp32/fp16 engines against an fp32 ML package with this change in place, on x86 (TensorRT 10.8) and on DRIVE Thor — zero behavior change.
- **Strongly typed path**: explicit-fp16 PTv3 models built with `"as-is"` on x86 and on the embedded target (DRIVE Thor). The engines deserialize, create execution contexts, and run `enqueueV3` cleanly.
- **Independence from the model's precision**: the fp32 export can also build as-is (pure fp32 engines, verified on x86).

## Notes for reviewers

I found having `"as-is"` as a `precision` value instead of having an extra `bool strongly_typed` is cleaner, as separating the two would result in some invalid combinations that would have to be silently ignored or error-handled (e.g. `strongly_typed = true; precision = "fp16"` on an fp32 onnx).

## Interface changes

`TrtCommonConfig::precision` accepts `"as-is"`; `TrtCommon` gains an `isStronglyTyped()` accessor. No signature changes; existing callers are unaffected.

The package now requires **TensorRT 10.0** or later (it declared 8.5 before). `kSTRONGLY_TYPED` does not exist on pre-10 TensorRT.

## Effects on system behavior

None unless a consumer passes the new precision value.
