### PR TITLE
fix(streampetr): initialize memory

### DIFF
--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/memory.cuh
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/memory.cuh
@@ -51,6 +51,8 @@ struct Memory
     pre_len = pre_length;
     mem_stream = stream;
     cudaMallocAsync(&mem_buf, sizeof(float) * mem_len, mem_stream);
+    // zero-initialize memory
+    cudaMemsetAsync(mem_buf, 0, sizeof(float) * mem_len, mem_stream);
   }
 
   void StepReset();

--- a/perception/autoware_camera_streampetr/lib/network/network.cpp
+++ b/perception/autoware_camera_streampetr/lib/network/network.cpp
@@ -188,6 +188,9 @@ void StreamPetrNetwork::initializeMemoryAndProfiling()
   mem_.pre_buf = static_cast<float *>(pts_head_->bindings["pre_memory_timestamp"]->ptr);
   mem_.post_buf = static_cast<float *>(pts_head_->bindings["post_memory_timestamp"]->ptr);
 
+  // Clear pre_memory_* bindings.
+  wipe_memory();
+
   // events for measurement - pass profiler to Duration objects
   dur_backbone_ = std::make_unique<Duration>("backbone", profiler_);
   dur_ptshead_ = std::make_unique<Duration>("ptshead", profiler_);
@@ -213,13 +216,12 @@ void StreamPetrNetwork::configureNMSIfNeeded()
 
 void StreamPetrNetwork::wipe_memory()
 {
-  if (is_inference_initialized_) {
-    // Reset the memory buffers to zeros
-    pts_head_->bindings["pre_memory_embedding"]->initialize_to_zeros(stream_);
-    pts_head_->bindings["pre_memory_reference_point"]->initialize_to_zeros(stream_);
-    pts_head_->bindings["pre_memory_egopose"]->initialize_to_zeros(stream_);
-    pts_head_->bindings["pre_memory_velo"]->initialize_to_zeros(stream_);
-  }
+  // Reset the memory buffers to zeros.
+  pts_head_->bindings["pre_memory_timestamp"]->initialize_to_zeros(stream_);
+  pts_head_->bindings["pre_memory_embedding"]->initialize_to_zeros(stream_);
+  pts_head_->bindings["pre_memory_reference_point"]->initialize_to_zeros(stream_);
+  pts_head_->bindings["pre_memory_egopose"]->initialize_to_zeros(stream_);
+  pts_head_->bindings["pre_memory_velo"]->initialize_to_zeros(stream_);
 }
 
 void StreamPetrNetwork::inference_detector(


### PR DESCRIPTION
## Description

Fix stale/uninitialized GPU memory being used by StreamPetr's temporal memory buffers (`pre_memory_*`) on startup and after a desync/restart.

- `memory.cuh`: `Memory::init()` now zero-initializes `mem_buf` with `cudaMemsetAsync` right after `cudaMallocAsync`. Previously the buffer held whatever garbage was already in that GPU memory until the first explicit reset.
- `network.cpp`:
  - `initializeMemoryAndProfiling()` now calls `wipe_memory()` right after the `pre_memory_*`/`post_memory_*` bindings are set up, so the temporal buffers start at zero instead of relying on a later reset.
  - `wipe_memory()` now also resets `pre_memory_timestamp`, which was missing from the reset list.

## Related links


## How was this PR tested?

https://tier4.atlassian.net/wiki/spaces/~459732634/pages/5426643575/Difference+from+recorded+topics

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

No
