### PR TITLE
fix(autoware_system_monitor): avoid NUL process states

### DIFF
--- a/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/autoware_system_monitor/src/process_monitor/process_monitor.cpp
@@ -607,7 +607,8 @@ void ProcessMonitor::fillTaskInfo(
   info.virtualImage = to7DigitString(virtual_image_size_kb);
   info.residentSize = to6DigitString(resident_size_kb);
   info.sharedMemSize = to6DigitString(shared_mem_size_kb);
-  info.processStatus = raw_p->stat_info.state;
+  info.processStatus =
+    raw_p->stat_info.state == '\0' ? std::string{} : std::string(1, raw_p->stat_info.state);
   double cpuUsage = raw_p->diff_info.cpu_usage;
   info.cpuUsage = formatCpuUsage(cpuUsage, uptime_delta_sec, clock_tick_);
   info.memoryUsage = formatMemoryUsage(resident_size_kb, mem_total_kb_);

--- a/system/autoware_system_monitor/test/src/process_monitor/test_process_monitor.cpp
+++ b/system/autoware_system_monitor/test/src/process_monitor/test_process_monitor.cpp
@@ -245,6 +245,22 @@ class ProcessMonitorTestSuiteWithDummyProc : public ProcessMonitorTestSuite,
 {
 };
 
+class ProcessMonitorTestSuiteWithUnfilledRanking : public ProcessMonitorTestSuite
+{
+protected:
+  void SetUp() override
+  {
+    using std::placeholders::_1;
+    rclcpp::init(0, nullptr);
+    rclcpp::NodeOptions node_options;
+    // The dummy data has six processes, leaving the seventh ranking entry unfilled.
+    node_options.append_parameter_override("num_of_procs", 7);
+    monitor_ = std::make_unique<TestProcessMonitor>("test_process_monitor", node_options);
+    sub_ = monitor_->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+      "/diagnostics", 1000, std::bind(&TestProcessMonitor::diagCallback, monitor_.get(), _1));
+  }
+};
+
 DummyProcFile dummy_proc_files[] = {
   {"dummy_proc_base.tar.bz2"},  // Original test data. Used as the base for the variations.
   {"dummy_proc_stat_comm_variations.tar.bz2"},   // Test data with variations in the comm field of
@@ -343,6 +359,33 @@ TEST_F(ProcessMonitorTestSuite, highMemProcTest)
   for (int i = 0; i < monitor_->getNumOfProcs(); ++i) {
     ASSERT_TRUE(monitor_->findDiagStatus(fmt::format("High-mem Proc[{}]", i), status));
     ASSERT_EQ(status.level, DiagStatus::OK);
+  }
+}
+
+TEST_F(ProcessMonitorTestSuiteWithUnfilledRanking, emptyProcessStateTest)
+{
+  const std::string test_data_dir = exe_dir_ + "/test_data";
+  const std::string file_set_path = exe_dir_ + "/dummy_proc_base.tar.bz2";
+
+  int place_holder;
+  std::unique_ptr<int, std::function<void(int *)>> watch_dog(
+    &place_holder, [&](int *) { monitor_->cleanupTestData(test_data_dir); });
+
+  ASSERT_EQ(monitor_->prepareTestData(file_set_path, test_data_dir), 0);
+  monitor_->forceTimerEvent();
+  monitor_->update();
+
+  rclcpp::WallRate(2).sleep();
+  rclcpp::spin_some(monitor_->get_node_base_interface());
+
+  for (const std::string & task_name : {"High-load Proc[6]", "High-mem Proc[6]"}) {
+    DiagStatus status;
+    ASSERT_TRUE(monitor_->findDiagStatus(task_name, status));
+    ASSERT_EQ(status.level, DiagStatus::OK);
+
+    std::string process_state;
+    ASSERT_TRUE(findValue(status, "S", process_state));
+    EXPECT_TRUE(process_state.empty());
   }
 }
 


### PR DESCRIPTION
## Description

`ProcessMonitor` can leave default-initialized entries in the CPU and memory rankings when the configured number of slots exceeds the number of observed processes. The process state for an unfilled entry remains `'\0'`, and assigning that character directly to a `std::string` creates a one-byte embedded NUL. Fast-CDR rejects that value during serialization and can abort `system_monitor_container`.

This change maps only the default `'\0'` state to an empty string at the publishing boundary. Valid single-character Linux process states remain unchanged.

The regression test uses the existing dummy `/proc` data containing six processes, configures seven ranking slots, and verifies that both unfilled CPU and memory entries publish an empty `S` value.

## Related links

**Parent Issue:**

- #12870

## How was this PR tested?

- Passed the repository pre-commit checks for both modified files.
- Passed `clang-format` validation.
- Added a regression test covering both unfilled CPU and memory ranking entries.
- The ROS package test could not be run locally because the current host is macOS ARM64; it will be exercised by the PR CI on the supported Linux/ROS environment.

## Notes for reviewers

Valid Linux process states are preserved. Only the default `'\0'` value is converted to an empty string.

AI assistance: Codex assisted with repository inspection and initial patch preparation. I reviewed and understand every submitted change and ran the checks listed above.

## Interface changes

None.

## Effects on system behavior

Unfilled process ranking entries now publish an empty `S` value instead of a NUL-containing string. Valid process state values are unchanged.