### PR TITLE
perf(autoware_ptv3): cut PTv3 preprocessing from 13 radix sorts to 2

### DIFF
--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -49,7 +49,8 @@ public:
   /**
    * @brief Crops, voxelizes and deduplicates the input cloud.
    *
-   * The emitted voxels are sorted by their order-0 serialized code.
+   * The emitted voxels are sorted by their order-0 serialized code, which
+   * generateSerializedPoolingMetadata requires.
    *
    * @param input_data Input cloud in `input_format` layout.
    * @param input_format Point layout of `input_data`.
@@ -79,10 +80,14 @@ public:
    *
    * @param grid_coord Grid coordinates of the input voxels, laid out [num_voxels, 3].
    * @param serialized_code Codes of the input voxels, laid out [num_orders, num_voxels].
-   * @param num_voxels Number of input voxels.
+   * @param num_voxels Number of input voxels; clamped to max_num_voxels internally.
    * @param stages Output device buffers to fill, one per pooling stage.
    * @param stage_counts Output voxel count per level, laid out [num_stages + 1]; entry 0 is the
-   * input count.
+   * (clamped) input count.
+   * @pre The input voxels are sorted by their order-0 serialized code (`serialized_code` row 0),
+   * as generateFeatures emits them. The coarser levels are derived with prefix scans that rely on
+   * this ordering; an unsorted input silently produces wrong metadata. Asserted on device in
+   * debug builds.
    */
   void generateSerializedPoolingMetadata(
     const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
@@ -117,12 +122,15 @@ private:
   cudaEvent_t num_cropped_points_copy_event_;
   cudaEvent_t num_unique_points_copy_event_;
 
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_keys_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_keys_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_indices_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_indices_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_flags_d_{nullptr};
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_ids_d_{nullptr};
+  // Serialization order of the finest level (the input voxels), laid out
+  // [num_orders, num_voxels]. Row 0 is the identity; the remaining rows are the only sorts left in
+  // the pooling-metadata path.
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> finest_level_order_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_sorted_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_flags_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_ids_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> pooling_workspace_d_{nullptr};
   std::size_t pooling_workspace_size_{0};
   int code_sort_end_bit_{64};

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -131,11 +131,11 @@ private:
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_keys_d_{nullptr};
   // Sorted-keys output; CUB requires the buffer, nothing reads it afterwards.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_sorted_keys_d_{nullptr};
-  // Sort payload, filled with 0..n-1; sorting it by the keys yields the order's ranking, written
-  // directly into the input_level_order_d_ row.
+  // Filled with 0..n-1 and sorted alongside the keys, which leaves it listing the voxel indices
+  // in ascending code order; written directly into the input_level_order_d_ row.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_indices_d_{nullptr};
-  // Run-start flags over the current level: 1 where a new parent segment (or, when deriving a
-  // pooled order, a new rank run) begins, 0 elsewhere.
+  // Run-start flags: 1 where the parent voxel changes while walking a level, either in storage
+  // order (pooling) or as listed by one of its serialization orders; 0 elsewhere.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_flags_d_{nullptr};
   // Inclusive scan of run_flags_d_, numbering each element's run; run id - 1 is the pooled-level
   // slot the element scatters to.

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -126,7 +126,8 @@ private:
   // out [num_orders, num_voxels]. Row 0 is the identity; the remaining rows are the only sorts
   // left in the pooling-metadata path.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> input_level_order_d_{nullptr};
-  // Keys for one of those sorts: the input level's codes in the order being ranked.
+  // Keys for one of those sorts: each input voxel's code under the serialization order being
+  // sorted.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_keys_d_{nullptr};
   // Sorted-keys output; CUB requires the buffer, nothing reads it afterwards.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_sorted_keys_d_{nullptr};

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -122,23 +122,23 @@ private:
   cudaEvent_t num_cropped_points_copy_event_;
   cudaEvent_t num_unique_points_copy_event_;
 
-  // Serialization order of the input level (the deduplicated voxels generateFeatures emits), laid
-  // out [num_orders, num_voxels]. Row 0 is the identity; the remaining rows are the only sorts
-  // left in the pooling-metadata path.
+  /// Serialization order of the input level (the deduplicated voxels generateFeatures emits),
+  /// laid out [num_orders, num_voxels]. Row 0 is the identity; the remaining rows are the only
+  /// sorts left in the pooling-metadata path.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> input_level_order_d_{nullptr};
-  // Keys for one of those sorts: each input voxel's code under the serialization order being
-  // sorted.
+  /// Keys for one of those sorts: each input voxel's code under the serialization order being
+  /// sorted.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_keys_d_{nullptr};
-  // Sorted-keys output; CUB requires the buffer, nothing reads it afterwards.
+  /// Sorted-keys output; CUB requires the buffer, nothing reads it afterwards.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_sorted_keys_d_{nullptr};
-  // Filled with 0..n-1 and sorted alongside the keys, which leaves it listing the voxel indices
-  // in ascending code order; written directly into the input_level_order_d_ row.
+  /// Filled with 0..n-1 and sorted alongside the keys, which leaves it listing the voxel indices
+  /// in ascending code order; written directly into the input_level_order_d_ row.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_indices_d_{nullptr};
-  // Run-start flags: 1 where the parent voxel changes while walking a level, either in storage
-  // order (pooling) or as listed by one of its serialization orders; 0 elsewhere.
+  /// Run-start flags: 1 where the parent voxel changes while walking a level, either in storage
+  /// order (pooling) or as listed by one of its serialization orders; 0 elsewhere.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_flags_d_{nullptr};
-  // Inclusive scan of run_flags_d_, numbering each element's run; run id - 1 is the pooled-level
-  // slot the element scatters to.
+  /// Inclusive scan of run_flags_d_, numbering each element's run; run id - 1 is the pooled-level
+  /// slot the element scatters to.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_ids_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> pooling_workspace_d_{nullptr};
   std::size_t pooling_workspace_size_{0};

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -122,14 +122,22 @@ private:
   cudaEvent_t num_cropped_points_copy_event_;
   cudaEvent_t num_unique_points_copy_event_;
 
-  // Serialization order of the finest level (the input voxels), laid out
-  // [num_orders, num_voxels]. Row 0 is the identity; the remaining rows are the only sorts left in
-  // the pooling-metadata path.
-  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> finest_level_order_d_{nullptr};
+  // Serialization order of the input level (the deduplicated voxels generateFeatures emits), laid
+  // out [num_orders, num_voxels]. Row 0 is the identity; the remaining rows are the only sorts
+  // left in the pooling-metadata path.
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> input_level_order_d_{nullptr};
+  // Keys for one of those sorts: the input level's codes in the order being ranked.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_keys_d_{nullptr};
+  // Sorted-keys output; CUB requires the buffer, nothing reads it afterwards.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_sorted_keys_d_{nullptr};
+  // Sort payload, filled with 0..n-1; sorting it by the keys yields the order's ranking, written
+  // directly into the input_level_order_d_ row.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> order_sort_indices_d_{nullptr};
+  // Run-start flags over the current level: 1 where a new parent segment (or, when deriving a
+  // pooled order, a new rank run) begins, 0 elsewhere.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_flags_d_{nullptr};
+  // Inclusive scan of run_flags_d_, numbering each element's run; run id - 1 is the pooled-level
+  // slot the element scatters to.
   autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> run_ids_d_{nullptr};
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> pooling_workspace_d_{nullptr};
   std::size_t pooling_workspace_size_{0};

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -25,7 +25,7 @@
 #include <thrust/sequence.h>
 
 #include <algorithm>
-#include <limits>
+#include <cassert>
 #include <stdexcept>
 
 namespace autoware::ptv3
@@ -67,9 +67,10 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
   thrust::device_ptr<std::uint32_t> idx_ptr(code_indices_d_.get());
   thrust::sequence(policy, idx_ptr, idx_ptr + config_.cloud_capacity_, 0);
 
-  // Serialized codes occupy 3 * serialization_depth_ bits. std::max guards
-  // serialization_depth_ == 0 (CUB requires end_bit > begin_bit). The workspace query below uses
-  // the full 64 bits, which upper-bounds the scratch needed for any narrower range.
+  // Serialized codes occupy 3 * serialization_depth_ bits, and pooling only right-shifts them, so
+  // this bound holds for every stage. std::max guards serialization_depth_ == 0 (CUB requires
+  // end_bit > begin_bit). Workspace queries below use the full 64 bits, which upper-bounds the
+  // scratch needed for any narrower range.
   code_sort_end_bit_ = std::max(1, 3 * config_.serialization_depth_);
 
   std::int64_t * int64_nullptr = nullptr;
@@ -100,20 +101,22 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
   num_cropped_points_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
   num_unique_points_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
 
-  pooling_keys_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_sorted_keys_d_ =
+  const auto num_orders = static_cast<std::int64_t>(config_.serialization_orders_.size());
+  finest_level_order_d_ =
+    autoware::cuda_utils::make_unique<std::int64_t[]>(num_orders * config_.max_num_voxels_);
+  order_sort_keys_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  order_sort_sorted_keys_d_ =
     autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_indices_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_sorted_indices_d_ =
+  order_sort_indices_d_ =
     autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_run_flags_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
-  pooling_run_ids_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  run_flags_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  run_ids_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
 
   std::size_t pooling_sort_workspace_size = 0;
   std::size_t pooling_scan_workspace_size = 0;
   cub::DeviceRadixSort::SortPairs(
     nullptr, pooling_sort_workspace_size, int64_nullptr, int64_nullptr, int64_nullptr,
-    int64_nullptr, config_.max_num_voxels_, 0, 63, nullptr);
+    int64_nullptr, config_.max_num_voxels_, 0, 64, nullptr);
   cub::DeviceScan::InclusiveSum(
     nullptr, pooling_scan_workspace_size, int64_nullptr, int64_nullptr, config_.max_num_voxels_,
     nullptr);
@@ -354,18 +357,54 @@ __global__ void computeGridCoordsAndSerializationKernel(
   codes[idx + num_points] = serializeCoord(coord.x, coord.y, coord.z, depth, true);
 }
 
-constexpr std::int64_t kInvalidPoolingKey = std::numeric_limits<std::int64_t>::max();
-
 __global__ void setInitialStageCountKernel(
   std::int64_t * __restrict__ stage_counts, std::int64_t num_voxels)
 {
   *stage_counts = num_voxels;
 }
 
-__global__ void preparePoolingSortInputKernel(
-  const std::int64_t * __restrict__ serialized_code, const std::int64_t * __restrict__ stage_counts,
-  std::int64_t * __restrict__ keys, std::int64_t * __restrict__ indices, std::int32_t stage_index,
-  std::int32_t pooling_depth, std::int64_t capacity)
+__global__ void fillIdentityKernel(std::int64_t * __restrict__ out, std::int64_t count)
+{
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= count) {
+    return;
+  }
+  out[idx] = idx;
+}
+
+__global__ void prepareFinestLevelOrderSortKernel(
+  const std::int64_t * __restrict__ serialized_code, std::int64_t * __restrict__ keys,
+  std::int64_t * __restrict__ indices, std::int64_t num_voxels, std::int32_t order_index)
+{
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= num_voxels) {
+    return;
+  }
+
+  // serialized_code is laid out densely as [num_orders, num_voxels].
+  keys[idx] = serialized_code[order_index * num_voxels + idx];
+  indices[idx] = idx;
+}
+
+/**
+ * @brief Marks the first child of every parent run.
+ *
+ * @pre The input level is ascending in order-0 code (asserted below), so the parent code
+ * (code >> 3 * pooling_depth) is non-decreasing and each parent's children are already
+ * contiguous; comparing against the previous element finds the run starts without sorting.
+ *
+ * @param serialized_code_in Input level's codes, laid out [num_orders, input_count]; only the
+ * order-0 row is read.
+ * @param stage_counts Per-level voxel counts; entry `stage_index` is the input level's count.
+ * @param run_flags Output flags: 1 at each parent run start, 0 elsewhere (including padding).
+ * @param stage_index Level the input arrays describe.
+ * @param pooling_depth Bits each grid coordinate is shifted right by, i.e. log2(pooling stride).
+ * @param capacity Padded length of the arrays (max_num_voxels).
+ */
+__global__ void markPoolingRunsKernel(
+  const std::int64_t * __restrict__ serialized_code_in,
+  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
+  std::int32_t stage_index, std::int32_t pooling_depth, std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
@@ -373,33 +412,28 @@ __global__ void preparePoolingSortInputKernel(
   }
 
   const auto input_count = stage_counts[stage_index];
-  keys[idx] = idx < input_count ? serialized_code[idx] >> (pooling_depth * 3) : kInvalidPoolingKey;
-  indices[idx] = idx;
-}
-
-__global__ void markPoolingRunsKernel(
-  const std::int64_t * __restrict__ sorted_keys, std::int64_t * __restrict__ run_flags,
-  std::int64_t capacity)
-{
-  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (idx >= capacity) {
+  if (idx >= input_count) {
+    run_flags[idx] = 0;
     return;
   }
 
-  const auto key = sorted_keys[idx];
-  run_flags[idx] = key != kInvalidPoolingKey && (idx == 0 || key != sorted_keys[idx - 1]) ? 1 : 0;
+  assert(idx == 0 || serialized_code_in[idx - 1] < serialized_code_in[idx]);
+
+  const auto shift = pooling_depth * 3;
+  const auto key = serialized_code_in[idx] >> shift;
+  run_flags[idx] = (idx == 0 || key != (serialized_code_in[idx - 1] >> shift)) ? 1 : 0;
 }
 
 __global__ void fillPoolingStageKernel(
   const std::int32_t * __restrict__ grid_coord_in,
-  const std::int64_t * __restrict__ serialized_code_in,
-  const std::int64_t * __restrict__ sorted_keys, const std::int64_t * __restrict__ sorted_indices,
-  const std::int64_t * __restrict__ run_flags, const std::int64_t * __restrict__ run_ids,
-  std::int64_t * __restrict__ indices_out, std::int64_t * __restrict__ indptr_out,
-  std::int64_t * __restrict__ head_indices_out, std::int64_t * __restrict__ cluster_out,
-  std::int32_t * __restrict__ grid_coord_out, std::int64_t * __restrict__ serialized_code_out,
-  std::int64_t * __restrict__ stage_counts, std::int32_t stage_index, std::int32_t pooling_depth,
-  std::int32_t num_orders, std::int64_t capacity)
+  const std::int64_t * __restrict__ serialized_code_in, const std::int64_t * __restrict__ run_flags,
+  const std::int64_t * __restrict__ run_ids, std::int64_t * __restrict__ indices_out,
+  std::int64_t * __restrict__ indptr_out, std::int64_t * __restrict__ head_indices_out,
+  std::int64_t * __restrict__ cluster_out, std::int32_t * __restrict__ grid_coord_out,
+  std::int64_t * __restrict__ serialized_code_out, std::int64_t * __restrict__ order_out,
+  std::int64_t * __restrict__ inverse_out, std::int64_t * __restrict__ stage_counts,
+  std::int32_t stage_index, std::int32_t pooling_depth, std::int32_t num_orders,
+  std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
@@ -418,64 +452,98 @@ __global__ void fillPoolingStageKernel(
     indptr_out[next_count] = input_count;
   }
 
-  if (sorted_keys[idx] == kInvalidPoolingKey) {
+  if (idx >= input_count) {
     return;
   }
 
-  const auto input_index = sorted_indices[idx];
+  // The input is already grouped by parent (see markPoolingRunsKernel), so the gather order is the
+  // identity.
+  indices_out[idx] = idx;
   const auto segment_index = run_ids[idx] - 1;
-  indices_out[idx] = input_index;
-  cluster_out[input_index] = segment_index;
+  cluster_out[idx] = segment_index;
 
   if (run_flags[idx] == 0) {
     return;
   }
 
   indptr_out[segment_index] = idx;
-  head_indices_out[segment_index] = input_index;
+  head_indices_out[segment_index] = idx;
   for (std::int32_t coord_index = 0; coord_index < 3; ++coord_index) {
     grid_coord_out[segment_index * 3 + coord_index] =
-      grid_coord_in[input_index * 3 + coord_index] >> pooling_depth;
+      grid_coord_in[idx * 3 + coord_index] >> pooling_depth;
   }
   for (std::int32_t order_index = 0; order_index < num_orders; ++order_index) {
     serialized_code_out[order_index * next_count + segment_index] =
-      serialized_code_in[order_index * input_count + input_index] >> (pooling_depth * 3);
+      serialized_code_in[order_index * input_count + idx] >> (pooling_depth * 3);
   }
+
+  // Segments are emitted in ascending order-0 code, so the pooled level's order-0 ranking is the
+  // identity and markPoolingRunsKernel's precondition holds for the next stage.
+  order_out[segment_index] = segment_index;
+  inverse_out[segment_index] = segment_index;
 }
 
-__global__ void prepareOrderSortInputKernel(
-  const std::int64_t * __restrict__ serialized_code, const std::int64_t * __restrict__ stage_counts,
-  std::int64_t * __restrict__ keys, std::int64_t * __restrict__ indices, std::int32_t stage_index,
-  std::int32_t order_index, std::int64_t capacity)
+/**
+ * @brief Marks where the parent voxel changes while walking the input level in
+ * order-`order_index` rank order.
+ *
+ * Every serialization order visits each parent's children contiguously and the parents in
+ * ascending pooled code, so compacting the run heads yields the pooled level's
+ * order-`order_index` ranking without sorting.
+ *
+ * @param order_in Input level's serialization orders, laid out [num_orders, input_count].
+ * @param cluster Parent segment index of each input voxel (see fillPoolingStageKernel).
+ * @param stage_counts Per-level voxel counts; entry `stage_index` is the input level's count.
+ * @param run_flags Output flags: 1 where the parent changes, 0 elsewhere (including padding).
+ * @param stage_index Level the input arrays describe.
+ * @param order_index Serialization order being walked.
+ * @param capacity Padded length of the arrays (max_num_voxels).
+ */
+__global__ void markOrderRunsKernel(
+  const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster,
+  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
+  std::int32_t stage_index, std::int32_t order_index, std::int64_t capacity)
 {
-  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (idx >= capacity) {
+  const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (rank >= capacity) {
     return;
   }
 
   const auto input_count = stage_counts[stage_index];
-  // serialized_code is stored densely as [num_orders, input_count] (see fillPoolingStageKernel).
-  keys[idx] =
-    idx < input_count ? serialized_code[order_index * input_count + idx] : kInvalidPoolingKey;
-  indices[idx] = idx;
+  if (rank >= input_count) {
+    run_flags[rank] = 0;
+    return;
+  }
+
+  // order_in is laid out densely as [num_orders, input_count].
+  const auto segment_index = cluster[order_in[order_index * input_count + rank]];
+  run_flags[rank] =
+    (rank == 0 || segment_index != cluster[order_in[order_index * input_count + rank - 1]]) ? 1 : 0;
 }
 
 __global__ void fillOrderAndInverseKernel(
-  const std::int64_t * __restrict__ sorted_keys, const std::int64_t * __restrict__ sorted_indices,
+  const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster,
+  const std::int64_t * __restrict__ run_flags, const std::int64_t * __restrict__ run_ids,
   const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ order_out,
   std::int64_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
   std::int64_t capacity)
 {
-  const auto count = stage_counts[stage_index];
   const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (rank >= capacity || rank >= count || sorted_keys[rank] == kInvalidPoolingKey) {
+  if (rank >= capacity) {
     return;
   }
 
-  // order/inverse are stored densely as [num_orders, count] to match the engine input layout.
-  const auto input_index = sorted_indices[rank];
-  order_out[order_index * count + rank] = input_index;
-  inverse_out[order_index * count + input_index] = rank;
+  const auto input_count = stage_counts[stage_index];
+  if (rank >= input_count || run_flags[rank] == 0) {
+    return;
+  }
+
+  // order/inverse are stored densely as [num_orders, out_count] to match the engine input layout.
+  const auto out_count = stage_counts[stage_index + 1];
+  const auto out_rank = run_ids[rank] - 1;
+  const auto segment_index = cluster[order_in[order_index * input_count + rank]];
+  order_out[order_index * out_count + out_rank] = segment_index;
+  inverse_out[order_index * out_count + segment_index] = out_rank;
 }
 
 std::int32_t poolingDepth(const std::int64_t stride)
@@ -498,75 +566,84 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
   const auto capacity = config_.max_num_voxels_;
   const auto num_orders = static_cast<std::int32_t>(config_.serialization_orders_.size());
   const auto num_blocks = divup(static_cast<std::size_t>(capacity), config_.threads_per_block_);
+  const auto clamped_num_voxels = std::min(num_voxels, capacity);
+  const auto voxel_blocks = divup(
+    static_cast<std::size_t>(std::max<std::int64_t>(clamped_num_voxels, 1)),
+    config_.threads_per_block_);
 
-  // The sort keys are serialized (Morton/Z-order) codes interleaving 3 grid coordinates of
-  // serialization_depth_ bits each, so they occupy at most 3 * serialization_depth_ bits (the MSB
-  // sits at 3 * serialization_depth_ - 1). Pooling stages only right-shift the codes, which can
-  // never raise the MSB, so this is a valid upper bound for every stage. The INT64_MAX padding
-  // sentinel still sorts last because its low bits are all set, and the full key value is preserved
-  // by the radix sort, so exact-equality sentinel checks remain valid. std::max guards a degenerate
-  // single-voxel grid (serialization_depth_ == 0), since CUB requires end_bit > begin_bit.
-  const int pooling_end_bit = std::max(1, 3 * config_.serialization_depth_);
-
-  setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, num_voxels);
+  setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, clamped_num_voxels);
   CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+  // The finest level (the input voxels) is already sorted by order-0 code, so its order-0 ranking
+  // is the identity. The remaining orders cannot be derived from it and need one real sort each -
+  // the only sorts in this function.
+  if (clamped_num_voxels > 0) {
+    fillIdentityKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
+      finest_level_order_d_.get(), clamped_num_voxels);
+    CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+    for (std::int32_t order_index = 1; order_index < num_orders; ++order_index) {
+      prepareFinestLevelOrderSortKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
+        serialized_code, order_sort_keys_d_.get(), order_sort_indices_d_.get(), clamped_num_voxels,
+        order_index);
+      CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+      CHECK_CUDA_ERROR(
+        cub::DeviceRadixSort::SortPairs(
+          pooling_workspace_d_.get(), pooling_workspace_size_, order_sort_keys_d_.get(),
+          order_sort_sorted_keys_d_.get(), order_sort_indices_d_.get(),
+          finest_level_order_d_.get() + order_index * clamped_num_voxels, clamped_num_voxels, 0,
+          code_sort_end_bit_, stream_));
+    }
+  }
 
   const std::int32_t * current_grid_coord = grid_coord;
   const std::int64_t * current_serialized_code = serialized_code;
+  const std::int64_t * current_order = finest_level_order_d_.get();
 
   for (std::size_t stage_index = 0; stage_index < stages.size(); ++stage_index) {
     const auto & stage = stages[stage_index];
     const auto pooling_depth = poolingDepth(config_.pooling_strides_[stage_index]);
 
-    preparePoolingSortInputKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-      current_serialized_code, stage_counts, pooling_keys_d_.get(), pooling_indices_d_.get(),
+    markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+      current_serialized_code, stage_counts, run_flags_d_.get(),
       static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
     CHECK_CUDA_ERROR(
-      cub::DeviceRadixSort::SortPairs(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-        capacity, 0, pooling_end_bit, stream_));
-
-    markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-      pooling_sorted_keys_d_.get(), pooling_run_flags_d_.get(), capacity);
-    CHECK_CUDA_ERROR(cudaPeekAtLastError());
-
-    CHECK_CUDA_ERROR(
       cub::DeviceScan::InclusiveSum(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
-        pooling_run_ids_d_.get(), capacity, stream_));
+        pooling_workspace_d_.get(), pooling_workspace_size_, run_flags_d_.get(), run_ids_d_.get(),
+        capacity, stream_));
 
     fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-      current_grid_coord, current_serialized_code, pooling_sorted_keys_d_.get(),
-      pooling_sorted_indices_d_.get(), pooling_run_flags_d_.get(), pooling_run_ids_d_.get(),
+      current_grid_coord, current_serialized_code, run_flags_d_.get(), run_ids_d_.get(),
       stage.indices, stage.indptr, stage.head_indices, stage.cluster, stage.grid_coord,
-      stage.serialized_code, stage_counts, static_cast<std::int32_t>(stage_index), pooling_depth,
-      num_orders, capacity);
+      stage.serialized_code, stage.serialized_order, stage.serialized_inverse, stage_counts,
+      static_cast<std::int32_t>(stage_index), pooling_depth, num_orders, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    for (std::int32_t order_index = 0; order_index < num_orders; ++order_index) {
-      prepareOrderSortInputKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-        stage.serialized_code, stage_counts, pooling_keys_d_.get(), pooling_indices_d_.get(),
-        static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
+    // Order 0 was already written as the identity by fillPoolingStageKernel above.
+    for (std::int32_t order_index = 1; order_index < num_orders; ++order_index) {
+      markOrderRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+        current_order, stage.cluster, stage_counts, run_flags_d_.get(),
+        static_cast<std::int32_t>(stage_index), order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
       CHECK_CUDA_ERROR(
-        cub::DeviceRadixSort::SortPairs(
-          pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-          pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-          capacity, 0, pooling_end_bit, stream_));
+        cub::DeviceScan::InclusiveSum(
+          pooling_workspace_d_.get(), pooling_workspace_size_, run_flags_d_.get(), run_ids_d_.get(),
+          capacity, stream_));
 
       fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-        pooling_sorted_keys_d_.get(), pooling_sorted_indices_d_.get(), stage_counts,
-        stage.serialized_order, stage.serialized_inverse,
-        static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
+        current_order, stage.cluster, run_flags_d_.get(), run_ids_d_.get(), stage_counts,
+        stage.serialized_order, stage.serialized_inverse, static_cast<std::int32_t>(stage_index),
+        order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
     }
 
     current_grid_coord = stage.grid_coord;
     current_serialized_code = stage.serialized_code;
+    current_order = stage.serialized_order;
   }
 }
 
@@ -719,7 +796,7 @@ std::size_t PreprocessCuda::generateFeatures(
     coord_min_z, config_.serialization_depth_);
 
   // This sort both groups duplicates for the compaction below and leaves the voxels in order-0
-  // serialization order.
+  // serialization order, which generateSerializedPoolingMetadata requires.
   CHECK_CUDA_ERROR(
     cub::DeviceRadixSort::SortPairs(
       reinterpret_cast<void *>(generate_feature_workspace_d_.get()),

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -357,9 +357,9 @@ __global__ void computeGridCoordsAndSerializationKernel(
 }
 
 __global__ void setInitialStageCountKernel(
-  std::int64_t * __restrict__ stage_counts, std::int64_t num_voxels)
+  std::int64_t * __restrict__ stage_counts_out, std::int64_t num_voxels)
 {
-  *stage_counts = num_voxels;
+  *stage_counts_out = num_voxels;
 }
 
 /**
@@ -380,24 +380,24 @@ __global__ void fillIdentityKernel(std::int64_t * __restrict__ out, std::int64_t
 /**
  * @brief Stages the key/value pair for one of the input-level order sorts.
  *
- * @param serialized_code Input voxels' codes, laid out [num_orders, num_voxels]; only the
+ * @param serialized_code_in Input voxels' codes, laid out [num_orders, num_voxels]; only the
  * `order_index` row is read.
- * @param keys Output sort keys: that row's codes.
- * @param indices Output sort values: 0..num_voxels-1.
+ * @param keys_out Sort keys: that row's codes.
+ * @param indices_out Sort values: 0..num_voxels-1.
  * @param num_voxels Number of input voxels.
  * @param order_index Serialization order being sorted.
  */
 __global__ void prepareInputLevelOrderSortKernel(
-  const std::int64_t * __restrict__ serialized_code, std::int64_t * __restrict__ keys,
-  std::int64_t * __restrict__ indices, std::int64_t num_voxels, std::int32_t order_index)
+  const std::int64_t * __restrict__ serialized_code_in, std::int64_t * __restrict__ keys_out,
+  std::int64_t * __restrict__ indices_out, std::int64_t num_voxels, std::int32_t order_index)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= num_voxels) {
     return;
   }
 
-  keys[idx] = serialized_code[order_index * num_voxels + idx];
-  indices[idx] = idx;
+  keys_out[idx] = serialized_code_in[order_index * num_voxels + idx];
+  indices_out[idx] = idx;
 }
 
 /**
@@ -409,15 +409,15 @@ __global__ void prepareInputLevelOrderSortKernel(
  *
  * @param serialized_code_in Input level's codes, laid out [num_orders, input_count]; only the
  * order-0 row is read.
- * @param stage_counts Per-level voxel counts; entry `stage_index` is the input level's count.
- * @param run_flags Output flags: 1 at each parent run start, 0 elsewhere (including padding).
+ * @param stage_counts_in Per-level voxel counts; entry `stage_index` is the input level's count.
+ * @param run_flags_out Flags: 1 at each parent run start, 0 elsewhere (including padding).
  * @param stage_index Level the input arrays describe.
  * @param pooling_depth Bits each grid coordinate is shifted right by, i.e. log2(pooling stride).
  * @param capacity Padded length of the arrays (max_num_voxels).
  */
 __global__ void markPoolingRunsKernel(
   const std::int64_t * __restrict__ serialized_code_in,
-  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
+  const std::int64_t * __restrict__ stage_counts_in, std::int64_t * __restrict__ run_flags_out,
   std::int32_t stage_index, std::int32_t pooling_depth, std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -425,9 +425,9 @@ __global__ void markPoolingRunsKernel(
     return;
   }
 
-  const auto input_count = stage_counts[stage_index];
+  const auto input_count = stage_counts_in[stage_index];
   if (idx >= input_count) {
-    run_flags[idx] = 0;
+    run_flags_out[idx] = 0;
     return;
   }
 
@@ -435,20 +435,20 @@ __global__ void markPoolingRunsKernel(
 
   const auto shift = pooling_depth * 3;
   const auto key = serialized_code_in[idx] >> shift;
-  run_flags[idx] = (idx == 0 || key != (serialized_code_in[idx - 1] >> shift)) ? 1 : 0;
+  run_flags_out[idx] = (idx == 0 || key != (serialized_code_in[idx - 1] >> shift)) ? 1 : 0;
 }
 
 /**
  * @brief Emits the pooled level and its gather metadata from the parent-run flags.
  *
- * @pre `run_flags` marks the input level's parent-run starts (see markPoolingRunsKernel; zero
- * beyond `input_count`) and `run_ids` is its inclusive prefix sum over all `capacity` entries, so
- * `run_ids[capacity - 1]` is the pooled voxel count.
+ * @pre `run_flags_in` marks the input level's parent-run starts (see markPoolingRunsKernel; zero
+ * beyond `input_count`) and `run_ids_in` is its inclusive prefix sum over all `capacity` entries,
+ * so `run_ids_in[capacity - 1]` is the pooled voxel count.
  *
  * @param grid_coord_in Input level's grid coordinates, laid out [input_count, 3].
  * @param serialized_code_in Input level's codes, laid out [num_orders, input_count].
- * @param run_flags 1 at each parent run start, 0 elsewhere.
- * @param run_ids Each input voxel's 1-based parent segment number.
+ * @param run_flags_in 1 at each parent run start, 0 elsewhere.
+ * @param run_ids_in Each input voxel's 1-based parent segment number.
  * @param indices_out Output gather order for the pooling layer; the identity, as the input is
  * already grouped by parent.
  * @param indptr_out Output segment boundaries, [pooled_count + 1]: first input index of each
@@ -462,8 +462,8 @@ __global__ void markPoolingRunsKernel(
  * @param order_out Output pooled serialization orders, [num_orders, pooled_count]; only the
  * order-0 row is written here, the rest by fillOrderAndInverseKernel.
  * @param inverse_out Output inverse permutations of `order_out`, same layout and coverage.
- * @param stage_counts Per-level voxel counts; entry `stage_index` is the input level's count and
- * entry `stage_index + 1` is set to the pooled count.
+ * @param stage_counts_inout Per-level voxel counts; entry `stage_index` is the input level's
+ * count and entry `stage_index + 1` is set to the pooled count.
  * @param stage_index Level the input arrays describe.
  * @param pooling_depth Bits each grid coordinate is shifted right by, i.e. log2(pooling stride).
  * @param num_orders Number of serialization orders.
@@ -471,14 +471,14 @@ __global__ void markPoolingRunsKernel(
  */
 __global__ void fillPoolingStageKernel(
   const std::int32_t * __restrict__ grid_coord_in,
-  const std::int64_t * __restrict__ serialized_code_in, const std::int64_t * __restrict__ run_flags,
-  const std::int64_t * __restrict__ run_ids, std::int64_t * __restrict__ indices_out,
-  std::int64_t * __restrict__ indptr_out, std::int64_t * __restrict__ head_indices_out,
-  std::int64_t * __restrict__ cluster_out, std::int32_t * __restrict__ grid_coord_out,
-  std::int64_t * __restrict__ serialized_code_out, std::int64_t * __restrict__ order_out,
-  std::int64_t * __restrict__ inverse_out, std::int64_t * __restrict__ stage_counts,
-  std::int32_t stage_index, std::int32_t pooling_depth, std::int32_t num_orders,
-  std::int64_t capacity)
+  const std::int64_t * __restrict__ serialized_code_in,
+  const std::int64_t * __restrict__ run_flags_in, const std::int64_t * __restrict__ run_ids_in,
+  std::int64_t * __restrict__ indices_out, std::int64_t * __restrict__ indptr_out,
+  std::int64_t * __restrict__ head_indices_out, std::int64_t * __restrict__ cluster_out,
+  std::int32_t * __restrict__ grid_coord_out, std::int64_t * __restrict__ serialized_code_out,
+  std::int64_t * __restrict__ order_out, std::int64_t * __restrict__ inverse_out,
+  std::int64_t * __restrict__ stage_counts_inout, std::int32_t stage_index,
+  std::int32_t pooling_depth, std::int32_t num_orders, std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (idx >= capacity) {
@@ -490,10 +490,10 @@ __global__ void fillPoolingStageKernel(
   // stage's input count (the original serialized_code is laid out [2, num_voxels]) and the output
   // by the stage's output count. Using `capacity` as the stride here would both misread the
   // dense input and produce a non-dense output that TensorRT cannot consume.
-  const auto input_count = stage_counts[stage_index];
-  const auto next_count = run_ids[capacity - 1];
+  const auto input_count = stage_counts_inout[stage_index];
+  const auto next_count = run_ids_in[capacity - 1];
   if (idx == 0) {
-    stage_counts[stage_index + 1] = next_count;
+    stage_counts_inout[stage_index + 1] = next_count;
     indptr_out[next_count] = input_count;
   }
 
@@ -502,10 +502,10 @@ __global__ void fillPoolingStageKernel(
   }
 
   indices_out[idx] = idx;
-  const auto segment_index = run_ids[idx] - 1;
+  const auto segment_index = run_ids_in[idx] - 1;
   cluster_out[idx] = segment_index;
 
-  if (run_flags[idx] == 0) {
+  if (run_flags_in[idx] == 0) {
     return;
   }
 
@@ -535,16 +535,16 @@ __global__ void fillPoolingStageKernel(
  * order-`order_index` code without sorting.
  *
  * @param order_in Input level's serialization orders, laid out [num_orders, input_count].
- * @param cluster Parent segment index of each input voxel (see fillPoolingStageKernel).
- * @param stage_counts Per-level voxel counts; entry `stage_index` is the input level's count.
- * @param run_flags Output flags: 1 where the parent changes, 0 elsewhere (including padding).
+ * @param cluster_in Parent segment index of each input voxel (see fillPoolingStageKernel).
+ * @param stage_counts_in Per-level voxel counts; entry `stage_index` is the input level's count.
+ * @param run_flags_out Flags: 1 where the parent changes, 0 elsewhere (including padding).
  * @param stage_index Level the input arrays describe.
  * @param order_index Serialization order being walked.
  * @param capacity Padded length of the arrays (max_num_voxels).
  */
 __global__ void markOrderRunsKernel(
-  const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster,
-  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
+  const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster_in,
+  const std::int64_t * __restrict__ stage_counts_in, std::int64_t * __restrict__ run_flags_out,
   std::int32_t stage_index, std::int32_t order_index, std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -552,22 +552,22 @@ __global__ void markOrderRunsKernel(
     return;
   }
 
-  const auto input_count = stage_counts[stage_index];
+  const auto input_count = stage_counts_in[stage_index];
   if (idx >= input_count) {
-    run_flags[idx] = 0;
+    run_flags_out[idx] = 0;
     return;
   }
 
-  // order_in is laid out densely as [num_orders, input_count].
-  const auto segment_index = cluster[order_in[order_index * input_count + idx]];
-  run_flags[idx] =
-    (idx == 0 || segment_index != cluster[order_in[order_index * input_count + idx - 1]]) ? 1 : 0;
+  const auto segment_index = cluster_in[order_in[order_index * input_count + idx]];
+  run_flags_out[idx] =
+    (idx == 0 || segment_index != cluster_in[order_in[order_index * input_count + idx - 1]]) ? 1
+                                                                                             : 0;
 }
 
 __global__ void fillOrderAndInverseKernel(
-  const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster,
-  const std::int64_t * __restrict__ run_flags, const std::int64_t * __restrict__ run_ids,
-  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ order_out,
+  const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster_in,
+  const std::int64_t * __restrict__ run_flags_in, const std::int64_t * __restrict__ run_ids_in,
+  const std::int64_t * __restrict__ stage_counts_in, std::int64_t * __restrict__ order_out,
   std::int64_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
   std::int64_t capacity)
 {
@@ -576,15 +576,15 @@ __global__ void fillOrderAndInverseKernel(
     return;
   }
 
-  const auto input_count = stage_counts[stage_index];
-  if (idx >= input_count || run_flags[idx] == 0) {
+  const auto input_count = stage_counts_in[stage_index];
+  if (idx >= input_count || run_flags_in[idx] == 0) {
     return;
   }
 
   // order/inverse are stored densely as [num_orders, out_count] to match the engine input layout.
-  const auto out_count = stage_counts[stage_index + 1];
-  const auto out_idx = run_ids[idx] - 1;
-  const auto segment_index = cluster[order_in[order_index * input_count + idx]];
+  const auto out_count = stage_counts_in[stage_index + 1];
+  const auto out_idx = run_ids_in[idx] - 1;
+  const auto segment_index = cluster_in[order_in[order_index * input_count + idx]];
   order_out[order_index * out_count + out_idx] = segment_index;
   inverse_out[order_index * out_count + segment_index] = out_idx;
 }

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -476,19 +476,19 @@ __global__ void fillPoolingStageKernel(
       serialized_code_in[order_index * input_count + idx] >> (pooling_depth * 3);
   }
 
-  // Segments are emitted in ascending order-0 code, so the pooled level's order-0 ranking is the
-  // identity and markPoolingRunsKernel's precondition holds for the next stage.
+  // Segments are emitted in ascending order-0 code, so the pooled level's order-0 row is simply
+  // 0..n-1 and markPoolingRunsKernel's precondition holds for the next stage.
   order_out[segment_index] = segment_index;
   inverse_out[segment_index] = segment_index;
 }
 
 /**
- * @brief Marks where the parent voxel changes while walking the input level in
- * order-`order_index` rank order.
+ * @brief Marks where the parent voxel changes while walking the input level as listed by
+ * serialization order `order_index`.
  *
  * Every serialization order visits each parent's children contiguously and the parents in
- * ascending pooled code, so compacting the run heads yields the pooled level's
- * order-`order_index` ranking without sorting.
+ * ascending pooled code, so compacting the run heads lists the pooled level's voxels in ascending
+ * order-`order_index` code without sorting.
  *
  * @param order_in Input level's serialization orders, laid out [num_orders, input_count].
  * @param cluster Parent segment index of each input voxel (see fillPoolingStageKernel).
@@ -503,21 +503,21 @@ __global__ void markOrderRunsKernel(
   const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ run_flags,
   std::int32_t stage_index, std::int32_t order_index, std::int64_t capacity)
 {
-  const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (rank >= capacity) {
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= capacity) {
     return;
   }
 
   const auto input_count = stage_counts[stage_index];
-  if (rank >= input_count) {
-    run_flags[rank] = 0;
+  if (idx >= input_count) {
+    run_flags[idx] = 0;
     return;
   }
 
   // order_in is laid out densely as [num_orders, input_count].
-  const auto segment_index = cluster[order_in[order_index * input_count + rank]];
-  run_flags[rank] =
-    (rank == 0 || segment_index != cluster[order_in[order_index * input_count + rank - 1]]) ? 1 : 0;
+  const auto segment_index = cluster[order_in[order_index * input_count + idx]];
+  run_flags[idx] =
+    (idx == 0 || segment_index != cluster[order_in[order_index * input_count + idx - 1]]) ? 1 : 0;
 }
 
 __global__ void fillOrderAndInverseKernel(
@@ -527,22 +527,22 @@ __global__ void fillOrderAndInverseKernel(
   std::int64_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
   std::int64_t capacity)
 {
-  const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (rank >= capacity) {
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= capacity) {
     return;
   }
 
   const auto input_count = stage_counts[stage_index];
-  if (rank >= input_count || run_flags[rank] == 0) {
+  if (idx >= input_count || run_flags[idx] == 0) {
     return;
   }
 
   // order/inverse are stored densely as [num_orders, out_count] to match the engine input layout.
   const auto out_count = stage_counts[stage_index + 1];
-  const auto out_rank = run_ids[rank] - 1;
-  const auto segment_index = cluster[order_in[order_index * input_count + rank]];
-  order_out[order_index * out_count + out_rank] = segment_index;
-  inverse_out[order_index * out_count + segment_index] = out_rank;
+  const auto out_idx = run_ids[idx] - 1;
+  const auto segment_index = cluster[order_in[order_index * input_count + idx]];
+  order_out[order_index * out_count + out_idx] = segment_index;
+  inverse_out[order_index * out_count + segment_index] = out_idx;
 }
 
 std::int32_t poolingDepth(const std::int64_t stride)
@@ -573,9 +573,9 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
   setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, clamped_num_voxels);
   CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-  // The input level is already sorted by order-0 code, so its order-0 ranking is the identity.
-  // The remaining orders cannot be derived from it and need one real sort each - the only sorts
-  // in this function.
+  // The input level is already sorted by order-0 code, so its order-0 row is simply 0..n-1. The
+  // remaining orders cannot be derived from it and need one real sort each - the only sorts in
+  // this function.
   if (clamped_num_voxels > 0) {
     fillIdentityKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
       input_level_order_d_.get(), clamped_num_voxels);

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -362,6 +362,12 @@ __global__ void setInitialStageCountKernel(
   *stage_counts = num_voxels;
 }
 
+/**
+ * @brief Writes the sequence 0..count-1 to `out`.
+ *
+ * @param out Output array.
+ * @param count Number of elements to write.
+ */
 __global__ void fillIdentityKernel(std::int64_t * __restrict__ out, std::int64_t count)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -371,6 +377,16 @@ __global__ void fillIdentityKernel(std::int64_t * __restrict__ out, std::int64_t
   out[idx] = idx;
 }
 
+/**
+ * @brief Stages the key/value pair for one of the input-level order sorts.
+ *
+ * @param serialized_code Input voxels' codes, laid out [num_orders, num_voxels]; only the
+ * `order_index` row is read.
+ * @param keys Output sort keys: that row's codes.
+ * @param indices Output sort values: 0..num_voxels-1.
+ * @param num_voxels Number of input voxels.
+ * @param order_index Serialization order being sorted.
+ */
 __global__ void prepareInputLevelOrderSortKernel(
   const std::int64_t * __restrict__ serialized_code, std::int64_t * __restrict__ keys,
   std::int64_t * __restrict__ indices, std::int64_t num_voxels, std::int32_t order_index)
@@ -380,7 +396,6 @@ __global__ void prepareInputLevelOrderSortKernel(
     return;
   }
 
-  // serialized_code is laid out densely as [num_orders, num_voxels].
   keys[idx] = serialized_code[order_index * num_voxels + idx];
   indices[idx] = idx;
 }
@@ -423,6 +438,37 @@ __global__ void markPoolingRunsKernel(
   run_flags[idx] = (idx == 0 || key != (serialized_code_in[idx - 1] >> shift)) ? 1 : 0;
 }
 
+/**
+ * @brief Emits the pooled level and its gather metadata from the parent-run flags.
+ *
+ * @pre `run_flags` marks the input level's parent-run starts (see markPoolingRunsKernel; zero
+ * beyond `input_count`) and `run_ids` is its inclusive prefix sum over all `capacity` entries, so
+ * `run_ids[capacity - 1]` is the pooled voxel count.
+ *
+ * @param grid_coord_in Input level's grid coordinates, laid out [input_count, 3].
+ * @param serialized_code_in Input level's codes, laid out [num_orders, input_count].
+ * @param run_flags 1 at each parent run start, 0 elsewhere.
+ * @param run_ids Each input voxel's 1-based parent segment number.
+ * @param indices_out Output gather order for the pooling layer; the identity, as the input is
+ * already grouped by parent.
+ * @param indptr_out Output segment boundaries, [pooled_count + 1]: first input index of each
+ * segment, terminated by `input_count`.
+ * @param head_indices_out Output representative input voxel per segment: its run start.
+ * @param cluster_out Output parent segment index of each input voxel.
+ * @param grid_coord_out Output pooled coordinates, [pooled_count, 3]: the input coordinates
+ * right-shifted by `pooling_depth`.
+ * @param serialized_code_out Output pooled codes, [num_orders, pooled_count]: the input codes
+ * right-shifted by `3 * pooling_depth`.
+ * @param order_out Output pooled serialization orders, [num_orders, pooled_count]; only the
+ * order-0 row is written here, the rest by fillOrderAndInverseKernel.
+ * @param inverse_out Output inverse permutations of `order_out`, same layout and coverage.
+ * @param stage_counts Per-level voxel counts; entry `stage_index` is the input level's count and
+ * entry `stage_index + 1` is set to the pooled count.
+ * @param stage_index Level the input arrays describe.
+ * @param pooling_depth Bits each grid coordinate is shifted right by, i.e. log2(pooling stride).
+ * @param num_orders Number of serialization orders.
+ * @param capacity Padded length of the arrays (max_num_voxels).
+ */
 __global__ void fillPoolingStageKernel(
   const std::int32_t * __restrict__ grid_coord_in,
   const std::int64_t * __restrict__ serialized_code_in, const std::int64_t * __restrict__ run_flags,
@@ -455,8 +501,6 @@ __global__ void fillPoolingStageKernel(
     return;
   }
 
-  // The input is already grouped by parent (see markPoolingRunsKernel), so the gather order is the
-  // identity.
   indices_out[idx] = idx;
   const auto segment_index = run_ids[idx] - 1;
   cluster_out[idx] = segment_index;

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -69,8 +69,7 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
 
   // Serialized codes occupy 3 * serialization_depth_ bits, and pooling only right-shifts them, so
   // this bound holds for every stage. std::max guards serialization_depth_ == 0 (CUB requires
-  // end_bit > begin_bit). Workspace queries below use the full 64 bits, which upper-bounds the
-  // scratch needed for any narrower range.
+  // end_bit > begin_bit).
   code_sort_end_bit_ = std::max(1, 3 * config_.serialization_depth_);
 
   std::int64_t * int64_nullptr = nullptr;
@@ -102,7 +101,7 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
   num_unique_points_ = autoware::cuda_utils::make_unique_host<std::uint32_t>();
 
   const auto num_orders = static_cast<std::int64_t>(config_.serialization_orders_.size());
-  finest_level_order_d_ =
+  input_level_order_d_ =
     autoware::cuda_utils::make_unique<std::int64_t[]>(num_orders * config_.max_num_voxels_);
   order_sort_keys_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
   order_sort_sorted_keys_d_ =
@@ -372,7 +371,7 @@ __global__ void fillIdentityKernel(std::int64_t * __restrict__ out, std::int64_t
   out[idx] = idx;
 }
 
-__global__ void prepareFinestLevelOrderSortKernel(
+__global__ void prepareInputLevelOrderSortKernel(
   const std::int64_t * __restrict__ serialized_code, std::int64_t * __restrict__ keys,
   std::int64_t * __restrict__ indices, std::int64_t num_voxels, std::int32_t order_index)
 {
@@ -574,16 +573,16 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
   setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, clamped_num_voxels);
   CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-  // The finest level (the input voxels) is already sorted by order-0 code, so its order-0 ranking
-  // is the identity. The remaining orders cannot be derived from it and need one real sort each -
-  // the only sorts in this function.
+  // The input level is already sorted by order-0 code, so its order-0 ranking is the identity.
+  // The remaining orders cannot be derived from it and need one real sort each - the only sorts
+  // in this function.
   if (clamped_num_voxels > 0) {
     fillIdentityKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
-      finest_level_order_d_.get(), clamped_num_voxels);
+      input_level_order_d_.get(), clamped_num_voxels);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
     for (std::int32_t order_index = 1; order_index < num_orders; ++order_index) {
-      prepareFinestLevelOrderSortKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
+      prepareInputLevelOrderSortKernel<<<voxel_blocks, config_.threads_per_block_, 0, stream_>>>(
         serialized_code, order_sort_keys_d_.get(), order_sort_indices_d_.get(), clamped_num_voxels,
         order_index);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
@@ -592,14 +591,14 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
         cub::DeviceRadixSort::SortPairs(
           pooling_workspace_d_.get(), pooling_workspace_size_, order_sort_keys_d_.get(),
           order_sort_sorted_keys_d_.get(), order_sort_indices_d_.get(),
-          finest_level_order_d_.get() + order_index * clamped_num_voxels, clamped_num_voxels, 0,
+          input_level_order_d_.get() + order_index * clamped_num_voxels, clamped_num_voxels, 0,
           code_sort_end_bit_, stream_));
     }
   }
 
   const std::int32_t * current_grid_coord = grid_coord;
   const std::int64_t * current_serialized_code = serialized_code;
-  const std::int64_t * current_order = finest_level_order_d_.get();
+  const std::int64_t * current_order = input_level_order_d_.get();
 
   for (std::size_t stage_index = 0; stage_index < stages.size(); ++stage_index) {
     const auto & stage = stages[stage_index];

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -22,10 +22,13 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <map>
 #include <numeric>
+#include <random>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -92,6 +95,32 @@ std::vector<std::int64_t> make_serialized_code(
     code[count + index] = serialize_coord(x, y, z, depth, true);
   }
   return code;
+}
+
+// generateSerializedPoolingMetadata requires its input sorted by order-0 serialized code (as
+// generateFeatures emits it), so hand-built levels must be sorted the same way.
+std::vector<std::int32_t> sort_grid_coord_by_order0(
+  const std::vector<std::int32_t> & grid_coord, const std::int32_t depth)
+{
+  const auto count = grid_coord.size() / 3;
+  std::vector<std::size_t> order(count);
+  std::iota(order.begin(), order.end(), 0);
+  const auto code_of = [&grid_coord, depth](const std::size_t index) {
+    return serialize_coord(
+      grid_coord[index * 3 + 0], grid_coord[index * 3 + 1], grid_coord[index * 3 + 2], depth,
+      false);
+  };
+  std::stable_sort(order.begin(), order.end(), [&code_of](const auto lhs, const auto rhs) {
+    return code_of(lhs) < code_of(rhs);
+  });
+
+  std::vector<std::int32_t> sorted(grid_coord.size());
+  for (std::size_t rank = 0; rank < count; ++rank) {
+    for (std::size_t coord = 0; coord < 3; ++coord) {
+      sorted[rank * 3 + coord] = grid_coord[order[rank] * 3 + coord];
+    }
+  }
+  return sorted;
 }
 
 std::vector<std::int64_t> stable_argsort(const std::vector<std::int64_t> & values)
@@ -228,6 +257,27 @@ void expect_permutation(const std::vector<std::int64_t> & values, const std::str
   EXPECT_EQ(sorted, expected) << name;
 }
 
+// A fixture whose serialization orders rank a level identically cannot detect an implementation
+// that returns the same ranking for every order, so require the orders to disagree.
+void expect_orders_diverge(
+  const std::vector<std::int64_t> & order, const std::size_t count, const std::size_t num_orders,
+  const std::string & name)
+{
+  ASSERT_GE(num_orders, 2u) << name;
+  const auto row = [&order, count](const std::size_t index) {
+    const auto begin = static_cast<std::ptrdiff_t>(index * count);
+    return std::vector<std::int64_t>(
+      order.begin() + begin, order.begin() + begin + static_cast<std::ptrdiff_t>(count));
+  };
+  const auto first = row(0);
+  for (std::size_t index = 1; index < num_orders; ++index) {
+    EXPECT_NE(first, row(index))
+      << name << ": serialization orders 0 and " << index << " rank this level identically, so the "
+      << "fixture cannot detect a wrong per-order derivation. Pick coordinates that vary in both x "
+      << "and y.";
+  }
+}
+
 class SerializedPoolingMetadataTest : public PTv3CudaTest
 {
 };
@@ -236,7 +286,8 @@ TEST_F(SerializedPoolingMetadataTest, DetectionGridCoord3StaysInsideBevGrid)
 {
   const auto config = make_detection_test_config();
   constexpr std::size_t kNumOrders = 2;
-  const std::vector<std::int32_t> grid_coord{0, 0, 0, 15, 15, 0};
+  const auto grid_coord =
+    sort_grid_coord_by_order0({0, 0, 0, 15, 15, 0}, config.serialization_depth_);
   const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
   const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
 
@@ -278,12 +329,118 @@ TEST_F(SerializedPoolingMetadataTest, DetectionGridCoord3StaysInsideBevGrid)
   }
 }
 
+// Randomized sweep against the CPU reference: the scan-based derivation assumes pooling preserves
+// the serialization order, so exercise that across many occupancy patterns.
+TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForRandomizedClouds)
+{
+  const auto config = make_test_config();
+  constexpr std::size_t kNumOrders = 2;
+  const auto stage_count = config.pooling_strides_.size();
+
+  PreprocessCuda preprocess(config, stream_);
+  auto grid_coord_d = makeDeviceBuffer<std::int32_t>(config.max_num_voxels_ * 3);
+  auto serialized_code_d = makeDeviceBuffer<std::int64_t>(config.max_num_voxels_ * kNumOrders);
+  auto stage_counts_d = makeDeviceBuffer<std::int64_t>(stage_count + 1);
+  std::vector<DeviceStage> device_stages;
+  std::vector<SerializedPoolingDeviceStageView> stage_views;
+  for (std::size_t stage = 0; stage < stage_count; ++stage) {
+    device_stages.emplace_back(config.max_num_voxels_, kNumOrders);
+  }
+  for (auto & stage : device_stages) {
+    stage_views.push_back(
+      SerializedPoolingDeviceStageView{
+        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+        stage.serialized_inverse.get()});
+  }
+
+  // The grid spans 2^serialization_depth_ cells per axis; draw from a sub-cube so that pooling
+  // actually merges cells instead of every voxel ending up in its own parent.
+  const std::int32_t extent = 1 << config.serialization_depth_;
+  std::mt19937 rng(20260805U);
+
+  for (int trial = 0; trial < 32; ++trial) {
+    const std::size_t requested =
+      1U + static_cast<std::size_t>(rng() % static_cast<unsigned>(config.max_num_voxels_));
+    std::uniform_int_distribution<std::int32_t> coord_dist(0, extent - 1);
+
+    // Deduplicate: the pipeline never feeds repeated voxels into the metadata builder.
+    std::set<std::array<std::int32_t, 3>> unique_coords;
+    for (std::size_t i = 0; i < requested; ++i) {
+      unique_coords.insert({coord_dist(rng), coord_dist(rng), coord_dist(rng)});
+    }
+    std::vector<std::int32_t> grid_coord;
+    grid_coord.reserve(unique_coords.size() * 3);
+    for (const auto & coord : unique_coords) {
+      grid_coord.insert(grid_coord.end(), coord.begin(), coord.end());
+    }
+    grid_coord = sort_grid_coord_by_order0(grid_coord, config.serialization_depth_);
+
+    const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
+    const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
+
+    copyToDevice(grid_coord_d.get(), grid_coord);
+    copyToDevice(serialized_code_d.get(), serialized_code);
+    preprocess.generateSerializedPoolingMetadata(
+      grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, stage_counts_d.get());
+    ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
+
+    std::vector<CpuStage> references;
+    references.push_back(
+      make_stage_reference(grid_coord, serialized_code, kNumOrders, config.pooling_strides_[0]));
+    for (std::size_t stage = 1; stage < stage_count; ++stage) {
+      references.push_back(make_stage_reference(
+        references[stage - 1].grid_coord, references[stage - 1].serialized_code, kNumOrders,
+        config.pooling_strides_[stage]));
+    }
+
+    const auto stage_counts = copyToHost(stage_counts_d.get(), stage_count + 1);
+    const auto trial_prefix =
+      "trial " + std::to_string(trial) + " (" + std::to_string(num_voxels) + " voxels) ";
+    ASSERT_EQ(stage_counts[0], num_voxels) << trial_prefix;
+
+    for (std::size_t stage_index = 0; stage_index < references.size(); ++stage_index) {
+      const auto & expected = references[stage_index];
+      const auto & actual = device_stages[stage_index];
+      const auto in_count = static_cast<std::size_t>(stage_counts[stage_index]);
+      const auto out_count = static_cast<std::size_t>(stage_counts[stage_index + 1]);
+      const auto prefix = trial_prefix + "stage " + std::to_string(stage_index) + " ";
+
+      ASSERT_EQ(out_count, expected.head_indices.size()) << prefix + "out_count";
+      expect_equal(
+        copyToHost(actual.indices.get(), in_count), expected.indices, prefix + "indices");
+      expect_equal(
+        copyToHost(actual.indptr.get(), out_count + 1), expected.indptr, prefix + "indptr");
+      expect_equal(
+        copyToHost(actual.head_indices.get(), out_count), expected.head_indices,
+        prefix + "head_indices");
+      expect_equal(
+        copyToHost(actual.cluster.get(), in_count), expected.cluster, prefix + "cluster");
+      expect_equal(
+        copyToHost(actual.grid_coord.get(), out_count * 3), expected.grid_coord,
+        prefix + "grid_coord");
+      expect_equal(
+        copyToHost(actual.serialized_code.get(), out_count * kNumOrders), expected.serialized_code,
+        prefix + "serialized_code");
+      expect_equal(
+        copyToHost(actual.serialized_order.get(), out_count * kNumOrders),
+        expected.serialized_order, prefix + "serialized_order");
+      expect_equal(
+        copyToHost(actual.serialized_inverse.get(), out_count * kNumOrders),
+        expected.serialized_inverse, prefix + "serialized_inverse");
+    }
+  }
+}
+
 TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
 {
   const auto config = make_test_config();
   constexpr std::size_t kNumOrders = 2;
-  const std::vector<std::int32_t> grid_coord{5, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 3,  0, 1,
-                                             4, 4, 0, 5, 4, 1, 8, 0, 0, 9, 0, 0, 10, 2, 0};
+  // Chosen so that "z" and "z-trans" rank the voxels differently at every level (enforced by
+  // expect_orders_diverge below) and pooling merges voxels at every stage (10 -> 6 -> 4).
+  const auto grid_coord = sort_grid_coord_by_order0(
+    {3, 0, 2, 3, 1, 3, 0, 5, 2, 4, 2, 0, 5, 2, 1, 5, 3, 0, 4, 3, 3, 5, 4, 1, 4, 4, 2, 5, 4, 2},
+    config.serialization_depth_);
   const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
   const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
 
@@ -351,6 +508,8 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     const auto serialized_order = copyToHost(actual.serialized_order.get(), out_count * kNumOrders);
     const auto serialized_inverse =
       copyToHost(actual.serialized_inverse.get(), out_count * kNumOrders);
+    expect_orders_diverge(
+      expected.serialized_order, out_count, kNumOrders, prefix + "reference serialized_order");
     expect_equal(serialized_order, expected.serialized_order, prefix + "serialized_order");
     expect_equal(serialized_inverse, expected.serialized_inverse, prefix + "serialized_inverse");
     for (std::size_t order = 0; order < kNumOrders; ++order) {

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -22,13 +22,10 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <map>
 #include <numeric>
-#include <random>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -329,13 +326,57 @@ TEST_F(SerializedPoolingMetadataTest, DetectionGridCoord3StaysInsideBevGrid)
   }
 }
 
-// Randomized sweep against the CPU reference: the scan-based derivation assumes pooling preserves
-// the serialization order, so exercise that across many occupancy patterns.
-TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForRandomizedClouds)
+// Hand-crafted voxel layouts against the CPU reference: each case pins one boundary of the
+// scan-based derivation, and the levels are small enough to verify by hand (stride-2 pooling
+// merges voxels whose grid coordinates match after one right-shift per stage).
+TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForEdgeCaseClouds)
 {
   const auto config = make_test_config();
   constexpr std::size_t kNumOrders = 2;
   const auto stage_count = config.pooling_strides_.size();
+
+  struct EdgeCase
+  {
+    std::string name;
+    // Unique (x, y, z) triplets in any order (the pipeline never emits duplicate voxels); sorted
+    // by order-0 code before upload.
+    std::vector<std::int32_t> grid_coord;
+    // Hand-verified voxel count per level: input, then one entry per pooling stage.
+    std::vector<std::int64_t> expected_stage_counts;
+    // Whether every level of two or more voxels must satisfy expect_orders_diverge.
+    bool orders_diverge;
+  };
+
+  // A 4x4x2 box fills the level to exactly max_num_voxels (asserted below), leaving no padded
+  // entries, and pools into four runs of eight voxels each.
+  ASSERT_EQ(config.max_num_voxels_, 32);
+  std::vector<std::int32_t> full_capacity_box;
+  for (std::int32_t x = 0; x < 4; ++x) {
+    for (std::int32_t y = 0; y < 4; ++y) {
+      for (std::int32_t z = 0; z < 2; ++z) {
+        full_capacity_box.insert(full_capacity_box.end(), {x, y, z});
+      }
+    }
+  }
+
+  const std::vector<EdgeCase> cases = {
+    // The input-level sorts and every run are skipped; all levels stay empty.
+    {"empty input", {}, {0, 0, 0}, false},
+    // One run of length 1 per level; all metadata is the identity mapping.
+    {"single voxel", {5, 3, 1}, {1, 1, 1}, false},
+    // A full 2x2x2 block: the whole level is a single run and collapses to one voxel.
+    {"one full parent",
+     {0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1},
+     {8, 1, 1},
+     false},
+    // Voxels spaced four cells apart never share a parent: every run has length 1 and no stage
+    // merges anything.
+    {"no merging", {0, 0, 0, 4, 0, 0, 8, 0, 0, 12, 0, 0}, {4, 4, 4}, false},
+    // Parent runs of length 3, 1 and 2 in level order: multi-voxel runs at both ends of the
+    // level with a single-voxel run in between, then everything merges into one voxel.
+    {"mixed run lengths", {0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 2, 0, 2, 0, 0, 3, 1, 1}, {6, 3, 1}, true},
+    {"full capacity", full_capacity_box, {32, 4, 1}, true},
+  };
 
   PreprocessCuda preprocess(config, stream_);
   auto grid_coord_d = makeDeviceBuffer<std::int32_t>(config.max_num_voxels_ * 3);
@@ -354,28 +395,9 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForRandomizedClouds)
         stage.serialized_inverse.get()});
   }
 
-  // The grid spans 2^serialization_depth_ cells per axis; draw from a sub-cube so that pooling
-  // actually merges cells instead of every voxel ending up in its own parent.
-  const std::int32_t extent = 1 << config.serialization_depth_;
-  std::mt19937 rng(20260805U);
-
-  for (int trial = 0; trial < 32; ++trial) {
-    const std::size_t requested =
-      1U + static_cast<std::size_t>(rng() % static_cast<unsigned>(config.max_num_voxels_));
-    std::uniform_int_distribution<std::int32_t> coord_dist(0, extent - 1);
-
-    // Deduplicate: the pipeline never feeds repeated voxels into the metadata builder.
-    std::set<std::array<std::int32_t, 3>> unique_coords;
-    for (std::size_t i = 0; i < requested; ++i) {
-      unique_coords.insert({coord_dist(rng), coord_dist(rng), coord_dist(rng)});
-    }
-    std::vector<std::int32_t> grid_coord;
-    grid_coord.reserve(unique_coords.size() * 3);
-    for (const auto & coord : unique_coords) {
-      grid_coord.insert(grid_coord.end(), coord.begin(), coord.end());
-    }
-    grid_coord = sort_grid_coord_by_order0(grid_coord, config.serialization_depth_);
-
+  for (const auto & edge_case : cases) {
+    const auto grid_coord =
+      sort_grid_coord_by_order0(edge_case.grid_coord, config.serialization_depth_);
     const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
     const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
 
@@ -395,18 +417,20 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForRandomizedClouds)
     }
 
     const auto stage_counts = copyToHost(stage_counts_d.get(), stage_count + 1);
-    const auto trial_prefix =
-      "trial " + std::to_string(trial) + " (" + std::to_string(num_voxels) + " voxels) ";
-    ASSERT_EQ(stage_counts[0], num_voxels) << trial_prefix;
+    ASSERT_EQ(stage_counts, edge_case.expected_stage_counts) << edge_case.name;
 
     for (std::size_t stage_index = 0; stage_index < references.size(); ++stage_index) {
       const auto & expected = references[stage_index];
       const auto & actual = device_stages[stage_index];
       const auto in_count = static_cast<std::size_t>(stage_counts[stage_index]);
       const auto out_count = static_cast<std::size_t>(stage_counts[stage_index + 1]);
-      const auto prefix = trial_prefix + "stage " + std::to_string(stage_index) + " ";
+      const auto prefix = edge_case.name + " stage " + std::to_string(stage_index) + " ";
 
       ASSERT_EQ(out_count, expected.head_indices.size()) << prefix + "out_count";
+      if (edge_case.orders_diverge && out_count >= 2) {
+        expect_orders_diverge(
+          expected.serialized_order, out_count, kNumOrders, prefix + "reference serialized_order");
+      }
       expect_equal(
         copyToHost(actual.indices.get(), in_count), expected.indices, prefix + "indices");
       expect_equal(

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -258,7 +258,7 @@ void expect_permutation(const std::vector<std::int64_t> & values, const std::str
 }
 
 // A fixture whose serialization orders rank a level identically cannot detect an implementation
-// that returns the same ranking for every order, so require the orders to disagree.
+// that returns the same row for every order, so require the orders to disagree.
 void expect_orders_diverge(
   const std::vector<std::int64_t> & order, const std::size_t count, const std::size_t num_orders,
   const std::string & name)

--- a/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
+++ b/perception/autoware_ptv3/test/test_preprocess_kernel.cpp
@@ -254,8 +254,8 @@ TEST_F(PreprocessKernelTest, CroppedVoxelCoordsStayInsideGridBounds)
   }
 }
 
-// generateFeatures sorts the emitted voxels by their order-0 serialized code; this pins that
-// postcondition down at its source.
+// generateSerializedPoolingMetadata requires voxels ordered by their order-0 serialized code; this
+// pins that contract of generateFeatures down at its source.
 TEST_F(PreprocessKernelTest, VoxelsAreOrderedByOrder0SerializedCode)
 {
   PTv3ConfigParams params;


### PR DESCRIPTION
## Status quo

After #13153, voxels leave deduplication already sorted by their order-0 serialized code — but the pooling-metadata path still runs 12 radix sorts per frame: per pooling stage, one sort to group voxels by parent plus one sort per serialization order (`12 = 4 x (1 + 2)`).

Every pooling sort runs over `max_num_voxels` (default 192k) padded entries regardless of the stage's real occupancy, so per-sort cost is flat at ~70 us: the deepest stage, holding much fewer voxels, costs as much as the initial deduplication.

## What this PR does

Right-shifting a serialized code by `3 x pooling_depth` bits yields the parent voxel's code, and that relationship is monotone, so a level stored in ascending serialized code stays sorted after pooling. Two consequences:

- **Order 0 never needs sorting.** Segments are emitted in increasing parent code, so the pooled level's order-0 ranking is the identity at every level. The old code spent a full 63-bit sort per stage computing it.
- **The other orders never need sorting either.** Every order right-shifts to the same parent partition, so walking a level in order-o rank sequence visits each parent's children contiguously; compacting the run heads yields the pooled level's order-o ranking directly.

The hierarchy is therefore built from prefix scans and run compaction. The only remaining sorts are the per-order sorts at the finest level (skipped entirely for empty inputs): **13 radix sorts -> 2** across the whole preprocessing stage.

The sorted-input precondition is documented on `generateSerializedPoolingMetadata` (`@pre`) and asserted on device in `markPoolingRunsKernel`, which validates every level as it is consumed. The assert compiles out in Release/RelWithDebInfo (`-DNDEBUG` reaches the device front end; verified absent from the PTX and the built `.so`); in Debug it pinpoints an unsorted input instead of silently producing wrong metadata.

## Code changes

Removed kernels: 
* `preparePoolingSortInputKernel`
* `prepareOrderSortInputKernel`
* `kInvalidPoolingKey` padding sentinel

Added kernels: 
* `fillIdentityKernel`
* `prepareFinestLevelOrderSortKernel`
* `markOrderRunsKernel`

Reworked kernels: 
* `markPoolingRunsKernel` (reads codes directly instead of sorted keys)
* `fillPoolingStageKernel` (emits identity gather order and identity order-0)
* `fillOrderAndInverseKernel` (scan-based instead of sort-based)

Buffers: the four pooling-sort scratch buffers become three finest-level sort buffers plus a `[num_orders, max_num_voxels]` order table; the run-flag/run-id buffers remain.

## Benchmark

Measured on the full stack (this PR + #13153, which is perf-neutral on its own):

<img width="3747" height="758" alt="image" src="https://github.com/user-attachments/assets/922243c1-cf75-4e0e-ac20-07df38d0fc53" />

| | before | after |
|---|---|---|
| radix sorts per frame | 13 | **2** |
| preprocessing stage mean | 2.232 ms | **0.936 ms** |
| preprocessing kernel launches | 140 | **62** |
| radix-sort kernel time | 694 us | **116 us** |
| node GPU memory footprint | 11226 MiB | **11188 MiB** |
| total PTv3 runtime | 38.7 ms | **37.0 ms** |

## Tests

The metadata tests could not detect a swapped serialization order before this PR: the fixed-input fixture is almost entirely `y=0`, so it is nearly invariant under transposing x and y. Fixed by replacing the fixture with a level whose two orders rank the voxels differently at every level and where pooling genuinely merges at every stage (10 -> 6 -> 4), by adding `expect_orders_diverge` so the property is asserted rather than assumed, and by adding `MatchesCpuReferenceForEdgeCaseClouds`: hand-crafted layouts vs the CPU `stable_argsort` reference (all eight metadata arrays, every stage), each pinning one boundary with hand-verified level sizes — empty input, a single voxel, a full parent block, no merging at all, mixed run lengths, and a level at exactly `max_num_voxels`.

Verified by mutating `markOrderRunsKernel` to walk order 0's listing for every order: both reference tests fail (the mixed-run-lengths case catches it; its runs sit at different positions under the two orders).

## Validation

Before/after side-by-side comparison showed no visual discrepancies:

[Screencast from 2026年08月06日 20時11分32秒.webm](https://github.com/user-attachments/assets/968e0906-56b6-49fc-a055-f25a28a9ed5e)

Comparing frames numerically was tricky since TensorRT kernels seem to have floating-point nondeterminism I can't influence. Before vs. after results were within run-to-run variance of both before vs. before, and after vs. after, so it's OK.

## Stack

- PR 1, #13153 (**merged**): replaces voxelization hashing with serialized codes; establishes the sorted-order postcondition this PR relies on.
- **PR 2 (this one)**: derives the pooling metadata with prefix scans instead of sorts. Depends on PR 1.
- PR 3, #13155: replaces the encoder's `serialized_code` input with `serialized_order` / `serialized_inverse`. Breaking; depends on this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

