### PR TITLE
refactor(autoware_spheric_collision_detector): remove the dead pointcloud subscription path

### DIFF
--- a/control/autoware_spheric_collision_detector/CMakeLists.txt
+++ b/control/autoware_spheric_collision_detector/CMakeLists.txt
@@ -6,7 +6,6 @@ autoware_package()
 
 include_directories(
   include
-  ${PCL_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
 )

--- a/control/autoware_spheric_collision_detector/include/autoware/spheric_collision_detector/spheric_collision_detector.hpp
+++ b/control/autoware_spheric_collision_detector/include/autoware/spheric_collision_detector/spheric_collision_detector.hpp
@@ -25,12 +25,8 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <boost/optional.hpp>
-
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 
 #include <chrono>
 #include <fstream>

--- a/control/autoware_spheric_collision_detector/include/autoware/spheric_collision_detector/spheric_collision_detector_node.hpp
+++ b/control/autoware_spheric_collision_detector/include/autoware/spheric_collision_detector/spheric_collision_detector_node.hpp
@@ -29,7 +29,6 @@
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -55,7 +54,6 @@ private:
   // Subscriber
   std::shared_ptr<autoware_utils::SelfPoseListener> self_pose_listener_;
   std::shared_ptr<autoware_utils::TransformListener> transform_listener_;
-  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_obstacle_pointcloud_;
   rclcpp::Subscription<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr
     sub_object_recognition_;
   rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr
@@ -67,14 +65,12 @@ private:
   // Data Buffer
   geometry_msgs::msg::PoseStamped::ConstSharedPtr current_pose_;
   geometry_msgs::msg::Twist::ConstSharedPtr current_twist_;
-  // sensor_msgs::msg::PointCloud2::ConstSharedPtr obstacle_pointcloud_;
   autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr object_recognition_;
 
   autoware_planning_msgs::msg::Trajectory::ConstSharedPtr predicted_trajectory_;
   geometry_msgs::msg::TransformStamped object_recognition_transform_;
 
   // Callback
-  // void onObstaclePointcloud(const sensor_msgs::msg::PointCloud2::SharedPtr msg);
   void onPredictedTrajectory(const autoware_planning_msgs::msg::Trajectory::SharedPtr msg);
   void onOdom(const nav_msgs::msg::Odometry::SharedPtr msg);
   void onObjectRecognition(const autoware_perception_msgs::msg::DetectedObjects::SharedPtr msg);

--- a/control/autoware_spheric_collision_detector/package.xml
+++ b/control/autoware_spheric_collision_detector/package.xml
@@ -21,7 +21,6 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>pcl_ros</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/control/autoware_spheric_collision_detector/src/spheric_collision_detector_node/spheric_collision_detector.cpp
+++ b/control/autoware_spheric_collision_detector/src/spheric_collision_detector_node/spheric_collision_detector.cpp
@@ -17,13 +17,11 @@
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
-#include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <boost/geometry.hpp>
 
-#include <pcl_conversions/pcl_conversions.h>
 #include <tf2/utils.h>
 
 #include <iostream>

--- a/control/autoware_spheric_collision_detector/test/test_spheric_collision_detector.cpp
+++ b/control/autoware_spheric_collision_detector/test/test_spheric_collision_detector.cpp
@@ -14,3 +14,110 @@
 
 #include "../src/spheric_collision_detector_node/spheric_collision_detector.cpp"  // NOLINT
 #include "gtest/gtest.h"
+
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <vector>
+
+// The functions exercised below live in the anonymous namespace of
+// spheric_collision_detector.cpp, which is pulled into this translation unit by the
+// include above. Every expected value is an independent, hand-computed oracle; none is
+// derived by re-running the function under test.
+
+namespace
+{
+
+TEST(SphericCollisionDetectorCore, CalcBrakingDistanceStationary)
+{
+  // v = 0 -> idling (v * delay) = 0 and braking (v^2 / (2 * decel)) = 0 -> total 0.
+  EXPECT_DOUBLE_EQ(calcBrakingDistance(0.0, 2.0, 0.3), 0.0);
+}
+
+TEST(SphericCollisionDetectorCore, CalcBrakingDistanceMoving)
+{
+  // v = 10, decel = 2, delay = 0.5 -> idling = 5.0, braking = 100 / 4 = 25.0 -> total 30.0.
+  EXPECT_DOUBLE_EQ(calcBrakingDistance(10.0, 2.0, 0.5), 30.0);
+  // v = 4, decel = 8, delay = 0.25 -> idling = 1.0, braking = 16 / 16 = 1.0 -> total 2.0.
+  EXPECT_DOUBLE_EQ(calcBrakingDistance(4.0, 8.0, 0.25), 2.0);
+}
+
+TEST(SphericCollisionDetectorCore, ComputeLargestDistFootprintSelectsEachAxis)
+{
+  // d1 = |x_front - x_center|, d2 = |x_center - x_rear|, d3 = |y_left - y_right|.
+  // Returns 0.5 * max(d1, d2, d3), with ties resolving to d3.
+  spheric_collision_detector::FootprintCoords fc_d1{10.0, 0.0, 1.0, 0.0, 1.0};
+  // d1 = 10, d2 = 1, d3 = 1 -> 0.5 * 10 = 5.0.
+  EXPECT_DOUBLE_EQ(computeLargestDistFootprint(fc_d1), 5.0);
+
+  spheric_collision_detector::FootprintCoords fc_d2{0.0, 0.0, -8.0, 1.0, 0.0};
+  // d1 = 0, d2 = 8, d3 = 1 -> 0.5 * 8 = 4.0.
+  EXPECT_DOUBLE_EQ(computeLargestDistFootprint(fc_d2), 4.0);
+
+  spheric_collision_detector::FootprintCoords fc_d3{1.0, 0.0, 0.0, 3.0, -3.0};
+  // d1 = 1, d2 = 0, d3 = 6 -> neither branch wins, else -> 0.5 * 6 = 3.0.
+  EXPECT_DOUBLE_EQ(computeLargestDistFootprint(fc_d3), 3.0);
+}
+
+TEST(SphericCollisionDetectorCore, CreateObstacleSpheresSingleObject)
+{
+  // One object at the local origin (identity orientation), transformed by a pure
+  // translation (10, 5, 2). dim_x (length) = 2.0, dim_y (width) = 1.0.
+  // sphere_radius = dim_y * 0.5 = 0.5, x_front = 0.35 * dim_x = 0.7, x_rear = -0.7.
+  // Local centre x offsets: {0.7, 0.35, 0, -0.35, -0.7}; the translation shifts them to
+  // x + 10, y + 5, z = 2 (the transformed pose's z).
+  autoware_perception_msgs::msg::DetectedObjects objects;
+  autoware_perception_msgs::msg::DetectedObject obj;
+  obj.kinematics.pose_with_covariance.pose.orientation.w = 1.0;
+  obj.shape.dimensions.x = 2.0;
+  obj.shape.dimensions.y = 1.0;
+  autoware_perception_msgs::msg::ObjectClassification classification;
+  classification.label = 1;
+  obj.classification.push_back(classification);
+  objects.objects.push_back(obj);
+
+  geometry_msgs::msg::TransformStamped transform;
+  transform.transform.rotation.w = 1.0;
+  transform.transform.translation.x = 10.0;
+  transform.transform.translation.y = 5.0;
+  transform.transform.translation.z = 2.0;
+
+  std::vector<autoware_utils::LinearRing2d> object_area;
+  const auto obstacles = createObstacleSpheres(objects, transform, object_area);
+
+  ASSERT_EQ(obstacles.size(), 1u);
+  ASSERT_EQ(obstacles.front().size(), 5u);
+
+  const std::vector<double> expected_x{10.7, 10.35, 10.0, 9.65, 9.3};
+  for (size_t i = 0; i < expected_x.size(); ++i) {
+    const auto & sphere = obstacles.front().at(i);
+    EXPECT_NEAR(sphere->center_.x(), expected_x.at(i), 1e-6);
+    EXPECT_NEAR(sphere->center_.y(), 5.0, 1e-6);
+    EXPECT_NEAR(sphere->center_.z(), 2.0, 1e-6);
+    EXPECT_NEAR(sphere->radius_, 0.5, 1e-6);
+    EXPECT_EQ(sphere->tag_, 1);
+  }
+
+  ASSERT_EQ(object_area.size(), 1u);
+  ASSERT_EQ(object_area.front().size(), 5u);
+  for (size_t i = 0; i < expected_x.size(); ++i) {
+    EXPECT_NEAR(object_area.front().at(i).x(), expected_x.at(i), 1e-6);
+    EXPECT_NEAR(object_area.front().at(i).y(), 5.0, 1e-6);
+  }
+}
+
+TEST(SphericCollisionDetectorCore, CreateObstacleSpheresEmptyInput)
+{
+  // No objects -> the loop body never runs; both outputs stay empty and nothing crashes.
+  autoware_perception_msgs::msg::DetectedObjects objects;
+  geometry_msgs::msg::TransformStamped transform;
+  transform.transform.rotation.w = 1.0;
+
+  std::vector<autoware_utils::LinearRing2d> object_area;
+  const auto obstacles = createObstacleSpheres(objects, transform, object_area);
+
+  EXPECT_TRUE(obstacles.empty());
+  EXPECT_TRUE(object_area.empty());
+}
+
+}  // namespace


### PR DESCRIPTION
## Description

Removes the dead `sensor_msgs/PointCloud2` subscription path from `autoware_spheric_collision_detector` and adds unit tests for previously untested collision-input helpers.

The node declared a `PointCloud2` subscription member (`sub_obstacle_pointcloud_`) plus two commented-out siblings (a data buffer and a callback) that were never created, assigned, or read. This detector approximates obstacles from `DetectedObjects` length/width and never touches point cloud data, so the whole path was inert.

Removed:
- the never-created `sub_obstacle_pointcloud_` member and the two commented-out buffer/callback siblings,
- the now-orphaned `sensor_msgs/msg/point_cloud2.hpp`, `pcl/point_cloud.h`, `pcl/point_types.h`, `pcl_ros/transforms.hpp`, and `pcl_conversions/pcl_conversions.h` includes,
- the `pcl_ros` dependency in `package.xml`,
- the dangling `${PCL_INCLUDE_DIRS}` reference in `CMakeLists.txt`.

Added 5 gtest cases (the test file previously had zero assertions) for `calcBrakingDistance`, `computeLargestDistFootprint` (all three axis-selection branches), and `createObstacleSpheres` (single-object and empty-input), each against independent hand-computed oracles.

Diff: 6 files, +107/-12. No runtime code path other than the dead one was modified.

## Related links

**Parent Issue:** https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

- Container build on `autoware:universe-devel-jazzy`: `colcon build --packages-select autoware_spheric_collision_detector --cmake-args -DCMAKE_BUILD_TYPE=Release` green.
- `colcon test --packages-select autoware_spheric_collision_detector` + `colcon test-result --verbose`: 100% tests passed, 0 failures out of 5 (gtest: 5/5 `SphericCollisionDetectorCore.*` cases; plus copyright, cppcheck, lint_cmake, xmllint all pass).
- `pre-commit run --from-ref origin/main --to-ref HEAD`: clean (clang-format, cpplint, sort/prettier package.xml, fix include guard, check package depends all pass; no files modified).

## youtalk fork CI

Re-cut branch verified green on the youtalk fork before this upstream submission: youtalk/autoware_universe#20 (base `civ/ci-base` = upstream `main` + the fork's Ubicloud CI-routing commit, so the head branch itself carries zero fork-only content).

- `build-and-test-differential (jazzy)`: PASS — https://github.com/youtalk/autoware_universe/actions/runs/31652551731/job/94299958494
- `build-and-test-differential (humble)`: PASS — https://github.com/youtalk/autoware_universe/actions/runs/31652551731/job/94299958493
- `spell-check-differential`: PASS — https://github.com/youtalk/autoware_universe/actions/runs/31652471472/job/94299616967
- `cppcheck-differential`: PASS — https://github.com/youtalk/autoware_universe/actions/runs/31652471425/job/94299616627
- `dco`: PASS — https://github.com/youtalk/autoware_universe/actions/runs/31652471417/job/94299616593
- `pre-commit-lite` (this fork is public, so `pre-commit-lite` is the applicable job — the plain `pre-commit` workflow only runs on private repos): PASS — https://github.com/youtalk/autoware_universe/actions/runs/31652471468/job/94299616615
- `pre-commit-optional`: PASS — https://github.com/youtalk/autoware_universe/actions/runs/31652471401/job/94299616832

One red is visible on that PR and it is a labelling artefact, not a code failure: `require-label` has both a FAILURE (https://github.com/youtalk/autoware_universe/actions/runs/31652471697/job/94299617515) and a SUCCESS (https://github.com/youtalk/autoware_universe/actions/runs/31652551731/job/94299857848) instance on the same head commit, because the `run:build-and-test-differential` label was applied after the PR was created — the first run saw an unlabelled PR and the re-triggered run saw the labelled one. The SUCCESS instance is the real verdict, and it is what let the differential build above run at all.

## Notes for reviewers

No behavior change: the live `DetectedObjects`/`Trajectory`/`Odometry` subscriptions, the sphere-collision math, params, launch, config, and schema are byte-identical. The removed member never had a `create_subscription` call, so nothing was subscribed at runtime.

Pre-existing issues found but deliberately left out of scope (one branch = one concern; each is a candidate follow-up):
- `README.md` I/O table still lists stale `autoware_auto_planning_msgs`/`autoware_auto_perception_msgs` message-type names for the live subscriptions.
- `schema/autoware_spheric_collision_detector.json` `$ref` points at `#/definitions/spheric_collision_detector`, but the only defined key is `vehicle_cmd_gate` (copy-paste leftover).
- `Input::obstacle_transform` is a genuinely dead struct field with no reads.
- `out_file_` (`std::ofstream`) and its `<fstream>` include are dead/unused — same dead-code class as this PR but distinct from the pointcloud path.
- `computeLargestDistFootprint` uses strict `>` in both branches, so a tie (`d1==d2` both `> d3`) falls through to the smaller `d3`, which can underestimate `ego_sphere_radius_`. The new `ComputeLargestDistFootprintSelectsEachAxis` test covers the three strict-winner branches but not the tie; a follow-up should fix the tie handling and add a pinning test.
- The test target uses `ament_add_ros_isolated_gtest` though the new tests exercise pure functions with no middleware; trimming to `ament_auto_add_gtest` is a lightest-harness follow-up.

## Interface changes

None.

## Effects on system behavior

None.
