### PR TITLE
feat(multi_object_tracker): tracker batch trigger on stale target stream

### DIFF
--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -194,7 +194,7 @@ MeasurementProcessingResult process_measurement(
   state.processor->updateEgoPose(ego_pose);
 
   const auto association_result = state.processor->associate(*objects);
-  state.input_manager->push(channel_index, *objects, association_result);
+  state.input_manager->push(channel_index, *objects, association_result, current_time);
 
   result.has_objects = true;
   result.should_process = (channel_index == state.input_manager->getTargetChannelIdx());

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -282,11 +282,12 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   }
 
   ////// callback timer
-  // Measurement batch processing is timer-backed so a stalled latency-reference stream cannot block
-  // all tracker updates. The measurement callback trigger below is kept as a low-latency fast path.
-  const auto batch_timer_period = rclcpp::Rate(params_.publish_rate).period();
-  batch_timer_ = autoware::agnocast_wrapper::create_timer(
-    this, get_clock(), batch_timer_period, std::bind(&MultiObjectTracker::onBatchTimer, this));
+  // Refresh target stream selection periodically so a stalled latency-reference stream can fail
+  // over without changing the publish cadence. Measurement callbacks remain the batch trigger.
+  const auto channel_optimizer_timer_period = rclcpp::Rate(params_.publish_rate).period();
+  channel_optimizer_timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), channel_optimizer_timer_period,
+    std::bind(&MultiObjectTracker::onChannelOptimizerTimer, this));
 
   // The publish timer is an independent trigger: when disabled, tracks are published on
   // measurement; when enabled, the timer drives publishing. The export reference
@@ -352,12 +353,12 @@ void MultiObjectTracker::processObjects()
   }
 }
 
-void MultiObjectTracker::onBatchTimer()
+void MultiObjectTracker::onChannelOptimizerTimer()
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
-  processObjects();
+  state_.input_manager->optimizeChannelTimings(this->now());
 }
 
 void MultiObjectTracker::onTimer()

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -282,6 +282,12 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   }
 
   ////// callback timer
+  // Measurement batch processing is timer-backed so a stalled latency-reference stream cannot block
+  // all tracker updates. The measurement callback trigger below is kept as a low-latency fast path.
+  const auto batch_timer_period = rclcpp::Rate(params_.publish_rate).period();
+  batch_timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), batch_timer_period, std::bind(&MultiObjectTracker::onBatchTimer, this));
+
   // The publish timer is an independent trigger: when disabled, tracks are published on
   // measurement; when enabled, the timer drives publishing. The export reference
   // (delay_compensation) is orthogonal.
@@ -344,6 +350,14 @@ void MultiObjectTracker::processObjects()
   if (result.should_publish) {
     publish();
   }
+}
+
+void MultiObjectTracker::onBatchTimer()
+{
+  std::unique_ptr<ScopedTimeTrack> st_ptr;
+  if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
+
+  processObjects();
 }
 
 void MultiObjectTracker::onTimer()

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -51,9 +51,9 @@ private:
   AUTOWARE_PUBLISHER_PTR(autoware_utils_debug::ProcessingTimeDetail)
   detailed_processing_time_publisher_;
 
-  // publish timer
+  // timers
   AUTOWARE_TIMER_PTR publish_timer_;
-  AUTOWARE_TIMER_PTR batch_timer_;
+  AUTOWARE_TIMER_PTR channel_optimizer_timer_;
 
   // parameters and internal state
   MultiObjectTrackerParameters params_;
@@ -68,7 +68,7 @@ private:
 
   // callback functions
   void onTimer();
-  void onBatchTimer();
+  void onChannelOptimizerTimer();
   void processObjects();
   void onMeasurement(
     const size_t channel_index,

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -53,6 +53,7 @@ private:
 
   // publish timer
   AUTOWARE_TIMER_PTR publish_timer_;
+  AUTOWARE_TIMER_PTR batch_timer_;
 
   // parameters and internal state
   MultiObjectTrackerParameters params_;
@@ -67,6 +68,7 @@ private:
 
   // callback functions
   void onTimer();
+  void onBatchTimer();
   void processObjects();
   void onMeasurement(
     const size_t channel_index,

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -332,34 +332,57 @@ void InputManager::getObjectTimeInterval(
   }
 }
 
-void InputManager::optimizeTimings()
+bool InputManager::isStreamFresh(const InputStream & input_stream, const rclcpp::Time & now) const
 {
-  double max_latency_mean = 0.0;
-  uint selected_stream_idx = 0;
-  double selected_stream_latency_std = 0.1;
-  double selected_stream_interval = 0.1;
-  double selected_stream_interval_std = 0.01;
+  if (!input_stream.isTimeInitialized()) {
+    return false;
+  }
+
+  double latency_mean, latency_var, interval_mean, interval_var;
+  input_stream.getTimeStatistics(latency_mean, latency_var, interval_mean, interval_var);
+
+  constexpr double min_freshness_timeout = 0.3;     // [s]
+  constexpr double interval_timeout_multiplier = 3.0;
+  const double expected_interval = interval_mean > 1e-3 ? interval_mean : target_stream_interval_;
+  const double freshness_timeout =
+    std::max(min_freshness_timeout, interval_timeout_multiplier * expected_interval);
+
+  return (now - input_stream.getLatestMessageTime()).seconds() <= freshness_timeout;
+}
+
+void InputManager::optimizeTimings(const rclcpp::Time & now)
+{
+  double max_latency_mean = -1.0;
+  uint selected_stream_idx = target_stream_idx_;
+  double selected_stream_latency_std = target_stream_latency_std_;
+  double selected_stream_interval = target_stream_interval_;
+  double selected_stream_interval_std = target_stream_interval_std_;
+  bool selected_stream = false;
 
   {
     // ANALYSIS: Get the streams statistics
-    // select the stream that has the maximum latency
+    // select the fresh stream that has the maximum latency
     double latency_mean, latency_var, interval_mean, interval_var;
     for (const auto & input_stream : input_streams_) {
-      if (!input_stream->isTimeInitialized()) continue;
+      if (!isStreamFresh(*input_stream, now)) continue;
       input_stream->getTimeStatistics(latency_mean, latency_var, interval_mean, interval_var);
-      if (latency_mean > max_latency_mean) {
+      if (!selected_stream || latency_mean > max_latency_mean) {
         max_latency_mean = latency_mean;
         selected_stream_idx = input_stream->getIndex();
         selected_stream_latency_std = std::sqrt(latency_var);
         selected_stream_interval = interval_mean;
         selected_stream_interval_std = std::sqrt(interval_var);
+        selected_stream = true;
       }
     }
   }
 
+  if (!selected_stream) {
+    return;
+  }
+
   // Set the target stream index, which has the maximum latency
   // trigger will be called next time
-  // if no stream is initialized, the target stream index will be 0 and wait for the initialization
   target_stream_idx_ = selected_stream_idx;
   target_stream_latency_ = max_latency_mean;
   target_stream_latency_std_ = selected_stream_latency_std;
@@ -378,15 +401,14 @@ bool InputManager::getObjects(
   // Clear the objects
   objects_with_associations.clear();
 
+  // Optimize the target stream, latency, and its band before computing the batch window so a stale
+  // target can fail over to a fresh stream within the same processing cycle.
+  optimizeTimings(now);
+
   // Get the time interval for the objects
   rclcpp::Time object_latest_time;
   rclcpp::Time object_earliest_time;
   getObjectTimeInterval(now, object_latest_time, object_earliest_time);
-
-  // Optimize the target stream, latency, and its band
-  // The result will be used for the next time, so the optimization is after getting the time
-  // interval
-  optimizeTimings();
 
   // Get objects from all input streams
   // adds up to the objects vector for efficient processing

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -414,14 +414,15 @@ bool InputManager::getObjects(
   // Clear the objects
   objects_with_associations.clear();
 
-  // Optimize the target stream, latency, and its band before computing the batch window so a stale
-  // target can fail over to a fresh stream within the same processing cycle.
-  optimizeChannelTimings(now);
-
   // Get the time interval for the objects
   rclcpp::Time object_latest_time;
   rclcpp::Time object_earliest_time;
   getObjectTimeInterval(now, object_latest_time, object_earliest_time);
+
+  // Optimize the target stream, latency, and its band.
+  // The result will be used for the next time, so the optimization is after getting the time
+  // interval.
+  optimizeChannelTimings(now);
 
   // Get objects from all input streams
   // adds up to the objects vector for efficient processing

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -341,7 +341,7 @@ bool InputManager::isStreamFresh(const InputStream & input_stream, const rclcpp:
   double latency_mean, latency_var, interval_mean, interval_var;
   input_stream.getTimeStatistics(latency_mean, latency_var, interval_mean, interval_var);
 
-  constexpr double min_freshness_timeout = 0.3;     // [s]
+  constexpr double min_freshness_timeout = 0.3;  // [s]
   constexpr double interval_timeout_multiplier = 3.0;
   const double expected_interval = interval_mean > 1e-3 ? interval_mean : target_stream_interval_;
   const double freshness_timeout =

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace autoware::multi_object_tracker
@@ -312,37 +313,40 @@ void InputManager::getObjectTimeInterval(
   const rclcpp::Time & now, rclcpp::Time & object_latest_time,
   rclcpp::Time & object_earliest_time) const
 {
-  // Set the object time interval
+  // The newest measurement of the target stream, once its time statistics are initialized
+  const auto & target_stream = input_streams_.at(target_stream_idx_);
+  const std::optional<rclcpp::Time> target_latest_measurement =
+    target_stream->isTimeInitialized()
+      ? std::make_optional(target_stream->getLatestMeasurementTime())
+      : std::nullopt;
 
   // 1. object_latest_time
-  // The object_latest_time is the current time minus the target stream latency
-  object_latest_time =
+  // The current time minus the target stream latency, kept at or above the target stream's
+  // newest measurement
+  const rclcpp::Time latency_based_latest_time =
     now - rclcpp::Duration::from_seconds(target_stream_latency_ - 0.1 * target_stream_latency_std_);
-
-  // check the target stream can be included in the object time interval
-  if (input_streams_.at(target_stream_idx_)->isTimeInitialized()) {
-    const rclcpp::Time latest_measurement_time =
-      input_streams_.at(target_stream_idx_)->getLatestMeasurementTime();
-    // if the object_latest_time is older than the latest measurement time, set it to the latest
-    // object time
-    object_latest_time =
-      object_latest_time < latest_measurement_time ? latest_measurement_time : object_latest_time;
-  }
+  object_latest_time = target_latest_measurement
+                         ? std::max(latency_based_latest_time, *target_latest_measurement)
+                         : latency_based_latest_time;
 
   // 2. object_earliest_time
-  // The default object_earliest_time is to have a 1-second time interval
-  const rclcpp::Time object_earliest_time_default =
+  // The window start resumes from the export watermark; a watermark ahead of the window end
+  // falls back to the default 1-second interval
+  const rclcpp::Time earliest_time_default =
     object_latest_time - rclcpp::Duration::from_seconds(1.0);
-  if (
-    latest_exported_object_time_ < object_earliest_time_default ||
-    latest_exported_object_time_ > object_latest_time) {
-    // if the latest exported object time is too old or newer than the object_latest_time,
-    // set to the default
-    object_earliest_time = object_earliest_time_default;
-  } else {
-    // The object_earliest_time is the latest exported object time
-    object_earliest_time = latest_exported_object_time_;
-  }
+  const rclcpp::Time export_resume_time = latest_exported_object_time_ > object_latest_time
+                                            ? earliest_time_default
+                                            : latest_exported_object_time_;
+
+  // The window start stays at or below the target stream's newest measurement: objects below the
+  // window start are dropped by getObjectsOlderThan(), so the target's backlog is exported while
+  // the latency estimate converges
+  const rclcpp::Time target_covered_time =
+    target_latest_measurement ? std::min(export_resume_time, *target_latest_measurement)
+                              : export_resume_time;
+
+  // Bounded to the 1-second interval
+  object_earliest_time = std::max(target_covered_time, earliest_time_default);
 }
 
 bool InputManager::isStreamFresh(const InputStream & input_stream, const rclcpp::Time & now) const

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -49,6 +49,13 @@ InputStream::InputStream(
 void InputStream::push(
   const types::DynamicObjectList & objects, const types::AssociationResult & association)
 {
+  push(objects, association, clock_->now());
+}
+
+void InputStream::push(
+  const types::DynamicObjectList & objects, const types::AssociationResult & association,
+  const rclcpp::Time & now)
+{
   // Move the objects_with_uncertainty to the objects queue
   objects_que_.push_back(types::ObjectsWithAssociation{objects, association});
   while (objects_que_.size() > que_size_) {
@@ -56,7 +63,6 @@ void InputStream::push(
   }
 
   // update the timing statistics
-  rclcpp::Time now = clock_->now();
   rclcpp::Time objects_time(objects.header.stamp);
   updateTimingStatus(now, objects_time);
 
@@ -265,13 +271,20 @@ void InputManager::push(
   const size_t channel_index, const types::DynamicObjectList & objects,
   const types::AssociationResult & association)
 {
+  push(channel_index, objects, association, clock_->now());
+}
+
+void InputManager::push(
+  const size_t channel_index, const types::DynamicObjectList & objects,
+  const types::AssociationResult & association, const rclcpp::Time & now)
+{
   if (channel_index >= input_streams_.size()) {
     RCLCPP_WARN(
       logger_, "InputManager::push Invalid channel index: %lu, input_streams_ size: %lu",
       channel_index, input_streams_.size());
     return;
   }
-  input_streams_.at(channel_index)->push(objects, association);
+  input_streams_.at(channel_index)->push(objects, association, now);
 }
 
 std::optional<types::DynamicObjectList> InputManager::processMessage(
@@ -350,7 +363,7 @@ bool InputManager::isStreamFresh(const InputStream & input_stream, const rclcpp:
   return (now - input_stream.getLatestMessageTime()).seconds() <= freshness_timeout;
 }
 
-void InputManager::optimizeTimings(const rclcpp::Time & now)
+void InputManager::optimizeChannelTimings(const rclcpp::Time & now)
 {
   double max_latency_mean = -1.0;
   uint selected_stream_idx = target_stream_idx_;
@@ -403,7 +416,7 @@ bool InputManager::getObjects(
 
   // Optimize the target stream, latency, and its band before computing the batch window so a stale
   // target can fail over to a fresh stream within the same processing cycle.
-  optimizeTimings(now);
+  optimizeChannelTimings(now);
 
   // Get the time interval for the objects
   rclcpp::Time object_latest_time;

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -354,53 +354,79 @@ bool InputManager::isStreamFresh(const InputStream & input_stream, const rclcpp:
   double latency_mean, latency_var, interval_mean, interval_var;
   input_stream.getTimeStatistics(latency_mean, latency_var, interval_mean, interval_var);
 
-  constexpr double min_freshness_timeout = 0.3;  // [s]
-  constexpr double interval_timeout_multiplier = 3.0;
+  // The timeout is capped by the margin, so that a rate-dropped channel, which has a gradually
+  // increasing interval, is not relaxed into the 'fresh' condition by its own statistics.
+  // A channel slower than 'freshness_margin * 2.0' interval is always treated as not fresh.
+  constexpr double freshness_margin = 0.2;  // [s]
   const double expected_interval = interval_mean > 1e-3 ? interval_mean : target_stream_interval_;
-  const double freshness_timeout =
-    std::max(min_freshness_timeout, interval_timeout_multiplier * expected_interval);
+  const double freshness_timeout = std::min(expected_interval, freshness_margin) + freshness_margin;
 
-  return (now - input_stream.getLatestMessageTime()).seconds() <= freshness_timeout;
+  const double elapsed = (now - input_stream.getLatestMessageTime()).seconds();
+  return 0.0 <= elapsed && elapsed <= freshness_timeout;
 }
 
 void InputManager::optimizeChannelTimings(const rclcpp::Time & now)
 {
-  double max_latency_mean = -1.0;
-  uint selected_stream_idx = target_stream_idx_;
-  double selected_stream_latency_std = target_stream_latency_std_;
-  double selected_stream_interval = target_stream_interval_;
-  double selected_stream_interval_std = target_stream_interval_std_;
-  bool selected_stream = false;
-
-  {
-    // ANALYSIS: Get the streams statistics
-    // select the fresh stream that has the maximum latency
-    double latency_mean, latency_var, interval_mean, interval_var;
-    for (const auto & input_stream : input_streams_) {
-      if (!isStreamFresh(*input_stream, now)) continue;
-      input_stream->getTimeStatistics(latency_mean, latency_var, interval_mean, interval_var);
-      if (!selected_stream || latency_mean > max_latency_mean) {
-        max_latency_mean = latency_mean;
-        selected_stream_idx = input_stream->getIndex();
-        selected_stream_latency_std = std::sqrt(latency_var);
-        selected_stream_interval = interval_mean;
-        selected_stream_interval_std = std::sqrt(interval_var);
-        selected_stream = true;
-      }
+  // ANALYSIS: Get the streams statistics
+  // select the fresh stream that has the maximum latency
+  double latency_mean, latency_var, interval_mean, interval_var;
+  bool is_candidate_found = false;
+  uint candidate_stream_idx = target_stream_idx_;
+  double candidate_latency_mean = -1.0;
+  for (const auto & input_stream : input_streams_) {
+    if (!isStreamFresh(*input_stream, now)) continue;
+    input_stream->getTimeStatistics(latency_mean, latency_var, interval_mean, interval_var);
+    if (!is_candidate_found || latency_mean > candidate_latency_mean) {
+      is_candidate_found = true;
+      candidate_stream_idx = input_stream->getIndex();
+      candidate_latency_mean = latency_mean;
     }
   }
 
-  if (!selected_stream) {
+  if (!is_candidate_found) {
+    // no fresh stream is available, keep the current target stream
     return;
   }
 
-  // Set the target stream index, which has the maximum latency
+  // DECISION: Set the target stream index, which has the maximum latency
   // trigger will be called next time
-  target_stream_idx_ = selected_stream_idx;
-  target_stream_latency_ = max_latency_mean;
-  target_stream_latency_std_ = selected_stream_latency_std;
-  target_stream_interval_ = selected_stream_interval;
-  target_stream_interval_std_ = selected_stream_interval_std;
+  const auto & current_target_stream = input_streams_.at(target_stream_idx_);
+  if (!isStreamFresh(*current_target_stream, now)) {
+    // the current target stream is stale, fail over to the fresh candidate immediately
+    target_stream_idx_ = candidate_stream_idx;
+  } else if (candidate_stream_idx != target_stream_idx_) {
+    // both streams are fresh: switch only if the candidate is clearly slower than the current
+    // target, to avoid frequent flipping between streams of similar latency
+    constexpr double latency_hysteresis = 0.03;  // [s]
+    double target_latency_mean, target_latency_var, target_interval_mean, target_interval_var;
+    current_target_stream->getTimeStatistics(
+      target_latency_mean, target_latency_var, target_interval_mean, target_interval_var);
+    if (candidate_latency_mean > target_latency_mean + latency_hysteresis) {
+      target_stream_idx_ = candidate_stream_idx;
+    }
+  }
+
+  // UPDATE: Refresh the timing statistics of the target stream
+  input_streams_.at(target_stream_idx_)
+    ->getTimeStatistics(latency_mean, latency_var, interval_mean, interval_var);
+
+  // Shift the target latency gradually when it increases, because an increase moves the batch
+  // window backward in time. A backward jump exports objects older than the tracker time, which
+  // makes the trackers stale. The increase rate is much slower than the elapsed time, so the
+  // batch window end (now - target_stream_latency_) keeps moving forward.
+  constexpr double max_latency_increase_rate = 0.2;  // [s/s]
+  const double elapsed = last_optimization_time_
+                           ? std::clamp((now - *last_optimization_time_).seconds(), 0.0, 1.0)
+                           : 0.0;
+  target_stream_latency_ =
+    latency_mean > target_stream_latency_
+      ? std::min(latency_mean, target_stream_latency_ + max_latency_increase_rate * elapsed)
+      : latency_mean;  // a decrease is applied immediately, it moves the window forward
+  last_optimization_time_ = now;
+
+  target_stream_latency_std_ = std::sqrt(latency_var);
+  target_stream_interval_ = interval_mean;
+  target_stream_interval_std_ = std::sqrt(interval_var);
 }
 
 bool InputManager::getObjects(
@@ -418,11 +444,6 @@ bool InputManager::getObjects(
   rclcpp::Time object_latest_time;
   rclcpp::Time object_earliest_time;
   getObjectTimeInterval(now, object_latest_time, object_earliest_time);
-
-  // Optimize the target stream, latency, and its band.
-  // The result will be used for the next time, so the optimization is after getting the time
-  // interval.
-  optimizeChannelTimings(now);
 
   // Get objects from all input streams
   // adds up to the objects vector for efficient processing

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
@@ -101,6 +101,7 @@ public:
 
   void setTriggerFunction(std::function<void(size_t)> func_trigger);
   size_t getTargetChannelIdx() const { return target_stream_idx_; }
+  double getTargetStreamLatency() const { return target_stream_latency_; }
   std::optional<types::DynamicObjectList> processMessage(
     const size_t channel_index,
     AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg);
@@ -132,6 +133,7 @@ private:
   double target_stream_latency_std_{0.04};   // [s]
   double target_stream_interval_{0.1};       // [s]
   double target_stream_interval_std_{0.02};  // [s]
+  std::optional<rclcpp::Time> last_optimization_time_;
 
 private:
   void getObjectTimeInterval(

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
@@ -66,6 +66,7 @@ public:
     interval_var = interval_var_;
   }
   rclcpp::Time getLatestMeasurementTime() const { return latest_measurement_time_; }
+  rclcpp::Time getLatestMessageTime() const { return latest_message_time_; }
 
 private:
   const types::InputChannel channel_;
@@ -129,7 +130,8 @@ private:
   void getObjectTimeInterval(
     const rclcpp::Time & now, rclcpp::Time & object_latest_time,
     rclcpp::Time & object_earliest_time) const;
-  void optimizeTimings();
+  bool isStreamFresh(const InputStream & input_stream, const rclcpp::Time & now) const;
+  void optimizeTimings(const rclcpp::Time & now);
 };
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.hpp
@@ -47,6 +47,9 @@ public:
   std::optional<types::DynamicObjectList> processMessage(
     AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) msg);
   void push(const types::DynamicObjectList & objects, const types::AssociationResult & association);
+  void push(
+    const types::DynamicObjectList & objects, const types::AssociationResult & association,
+    const rclcpp::Time & now);
   void updateTimingStatus(const rclcpp::Time & now, const rclcpp::Time & objects_time);
 
   bool isTimeInitialized() const { return initial_count_ > 0; }
@@ -104,6 +107,10 @@ public:
   void push(
     const size_t channel_index, const types::DynamicObjectList & objects,
     const types::AssociationResult & association);
+  void push(
+    const size_t channel_index, const types::DynamicObjectList & objects,
+    const types::AssociationResult & association, const rclcpp::Time & now);
+  void optimizeChannelTimings(const rclcpp::Time & now);
 
   bool getObjects(
     const rclcpp::Time & now, types::ObjectsWithAssociationList & objects_with_associations);
@@ -131,7 +138,6 @@ private:
     const rclcpp::Time & now, rclcpp::Time & object_latest_time,
     rclcpp::Time & object_earliest_time) const;
   bool isStreamFresh(const InputStream & input_stream, const rclcpp::Time & now) const;
-  void optimizeTimings(const rclcpp::Time & now);
 };
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
@@ -37,7 +37,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -498,7 +497,9 @@ namespace
 
 constexpr size_t kHighLatencyChannel = 0;
 constexpr size_t kLowLatencyChannel = 1;
-constexpr auto kTargetStaleWait = 600ms;
+constexpr int32_t kTestStartSec = 2000000000;
+constexpr double kMeasurementInterval = 0.1;
+constexpr double kStaleElapsedTime = 0.6;
 
 std::vector<autoware::multi_object_tracker::types::InputChannel> makeInputManagerChannels()
 {
@@ -533,38 +534,35 @@ autoware::multi_object_tracker::InputManager makeInputManagerForTriggerTest(
 
 rclcpp::Time pushEmptyMeasurement(
   autoware::multi_object_tracker::InputManager & manager, const size_t channel_index,
-  const rclcpp::Clock::SharedPtr & clock, const double latency_sec)
+  const rclcpp::Time & now, const double latency_sec)
 {
   autoware::multi_object_tracker::types::DynamicObjectList objects;
   objects.channel_index = static_cast<uint>(channel_index);
-  const rclcpp::Time measurement_time = clock->now() - rclcpp::Duration::from_seconds(latency_sec);
+  const rclcpp::Time measurement_time = now - rclcpp::Duration::from_seconds(latency_sec);
   objects.header.stamp = static_cast<builtin_interfaces::msg::Time>(measurement_time);
 
-  manager.push(channel_index, objects, autoware::multi_object_tracker::types::AssociationResult{});
+  manager.push(
+    channel_index, objects, autoware::multi_object_tracker::types::AssociationResult{}, now);
   return measurement_time;
 }
 
-void feedRegularMeasurements(
-  autoware::multi_object_tracker::InputManager & manager, const size_t channel_index,
-  const rclcpp::Clock::SharedPtr & clock, const double latency_sec, const size_t count)
+rclcpp::Time advanceTime(const rclcpp::Time & now, const double seconds)
 {
-  for (size_t i = 0; i < count; ++i) {
-    pushEmptyMeasurement(manager, channel_index, clock, latency_sec);
-    std::this_thread::sleep_for(1ms);
-  }
+  return now + rclcpp::Duration::from_seconds(seconds);
 }
 
-void initializeLatencyStatistics(
-  autoware::multi_object_tracker::InputManager & manager, const rclcpp::Clock::SharedPtr & clock)
+rclcpp::Time initializeLatencyStatistics(autoware::multi_object_tracker::InputManager & manager)
 {
+  rclcpp::Time now(kTestStartSec, 0, RCL_ROS_TIME);
   for (size_t i = 0; i < 20; ++i) {
-    pushEmptyMeasurement(manager, kHighLatencyChannel, clock, 0.5);
-    pushEmptyMeasurement(manager, kLowLatencyChannel, clock, 0.05);
-    std::this_thread::sleep_for(1ms);
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.5);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
   }
 
   autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
-  manager.getObjects(clock->now(), objects);
+  manager.getObjects(now, objects);
+  return now;
 }
 
 bool hasMeasurementAtOrAfter(
@@ -584,7 +582,7 @@ TEST(InputManagerTargetSelection, SelectsLargestLatencyStreamAfterTimingOptimiza
   const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
   auto manager = makeInputManagerForTriggerTest(clock);
 
-  initializeLatencyStatistics(manager, clock);
+  initializeLatencyStatistics(manager);
 
   EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
 }
@@ -593,14 +591,16 @@ TEST(InputManagerTargetSelection, FailsOverFromStaleTargetToFreshStream)
 {
   const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
   auto manager = makeInputManagerForTriggerTest(clock);
-  initializeLatencyStatistics(manager, clock);
+  rclcpp::Time now = initializeLatencyStatistics(manager);
   ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
 
-  std::this_thread::sleep_for(kTargetStaleWait);
-  feedRegularMeasurements(manager, kLowLatencyChannel, clock, 0.05, 5);
+  now = advanceTime(now, kStaleElapsedTime);
+  for (size_t i = 0; i < 5; ++i) {
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+  }
 
-  autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
-  manager.getObjects(clock->now(), objects);
+  manager.optimizeChannelTimings(now);
 
   EXPECT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
 }
@@ -609,18 +609,19 @@ TEST(InputManagerTargetSelection, BatchWindowAdvancesWithFreshStreamAfterTargetD
 {
   const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
   auto manager = makeInputManagerForTriggerTest(clock);
-  initializeLatencyStatistics(manager, clock);
+  rclcpp::Time now = initializeLatencyStatistics(manager);
   ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
 
-  std::this_thread::sleep_for(kTargetStaleWait);
+  now = advanceTime(now, kStaleElapsedTime);
   rclcpp::Time latest_fresh_measurement(0, 0, RCL_ROS_TIME);
   for (size_t i = 0; i < 5; ++i) {
-    latest_fresh_measurement = pushEmptyMeasurement(manager, kLowLatencyChannel, clock, 0.05);
-    std::this_thread::sleep_for(1ms);
+    latest_fresh_measurement = pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
   }
 
+  manager.optimizeChannelTimings(now);
   autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
-  manager.getObjects(clock->now(), objects);
+  manager.getObjects(now, objects);
 
   EXPECT_TRUE(hasMeasurementAtOrAfter(objects, kLowLatencyChannel, latest_fresh_measurement));
 }

--- a/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
@@ -560,8 +560,7 @@ rclcpp::Time initializeLatencyStatistics(autoware::multi_object_tracker::InputMa
     now = advanceTime(now, kMeasurementInterval);
   }
 
-  autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
-  manager.getObjects(now, objects);
+  manager.optimizeChannelTimings(now);
   return now;
 }
 
@@ -624,6 +623,120 @@ TEST(InputManagerTargetSelection, BatchWindowAdvancesWithFreshStreamAfterTargetD
   manager.getObjects(now, objects);
 
   EXPECT_TRUE(hasMeasurementAtOrAfter(objects, kLowLatencyChannel, latest_fresh_measurement));
+}
+
+TEST(InputManagerTargetSelection, KeepsTargetWithinLatencyHysteresis)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+
+  // both channels have the same latency, so the first one is selected as the target
+  rclcpp::Time now(kTestStartSec, 0, RCL_ROS_TIME);
+  for (size_t i = 0; i < 20; ++i) {
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.30);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+  }
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  // a latency difference smaller than the hysteresis must not flip the target stream
+  for (size_t i = 0; i < 30; ++i) {
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.32);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+  }
+  EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  // a latency difference larger than the hysteresis switches the target stream
+  for (size_t i = 0; i < 100; ++i) {
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.60);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+  }
+  EXPECT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
+}
+
+TEST(InputManagerTargetSelection, ShiftsTargetLatencyGraduallyOnIncrease)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+  rclcpp::Time now = initializeLatencyStatistics(manager);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  // the target latency must not jump to the target stream latency at once, otherwise the batch
+  // window moves backward in time
+  constexpr double max_latency_increase_rate = 0.2;  // [s/s]
+  const double max_latency_step = max_latency_increase_rate * kMeasurementInterval;
+  double previous_latency = manager.getTargetStreamLatency();
+  for (size_t i = 0; i < 20; ++i) {
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.5);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+
+    const double latency = manager.getTargetStreamLatency();
+    EXPECT_GE(latency, previous_latency);
+    EXPECT_LE(latency - previous_latency, max_latency_step + 1e-6);
+    previous_latency = latency;
+  }
+
+  // it converges to the latency of the target stream
+  EXPECT_NEAR(manager.getTargetStreamLatency(), 0.5, 1e-2);
+}
+
+TEST(InputManagerTargetSelection, AppliesTargetLatencyDecreaseImmediately)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+  rclcpp::Time now = initializeLatencyStatistics(manager);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  for (size_t i = 0; i < 20; ++i) {
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.5);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+  }
+  ASSERT_NEAR(manager.getTargetStreamLatency(), 0.5, 1e-2);
+
+  // on a failover to a fresh low latency stream, the batch window recovers without a delay
+  now = advanceTime(now, kStaleElapsedTime);
+  pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+  manager.optimizeChannelTimings(now);
+
+  EXPECT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
+  EXPECT_NEAR(manager.getTargetStreamLatency(), 0.05, 1e-2);
+}
+
+TEST(InputManagerTargetSelection, TreatsRateDroppedStreamAsStale)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+  rclcpp::Time now = initializeLatencyStatistics(manager);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  // the target stream gradually drops its rate, which grows its interval statistics
+  double interval = kMeasurementInterval;
+  for (size_t i = 0; i < 60; ++i) {
+    constexpr double interval_growth_rate = 1.02;
+    interval *= interval_growth_rate;
+    now = advanceTime(now, interval);
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.5);
+  }
+  manager.optimizeChannelTimings(now);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  // the freshness timeout must not be relaxed by the grown interval statistics
+  for (size_t i = 0; i < 5; ++i) {
+    now = advanceTime(now, kMeasurementInterval);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+  }
+  manager.optimizeChannelTimings(now);
+
+  EXPECT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
 }
 
 TEST_F(MultiObjectTrackerTest, DISABLED_PerformanceVsCarCount)

--- a/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
@@ -537,8 +537,7 @@ rclcpp::Time pushEmptyMeasurement(
 {
   autoware::multi_object_tracker::types::DynamicObjectList objects;
   objects.channel_index = static_cast<uint>(channel_index);
-  const rclcpp::Time measurement_time =
-    clock->now() - rclcpp::Duration::from_seconds(latency_sec);
+  const rclcpp::Time measurement_time = clock->now() - rclcpp::Duration::from_seconds(latency_sec);
   objects.header.stamp = static_cast<builtin_interfaces::msg::Time>(measurement_time);
 
   manager.push(channel_index, objects, autoware::multi_object_tracker::types::AssociationResult{});
@@ -572,11 +571,10 @@ bool hasMeasurementAtOrAfter(
   const autoware::multi_object_tracker::types::ObjectsWithAssociationList & objects,
   const size_t channel_index, const rclcpp::Time & timestamp)
 {
-  return std::any_of(
-    objects.begin(), objects.end(), [&](const auto & objects_with_association) {
-      return objects_with_association.objects.channel_index == channel_index &&
-             objects_with_association.getTimestamp() >= timestamp;
-    });
+  return std::any_of(objects.begin(), objects.end(), [&](const auto & objects_with_association) {
+    return objects_with_association.objects.channel_index == channel_index &&
+           objects_with_association.getTimestamp() >= timestamp;
+  });
 }
 
 }  // namespace
@@ -617,8 +615,7 @@ TEST(InputManagerTargetSelection, BatchWindowAdvancesWithFreshStreamAfterTargetD
   std::this_thread::sleep_for(kTargetStaleWait);
   rclcpp::Time latest_fresh_measurement(0, 0, RCL_ROS_TIME);
   for (size_t i = 0; i < 5; ++i) {
-    latest_fresh_measurement =
-      pushEmptyMeasurement(manager, kLowLatencyChannel, clock, 0.05);
+    latest_fresh_measurement = pushEmptyMeasurement(manager, kLowLatencyChannel, clock, 0.05);
     std::this_thread::sleep_for(1ms);
   }
 

--- a/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "../src/multi_object_tracker_node.hpp"
+#include "../src/processor/input_manager.hpp"
 #include "autoware/multi_object_tracker/odometry.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 #include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
@@ -36,6 +37,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -490,6 +492,141 @@ public:
   MultiObjectTrackerTest() = default;
   ~MultiObjectTrackerTest() override = default;
 };
+
+namespace
+{
+
+constexpr size_t kHighLatencyChannel = 0;
+constexpr size_t kLowLatencyChannel = 1;
+constexpr auto kTargetStaleWait = 600ms;
+
+std::vector<autoware::multi_object_tracker::types::InputChannel> makeInputManagerChannels()
+{
+  std::vector<autoware::multi_object_tracker::types::InputChannel> channels;
+  channels.reserve(2);
+
+  for (size_t i = 0; i < 2; ++i) {
+    autoware::multi_object_tracker::types::InputChannel channel;
+    channel.index = static_cast<uint>(i);
+    channel.is_enabled = true;
+    channel.long_name = "test_channel_" + std::to_string(i);
+    channel.short_name = "ch" + std::to_string(i);
+    channel.is_spawn_enabled = true;
+    channel.trust_existence_probability = true;
+    channel.trust_extension = true;
+    channel.trust_classification = true;
+    channel.trust_orientation = true;
+    channels.push_back(channel);
+  }
+
+  return channels;
+}
+
+autoware::multi_object_tracker::InputManager makeInputManagerForTriggerTest(
+  const rclcpp::Clock::SharedPtr & clock)
+{
+  autoware::multi_object_tracker::InputManager manager(
+    nullptr, rclcpp::get_logger("test_input_manager"), clock);
+  manager.init(makeInputManagerChannels());
+  return manager;
+}
+
+rclcpp::Time pushEmptyMeasurement(
+  autoware::multi_object_tracker::InputManager & manager, const size_t channel_index,
+  const rclcpp::Clock::SharedPtr & clock, const double latency_sec)
+{
+  autoware::multi_object_tracker::types::DynamicObjectList objects;
+  objects.channel_index = static_cast<uint>(channel_index);
+  const rclcpp::Time measurement_time =
+    clock->now() - rclcpp::Duration::from_seconds(latency_sec);
+  objects.header.stamp = static_cast<builtin_interfaces::msg::Time>(measurement_time);
+
+  manager.push(channel_index, objects, autoware::multi_object_tracker::types::AssociationResult{});
+  return measurement_time;
+}
+
+void feedRegularMeasurements(
+  autoware::multi_object_tracker::InputManager & manager, const size_t channel_index,
+  const rclcpp::Clock::SharedPtr & clock, const double latency_sec, const size_t count)
+{
+  for (size_t i = 0; i < count; ++i) {
+    pushEmptyMeasurement(manager, channel_index, clock, latency_sec);
+    std::this_thread::sleep_for(1ms);
+  }
+}
+
+void initializeLatencyStatistics(
+  autoware::multi_object_tracker::InputManager & manager, const rclcpp::Clock::SharedPtr & clock)
+{
+  for (size_t i = 0; i < 20; ++i) {
+    pushEmptyMeasurement(manager, kHighLatencyChannel, clock, 0.5);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, clock, 0.05);
+    std::this_thread::sleep_for(1ms);
+  }
+
+  autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+  manager.getObjects(clock->now(), objects);
+}
+
+bool hasMeasurementAtOrAfter(
+  const autoware::multi_object_tracker::types::ObjectsWithAssociationList & objects,
+  const size_t channel_index, const rclcpp::Time & timestamp)
+{
+  return std::any_of(
+    objects.begin(), objects.end(), [&](const auto & objects_with_association) {
+      return objects_with_association.objects.channel_index == channel_index &&
+             objects_with_association.getTimestamp() >= timestamp;
+    });
+}
+
+}  // namespace
+
+TEST(InputManagerTargetSelection, SelectsLargestLatencyStreamAfterTimingOptimization)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+
+  initializeLatencyStatistics(manager, clock);
+
+  EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+}
+
+TEST(InputManagerTargetSelection, FailsOverFromStaleTargetToFreshStream)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+  initializeLatencyStatistics(manager, clock);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  std::this_thread::sleep_for(kTargetStaleWait);
+  feedRegularMeasurements(manager, kLowLatencyChannel, clock, 0.05, 5);
+
+  autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+  manager.getObjects(clock->now(), objects);
+
+  EXPECT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
+}
+
+TEST(InputManagerTargetSelection, BatchWindowAdvancesWithFreshStreamAfterTargetDropout)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+  initializeLatencyStatistics(manager, clock);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  std::this_thread::sleep_for(kTargetStaleWait);
+  rclcpp::Time latest_fresh_measurement(0, 0, RCL_ROS_TIME);
+  for (size_t i = 0; i < 5; ++i) {
+    latest_fresh_measurement =
+      pushEmptyMeasurement(manager, kLowLatencyChannel, clock, 0.05);
+    std::this_thread::sleep_for(1ms);
+  }
+
+  autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+  manager.getObjects(clock->now(), objects);
+
+  EXPECT_TRUE(hasMeasurementAtOrAfter(objects, kLowLatencyChannel, latest_fresh_measurement));
+}
 
 TEST_F(MultiObjectTrackerTest, DISABLED_PerformanceVsCarCount)
 {

--- a/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
@@ -495,8 +495,8 @@ public:
 namespace
 {
 
-constexpr size_t kHighLatencyChannel = 0;
-constexpr size_t kLowLatencyChannel = 1;
+constexpr size_t kHighLatencyChannel = 1;
+constexpr size_t kLowLatencyChannel = 0;
 constexpr int32_t kTestStartSec = 2000000000;
 constexpr double kMeasurementInterval = 0.1;
 constexpr double kStaleElapsedTime = 0.6;
@@ -625,6 +625,48 @@ TEST(InputManagerTargetSelection, BatchWindowAdvancesWithFreshStreamAfterTargetD
   EXPECT_TRUE(hasMeasurementAtOrAfter(objects, kLowLatencyChannel, latest_fresh_measurement));
 }
 
+TEST(InputManagerTargetSelection, ExportsRecoveredTargetMeasurementsDuringLatencyRamp)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+  rclcpp::Time now = initializeLatencyStatistics(manager);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  // converge the target latency and the export watermark to the steady state
+  for (size_t i = 0; i < 20; ++i) {
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.5);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+    autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+    manager.getObjects(now, objects);
+  }
+
+  // target dropout: fail over to the low-latency stream, the watermark follows it
+  now = advanceTime(now, kStaleElapsedTime);
+  for (size_t i = 0; i < 5; ++i) {
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+    autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+    manager.getObjects(now, objects);
+  }
+  ASSERT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
+
+  // recovery: every high-latency measurement is exported while the latency estimate converges
+  for (size_t i = 0; i < 20; ++i) {
+    const rclcpp::Time pushed = pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.5);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+    autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+    manager.getObjects(now, objects);
+    EXPECT_TRUE(hasMeasurementAtOrAfter(objects, kHighLatencyChannel, pushed))
+      << "high-latency measurement lost at ramp cycle " << i;
+  }
+  EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+}
+
 TEST(InputManagerTargetSelection, KeepsTargetWithinLatencyHysteresis)
 {
   const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
@@ -633,30 +675,30 @@ TEST(InputManagerTargetSelection, KeepsTargetWithinLatencyHysteresis)
   // both channels have the same latency, so the first one is selected as the target
   rclcpp::Time now(kTestStartSec, 0, RCL_ROS_TIME);
   for (size_t i = 0; i < 20; ++i) {
-    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
     pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
     now = advanceTime(now, kMeasurementInterval);
     manager.optimizeChannelTimings(now);
   }
-  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
 
   // a latency difference smaller than the hysteresis must not flip the target stream
   for (size_t i = 0; i < 30; ++i) {
-    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
-    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.32);
-    now = advanceTime(now, kMeasurementInterval);
-    manager.optimizeChannelTimings(now);
-  }
-  EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
-
-  // a latency difference larger than the hysteresis switches the target stream
-  for (size_t i = 0; i < 100; ++i) {
-    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
-    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.60);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.32);
     now = advanceTime(now, kMeasurementInterval);
     manager.optimizeChannelTimings(now);
   }
   EXPECT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
+
+  // a latency difference larger than the hysteresis switches the target stream
+  for (size_t i = 0; i < 100; ++i) {
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.60);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+  }
+  EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
 }
 
 TEST(InputManagerTargetSelection, ShiftsTargetLatencyGraduallyOnIncrease)


### PR DESCRIPTION
## Description
  Fix input batch processing when the current latency-reference input stream becomes stale.

  The multi object tracker selects the input stream with the largest latency as the target stream for batching. If that target stream stops receiving messages, the batch window could stop advancing, even when
  other input streams are still fresh. This could result in decreasing output topic Hz and linearly increasing `debug/input_latency`.

  This PR updates the channel timing optimization so that stale input streams are excluded from target stream selection. When the previous target stream becomes stale, the input manager can fail over to a
  fresh stream and continue advancing the batch window.

  The periodic timer was also updated based on review feedback:
  - It no longer calls `processObjects()`.
  - It only refreshes the channel timing optimizer.
  - Therefore, it does not introduce an unexpected publish path or change publish timing.

  `delay_compensation` remains independent of this fix. It only affects the publish/export reference time after batch processing; the stale target stream failover is handled before that in `InputManager`.

  ## Changes

  - Add freshness-aware channel timing optimization.
  - Expose `InputManager::optimizeChannelTimings(now)` for the optimizer timer and deterministic tests.
  - Rename the timer callback to `onChannelOptimizerTimer()` to clarify that it only updates channel selection.
  - Make target stream selection tests deterministic by injecting synthetic `rclcpp::Time` instead of using wall-clock sleeps.

## Related links

**Parent Issue:**

- https://star4.slack.com/archives/C076ZGRC15X/p1786086049624789?thread_ts=1786015513.168119&cid=C076ZGRC15X

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

  ```bash
  colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --parallel-workers 6 --packages-up-to autoware_multi_object_tracker

  /home/yoshiri/autoware/build/autoware_multi_object_tracker/test_multi_object_tracker --gtest_filter='InputManagerTargetSelection.*'
```

  Result: 3/3 passed.

```
  colcon test --packages-select autoware_multi_object_tracker --event-handlers console_direct+
```
  Result: gtest passed, 54/54 tests passed.

  Known existing issue: package-level colcon test still reports copyright failures because CONTRIBUTING.md and LICENSE are not found.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
