### PR TITLE
chore(planning): update package maintainers

### DIFF
--- a/planning/autoware_external_velocity_limit_selector/package.xml
+++ b/planning/autoware_external_velocity_limit_selector/package.xml
@@ -4,7 +4,6 @@
   <name>autoware_external_velocity_limit_selector</name>
   <version>0.52.0</version>
   <description>The autoware_external_velocity_limit_selector ROS 2 package</description>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
   <maintainer email="tomohito.ando@tier4.jp">Tomohito Ando</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/planning/autoware_rtc_interface/package.xml
+++ b/planning/autoware_rtc_interface/package.xml
@@ -5,13 +5,13 @@
   <description>The autoware_rtc_interface package</description>
 
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
   <author email="taiki.tanaka@tier4.jp">Taiki Tanaka</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/autoware_scenario_selector/package.xml
+++ b/planning/autoware_scenario_selector/package.xml
@@ -9,9 +9,10 @@
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <license>Apache License 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/autoware_surround_obstacle_checker/package.xml
+++ b/planning/autoware_surround_obstacle_checker/package.xml
@@ -4,7 +4,6 @@
   <name>autoware_surround_obstacle_checker</name>
   <version>0.52.0</version>
   <description>The autoware_surround_obstacle_checker package</description>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
   <license>Apache License 2.0</license>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/package.xml
@@ -5,7 +5,6 @@
   <version>0.52.0</version>
   <description>The behavior_path_avoidance_by_lane_change_module package</description>
 
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
@@ -15,6 +14,8 @@
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/package.xml
@@ -6,12 +6,12 @@
   <description>The autoware_behavior_path_dynamic_obstacle_avoidance_module package</description>
 
   <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml
@@ -7,11 +7,11 @@
 
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="taiki.yamada@tier4.jp">Taiki Yamada</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/package.xml
@@ -7,12 +7,12 @@
 
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
   <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
   <author email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml
@@ -6,12 +6,12 @@
   <description>The autoware_behavior_velocity_crosswalk_module package</description>
 
   <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml
@@ -5,13 +5,13 @@
   <version>0.52.0</version>
   <description>The autoware_behavior_velocity_detection_area_module package</description>
 
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
   <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/package.xml
@@ -11,9 +11,10 @@
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/package.xml
@@ -5,7 +5,6 @@
   <version>0.52.0</version>
   <description>The autoware_behavior_velocity_walkway_module package</description>
 
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/package.xml
@@ -7,9 +7,10 @@
 
   <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
   <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/planning/planning_validator/autoware_planning_validator/package.xml
+++ b/planning/planning_validator/autoware_planning_validator/package.xml
@@ -8,11 +8,11 @@
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <license>Apache License 2.0</license>
 
   <author email="takamasa.horibe@tier4.jp">Takamasa Horibe</author>
   <author email="yutaka.shimizu@tier4.jp">Yutaka Shimizu</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/package.xml
@@ -5,7 +5,6 @@
   <version>0.52.0</version>
   <description>The autoware_planning_validator_intersection_collision_checker package</description>
 
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
@@ -13,6 +12,7 @@
   <license>Apache License 2.0</license>
 
   <author email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/planning_validator/autoware_planning_validator_latency_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_latency_checker/package.xml
@@ -5,13 +5,13 @@
   <version>0.52.0</version>
   <description>The autoware_planning_validator_latency_checker package</description>
 
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
   <maintainer email="kyoichi.sugahara@tier4.jp">kyoichi sugahara</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
@@ -5,7 +5,6 @@
   <version>0.52.0</version>
   <description>The autoware_planning_validator_rear_collision_checker package</description>
 
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
   <maintainer email="kyoichi.sugahara@tier4.jp">kyoichi sugahara</maintainer>
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>

--- a/planning/planning_validator/autoware_planning_validator_test_utils/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_test_utils/package.xml
@@ -7,11 +7,11 @@
 
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/package.xml
@@ -5,13 +5,13 @@
   <version>0.52.0</version>
   <description>The autoware_planning_validator_trajectory_checker package</description>
 
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
   <maintainer email="kyoichi.sugahara@tier4.jp">kyoichi sugahara</maintainer>
 
   <license>Apache License 2.0</license>
 
   <author email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</author>
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>


### PR DESCRIPTION
## Description

This pull request updates package metadata in the `planning` directory by moving former maintainer entries to author entries where appropriate. This keeps maintainer metadata limited to current maintainers while preserving authorship information. The most important changes are:

- Updates affected `package.xml` files under `planning`.
- Keeps author entries grouped with existing author metadata.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `PRE_COMMIT_HOME=/tmp/pre-commit-cache /home/satoshi/.local/bin/pre-commit run --files planning/autoware_external_velocity_limit_selector/package.xml planning/autoware_rtc_interface/package.xml planning/autoware_scenario_selector/package.xml planning/autoware_surround_obstacle_checker/package.xml planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/package.xml planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/package.xml planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/package.xml planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/package.xml planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/package.xml planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/package.xml planning/planning_validator/autoware_planning_validator/package.xml planning/planning_validator/autoware_planning_validator_intersection_collision_checker/package.xml planning/planning_validator/autoware_planning_validator_latency_checker/package.xml planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml planning/planning_validator/autoware_planning_validator_test_utils/package.xml planning/planning_validator/autoware_planning_validator_trajectory_checker/package.xml`

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
