### PR TITLE
refactor(autoware_tensorrt_common): rename precision "as-is" to "strongly-typed"

### DIFF
--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -317,8 +317,8 @@ public:
   void printProfiling() const;
 
   /**
-   * @brief Whether the network is built strongly typed (precision "as-is"): tensor precisions
-   * are taken from the model itself.
+   * @brief Whether the network is built strongly typed (precision "strongly-typed"): tensor
+   * precisions are taken from the model itself.
    *
    * @return Whether the network is strongly typed.
    */

--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
@@ -40,7 +40,8 @@ namespace autoware
 {
 namespace tensorrt_common
 {
-constexpr std::array<std::string_view, 4> valid_precisions = {"fp32", "fp16", "int8", "as-is"};
+constexpr std::array<std::string_view, 4> valid_precisions = {
+  "fp32", "fp16", "int8", "strongly-typed"};
 
 /**
  * @brief Return a human-readable name for a TensorRT DataType.
@@ -82,8 +83,8 @@ struct TrtCommonConfig
    *
    * @param[in] onnx_path ONNX model path
    * @param[in] precision precision requested for the weakly typed build ("fp32", "fp16",
-   *            "int8"), or "as-is" to build a strongly typed network where every tensor
-   *            precision is taken from the model itself.
+   *            "int8"), or "strongly-typed" to build a strongly typed network where every
+   *            tensor precision is taken from the model itself.
    * @param[in] engine_path TensorRT engine path
    * @param[in] max_workspace_size maximum workspace size for TensorRT
    * @param[in] dla_core_id DLA core ID
@@ -131,8 +132,8 @@ struct TrtCommonConfig
   //!< @brief ONNX model path.
   const fs::path onnx_path;
 
-  //!< @brief Precision requested for the weakly typed build, or "as-is" for a strongly typed
-  //!< network with tensor precisions taken from the model itself.
+  //!< @brief Precision requested for the weakly typed build, or "strongly-typed" for a
+  //!< strongly typed network with tensor precisions taken from the model itself.
   const std::string precision;
 
   //!< @brief TensorRT engine path.

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -564,7 +564,7 @@ bool TrtCommon::initialize()
 
 bool TrtCommon::isStronglyTyped() const
 {
-  return trt_config_->precision == "as-is";
+  return trt_config_->precision == "strongly-typed";
 }
 
 bool TrtCommon::buildEngineFromOnnx()


### PR DESCRIPTION
## Description

Renames the TensorRT precision value added in #13160 from `"as-is"` to `"strongly-typed"`.

`"as-is"` describes how the artifact is treated; the setting's actual effect is the build mode — the network is created with `NetworkDefinitionCreationFlag::kSTRONGLY_TYPED` and every tensor precision comes from the model. Sitting in an enum next to `fp32`/`fp16`/`int8`, `"as-is"` also reads as a precision, which it is not. `"strongly-typed"` says what happens and matches the accessor (`isStronglyTyped()`) and the log lines already in the code.

No functional change: only the accepted string differs.

## Related links

- Introduced the value: #13160 (merged)
- First consumer, updated to the new name: #13159

## How was this PR tested?

`colcon build` of `autoware_tensorrt_common` (x86, TensorRT 10.8). Building PTv3 engines strongly typed through #13159 with the renamed value; behavior is identical to `"as-is"` before the rename.

## Notes for reviewers

The value has no users in `main`: it was added by #13160 and its first consumer (#13159) is still open, so this rename breaks no existing configuration. Doing it now avoids a deprecation path later.

## Interface changes

`TrtCommonConfig::precision` accepts `"strongly-typed"` instead of `"as-is"`. `"fp32"`, `"fp16"` and `"int8"` are unchanged. No signature changes.

## Effects on system behavior

None. No in-tree consumer passes the old value.
