### PR TITLE
feat(autoware_carla_interface): sort steering curve before interpolation

### DIFF
--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -698,6 +698,11 @@ class carla_ros2_interface(object):
                 return  # Skip if vehicle not initialized yet
 
             steer_curve = self.physics_control.steering_curve
+            # numpy.interp requires the sample x-coordinates to be increasing.
+            # CARLA 0.10 can return the steering-curve points out of order,
+            # so sort by x before interpolating. On 0.9.x the curve is already
+            # sorted, making this a no-op.
+            steer_curve = sorted(steer_curve, key=lambda v: v.x)
             current_vel = self.ego_actor.get_velocity()
             max_steer_ratio = numpy.interp(
                 abs(current_vel.x), [v.x for v in steer_curve], [v.y for v in steer_curve]


### PR DESCRIPTION
## Description

`control_callback` feeds the vehicle's `steering_curve` into `numpy.interp`, which requires the sample x-coordinates to be monotonically increasing. CARLA 0.10 can return the steering-curve points out of order, in which case the steer ratio is computed incorrectly.

Sort the curve points by x before interpolating. On CARLA 0.9.x the curve is already sorted, so this is a behavioral no-op.

This is one of a series of small hardening PRs toward CARLA 0.10.0 support. Only the sort is extracted; the OnePlanner-specific steer tuning is not included.

## How was this PR tested?

- Confirmed `colcon build --packages-select autoware_carla_interface --symlink-install` passes in the jazzy dev container.

## Backward compatibility

- On CARLA 0.9.x the curve is already sorted in ascending x, so the sort does not change the order and the behavior is unchanged.
