### PR TITLE
feat(autoware_carla_interface): make world loading version-tolerant with force_load_world

### DIFF
--- a/simulator/autoware_carla_interface/README.md
+++ b/simulator/autoware_carla_interface/README.md
@@ -225,7 +225,7 @@ For CARLA sensor parameters, see [CARLA Sensor Reference](https://carla.readthed
 
 The IMU and GNSS are spawned noise-free unless the mapping says otherwise, which
 is what reproducing a run wants. It also means anything consuming those sensors
-sees a measurement no hardware produces: a localisation or odometry stack scored
+sees a measurement no hardware produces: a localization or odometry stack scored
 against a perfect gyro reports an accuracy it will not reach on a vehicle.
 
 Set any of the CARLA noise attributes under the sensor's `parameters` to get a
@@ -248,7 +248,7 @@ sensor_mappings:
       noise_accel_stddev_x: 0.01
 ```
 
-Recognised names are `noise_accel_stddev_{x,y,z}`, `noise_gyro_stddev_{x,y,z}`
+Recognized names are `noise_accel_stddev_{x,y,z}`, `noise_gyro_stddev_{x,y,z}`
 and `noise_gyro_bias_{x,y,z}` for the IMU, and `noise_{alt,lat,lon}_stddev` and
 `noise_{alt,lat,lon}_bias` for the GNSS. Anything left out stays at zero.
 
@@ -294,6 +294,13 @@ The `carla_ros.py` sets up the CARLA world:
    client.load_world(self.map_name)
    self.world = client.get_world()
    ```
+
+   After loading, the interface checks that the map CARLA is actually running is
+   the one that was requested. If it is not - the level does not exist, the
+   server failed to switch, or the connection dropped - the mismatch is logged to
+   `rosout` and the node aborts with `CarlaWorldLoadError`. Running Autoware
+   against a map the simulator is not simulating would silently invalidate the
+   whole run, so it is treated as fatal rather than tolerated.
 
 3. **Spawn Ego Vehicle**:
 

--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -16,6 +16,7 @@
     <arg name="fixed_delta_seconds" default="0.05" description="Time step for CARLA, FPS=1/value"/>
     <arg name="use_traffic_manager" default="False"/>
     <arg name="max_real_delta_seconds" default="0.05"/>
+    <arg name="force_load_world" default="False" description="Always reload the CARLA world with client.load_world() instead of load_world_if_different()"/>
     <arg name="no_rendering_mode" default="False" description="Disable CARLA rendering via world settings for headless/faster simulation"/>
     <arg name="map_origin_x" default="0.0" description="X offset from the CARLA world origin to the Autoware map frame origin (0.0 for stock CARLA towns)"/>
     <arg name="map_origin_y" default="0.0" description="Y offset from the CARLA world origin to the Autoware map frame origin (0.0 for stock CARLA towns)"/>
@@ -59,6 +60,7 @@
       <param name="vehicle_type" value="$(var vehicle_type)"/>
       <param name="use_traffic_manager" value="$(var use_traffic_manager)"/>
       <param name="max_real_delta_seconds" value="$(var max_real_delta_seconds)"/>
+      <param name="force_load_world" value="$(var force_load_world)"/>
       <param name="no_rendering_mode" value="$(var no_rendering_mode)"/>
       <param name="map_origin_x" value="$(var map_origin_x)"/>
       <param name="map_origin_y" value="$(var map_origin_y)"/>

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
@@ -27,6 +27,10 @@ from .modules.carla_wrapper import SensorReceivedNoData
 from .modules.carla_wrapper import SensorWrapper
 
 
+class CarlaWorldLoadError(RuntimeError):
+    """Raised when CARLA is not running the map the bridge was asked to load."""
+
+
 class SensorLoop(object):
 
     def __init__(self):
@@ -60,6 +64,7 @@ class InitializeInterface(object):
     def __init__(self):
         self.interface = carla_ros2_interface()
         self.param_ = self.interface.get_param()
+        self.logger = self.interface.logger
         self.world = None
         self.sensor_wrapper = None
         self.ego_actor = None
@@ -77,6 +82,7 @@ class InitializeInterface(object):
         self.spawn_point = self.param_["spawn_point"]
         self.use_traffic_manager = self.param_["use_traffic_manager"]
         self.max_real_delta_seconds = self.param_["max_real_delta_seconds"]
+        self.force_load_world = self.param_["force_load_world"]
         self.no_rendering_mode = self.param_["no_rendering_mode"]
 
     def _parse_spawn_point(self):
@@ -96,6 +102,85 @@ class InitializeInterface(object):
         else:
             randomize = True
         return spawn_point, randomize
+
+    def _reload_world(self, client):
+        """Reload the world via client.load_world(); return the failure, if any."""
+        self.logger.info(f"Loading CARLA world '{self.carla_map}' with client.load_world()")
+        try:
+            client.load_world(self.carla_map)
+        except RuntimeError as exc:
+            # Not fatal on its own: some API versions raise after the level has
+            # actually switched. _verify_world_loaded decides, from the map that
+            # is really active, whether this run can continue.
+            self.logger.warning(
+                f"client.load_world() raised while loading '{self.carla_map}': {exc}"
+            )
+            return exc
+        return None
+
+    @staticmethod
+    def _normalize_map_name(map_name):
+        """Reduce a CARLA level name such as 'Carla/Maps/Town01' to 'Town01'."""
+        return map_name.split("/")[-1]
+
+    def _current_world_map(self, client):
+        """Return the current world's map name, or None if it cannot be determined."""
+        try:
+            return self._normalize_map_name(client.get_world().get_map().name)
+        except RuntimeError as exc:
+            self.logger.warning(f"Failed to query the active CARLA map: {exc}")
+            return None
+
+    def _load_world_if_different(self, client):
+        """Try load_world_if_different(); return True on success, False to fall back."""
+        if not hasattr(client, "load_world_if_different"):
+            return False
+        try:
+            self.logger.info(
+                f"Loading CARLA world '{self.carla_map}' with load_world_if_different()"
+            )
+            client.load_world_if_different(self.carla_map)
+            return True
+        except RuntimeError as exc:
+            self.logger.warning(
+                "load_world_if_different failed; falling back to load_world "
+                f"for '{self.carla_map}': {exc}"
+            )
+            return False
+
+    def _verify_world_loaded(self, client, load_error):
+        """Raise unless the requested map is the world CARLA is actually running."""
+        expected = self._normalize_map_name(self.carla_map)
+        deadline = time.time() + max(float(self.timeout), 1.0)
+        current = None
+        while True:
+            current = self._current_world_map(client)
+            if current == expected:
+                self.logger.info(f"Loaded CARLA world '{expected}'")
+                return
+            if time.time() >= deadline:
+                break
+            time.sleep(1.0)
+
+        message = (
+            f"CARLA world mismatch: requested map '{expected}' but the active world is "
+            f"'{current if current is not None else 'unknown'}'. Continuing would run "
+            "Autoware against a map the simulator is not simulating, so the bridge is "
+            "aborted."
+        )
+        self.logger.error(message)
+        raise CarlaWorldLoadError(message) from load_error
+
+    def _load_carla_world(self, client):
+        """Load the requested map while supporting CARLA Python API version differences."""
+        load_error = None
+        if self.force_load_world:
+            load_error = self._reload_world(client)
+        elif not self._load_world_if_different(client):
+            if self._current_world_map(client) != self._normalize_map_name(self.carla_map):
+                load_error = self._reload_world(client)
+
+        self._verify_world_loaded(client, load_error)
 
     def _setup_traffic_manager(self, client):
         """Configure traffic manager with NPC vehicles."""
@@ -136,7 +221,7 @@ class InitializeInterface(object):
     def load_world(self):
         client = carla.Client(self.local_host, self.port)
         client.set_timeout(self.timeout)
-        client.load_world_if_different(self.carla_map)
+        self._load_carla_world(client)
 
         # Wait for the world to be fully loaded
         # This is critical for non-default maps that need time to load
@@ -251,13 +336,17 @@ class InitializeInterface(object):
 def main():
     """Run the CARLA-Autoware bridge with proper cleanup on all exit paths."""
     carla_bridge = InitializeInterface()
-    carla_bridge.load_world()
-
-    # Register signal handlers for graceful shutdown
-    signal.signal(signal.SIGINT, carla_bridge._stop_loop)
-    signal.signal(signal.SIGTERM, carla_bridge._stop_loop)
 
     try:
+        # Loading the world is inside the try so that a failure here, a map
+        # mismatch above all, shuts the ROS interface down instead of leaving
+        # the non-daemon spin thread keeping a half-initialized process alive.
+        carla_bridge.load_world()
+
+        # Register signal handlers for graceful shutdown
+        signal.signal(signal.SIGINT, carla_bridge._stop_loop)
+        signal.signal(signal.SIGTERM, carla_bridge._stop_loop)
+
         carla_bridge.run_bridge()
     except KeyboardInterrupt:
         print("\nReceived keyboard interrupt, shutting down...")

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -71,6 +71,7 @@ class carla_ros2_interface(object):
             "vehicle_type": (rclpy.Parameter.Type.STRING, None),
             "use_traffic_manager": (rclpy.Parameter.Type.BOOL, None),
             "max_real_delta_seconds": (rclpy.Parameter.Type.DOUBLE, None),
+            "force_load_world": (rclpy.Parameter.Type.BOOL, False),
             "no_rendering_mode": (rclpy.Parameter.Type.BOOL, False),
             "map_origin_x": (rclpy.Parameter.Type.DOUBLE, 0.0),
             "map_origin_y": (rclpy.Parameter.Type.DOUBLE, 0.0),

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/sensor_manager.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/sensor_manager.py
@@ -42,7 +42,7 @@ class SensorConfig:
     frequency_hz: float = 20.0
     qos_profile: str = "reliable"
     # What a camera's pixels are published as. A consumer that only wants
-    # luminance otherwise pays four times the bytes through serialisation and
+    # luminance otherwise pays four times the bytes through serialization and
     # the transport for three channels it discards on arrival.
     image_encoding: str = "bgra8"
     parameters: Dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Description

Replace the bare `client.load_world_if_different(self.carla_map)` call with a `_load_carla_world` helper that tolerates CARLA Python API version differences.

- When `force_load_world` (default `False`) is true, it always reloads via `client.load_world()`. This is useful when the server is already on the target level but needs to be reset.
- When false, it prefers `load_world_if_different` if available, and otherwise falls back to comparing the current map name and calling `load_world()`.

Whichever path is taken, the map CARLA is actually running is verified afterwards. A mismatch — the level does not exist, the server failed to switch, or the connection dropped — is logged to `rosout` at error level with both the requested and the active map name, and `CarlaWorldLoadError` is raised so the process exits. Running Autoware against a map the simulator is not simulating would silently invalidate the whole run, so it is fatal rather than tolerated. Loading now happens inside `main()`'s `try`/`finally` so the ROS interface is shut down on failure instead of leaving the non-daemon spin thread holding a half-initialized process open.

This is one of a series of small enabler PRs toward CARLA 0.10.0 support.

## How was this PR tested?

- Confirmed `colcon build --packages-select autoware_carla_interface --symlink-install` passes in the jazzy dev container.
- Exercised `_load_carla_world` / `_verify_world_loaded` against a stubbed CARLA client for: map already active, switch via `load_world_if_different`, load failure leaving the old map active (raises), connection refused (raises), `force_load_world`, a path-prefixed `carla_map` value, and an old API without `load_world_if_different`.

## Backward compatibility

- With the default parameters this reproduces the previous behavior on CARLA 0.9.x (`load_world_if_different` exists, so it is used). In addition, the `hasattr` fallback covers API variants that do not provide it.
- The behavior change is on the failure path only: a run that would previously have continued against the wrong world now stops.

## Related PR

- autowarefoundation/autoware_launch#1948 — the downstream autoware_launch change that declares and forwards this argument from `e2e_simulator.launch.xml` (Draft; to be merged after this PR).
