### PR TITLE
docs: replace retired model hosting URLs with Hugging Face links

### DIFF
--- a/e2e/autoware_tensorrt_vad/README.md
+++ b/e2e/autoware_tensorrt_vad/README.md
@@ -120,7 +120,7 @@ To download the latest models, simply run the provided setup script:
 The models will be downloaded to `~/autoware_data/ml_models/vad/` by default.
 
 **Manual Download** (if needed):
-Models are hosted at: <https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/>
+Models are hosted at: <https://huggingface.co/AutowareFoundation/tensorrt_vad/tree/v0.1>
 
 ### Model Preparation
 

--- a/localization/yabloc/yabloc_pose_initializer/README.md
+++ b/localization/yabloc/yabloc_pose_initializer/README.md
@@ -4,16 +4,13 @@ This package contains a node related to initial pose estimation.
 
 - [camera_pose_initializer](#camera_pose_initializer)
 
-This package requires the pre-trained semantic segmentation model for runtime. This model is usually downloaded by `ansible` during env preparation phase of the [installation](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/).
+This package requires the pre-trained semantic segmentation model for runtime. This model is usually downloaded by the [ansible artifacts role](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts) during the installation.
 It is also possible to download it manually. Even if the model is not downloaded, initialization will still complete, but the accuracy may be compromised.
 
-To download and extract the model manually:
+The model is hosted on [Hugging Face](https://huggingface.co/AutowareFoundation/yabloc_pose_initializer/tree/v1.0). To download it manually with the [hf CLI](https://huggingface.co/docs/huggingface_hub/guides/cli):
 
 ```bash
-$ mkdir -p ~/autoware_data/ml_models/yabloc_pose_initializer/
-$ wget -P ~/autoware_data/ml_models/yabloc_pose_initializer/ \
-       https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz
-$ tar xzf ~/autoware_data/ml_models/yabloc_pose_initializer/resources.tar.gz -C ~/autoware_data/ml_models/yabloc_pose_initializer/
+hf download AutowareFoundation/yabloc_pose_initializer --revision v1.0 --local-dir ~/autoware_data/ml_models/yabloc_pose_initializer
 ```
 
 ## Note

--- a/perception/autoware_bevfusion/README.md
+++ b/perception/autoware_bevfusion/README.md
@@ -68,16 +68,9 @@ This node assumes that the input pointcloud follows the `PointXYZIRC` layout def
 
 ## Trained Models
 
-You can download the onnx and config files in the following links.
-The files need to be placed inside `$(env HOME)/autoware_data/ml_models/bevfusion`
-
-- lidar-only model:
-  - [onnx](https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v1/bevfusion_lidar.onnx)
-  - [config](https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v1/ml_package_bevfusion_lidar.param.yaml)
-- camera-lidar model:
-  - [onnx](https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v1/bevfusion_camera_lidar.onnx)
-  - [config](https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v1/ml_package_bevfusion_camera_lidar.param.yaml)
-- [class remapper](https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v1/detection_class_remapper.param.yaml)
+The model bundle is hosted on [Hugging Face](https://huggingface.co/AutowareFoundation/bevfusion/tree/v2.0).
+The [ansible artifacts role](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts) downloads it into `$(env HOME)/autoware_data/ml_models/bevfusion`.
+It holds the ONNX files and the ML package configs for the lidar-only and the camera-lidar models, and the class remapper.
 
 The model was trained in TIER IV's internal database (~35k lidar frames) for 30 epochs.
 

--- a/perception/autoware_camera_streampetr/README.md
+++ b/perception/autoware_camera_streampetr/README.md
@@ -167,6 +167,7 @@ Required model files:
 - `simplify_extract_img_feat.onnx` (backbone)
 - `simplify_pts_head_memory.onnx` (head)
 - `simplify_position_embedding.onnx` (position embedding)
+- `ml_package_camera_streampetr.param.yaml` (ML package config)
 
 If you want to train and deploy your own model, you can find the source code for that in [AWML](https://github.com/tier4/AWML/tree/main/projects/StreamPETR).
 

--- a/perception/autoware_camera_streampetr/README.md
+++ b/perception/autoware_camera_streampetr/README.md
@@ -160,13 +160,13 @@ This node is camera-only and does not require pointcloud input. It assumes:
 
 ## Trained Models
 
-You can download the ONNX model files for StreamPETR. The files should be placed in the appropriate model directory as specified in the launch configuration.
+The model bundle is hosted on [Hugging Face](https://huggingface.co/AutowareFoundation/camera_streampetr/tree/v1.0). The [ansible artifacts role](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts) downloads it into `~/autoware_data/ml_models/camera_streampetr`.
 
 Required model files:
 
-- [Backbone ONNX Model](https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_extract_img_feat.onnx)
-- [Head ONNX Model](https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_pts_head_memory.onnx)
-- [Position Embedding ONNX Model](https://awf.ml.dev.web.auto/perception/models/streampetr/v1/simplify_position_embedding.onnx)
+- `simplify_extract_img_feat.onnx` (backbone)
+- `simplify_pts_head_memory.onnx` (head)
+- `simplify_position_embedding.onnx` (position embedding)
 
 If you want to train and deploy your own model, you can find the source code for that in [AWML](https://github.com/tier4/AWML/tree/main/projects/StreamPETR).
 

--- a/perception/autoware_lidar_centerpoint/README.md
+++ b/perception/autoware_lidar_centerpoint/README.md
@@ -310,22 +310,22 @@ ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml model_path:=
 
 #### v4.0 (2026/07)
 
-The model bundle moved to per-variant folders (`base`/`tiny`/`sigma`/`short_range`) with uniform file names, hosted on [Hugging Face](https://huggingface.co/AutowareFoundation/lidar_centerpoint). `sigma` and `short_range` weights are published for the first time. Earlier revisions remain available as tags on the same repository (`v3.0` = flat layout).
+The model bundle moved to per-variant folders (`base`/`tiny`/`sigma`/`short_range`) with uniform file names, hosted on [Hugging Face](https://huggingface.co/AutowareFoundation/lidar_centerpoint/tree/v4.0). `sigma` and `short_range` weights are published for the first time. Earlier revisions remain available as tags on the same repository (`v3.0` = flat layout). The `v1` and `v0` files below are not distributed any more.
 
 #### v1 (2022/07/06)
 
-| Name               | URLs                                                                                                     | Description                                                                                                                        |
-| ------------------ | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `centerpoint`      | [pts_voxel_encoder][v1-encoder-centerpoint] <br> [pts_backbone_neck_head][v1-head-centerpoint]           | There is a single change due to the limitation in the implementation of this package. `num_filters=[32, 32]` of `PillarFeatureNet` |
-| `centerpoint_tiny` | [pts_voxel_encoder][v1-encoder-centerpoint-tiny] <br> [pts_backbone_neck_head][v1-head-centerpoint-tiny] | The same model as `default` of `v0`.                                                                                               |
+| Name               | Files                                             | Description                                                                                                                        |
+| ------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `centerpoint`      | `pts_voxel_encoder` <br> `pts_backbone_neck_head` | There is a single change due to the limitation in the implementation of this package. `num_filters=[32, 32]` of `PillarFeatureNet` |
+| `centerpoint_tiny` | `pts_voxel_encoder` <br> `pts_backbone_neck_head` | The same model as `default` of `v0`.                                                                                               |
 
 These changes are compared with [this configuration](https://github.com/tianweiy/CenterPoint/blob/v0.2/configs/waymo/pp/waymo_centerpoint_pp_two_pfn_stride1_3x.py).
 
 #### v0 (2021/12/03)
 
-| Name      | URLs                                                                                   | Description                                                                                                                                          |
-| --------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default` | [pts_voxel_encoder][v0-encoder-default] <br> [pts_backbone_neck_head][v0-head-default] | There are two changes from the original CenterPoint architecture. `num_filters=[32]` of `PillarFeatureNet` and `ds_layer_strides=[2, 2, 2]` of `RPN` |
+| Name      | Files                                             | Description                                                                                                                                          |
+| --------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default` | `pts_voxel_encoder` <br> `pts_backbone_neck_head` | There are two changes from the original CenterPoint architecture. `num_filters=[32]` of `PillarFeatureNet` and `ds_layer_strides=[2, 2, 2]` of `RPN` |
 
 ## (Optional) Error detection and handling
 
@@ -377,13 +377,6 @@ Example:
   Currently, this package can't handle the chattering obstacles well. We plan to add some probabilistic filters in the perception layer to improve it.
   Also, there are some parameters that should be global(e.g. vehicle size, max steering, etc.). These will be refactored and defined as global parameters so that we can share the same parameters between different nodes.
 -->
-
-[v0-encoder-default]: https://awf.ml.dev.web.auto/perception/models/pts_voxel_encoder_default.onnx
-[v0-head-default]: https://awf.ml.dev.web.auto/perception/models/pts_backbone_neck_head_default.onnx
-[v1-encoder-centerpoint]: https://awf.ml.dev.web.auto/perception/models/centerpoint/v1/pts_voxel_encoder_centerpoint.onnx
-[v1-head-centerpoint]: https://awf.ml.dev.web.auto/perception/models/centerpoint/v1/pts_backbone_neck_head_centerpoint.onnx
-[v1-encoder-centerpoint-tiny]: https://awf.ml.dev.web.auto/perception/models/centerpoint/v1/pts_voxel_encoder_centerpoint_tiny.onnx
-[v1-head-centerpoint-tiny]: https://awf.ml.dev.web.auto/perception/models/centerpoint/v1/pts_backbone_neck_head_centerpoint_tiny.onnx
 
 ## Acknowledgment: deepen.ai's 3D Annotation Tools Contribution
 

--- a/perception/autoware_lidar_transfusion/README.md
+++ b/perception/autoware_lidar_transfusion/README.md
@@ -83,9 +83,8 @@ ros2 topic echo <input_topic> --field fields
 
 ## Trained Models
 
-You can download the onnx format of trained models by clicking on the links below.
-
-- TransFusion: [transfusion.onnx](https://awf.ml.dev.web.auto/perception/models/transfusion/t4xx1_90m/v2/transfusion.onnx)
+The model bundle (`transfusion.onnx`) is hosted on [Hugging Face](https://huggingface.co/AutowareFoundation/lidar_transfusion/tree/v2.1).
+The [ansible artifacts role](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts) downloads it into `~/autoware_data/ml_models/lidar_transfusion`.
 
 The model was trained in TIER IV's internal database (~11k lidar frames) for 50 epochs.
 

--- a/perception/autoware_lidar_transfusion/README.md
+++ b/perception/autoware_lidar_transfusion/README.md
@@ -83,7 +83,7 @@ ros2 topic echo <input_topic> --field fields
 
 ## Trained Models
 
-The model bundle (`transfusion.onnx`) is hosted on [Hugging Face](https://huggingface.co/AutowareFoundation/lidar_transfusion/tree/v2.1).
+The model bundle (`transfusion.onnx` and `transfusion_ml_package.param.yaml`) is hosted on [Hugging Face](https://huggingface.co/AutowareFoundation/lidar_transfusion/tree/v2.1).
 The [ansible artifacts role](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts) downloads it into `~/autoware_data/ml_models/lidar_transfusion`.
 
 The model was trained in TIER IV's internal database (~11k lidar frames) for 50 epochs.

--- a/perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer.cpp
@@ -300,7 +300,7 @@ TEST(CnnLampRecognizerDebugImageTest, HandlesNullElements)
 // ================== GPU-gated tests of the TensorRT classify() path ==================
 
 // Lamp recognizer model, downloaded under autoware_data by the ansible artifacts role:
-// https://awf.ml.dev.web.auto/perception/models/traffic_light_classifier/v4/traffic_light_lamp_recognizer_comlops.onnx
+// https://huggingface.co/AutowareFoundation/traffic_light_classifier/tree/v4.0
 constexpr char model_filename[] = "traffic_light_lamp_recognizer_comlops.onnx";
 
 // Resolve a file under autoware_data, trying the canonical ml_models/ layout and the legacy


### PR DESCRIPTION
## Description

The model artifacts moved from `awf.ml.dev.web.auto` and the `autoware-files` S3 bucket to Hugging Face repositories under the AutowareFoundation org. Seven files still pointed manual downloads at the old hosts. This PR points them at the Hugging Face repositories instead.

The download notes now link to the [ansible artifacts role](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts) instead of the general source-installation page. The role README gives the ansible command that downloads every bundle, and the role pins each bundle to a tag. The yolox README already links to the role in the same way. Every Hugging Face link points at the `/tree/<tag>` of the revision the role downloads, not at the repository root.

- The migration tracker: autowarefoundation/autoware#7223

Per file:

- `perception/autoware_bevfusion/README.md`: the five per-file links (which also pointed at the outdated `v1` bundle) become one link to the [bevfusion](https://huggingface.co/AutowareFoundation/bevfusion) repository, plus the artifacts role link
- `perception/autoware_camera_streampetr/README.md`: the three per-file links become one repository link, plus the artifacts role link; the file names stay as plain text, and the list gains `ml_package_camera_streampetr.param.yaml`, which the launch file reads from the model directory
- `perception/autoware_lidar_transfusion/README.md`: same, one repository link plus the artifacts role link; the bundle note also names `transfusion_ml_package.param.yaml`, which the launch file reads from the model directory
- `e2e/autoware_tensorrt_vad/README.md`: the manual download URL becomes the repository link
- `localization/yabloc/yabloc_pose_initializer/README.md`: the `wget` + `tar xzf` instructions for the retired archive become one `hf download --revision v1.0` command, and the intro sentence links the artifacts role. The missing-model error of the node sends users to this README
- `perception/autoware_lidar_centerpoint/README.md`: the changelog rows for `v0` and `v1` lose their download links. Those files were never migrated and stop being distributed; the row content stays as history
- `perception/autoware_traffic_light_classifier/test/test_cnn_lamp_recognizer.cpp`: the model URL in a comment becomes the revision-pinned repository link. No code change

Two S3 links stay on purpose: the training datasets in the centerpoint and traffic_light_classifier READMEs. The bucket keeps serving datasets, maps and rosbags; only the model objects are retired.

## AI usage

**AI usage:** written with Claude Code from the file list in autowarefoundation/autoware#7223

**Self-review:** Checked all, run clean context reviews a couple of times. I think it is ready.

<details>
<summary><strong>Verification:</strong> After the change, a repo-wide grep finds the two intended dataset links and nothing else; markdownlint and prettier pass on every touched file.</summary>

### Grep for old hosts

- `grep -rn 'awf.ml.dev.web.auto|autoware-files' --include='*.md' --include='*.cpp'` over the repo returns exactly two hits, both `/dataset/` objects, in the centerpoint and traffic_light_classifier READMEs
- Every Hugging Face repository linked was created and verified byte-identical during the migration (autowarefoundation/autoware#7223)
- All seven `/tree/<tag>` links returned HTTP 200 on 2026-08-14, checked with `curl -s -o /dev/null -w '%{http_code}'`

### Cross-check against the launch files

- `lidar_transfusion.launch.xml` line 9 builds `ml_package_param_path` from the model directory, so the bundle note names `transfusion_ml_package.param.yaml` next to `transfusion.onnx`
- `streampetr.launch.xml` line 5 reads `ml_package_camera_streampetr.param.yaml` from `model_path`, so the required-files list includes it
- Not run: neither node was launched. The check reads the default paths in the launch files

### Hooks

- `pre-commit run` on the seven files: `markdownlint` and `prettier` `Passed` (prettier first re-aligned one table, then clean)
- The hooks ran again on the four READMEs after the artifacts role links were added, and once more on all seven files after the links were pinned to revisions: `Passed` both times
- After the review fixes, the hooks ran on the transfusion and streampetr READMEs: `Passed`
- Not run: a colcon build of `autoware_traffic_light_classifier`. The `.cpp` change is comment-only. The differential CI job builds it

</details>
