### PR TITLE
fix(yabloc_pose_initializer): load the ONNX model to survive OpenCV 4.9

### DIFF
--- a/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/semantic_segmentation.hpp
+++ b/localization/yabloc/yabloc_pose_initializer/include/yabloc_pose_initializer/camera/semantic_segmentation.hpp
@@ -33,7 +33,11 @@ public:
 private:
   static cv::Mat make_blob(const cv::Mat & image);
 
+  static cv::Mat make_nhwc_blob(const cv::Mat & image);
+
   static cv::Mat convert_blob_to_image(const cv::Mat & blob);
+
+  static cv::Mat convert_nhwc_blob_to_image(const cv::Mat & blob);
 
   static cv::Mat normalize(const cv::Mat & mask, double score_threshold = 0.5);
 

--- a/localization/yabloc/yabloc_pose_initializer/launch/yabloc_pose_initializer.launch.xml
+++ b/localization/yabloc/yabloc_pose_initializer/launch/yabloc_pose_initializer.launch.xml
@@ -1,6 +1,8 @@
 <launch>
   <arg name="data_path" default="$(env HOME)/autoware_data/ml_models"/>
-  <arg name="model_path" default="$(var data_path)/yabloc_pose_initializer/saved_model/model_float32.pb"/>
+  <!-- The ONNX is the default because the TensorFlow importer of OpenCV 4.9 and later applies
+       the final softmax along the wrong axis, which empties the mask. -->
+  <arg name="model_path" default="$(var data_path)/yabloc_pose_initializer/saved_model/model_float32.onnx"/>
 
   <node pkg="yabloc_pose_initializer" exec="yabloc_pose_initializer_node" output="both">
     <param from="$(var camera_pose_initializer_param_path)"/>

--- a/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp
+++ b/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp
@@ -19,6 +19,7 @@
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
 
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -27,6 +28,7 @@
 struct SemanticSegmentation::Impl
 {
   cv::dnn::Net net;
+  bool nhwc_input;
 };
 
 SemanticSegmentation::SemanticSegmentation(const std::string & model_path)
@@ -35,6 +37,9 @@ SemanticSegmentation::SemanticSegmentation(const std::string & model_path)
   impl_->net = cv::dnn::readNet(model_path);
   impl_->net.setPreferableBackend(cv::dnn::DNN_BACKEND_OPENCV);
   impl_->net.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);
+  // The ONNX export of the model declares an NHWC input, [1, 512, 896, 3]. The frozen
+  // TensorFlow graph takes the NCHW blob that make_blob() builds.
+  impl_->nhwc_input = std::filesystem::path(model_path).extension() == ".onnx";
 }
 
 cv::Mat SemanticSegmentation::make_blob(const cv::Mat & image)
@@ -45,6 +50,16 @@ cv::Mat SemanticSegmentation::make_blob(const cv::Mat & image)
   bool swap = true;
   bool crop = false;
   return cv::dnn::blobFromImage(image, scale, size, mean, swap, crop, CV_32F);
+}
+
+cv::Mat SemanticSegmentation::make_nhwc_blob(const cv::Mat & image)
+{
+  // The same preprocessing as make_blob(), laid out as NHWC instead of NCHW.
+  cv::Mat resized;
+  cv::resize(image, resized, cv::Size(896, 512));
+  cv::cvtColor(resized, resized, cv::COLOR_BGR2RGB);
+  resized.convertTo(resized, CV_32F);
+  return resized.reshape(1, std::vector<int>{1, 512, 896, 3});
 }
 
 cv::Mat SemanticSegmentation::convert_blob_to_image(const cv::Mat & blob)
@@ -70,16 +85,25 @@ cv::Mat SemanticSegmentation::convert_blob_to_image(const cv::Mat & blob)
   return image;
 }
 
+cv::Mat SemanticSegmentation::convert_nhwc_blob_to_image(const cv::Mat & blob)
+{
+  if (blob.size.dims() != 4 || blob.size[3] != 4) {
+    throw std::runtime_error("blob has invalid size");
+  }
+  return blob.reshape(4, std::vector<int>{blob.size[1], blob.size[2]}).clone();
+}
+
 cv::Mat SemanticSegmentation::inference(const cv::Mat & image, double score_threshold)
 {
-  cv::Mat blob = make_blob(image);
+  cv::Mat blob = impl_->nhwc_input ? make_nhwc_blob(image) : make_blob(image);
   impl_->net.setInput(blob);
   std::vector<std::string> output_layers = impl_->net.getUnconnectedOutLayersNames();
   std::vector<cv::Mat> masks;
   impl_->net.forward(masks, output_layers);
 
   cv::Mat mask = masks[0];
-  cv::Mat output = convert_blob_to_image(mask);
+  cv::Mat output =
+    impl_->nhwc_input ? convert_nhwc_blob_to_image(mask) : convert_blob_to_image(mask);
 
   cv::resize(output, output, cv::Size(image.cols, image.rows), 0, 0, cv::INTER_LINEAR);
 


### PR DESCRIPTION
## Very short summary

Starting from Ubuntu 26.04, this node will start to fail because of how OpenCV handles [`.pb` file](https://huggingface.co/AutowareFoundation/yabloc_pose_initializer/blob/main/saved_model/model_float32.pb)s. Therefore this PR makes the node use [`.onnx` model file](https://huggingface.co/AutowareFoundation/yabloc_pose_initializer/blob/main/saved_model/model_float32.onnx) instead. That's all.

## Description

From OpenCV 4.9, the TensorFlow importer of `cv::dnn` applies the last softmax of `model_float32.pb` along the width axis instead of the channel axis. The segmentation mask is then empty at the default threshold, with no error or warning. With an empty mask, the initializer picks the yaw from the lanelet-direction gain alone. The camera check exists to resolve the 180 degree ambiguity of a two-way road, and this signal is then gone.

Ubuntu 24.04 ships OpenCV 4.6, which imports the model correctly. Ubuntu 26.04 ships OpenCV 4.10, which does not. `package.xml` declares `libopencv-dev` with no version bound, so the fault arrives with the next platform, with no code change in Autoware.

The fix loads the ONNX export of the same network, which every tested OpenCV version imports correctly. The model bundle already delivers it at `saved_model/model_float32.onnx`, next to the `.pb`, so every install has the file.

A launch-only switch is not enough. NHWC and NCHW name the axis order of a tensor:

| Layout | Axis order | In this node |
| --- | --- | --- |
| NHWC | batch, height, width, channels | the input that the ONNX declares, `[1, 512, 896, 3]` |
| NCHW | batch, channels, height, width | the blob that `blobFromImage()` builds, `[1, 3, 512, 896]` |

The NCHW blob fails shape inference against the ONNX on every OpenCV version. The node therefore gains an NHWC blob builder and an NHWC output conversion, selected by the model file extension. The `.pb` path stays for an explicit `model_path` override.

- The migration that published the ONNX for this purpose: autowarefoundation/autoware#7223

## How to verify

The mask must stay exactly as it is on a correct OpenCV, and become non-empty on a broken one.

💘 The fastest way is the Colab notebook: <https://colab.research.google.com/gist/xmfcx/dfa73fb99e51cb7943c350db6b06f7d0/yabloc_opencv49_softmax_repro.ipynb>. It reproduces the fault, the NCHW dead end and the fix on MIT-licensed camera frames, with no local setup.

To verify on this machine instead:

1. Check out the branch and build the package:

   ```bash
   colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select yabloc_pose_initializer
   ```

2. Run `SemanticSegmentation::inference` on a street photo, once with `model_float32.pb` and once with `model_float32.onnx`. Use the distro OpenCV (4.6 on Ubuntu 24.04). The two masks must be pixel-identical. The MIT-licensed comma2k19 frames are a good input source (`hf download commaai/comma2k19 --repo-type dataset --include "data/demo-00000-of-00003.parquet"`, the `preview` column).

3. Repeat the runs with opencv-python 4.10 in a venv, with the same preprocessing. The `.pb` gives an all-zero mask. The ONNX with the NHWC blob gives the same mask as step 2.

<img width="1716" height="676" alt="image" src="https://github.com/user-attachments/assets/0d17ec09-2eed-46c0-92db-e8e561363c0a" />

## AI usage

**AI usage:** written with Claude Code from the migration audit that found the fault

**Self-review:** Ran it on some images from comma2k19 and confirmed it works. You can also check it in the gist colab link above.

<details>
<summary><strong>Verification:</strong> On 22 real camera frames, the patched ONNX path is bit-identical to the current <code>.pb</code> behavior on OpenCV 4.6. On OpenCV 4.10, where the <code>.pb</code> mask is empty on every frame, the patched path stays correct. Build, tests and hooks pass.</summary>

### Inference matrix on real camera frames

22 road-facing camera frames from the comma2k19 dataset (comma.ai, MIT license): residential streets, highways, a night intersection. The C++ runs use the system OpenCV 4.6.0 of Ubuntu 24.04, the library that the node links. The 4.10.0 runs use opencv-python in a venv with the same preprocessing.

| | `.pb` (current default) | `.onnx`, NCHW blob | `.onnx`, NHWC blob (this PR) |
| --- | --- | --- | --- |
| OpenCV 4.6.0 | reference masks | fails to load | bit-identical on 22 of 22 frames |
| OpenCV 4.10.0 | empty mask on 22 of 22 frames | fails to load | bit-identical on 19 of 22, 1 to 2 pixels differ on 3 |

- Reference masks on 4.6.0: road 104 071 to 353 293 pixels per frame, marks 729 to 28 262 pixels on every frame, curb on 5 frames. The clearest frame separates the road surface, both curbs, a painted STOP text, a bike symbol and a lane line into their channels
- `.pb` on 4.10.0: 0 mask pixels on all 22 frames, the regression that this PR prevents
- The patched path is bit-identical to every 4.6.0 reference mask. Differences of 1 to 2 pixels appear only between OpenCV versions, at the threshold boundary, and exist with or without this change
- `.onnx` with the NCHW blob fails on both versions with `Number of input channels should be multiple of 3 but got 896`, which is why the launch-only switch is not possible
- The measurement harness copies `make_nhwc_blob`, `convert_nhwc_blob_to_image` and `normalize` verbatim from the patched file and drives them exactly like `inference()`
- An earlier audit (2026-08-04) measured the `.pb` across four opencv-python versions: 4.6.0 and 4.8.1 correct, 4.9.0 and 4.10.0 empty
- The Colab notebook from the How to verify section ran end to end on 2026-08-15: the fix was bit-identical to the reference on 6 of 6 frames, on both OpenCV versions

### Build, tests, hooks

- `colcon build --packages-select yabloc_pose_initializer`: `Finished` in 29.1 s, Release, Ubuntu 24.04, ROS jazzy
- `colcon test --packages-select yabloc_pose_initializer`: `27 tests, 0 errors, 0 failures, 10 skipped`
- `pre-commit run` on the three changed files: `clang-format`, `cpplint`, `prettier launch.xml`, all `Passed`

### Not run

- The node itself against a live camera and a vector map. Both Google Drive links to the sample rosbag deny access, so there is no public data for a yabloc launch. The bit-identity of the mask is the argument that node behavior cannot change on current platforms
- The dead sample-data links are in the body of the PR that the yabloc README cites: #3946
- An Ubuntu 26.04 system build of the node. The 4.10 evidence is from opencv-python with the same preprocessing

</details>
