### PR TITLE
fix(vehicle): declare the dependencies these packages use

### DIFF
--- a/vehicle/autoware_accel_brake_map_calibrator/package.xml
+++ b/vehicle/autoware_accel_brake_map_calibrator/package.xml
@@ -19,11 +19,16 @@
   <depend>autoware_raw_vehicle_cmd_converter</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
+  <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_external_api_msgs</depend>

--- a/vehicle/autoware_accel_brake_map_calibrator/package.xml
+++ b/vehicle/autoware_accel_brake_map_calibrator/package.xml
@@ -35,9 +35,14 @@
   <depend>tier4_vehicle_msgs</depend>
   <depend>visualization_msgs</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>python3-matplotlib</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-pandas</exec_depend>
   <exec_depend>python3-scipy</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>rviz2</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/vehicle/autoware_external_cmd_converter/package.xml
+++ b/vehicle/autoware_external_cmd_converter/package.xml
@@ -17,7 +17,9 @@
   <depend>autoware_control_msgs</depend>
   <depend>autoware_raw_vehicle_cmd_converter</depend>
   <depend>autoware_test_utils</depend>
+  <depend>autoware_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
@@ -28,6 +30,7 @@
   <depend>tier4_system_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/vehicle/autoware_raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/package.xml
@@ -37,6 +37,7 @@
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/vehicle/autoware_raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/package.xml
@@ -34,6 +34,9 @@
   <depend>rclcpp_components</depend>
   <depend>tier4_vehicle_msgs</depend>
 
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>python3-matplotlib</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/vehicle/autoware_steer_offset_estimator/package.xml
+++ b/vehicle/autoware_steer_offset_estimator/package.xml
@@ -24,6 +24,7 @@
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tl_expected</depend>
   <depend>yaml_cpp_vendor</depend>

--- a/vehicle/autoware_steer_offset_estimator/package.xml
+++ b/vehicle/autoware_steer_offset_estimator/package.xml
@@ -24,6 +24,7 @@
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tl_expected</depend>
   <depend>yaml_cpp_vendor</depend>
   <exec_depend>autoware_global_parameter_loader</exec_depend>


### PR DESCRIPTION
## Description

Four vehicle packages use headers, symbols, or runtime programs of packages that they never declare. This adds the 19 missing entries: 9 `<depend>`, 8 `<exec_depend>`, and 2 `<test_depend>`.

The first commit adds the 10 entries from the checker. A review round on that commit found nine more: the imports of the installed Python scripts, the rviz2 node in a launch file, and a `tf2` use in an installed header.

These packages build and run today only because another declared dependency re-exports the owner, or because some other package installs the system library.

- Tracking issue: autowarefoundation/autoware_universe#13207
- Parent issue: autowarefoundation/autoware#7263

## The entries

Each entry links to the `package.xml` it goes into, and each example links to a line that uses the dependency, at the commit this branch starts from.

[`autoware_accel_brake_map_calibrator`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`builtin_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<depend>` | [`accel_brake_map_calibrator_node.hpp:307`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/include/autoware_accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp#L307) `builtin_interfaces::msg::Time` |
| [`diagnostic_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<depend>` | [`accel_brake_map_calibrator_node.cpp:1328`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp#L1328) `using DiagStatus = diagnostic_msgs::msg::DiagnosticStatus;` |
| [`eigen`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<depend>` | [`accel_brake_map_calibrator_node.hpp:28`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/include/autoware_accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp#L28) `#include <Eigen/Dense>` |
| [`nav_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<depend>` | [`accel_brake_map_calibrator_node.hpp:36`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/include/autoware_accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp#L36) `#include "nav_msgs/msg/occupancy_grid.hpp"` |
| [`tf2`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<depend>` | [`accel_brake_map_calibrator_node.hpp:29`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/include/autoware_accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp#L29) `#include <tf2/utils.hpp>` |
| [`ament_index_python`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<exec_depend>` | [`new_accel_brake_map_server.py:20`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/scripts/new_accel_brake_map_server.py#L20) `from ament_index_python.packages import get_package_share_directory` |
| [`python3-numpy`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<exec_depend>` | [`calc_utils.py:20`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/scripts/calc_utils.py#L20) `import numpy as np` |
| [`python3-yaml`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<exec_depend>` | [`new_accel_brake_map_server.py:30`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/scripts/new_accel_brake_map_server.py#L30) `import yaml` |
| [`rclpy`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<exec_depend>` | [`accel_tester.py:19`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/scripts/accel_tester.py#L19) `import rclpy` |
| [`rviz2`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/package.xml) | `<exec_depend>` | [`accel_brake_map_calibrator.launch.xml:40`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_accel_brake_map_calibrator/launch/accel_brake_map_calibrator.launch.xml#L40) `<node pkg="rviz2" exec="rviz2" ...>` |

The `<exec_depend>` entries cover the 15 Python files that `CMakeLists.txt` installs to `lib/autoware_accel_brake_map_calibrator`, and the rviz2 node that the launch file starts. 9 of the 15 files import `rclpy`.

[`autoware_external_cmd_converter`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_external_cmd_converter/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`autoware_utils`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_external_cmd_converter/package.xml) | `<depend>` | [`node.hpp:18`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_external_cmd_converter/include/autoware_external_cmd_converter/node.hpp#L18) `#include "autoware_utils/ros/polling_subscriber.hpp"` |
| [`diagnostic_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_external_cmd_converter/package.xml) | `<depend>` | [`node.cpp:181`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_external_cmd_converter/src/node.cpp#L181) `using diagnostic_msgs::msg::DiagnosticStatus;` |
| [`ament_index_cpp`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_external_cmd_converter/package.xml) | `<test_depend>` | [`test_external_cmd_converter.cpp:17`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_external_cmd_converter/tests/test_external_cmd_converter.cpp#L17) `#include <ament_index_cpp/get_package_share_directory.hpp>` |

[`autoware_raw_vehicle_cmd_converter`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`ament_index_python`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/package.xml) | `<exec_depend>` | [`plot_accel_brake_map.py:19`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/scripts/plot_accel_brake_map.py#L19) `from ament_index_python.packages import get_package_share_directory` |
| [`python3-matplotlib`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/package.xml) | `<exec_depend>` | [`plot_accel_brake_map.py:20`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/scripts/plot_accel_brake_map.py#L20) `import matplotlib.pyplot as plt` |
| [`python3-numpy`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/package.xml) | `<exec_depend>` | [`plot_accel_brake_map.py:21`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/scripts/plot_accel_brake_map.py#L21) `import numpy as np` |
| [`ament_index_cpp`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/package.xml) | `<test_depend>` | [`test_autoware_raw_vehicle_cmd_converter.cpp:15`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_raw_vehicle_cmd_converter/test/test_autoware_raw_vehicle_cmd_converter.cpp#L15) `#include "ament_index_cpp/get_package_share_directory.hpp"` |

The `<exec_depend>` entries cover `plot_accel_brake_map.py`, which `CMakeLists.txt` installs to `lib/autoware_raw_vehicle_cmd_converter`.

[`autoware_steer_offset_estimator`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_steer_offset_estimator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`tf2`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_steer_offset_estimator/package.xml) | `<depend>` | [`utils.hpp:48`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_steer_offset_estimator/include/autoware/steer_offset_estimator/utils.hpp#L48) `const tf2::Quaternion & q1, const tf2::Quaternion & q2);`, in an installed header |
| [`tf2_geometry_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_steer_offset_estimator/package.xml) | `<depend>` | [`utils.hpp:22`](https://github.com/autowarefoundation/autoware_universe/blob/4260f35f2bbed2b1cf9e9466e5fe2259babdfe1f/vehicle/autoware_steer_offset_estimator/include/autoware/steer_offset_estimator/utils.hpp#L22) `#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>`, in an installed header |

## AI usage

**AI usage:** written with Claude Code. The checker from the tracking issue produced the entries of the first commit, and Claude Code verified each entry against its source lines and applied the edits. A second Claude Code session, with a clean context, reviewed the first commit and found the entries of the second commit.

**Self-review:** All look good 👍

<details>
<summary><strong>Verification:</strong> every entry maps to a real use in the sources, and the four packages build cleanly with the new entries.</summary>

### The checker run

On `main` at `4260f35f2`, in a jazzy workspace.

- `fix_missing_deps.py --repo src/universe/autoware_universe/vehicle --write` reported `packages to edit 4` and `entries to add 10`: 8 `<depend>` and 2 `<test_depend>`.

### Per-entry source check, first commit

- Each of the 10 entries matched at least one source line in its package that includes or names the dependency. The tables above link one example per entry.
- Each entry was absent from its `package.xml` before the edit.
- `rosdep resolve eigen` returned `apt libeigen3-dev`.

### Build, first commit

- `colcon build --symlink-install --packages-select` for the four packages: `Summary: 4 packages finished [1min 18s]`, no errors.
- The only stderr output is a pre-existing CMake dev warning from `FindFLANN.cmake`.
- Not run at this stage: `colcon test`, and a build of the reverse-dependency closure.

### The review round

On the pull request branch at `512cdb7f9`, a second Claude Code session with a clean context proved each of the 10 entries against the sources, with one sub-agent per package. It did not run the checker.

- Each entry mapped to a direct use in the code its tag points to, with no duplicate and no wrong tag.
- All 10 example links above matched the quoted code at `4260f35f2`, checked with `git show`.
- `sort-package-xml` and `prettier-package-xml` passed on the four manifests, and the four packages built again: `Summary: 4 packages finished [15.7s]`.
- The sweep in the other direction found the nine entries of the second commit.

### The second commit

- Each of the nine entries maps to an import in an installed Python program, a node in a launch file, or a qualified name in an installed header. The tables above link one example per entry.
- `rosdep resolve` returned `apt` packages for `python3-numpy` and `python3-yaml`.
- `sort-package-xml` and `prettier-package-xml` passed on the three edited manifests.
- `colcon build --symlink-install --packages-select` for the three edited packages: `Summary: 3 packages finished [15.0s]`, no errors.
- Not run: `colcon test`, a build of the reverse-dependency closure, and any check on humble. The repository CI builds the pull request.

</details>
