### PR TITLE
refactor(autoware_lidar_centerpoint)!: scope model params to the manifest and check its version

### DIFF
--- a/perception/autoware_lidar_centerpoint/CMakeLists.txt
+++ b/perception/autoware_lidar_centerpoint/CMakeLists.txt
@@ -62,6 +62,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   ament_auto_add_library(${PROJECT_NAME}_lib SHARED
     lib/centerpoint_trt.cpp
     lib/detection_class_remapper.cpp
+    lib/ml_package_version.cpp
     lib/utils.cpp
     lib/ros_utils.cpp
     lib/preprocess/pointcloud_densification.cpp
@@ -147,6 +148,9 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     )
     ament_auto_add_gtest(test_ros_utils
       test/test_ros_utils.cpp
+    )
+    ament_auto_add_gtest(test_ml_package_version
+      test/test_ml_package_version.cpp
     )
     # Temporary disabled, tracked by:
     # https://github.com/autowarefoundation/autoware_universe/issues/7724

--- a/perception/autoware_lidar_centerpoint/README.md
+++ b/perception/autoware_lidar_centerpoint/README.md
@@ -36,22 +36,21 @@ Note that these parameters are associated with ONNX file, predefined during the 
 
 ### Core Parameters
 
-| Name                                             | Type         | Default Value             | Description                                                                              |
-| ------------------------------------------------ | ------------ | ------------------------- | ---------------------------------------------------------------------------------------- |
-| `model_path`                                     | string       | `""`                      | directory containing the model artifacts; relative file entries below resolve against it |
-| `encoder_onnx_path`                              | string       | `""`                      | VoxelFeatureEncoder ONNX file, relative to `model_path`                                  |
-| `encoder_engine_path`                            | string       | `""`                      | VoxelFeatureEncoder TensorRT Engine file, relative to `model_path`                       |
-| `head_onnx_path`                                 | string       | `""`                      | DetectionHead ONNX file, relative to `model_path`                                        |
-| `head_engine_path`                               | string       | `""`                      | DetectionHead TensorRT Engine file, relative to `model_path`                             |
-| `class_remapper_param_path`                      | string       | `""`                      | class remapper parameter file, relative to `model_path`                                  |
-| `build_only`                                     | bool         | `false`                   | shutdown the node after TensorRT engine file is built                                    |
-| `trt_precision`                                  | string       | `fp16`                    | TensorRT inference precision: `fp32` or `fp16`                                           |
-| `post_process_params.yaw_norm_thresholds`        | list[double] | [0.3, 0.3, 0.3, 0.3, 0.0] | An array of distance threshold values of norm of yaw [rad].                              |
-| `post_process_params.iou_nms_search_distance_2d` | double       | -                         | If two objects are farther than the value, NMS isn't applied.                            |
-| `post_process_params.iou_nms_threshold`          | double       | -                         | IoU threshold for the IoU-based Non Maximum Suppression                                  |
-| `post_process_params.has_twist`                  | boolean      | false                     | Indicates whether the model outputs twist value.                                         |
-| `densification_params.world_frame_id`            | string       | `map`                     | the world frame id to fuse multi-frame pointcloud                                        |
-| `densification_params.num_past_frames`           | int          | `1`                       | the number of past frames to fuse with the current frame                                 |
+{{ json_to_markdown("perception/autoware_lidar_centerpoint/schema/centerpoint_common.schema.json") }}
+
+### Detection Class Remapper
+
+{{ json_to_markdown("perception/autoware_lidar_centerpoint/schema/detection_class_remapper.schema.json") }}
+
+### Launch Parameters
+
+These are given by the launch file and are not part of any parameter file.
+
+| Name          | Type   | Default Value       | Description                                                                            |
+| ------------- | ------ | ------------------- | -------------------------------------------------------------------------------------- |
+| `model_path`  | string | `""`                | directory containing the model artifacts; relative manifest entries resolve against it |
+| `build_only`  | bool   | `false`             | shutdown the node after TensorRT engine file is built                                  |
+| `logger_name` | string | `lidar_centerpoint` | logger name used for the node logs and debug topics                                    |
 
 ### The `build_only` option
 
@@ -59,7 +58,7 @@ The `autoware_lidar_centerpoint` node has `build_only` option to build the Tenso
 Although it is preferred to move all the ROS parameters in `.param.yaml` file in Autoware Universe, the `build_only` option is not moved to the `.param.yaml` file for now, because it may be used as a flag to execute the build as a pre-task. You can execute with the following command:
 
 ```bash
-ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml model_path:=/home/autoware/autoware_data/ml_models/lidar_centerpoint/tiny build_only:=true
+ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml model_path:=/home/autoware/autoware_data/ml_models/lidar_centerpoint/base build_only:=true
 ```
 
 `model_path` points at the variant folder (`base`/`tiny`/`sigma`/`short_range`) of the model bundle; the engine files are written there.
@@ -70,7 +69,7 @@ ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml model_path:=
 
 ## Trained Models
 
-Trained models are hosted on Hugging Face at [AutowareFoundation/lidar_centerpoint](https://huggingface.co/AutowareFoundation/lidar_centerpoint) and downloaded to `~/autoware_data/ml_models/lidar_centerpoint/` by the ansible artifacts role (pinned to tag `v4.0`).
+Trained models are hosted on Hugging Face at [AutowareFoundation/lidar_centerpoint](https://huggingface.co/AutowareFoundation/lidar_centerpoint) and downloaded to `~/autoware_data/ml_models/lidar_centerpoint/` by the ansible artifacts role (pinned to tag `v4.1`).
 
 The bundle holds one self-contained folder per variant; the perception launcher (`lidar_dnn_detector.launch.xml`) selects the folder from the model name, and `lidar_centerpoint.launch.xml` takes the folder directly as `model_path`:
 
@@ -82,7 +81,9 @@ lidar_centerpoint/
 └── short_range/  # model_name: centerpoint_short_range
 ```
 
-Every variant folder contains the same file set: `pts_voxel_encoder.onnx`, `pts_backbone_neck_head.onnx`, `ml_package.param.yaml`, `detection_class_remapper.param.yaml` and `deploy_metadata.yaml`. TensorRT engine files are built locally into the variant folder on first launch (or via `build_only:=true`).
+Every variant folder contains the same file set: `pts_voxel_encoder.onnx`, `pts_backbone_neck_head.onnx`, `ml_package.param.yaml` and `detection_class_remapper.param.yaml`. TensorRT engine files are built locally into the variant folder on first launch (or via `build_only:=true`).
+
+`ml_package.param.yaml` declares the bundle version. The node reads major version 4 from minor version 1 upward and aborts otherwise, so a version error means the bundle has to be refreshed with the ansible artifacts role of the [autoware](https://github.com/autowarefoundation/autoware) repository.
 
 `Centerpoint` was trained in `nuScenes` (~28k lidar frames) [8] and TIER IV's internal database (~11k lidar frames) for 60 epochs.
 `Centerpoint tiny` was trained in `Argoverse 2` (~110k lidar frames) [9] and TIER IV's internal database (~11k lidar frames) for 20 epochs.
@@ -259,6 +260,8 @@ point_cloud_range, point_feature_size, voxel_size, etc. according to the trainin
 ```yaml
 /**:
   ros__parameters:
+    # model bundle version, checked against the range the node supports
+    version: v4.1
     # model files, relative to model_path
     encoder_onnx_path: pts_voxel_encoder.onnx
     encoder_engine_path: pts_voxel_encoder.engine
@@ -276,6 +279,7 @@ point_cloud_range, point_feature_size, voxel_size, etc. according to the trainin
       encoder_in_feature_size: 9
       has_variance: false
       has_twist: false
+      yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
       detection_score_thresholds:
         distance_bin_upper_limits: [50.0, 90.0, 121.0, 200.0]
         min_confidence_scores:
@@ -307,6 +311,10 @@ ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml model_path:=
 ```
 
 ### Changelog
+
+#### v4.1 (2026/08)
+
+`ml_package.param.yaml` gained `version` and `model_params.yaw_norm_thresholds`, the latter moved out of `centerpoint_common.param.yaml` because it is indexed by the predicted class. `deploy_metadata.yaml` is gone. Bundles of `v4.0` and earlier are rejected at startup.
 
 #### v4.0 (2026/07)
 

--- a/perception/autoware_lidar_centerpoint/README.md
+++ b/perception/autoware_lidar_centerpoint/README.md
@@ -257,38 +257,6 @@ python projects/AutowareCenterPoint/centerpoint_onnx_converter.py --cfg projects
 Rename the exported ONNX files to `pts_voxel_encoder.onnx` and `pts_backbone_neck_head.onnx`, and create a **ml_package.param.yaml** next to them. Set the model parameters like
 point_cloud_range, point_feature_size, voxel_size, etc. according to the training config file.
 
-```yaml
-/**:
-  ros__parameters:
-    # model bundle version, checked against the range the node supports
-    version: v4.1
-    # model files, relative to model_path
-    encoder_onnx_path: pts_voxel_encoder.onnx
-    encoder_engine_path: pts_voxel_encoder.engine
-    head_onnx_path: pts_backbone_neck_head.onnx
-    head_engine_path: pts_backbone_neck_head.engine
-    class_remapper_param_path: detection_class_remapper.param.yaml
-    trt_precision: fp16
-    model_params:
-      class_names: ["CAR", "TRUCK", "BUS", "BICYCLE", "PEDESTRIAN"]
-      point_feature_size: 4
-      max_voxel_size: 40000
-      point_cloud_range: [-51.2, -51.2, -3.0, 51.2, 51.2, 5.0]
-      voxel_size: [0.2, 0.2, 8.0]
-      downsample_factor: 1
-      encoder_in_feature_size: 9
-      has_variance: false
-      has_twist: false
-      yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
-      detection_score_thresholds:
-        distance_bin_upper_limits: [50.0, 90.0, 121.0, 200.0]
-        min_confidence_scores:
-          CAR: [0.35, 0.35, 0.35, 0.35]
-          TRUCK: [0.35, 0.35, 0.35, 0.35]
-          BUS: [0.35, 0.35, 0.35, 0.35]
-          BICYCLE: [0.35, 0.35, 0.35, 0.35]
-          PEDESTRIAN: [0.35, 0.35, 0.35, 0.35]
-```
 
 #### Launch the lidar_centerpoint node
 

--- a/perception/autoware_lidar_centerpoint/README.md
+++ b/perception/autoware_lidar_centerpoint/README.md
@@ -257,7 +257,6 @@ python projects/AutowareCenterPoint/centerpoint_onnx_converter.py --cfg projects
 Rename the exported ONNX files to `pts_voxel_encoder.onnx` and `pts_backbone_neck_head.onnx`, and create a **ml_package.param.yaml** next to them. Set the model parameters like
 point_cloud_range, point_feature_size, voxel_size, etc. according to the training config file.
 
-
 #### Launch the lidar_centerpoint node
 
 ```bash

--- a/perception/autoware_lidar_centerpoint/README.md
+++ b/perception/autoware_lidar_centerpoint/README.md
@@ -46,11 +46,11 @@ Note that these parameters are associated with ONNX file, predefined during the 
 
 These are given by the launch file and are not part of any parameter file.
 
-| Name          | Type   | Default Value       | Description                                                                            |
-| ------------- | ------ | ------------------- | -------------------------------------------------------------------------------------- |
-| `model_path`  | string | `""`                | directory containing the model artifacts; relative manifest entries resolve against it |
-| `build_only`  | bool   | `false`             | shutdown the node after TensorRT engine file is built                                  |
-| `logger_name` | string | `lidar_centerpoint` | logger name used for the node logs and debug topics                                    |
+| Name          | Type   | Default Value                             | Description                                                                            |
+| ------------- | ------ | ----------------------------------------- | -------------------------------------------------------------------------------------- |
+| `model_path`  | string | `$(var data_path)/lidar_centerpoint/base` | directory containing the model artifacts; relative manifest entries resolve against it |
+| `build_only`  | bool   | `false`                                   | shutdown the node after TensorRT engine file is built                                  |
+| `logger_name` | string | `lidar_centerpoint`                       | logger name used for the node logs and debug topics                                    |
 
 ### The `build_only` option
 
@@ -83,7 +83,7 @@ lidar_centerpoint/
 
 Every variant folder contains the same file set: `pts_voxel_encoder.onnx`, `pts_backbone_neck_head.onnx`, `ml_package.param.yaml` and `detection_class_remapper.param.yaml`. TensorRT engine files are built locally into the variant folder on first launch (or via `build_only:=true`).
 
-`ml_package.param.yaml` declares the bundle version. The node reads major version 4 from minor version 1 upward and aborts otherwise, so a version error means the bundle has to be refreshed with the ansible artifacts role of the [autoware](https://github.com/autowarefoundation/autoware) repository.
+`ml_package.param.yaml` declares the bundle version. The node reads major version 4 from minor version 1 upward and aborts otherwise, so a version error means the bundle has to be refreshed with the ansible artifacts role of the [autoware](https://github.com/autowarefoundation/autoware) repository. A minor bump can add manifest entries the node requires.
 
 `Centerpoint` was trained in `nuScenes` (~28k lidar frames) [8] and TIER IV's internal database (~11k lidar frames) for 60 epochs.
 `Centerpoint tiny` was trained in `Argoverse 2` (~110k lidar frames) [9] and TIER IV's internal database (~11k lidar frames) for 20 epochs.
@@ -255,7 +255,7 @@ python projects/AutowareCenterPoint/centerpoint_onnx_converter.py --cfg projects
 #### Create the ml_package file for the custom model
 
 Rename the exported ONNX files to `pts_voxel_encoder.onnx` and `pts_backbone_neck_head.onnx`, and create a **ml_package.param.yaml** next to them. Set the model parameters like
-point_cloud_range, point_feature_size, voxel_size, etc. according to the training config file.
+point_cloud_range, point_feature_size, voxel_size, etc. according to the training config file. The [ML Model Parameters](#ml-model-parameters) table lists every entry with its default; `version` has to be declared as well, or the node aborts at startup.
 
 #### Launch the lidar_centerpoint node
 

--- a/perception/autoware_lidar_centerpoint/config/centerpoint_common.param.yaml
+++ b/perception/autoware_lidar_centerpoint/config/centerpoint_common.param.yaml
@@ -5,7 +5,6 @@
       circle_nms_dist_threshold: 0.5
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
-      yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
     densification_params:
       world_frame_id: map
       num_past_frames: 1

--- a/perception/autoware_lidar_centerpoint/config/ml_package.param.yaml
+++ b/perception/autoware_lidar_centerpoint/config/ml_package.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    # model bundle version, checked against the range the node supports
+    version: v4.1
     # model files, relative to model_path
     encoder_onnx_path: pts_voxel_encoder.onnx
     encoder_engine_path: pts_voxel_encoder.engine
@@ -17,6 +19,7 @@
       encoder_in_feature_size: 9
       has_variance: false
       has_twist: false
+      yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
       detection_score_thresholds:
         # Upper bound of radial distance of 3d center_x and center_y in bounding boxes, and starting from 0
         # [0-50m), [50.0-90m), [90.0-121.0m), [121.0-200.0m), set a very high number for the last one to be safe

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/ml_package_version.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/ml_package_version.hpp
@@ -25,8 +25,9 @@ constexpr int SUPPORTED_ML_PACKAGE_MAJOR_VERSION = 4;
 constexpr int MINIMUM_ML_PACKAGE_MINOR_VERSION = 1;
 
 // Accepts "<major>.<minor>" with an optional leading "v"; throws std::invalid_argument when the
-// version is unreadable, of another major version, or below the minimum minor version.
-void check_ml_package_version(const std::string & version);
+// version is unreadable, of another major version, or below the minimum minor version. model_path
+// names the bundle in the message, and may be empty.
+void check_ml_package_version(const std::string & version, const std::string & model_path);
 
 }  // namespace autoware::lidar_centerpoint
 

--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/ml_package_version.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/ml_package_version.hpp
@@ -1,0 +1,33 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__LIDAR_CENTERPOINT__ML_PACKAGE_VERSION_HPP_
+#define AUTOWARE__LIDAR_CENTERPOINT__ML_PACKAGE_VERSION_HPP_
+
+#include <string>
+
+namespace autoware::lidar_centerpoint
+{
+// Manifest layout this node reads: the major version it is written against, and the minor version
+// from which the entries it requires are present.
+constexpr int SUPPORTED_ML_PACKAGE_MAJOR_VERSION = 4;
+constexpr int MINIMUM_ML_PACKAGE_MINOR_VERSION = 1;
+
+// Accepts "<major>.<minor>" with an optional leading "v"; throws std::invalid_argument when the
+// version is unreadable, of another major version, or below the minimum minor version.
+void check_ml_package_version(const std::string & version);
+
+}  // namespace autoware::lidar_centerpoint
+
+#endif  // AUTOWARE__LIDAR_CENTERPOINT__ML_PACKAGE_VERSION_HPP_

--- a/perception/autoware_lidar_centerpoint/launch/lidar_centerpoint.launch.xml
+++ b/perception/autoware_lidar_centerpoint/launch/lidar_centerpoint.launch.xml
@@ -4,7 +4,7 @@
   <arg name="output/objects" default="objects"/>
   <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="node_name" default="lidar_centerpoint" description="node name for autoware_lidar_centerpoint_node"/>
-  <arg name="model_path" default="$(var data_path)/lidar_centerpoint/tiny" description="directory containing the model artifacts"/>
+  <arg name="model_path" default="$(var data_path)/lidar_centerpoint/base" description="directory containing the model artifacts"/>
   <arg name="common_param_path" default="$(find-pkg-share autoware_lidar_centerpoint)/config/centerpoint_common.param.yaml"/>
   <arg name="build_only" default="false" description="shutdown node after TensorRT engine file is built"/>
 

--- a/perception/autoware_lidar_centerpoint/lib/ml_package_version.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/ml_package_version.cpp
@@ -31,6 +31,11 @@ std::string supported_range()
          "role of the autoware repository.";
 }
 
+std::string manifest_subject(const std::string & model_path)
+{
+  return model_path.empty() ? "The model manifest" : "The model manifest in '" + model_path + "'";
+}
+
 bool parse_version(const std::string & version, int & major, int & minor)
 {
   const std::string digits =
@@ -54,12 +59,13 @@ bool parse_version(const std::string & version, int & major, int & minor)
 }
 }  // namespace
 
-void check_ml_package_version(const std::string & version)
+void check_ml_package_version(const std::string & version, const std::string & model_path)
 {
+  const std::string subject = manifest_subject(model_path);
+
   if (version.empty()) {
     throw std::invalid_argument(
-      "The model manifest declares no version, so it predates the manifest layout this node "
-      "requires. " +
+      subject + " declares no version, so it predates the manifest layout this node requires. " +
       supported_range());
   }
 
@@ -67,13 +73,14 @@ void check_ml_package_version(const std::string & version)
   int minor = 0;
   if (!parse_version(version, major, minor)) {
     throw std::invalid_argument(
-      "The model manifest version '" + version + "' is not of the form '<major>.<minor>'. " +
-      supported_range());
+      subject + " declares version '" + version +
+      "', which is not of the form '<major>.<minor>'. " + supported_range());
   }
 
   if (major != SUPPORTED_ML_PACKAGE_MAJOR_VERSION || minor < MINIMUM_ML_PACKAGE_MINOR_VERSION) {
     throw std::invalid_argument(
-      "The model bundle version '" + version + "' is not supported. " + supported_range());
+      subject + " declares version '" + version + "', which is not supported. " +
+      supported_range());
   }
 }
 

--- a/perception/autoware_lidar_centerpoint/lib/ml_package_version.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/ml_package_version.cpp
@@ -1,0 +1,80 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/lidar_centerpoint/ml_package_version.hpp"
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+
+namespace autoware::lidar_centerpoint
+{
+namespace
+{
+std::string supported_range()
+{
+  return "This node reads model bundles of version v" +
+         std::to_string(SUPPORTED_ML_PACKAGE_MAJOR_VERSION) + "." +
+         std::to_string(MINIMUM_ML_PACKAGE_MINOR_VERSION) +
+         " or later within the same major version. Update the bundle with the ansible artifacts "
+         "role of the autoware repository.";
+}
+
+bool parse_version(const std::string & version, int & major, int & minor)
+{
+  const std::string digits =
+    (!version.empty() && (version.front() == 'v' || version.front() == 'V')) ? version.substr(1)
+                                                                             : version;
+  const auto separator = digits.find('.');
+  if (separator == std::string::npos) {
+    return false;
+  }
+
+  try {
+    std::size_t major_end = 0;
+    std::size_t minor_end = 0;
+    major = std::stoi(digits.substr(0, separator), &major_end);
+    minor = std::stoi(digits.substr(separator + 1), &minor_end);
+    return major >= 0 && minor >= 0 && major_end == separator &&
+           minor_end == digits.size() - separator - 1;
+  } catch (const std::exception &) {
+    return false;
+  }
+}
+}  // namespace
+
+void check_ml_package_version(const std::string & version)
+{
+  if (version.empty()) {
+    throw std::invalid_argument(
+      "The model manifest declares no version, so it predates the manifest layout this node "
+      "requires. " +
+      supported_range());
+  }
+
+  int major = 0;
+  int minor = 0;
+  if (!parse_version(version, major, minor)) {
+    throw std::invalid_argument(
+      "The model manifest version '" + version + "' is not of the form '<major>.<minor>'. " +
+      supported_range());
+  }
+
+  if (major != SUPPORTED_ML_PACKAGE_MAJOR_VERSION || minor < MINIMUM_ML_PACKAGE_MINOR_VERSION) {
+    throw std::invalid_argument(
+      "The model bundle version '" + version + "' is not supported. " + supported_range());
+  }
+}
+
+}  // namespace autoware::lidar_centerpoint

--- a/perception/autoware_lidar_centerpoint/schema/centerpoint_common.schema.json
+++ b/perception/autoware_lidar_centerpoint/schema/centerpoint_common.schema.json
@@ -34,11 +34,6 @@
               "default": 0.1,
               "minimum": 0.0,
               "maximum": 1.0
-            },
-            "yaw_norm_thresholds": {
-              "type": "array",
-              "description": "An array of distance threshold values of norm of yaw [rad].",
-              "default": [0.3, 0.3, 0.3, 0.3, 0.0]
             }
           }
         },

--- a/perception/autoware_lidar_centerpoint/schema/detection_class_remapper.schema.json
+++ b/perception/autoware_lidar_centerpoint/schema/detection_class_remapper.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Detection Class Remapper",
+  "type": "object",
+  "definitions": {
+    "detection_class_remapper": {
+      "type": "object",
+      "properties": {
+        "allow_remapping_by_area_matrix": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "description": "Whether to allow remapping of classes. Row is the original class, column is the class to remap to. The order of the 8x8 matrix classes comes from ObjectClassification msg.",
+          "default": [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0
+          ],
+          "minItems": 64,
+          "maxItems": 64
+        },
+        "min_area_matrix": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "minimum": 0.0
+          },
+          "description": "Minimum area for specific class to consider class remapping. [m^2]",
+          "default": [
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 12.1, 0.0, 36.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 36.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 36.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+          ],
+          "minItems": 64,
+          "maxItems": 64
+        },
+        "max_area_matrix": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "minimum": 0.0
+          },
+          "description": "Maximum area for specific class to consider class remapping. [m^2]",
+          "default": [
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 36.0, 0.0, 999.999, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 999.999, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 999.999, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+          ],
+          "minItems": 64,
+          "maxItems": 64
+        }
+      },
+      "required": ["allow_remapping_by_area_matrix", "min_area_matrix", "max_area_matrix"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/detection_class_remapper"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/perception/autoware_lidar_centerpoint/schema/ml_package.schema.json
+++ b/perception/autoware_lidar_centerpoint/schema/ml_package.schema.json
@@ -6,25 +6,36 @@
     "ml_package": {
       "type": "object",
       "properties": {
+        "version": {
+          "type": "string",
+          "description": "Model bundle version. The node reads major version 4 from minor version 1 upward.",
+          "default": "v4.1",
+          "pattern": "^v?[0-9]+\\.[0-9]+$"
+        },
         "encoder_onnx_path": {
           "type": "string",
-          "description": "VoxelFeatureEncoder ONNX file, relative to model_path (absolute paths allowed)."
+          "description": "VoxelFeatureEncoder ONNX file, relative to model_path (absolute paths allowed).",
+          "default": "pts_voxel_encoder.onnx"
         },
         "encoder_engine_path": {
           "type": "string",
-          "description": "VoxelFeatureEncoder TensorRT Engine file, relative to model_path (absolute paths allowed)."
+          "description": "VoxelFeatureEncoder TensorRT Engine file, relative to model_path (absolute paths allowed).",
+          "default": "pts_voxel_encoder.engine"
         },
         "head_onnx_path": {
           "type": "string",
-          "description": "DetectionHead ONNX file, relative to model_path (absolute paths allowed)."
+          "description": "DetectionHead ONNX file, relative to model_path (absolute paths allowed).",
+          "default": "pts_backbone_neck_head.onnx"
         },
         "head_engine_path": {
           "type": "string",
-          "description": "DetectionHead TensorRT Engine file, relative to model_path (absolute paths allowed)."
+          "description": "DetectionHead TensorRT Engine file, relative to model_path (absolute paths allowed).",
+          "default": "pts_backbone_neck_head.engine"
         },
         "class_remapper_param_path": {
           "type": "string",
-          "description": "Class remapper parameter file, relative to model_path (absolute paths allowed)."
+          "description": "Class remapper parameter file, relative to model_path (absolute paths allowed).",
+          "default": "detection_class_remapper.param.yaml"
         },
         "trt_precision": {
           "type": "string",
@@ -83,6 +94,16 @@
               "description": "A size of encoder input feature channels.",
               "default": 9
             },
+            "yaw_norm_thresholds": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0
+              },
+              "description": "A minimum norm of the predicted yaw vector per class, in the order of `class_names`. Objects below the threshold are discarded.",
+              "default": [0.3, 0.3, 0.3, 0.3, 0.0]
+            },
             "detection_score_thresholds": {
               "type": "object",
               "description": "A dictionary of minimum confidence scores for each class and a distance bin upper limits.",
@@ -129,6 +150,7 @@
         }
       },
       "required": [
+        "version",
         "encoder_onnx_path",
         "encoder_engine_path",
         "head_onnx_path",

--- a/perception/autoware_lidar_centerpoint/schema/ml_package.schema.json
+++ b/perception/autoware_lidar_centerpoint/schema/ml_package.schema.json
@@ -8,7 +8,7 @@
       "properties": {
         "version": {
           "type": "string",
-          "description": "Model bundle version. The node reads major version 4 from minor version 1 upward.",
+          "description": "Model bundle version. The node reads major version 4 from minor version 1 upward; a minor bump may add manifest entries the node requires.",
           "default": "v4.1",
           "pattern": "^v?[0-9]+\\.[0-9]+$"
         },
@@ -75,12 +75,12 @@
             },
             "point_cloud_range": {
               "type": "array",
-              "description": "An array of distance ranges of each class, this must have same length with `class_names`.",
+              "description": "The range of the point cloud in [min_x, min_y, min_z, max_x, max_y, max_z] order. [m]",
               "default": [-76.8, -76.8, -4.0, 76.8, 76.8, 6.0]
             },
             "voxel_size": {
               "type": "array",
-              "description": "An array of voxel grid sizes for PointPainting, this must have same length with `paint_class_names`.",
+              "description": "The size of a voxel in [x, y, z] order. [m]",
               "default": [0.32, 0.32, 10.0]
             },
             "downsample_factor": {

--- a/perception/autoware_lidar_centerpoint/src/node.cpp
+++ b/perception/autoware_lidar_centerpoint/src/node.cpp
@@ -15,6 +15,7 @@
 #include "autoware/lidar_centerpoint/node.hpp"
 
 #include "autoware/lidar_centerpoint/centerpoint_config.hpp"
+#include "autoware/lidar_centerpoint/ml_package_version.hpp"
 #include "autoware/lidar_centerpoint/preprocess/pointcloud_densification.hpp"
 #include "autoware/lidar_centerpoint/ros_utils.hpp"
 #include "autoware/lidar_centerpoint/utils.hpp"
@@ -37,10 +38,10 @@ namespace autoware::lidar_centerpoint
 LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_options)
 : Node("lidar_center_point", node_options), tf_buffer_(this->get_clock())
 {
+  check_ml_package_version(this->declare_parameter<std::string>("version", ""));
+
   const float circle_nms_dist_threshold = static_cast<float>(
     this->declare_parameter<double>("post_process_params.circle_nms_dist_threshold"));
-  const auto yaw_norm_thresholds =
-    this->declare_parameter<std::vector<double>>("post_process_params.yaw_norm_thresholds");
   const std::string densification_world_frame_id =
     this->declare_parameter<std::string>("densification_params.world_frame_id");
   const int densification_num_past_frames =
@@ -75,6 +76,12 @@ LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<std::int64_t>("model_params.downsample_factor"));
   const std::size_t encoder_in_feature_size = static_cast<std::size_t>(
     this->declare_parameter<std::int64_t>("model_params.encoder_in_feature_size"));
+  const auto yaw_norm_thresholds =
+    this->declare_parameter<std::vector<double>>("model_params.yaw_norm_thresholds");
+  if (yaw_norm_thresholds.size() != class_names_.size()) {
+    throw std::invalid_argument(
+      "The number of yaw_norm_thresholds is not equal to the number of classes");
+  }
   // class remapper matrices are loaded from the file referenced in the model manifest
   const std::string class_remapper_param_path =
     resolve_path(this->declare_parameter<std::string>("class_remapper_param_path"));

--- a/perception/autoware_lidar_centerpoint/src/node.cpp
+++ b/perception/autoware_lidar_centerpoint/src/node.cpp
@@ -38,7 +38,10 @@ namespace autoware::lidar_centerpoint
 LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_options)
 : Node("lidar_center_point", node_options), tf_buffer_(this->get_clock())
 {
-  check_ml_package_version(this->declare_parameter<std::string>("version", ""));
+  // weight file entries are file names relative to model_path; absolute paths pass through
+  const std::filesystem::path model_path(this->declare_parameter<std::string>("model_path", ""));
+  check_ml_package_version(
+    this->declare_parameter<std::string>("version", ""), model_path.string());
 
   const float circle_nms_dist_threshold = static_cast<float>(
     this->declare_parameter<double>("post_process_params.circle_nms_dist_threshold"));
@@ -48,8 +51,6 @@ LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<int>("densification_params.num_past_frames");
   const std::string trt_precision = this->declare_parameter<std::string>("trt_precision");
   const std::size_t cloud_capacity = this->declare_parameter<std::int64_t>("cloud_capacity");
-  // weight file entries are file names relative to model_path; absolute paths pass through
-  const std::filesystem::path model_path(this->declare_parameter<std::string>("model_path", ""));
   const auto resolve_path = [&model_path](const std::string & file) {
     const std::filesystem::path path(file);
     return path.is_absolute() ? path.string() : (model_path / path).string();

--- a/perception/autoware_lidar_centerpoint/test/test_ml_package_version.cpp
+++ b/perception/autoware_lidar_centerpoint/test/test_ml_package_version.cpp
@@ -1,0 +1,45 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/lidar_centerpoint/ml_package_version.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+using autoware::lidar_centerpoint::check_ml_package_version;
+
+TEST(TestSuite, supportedVersions)
+{
+  EXPECT_NO_THROW(check_ml_package_version("v4.1"));
+  EXPECT_NO_THROW(check_ml_package_version("4.1"));
+  EXPECT_NO_THROW(check_ml_package_version("v4.2"));
+  EXPECT_NO_THROW(check_ml_package_version("v4.10"));
+}
+
+TEST(TestSuite, unsupportedVersions)
+{
+  EXPECT_THROW(check_ml_package_version("v4.0"), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v3.9"), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v5.0"), std::invalid_argument);
+}
+
+TEST(TestSuite, unreadableVersions)
+{
+  EXPECT_THROW(check_ml_package_version(""), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v4"), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v4.1.0"), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v4.x"), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("latest"), std::invalid_argument);
+}

--- a/perception/autoware_lidar_centerpoint/test/test_ml_package_version.cpp
+++ b/perception/autoware_lidar_centerpoint/test/test_ml_package_version.cpp
@@ -17,29 +17,41 @@
 #include <gtest/gtest.h>
 
 #include <stdexcept>
+#include <string>
 
 using autoware::lidar_centerpoint::check_ml_package_version;
 
 TEST(TestSuite, supportedVersions)
 {
-  EXPECT_NO_THROW(check_ml_package_version("v4.1"));
-  EXPECT_NO_THROW(check_ml_package_version("4.1"));
-  EXPECT_NO_THROW(check_ml_package_version("v4.2"));
-  EXPECT_NO_THROW(check_ml_package_version("v4.10"));
+  EXPECT_NO_THROW(check_ml_package_version("v4.1", ""));
+  EXPECT_NO_THROW(check_ml_package_version("4.1", ""));
+  EXPECT_NO_THROW(check_ml_package_version("v4.2", ""));
+  EXPECT_NO_THROW(check_ml_package_version("v4.10", ""));
 }
 
 TEST(TestSuite, unsupportedVersions)
 {
-  EXPECT_THROW(check_ml_package_version("v4.0"), std::invalid_argument);
-  EXPECT_THROW(check_ml_package_version("v3.9"), std::invalid_argument);
-  EXPECT_THROW(check_ml_package_version("v5.0"), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v4.0", ""), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v3.9", ""), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v5.0", ""), std::invalid_argument);
 }
 
 TEST(TestSuite, unreadableVersions)
 {
-  EXPECT_THROW(check_ml_package_version(""), std::invalid_argument);
-  EXPECT_THROW(check_ml_package_version("v4"), std::invalid_argument);
-  EXPECT_THROW(check_ml_package_version("v4.1.0"), std::invalid_argument);
-  EXPECT_THROW(check_ml_package_version("v4.x"), std::invalid_argument);
-  EXPECT_THROW(check_ml_package_version("latest"), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("", ""), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v4", ""), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v4.1.0", ""), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("v4.x", ""), std::invalid_argument);
+  EXPECT_THROW(check_ml_package_version("latest", ""), std::invalid_argument);
+}
+
+TEST(TestSuite, messageNamesTheBundle)
+{
+  const std::string model_path = "/data/ml_models/lidar_centerpoint/base";
+  try {
+    check_ml_package_version("v4.0", model_path);
+    FAIL() << "expected std::invalid_argument";
+  } catch (const std::invalid_argument & e) {
+    EXPECT_NE(std::string(e.what()).find(model_path), std::string::npos);
+  }
 }


### PR DESCRIPTION
## Description

Four leftovers from #13087, all in `autoware_lidar_centerpoint`:

1. **`yaw_norm_thresholds` moves into the model manifest.** The postprocess kernel indexes it by the predicted class (`yaw_norm_thresholds[label]`), so its length and order are bound to `model_params.class_names` — a model property, not a node one. It moves from `config/centerpoint_common.param.yaml` to `model_params` in `ml_package.param.yaml`, and the node now rejects a length that does not match the class list instead of reading out of bounds.
2. **The manifest declares its version and the node checks it.** `check_ml_package_version()` accepts major version 4 from minor version 1 upward, in the shape used by `autoware_tensorrt_vad`. Without it, a bundle that predates this layout fails with `Statically typed parameter ... must be initialized`, which says nothing about what to do.
3. **`detection_class_remapper.param.yaml` gets a schema**, modelled on the `autoware_lidar_transfusion` one, so the CI schema check covers the three matrices.
4. **The parameter tables are generated.** `### Core Parameters` was a hand-written table that had drifted (`post_process_params.has_twist` does not exist; manifest entries were listed as core params). It is replaced by `json_to_markdown` over `centerpoint_common.schema.json`, plus a new section for the remapper schema and a short table for the three launch-supplied parameters. The manifest path entries also gained the `default` fields the macro requires — without them the docs build raises `KeyError`.

The launch file now defaults `model_path` to the `base` variant, matching `design/LidarCenterpoint.node.yaml`.

## Breaking change

The node requires a **v4.1** model bundle. `v4.0` bundles carry neither `version` nor `model_params.yaw_norm_thresholds` and are refused at startup with a message pointing at the ansible artifacts role. The reverse is safe: a v4.1 bundle works with older code, since undeclared parameter overrides are ignored.

Related PRs, to merge in the same window:

- data: [AutowareFoundation/lidar_centerpoint PR #2](https://huggingface.co/AutowareFoundation/lidar_centerpoint/discussions/2) (tag `v4.1`)
- launch: autowarefoundation/autoware_launch#1949
- ansible: autowarefoundation/autoware#7274

## Tests performed

- `colcon build` + `colcon test` (11 tests, including the new `test_ml_package_version`).
- Schema/param validation for all three pairs, and for the four bundle manifests.
- Rendered all three schemas through `mkdocs_macros.format_json`.
- `ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml build_only:=true` picks `base` and builds the engines.
- Negative cases, each aborting with its own message: no `version`, `v4.0`, `v5.0`, missing `yaw_norm_thresholds`, and four thresholds for five classes.

## Notes for reviewers

`config/centerpoint_common.param.yaml` is mirrored in `autoware_launch` by the sync-params workflow; the mirror updates after this merges.
