### PR TITLE
refactor(autoware_camera_streampetr): split postprocessing out of the inference call

### DIFF
--- a/perception/autoware_camera_streampetr/README.md
+++ b/perception/autoware_camera_streampetr/README.md
@@ -81,6 +81,45 @@ No                  Yes                                                         
 | `latency/inference/postprocess` | `autoware_internal_debug_msgs::msg::Float64Stamped` | nms + filtering + converting network predictions to autoware format (ms). | 0.40                  |
 | `latency/cycle_time_ms`         | `autoware_internal_debug_msgs::msg::Float64Stamped` | Time between two consecutive predictions (ms).                            | 110.65                |
 
+All `latency/*` topics are published only when `debug_mode` is enabled.
+
+### Diagnostics
+
+Published on `/diagnostics` regardless of `debug_mode`, from a timer-driven updater (period
+`diagnostics.validation_callback_interval_ms`, hardware_id = the node name), so it keeps
+reporting when the cameras stop — precisely the condition it exists for.
+
+`camera_status` reports three key/values per camera — the resolved input `cameraN/topic` (the
+model input index and the physical camera differ on every deployment), `cameraN/image_age_ms`
+(node clock minus newest header stamp; `n/a` until the first frame) and `cameraN/state`, which
+collapses the camera into one state, most-specific-cause first:
+
+| `cameraN/state`       | Meaning                                                     | Level   |
+| --------------------- | ----------------------------------------------------------- | ------- |
+| `rejected`            | Newest frame dropped by the input validation                | `ERROR` |
+| `waiting_camera_info` | No `camera_info` yet (normal during start-up)               | `WARN`  |
+| `waiting_image`       | No first frame yet (normal during start-up)                 | `WARN`  |
+| `stale`               | Used to publish; newest frame older than `max_image_age_ms` | `ERROR` |
+| `active`              | Healthy                                                     | `OK`    |
+
+plus summary key/values:
+
+| Key                                          | Meaning                                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------------ |
+| `num_cameras`                                | Expected camera count (`rois_number`)                                          |
+| `num_waiting` / `num_stale` / `num_rejected` | State counts; the summary level falls out of these                             |
+| `stalest_camera_id` / `stalest_image_age_ms` | The camera that has gone longest without a new frame                           |
+| `max_inter_camera_time_diff_ms`              | Subscriber-side stamp spread between cameras (`n/a` while cameras are missing) |
+
+Timestamps and ages are formatted as fixed-point strings (never scientific notation), like the
+pointcloud concatenation node's diagnostics.
+
+The summary level is the worst camera state; additionally an inter-camera stamp spread above
+`max_camera_time_diff` raises a `WARN` (prediction cycles are being skipped by the sync check).
+`rejected` and `stale` are `ERROR` rather than `WARN` because neither recovers until the
+publisher is fixed: a rejected camera publishes an encoding other than `rgb8`/`bgr8`, or a buffer
+that is not densely packed, and those frames never reach the model.
+
 ## Parameters
 
 ### StreamPETR node
@@ -130,6 +169,8 @@ Example polygon files: `config/camera9_polygons.yaml`, `config/camera10_polygons
 - `anchor_camera_id`: ID of the anchor camera for synchronization (default: 0)
 - `debug_mode`: Enable debug mode for timing measurements
 - `build_only`: Build TensorRT engines and exit without running inference
+- `diagnostics.max_image_age_ms`: A camera whose newest frame is older than this is reported as stalled at `ERROR` level (default: 300.0)
+- `diagnostics.validation_callback_interval_ms`: Interval of the diagnostic callbacks (default: 100.0)
 
 ### The `build_only` option
 

--- a/perception/autoware_camera_streampetr/README.md
+++ b/perception/autoware_camera_streampetr/README.md
@@ -113,7 +113,7 @@ The `autoware_camera_streampetr` node has various parameters for configuration:
 Masking the area of the ego vehicle in order to reduce FP caused by reflection. Configure via **launch** or `camera_streampetr.param.yaml`, not `tensorrt_stream_petr.param.yaml` (model/post-process only).
 
 - `ego_mask.enabled`: Enable masking (default: `false`)
-- `ego_mask.fill_value_bgr`: BGR fill inside polygons, 0–255 (default: `[0, 0, 0]`)
+- `ego_mask.fill_value_rgb`: RGB fill inside polygons, 0–255 (default: `[0, 0, 0]`)
 - `ego_mask.roi_polygons_yaml`: One YAML path per model ROI index; empty string disables that ROI.
 
 Example polygon files: `config/camera9_polygons.yaml`, `config/camera10_polygons.yaml`.

--- a/perception/autoware_camera_streampetr/README.md
+++ b/perception/autoware_camera_streampetr/README.md
@@ -69,17 +69,17 @@ No                  Yes                                                         
 
 ### Output
 
-| Name                            | Type                                                | Description                                                               | RTX 3090 Latency (ms) |
-| ------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------- | --------------------- |
-| `~/output/objects`              | `autoware_perception_msgs::msg::DetectedObjects`    | Detected objects.                                                         | —                     |
-| `latency/preprocess`            | `autoware_internal_debug_msgs::msg::Float64Stamped` | Preprocessing time per image(ms).                                         | 3.25                  |
-| `latency/total`                 | `autoware_internal_debug_msgs::msg::Float64Stamped` | Total processing time (ms): preprocessing + inference + postprocessing.   | 26.04                 |
-| `latency/inference`             | `autoware_internal_debug_msgs::msg::Float64Stamped` | Total inference time (ms).                                                | 22.13                 |
-| `latency/inference/backbone`    | `autoware_internal_debug_msgs::msg::Float64Stamped` | Backbone inference time (ms).                                             | 16.21                 |
-| `latency/inference/ptshead`     | `autoware_internal_debug_msgs::msg::Float64Stamped` | Points head inference time (ms).                                          | 5.45                  |
-| `latency/inference/pos_embed`   | `autoware_internal_debug_msgs::msg::Float64Stamped` | Position embedding inference time (ms).                                   | 0.40                  |
-| `latency/inference/postprocess` | `autoware_internal_debug_msgs::msg::Float64Stamped` | nms + filtering + converting network predictions to autoware format (ms). | 0.40                  |
-| `latency/cycle_time_ms`         | `autoware_internal_debug_msgs::msg::Float64Stamped` | Time between two consecutive predictions (ms).                            | 110.65                |
+| Name                          | Type                                                | Description                                                                                                    | RTX 3090 Latency (ms) |
+| ----------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `~/output/objects`            | `autoware_perception_msgs::msg::DetectedObjects`    | Detected objects.                                                                                              | —                     |
+| `latency/preprocess`          | `autoware_internal_debug_msgs::msg::Float64Stamped` | Preprocessing time per image(ms).                                                                              | 3.25                  |
+| `latency/total`               | `autoware_internal_debug_msgs::msg::Float64Stamped` | Total processing time (ms): preprocessing + inference + postprocessing.                                        | 26.04                 |
+| `latency/inference`           | `autoware_internal_debug_msgs::msg::Float64Stamped` | Model forward pass (ms), stream-synchronized before returning.                                                 | 22.13                 |
+| `latency/inference/backbone`  | `autoware_internal_debug_msgs::msg::Float64Stamped` | Backbone inference time (ms).                                                                                  | 16.21                 |
+| `latency/inference/ptshead`   | `autoware_internal_debug_msgs::msg::Float64Stamped` | Points head inference time (ms).                                                                               | 5.45                  |
+| `latency/inference/pos_embed` | `autoware_internal_debug_msgs::msg::Float64Stamped` | Position embedding inference time (ms).                                                                        | 0.40                  |
+| `latency/postprocess`         | `autoware_internal_debug_msgs::msg::Float64Stamped` | bbox decode + nms + converting network predictions to autoware format (ms); disjoint from `latency/inference`. | 0.40                  |
+| `latency/cycle_time_ms`       | `autoware_internal_debug_msgs::msg::Float64Stamped` | Time between two consecutive predictions (ms).                                                                 | 110.65                |
 
 All `latency/*` topics are published only when `debug_mode` is enabled.
 
@@ -133,11 +133,14 @@ that is not densely packed, and those frames never reach the model.
 longer than `diagnostics.max_acceptable_consecutive_delay_ms`. It reports "waiting" until the
 first inference completes, and carries a per-stage breakdown of the thresholded cycle —
 `preprocess_time_ms`, `inference_time_ms` and `postprocess_time_ms`, mirroring the
-`latency/preprocess`, `latency/inference` and `latency/inference/postprocess` debug topics — so
-an over-budget `processing_time_ms` can be localized without enabling `debug_mode`. The stages
-do not add up to the total: `postprocess_time_ms` is measured inside the `inference_time_ms`
-window, and `preprocess_time_ms` is the cost of a single image rather than the sum over the
-cameras — compare them against their own history instead.
+`latency/preprocess`, `latency/inference` and `latency/postprocess` debug topics — so an
+over-budget `processing_time_ms` can be localized without enabling `debug_mode`.
+
+`inference_time_ms` (the model forward pass) and `postprocess_time_ms` (bbox decode and NMS)
+are disjoint stages. `preprocess_time_ms` however is the cost of a single image rather than the
+sum over the cameras, and the total is started from the anchor camera's callback, so
+preprocessing done in the other cameras' callbacks falls outside it — the stages do not add up
+to `processing_time_ms`; compare `preprocess_time_ms` against its own history instead.
 
 The newest published detection is reported under both clocks, because `processing_time_ms` only
 covers the work done inside the node:

--- a/perception/autoware_camera_streampetr/README.md
+++ b/perception/autoware_camera_streampetr/README.md
@@ -85,9 +85,17 @@ All `latency/*` topics are published only when `debug_mode` is enabled.
 
 ### Diagnostics
 
-Published on `/diagnostics` regardless of `debug_mode`, from a timer-driven updater (period
-`diagnostics.validation_callback_interval_ms`, hardware_id = the node name), so it keeps
-reporting when the cameras stop — precisely the condition it exists for.
+Published on `/diagnostics` regardless of `debug_mode`. Both statuses are tasks of one
+timer-driven updater (period `diagnostics.validation_callback_interval_ms`, hardware_id = the
+node name), so they keep reporting when the cameras or the inference stop — precisely the
+conditions they exist for — and always arrive in the same `/diagnostics` message. One status per
+failure mode, so a diagnostic graph can route input trouble and processing-time trouble to
+different paths.
+
+| Name                     | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| `camera_status`          | Per-camera input availability, staleness and validity |
+| `processing_time_status` | Per-cycle processing-time watchdog                    |
 
 `camera_status` reports three key/values per camera — the resolved input `cameraN/topic` (the
 model input index and the physical camera differ on every deployment), `cameraN/image_age_ms`
@@ -119,6 +127,32 @@ The summary level is the worst camera state; additionally an inter-camera stamp 
 `rejected` and `stale` are `ERROR` rather than `WARN` because neither recovers until the
 publisher is fixed: a rejected camera publishes an encoding other than `rgb8`/`bgr8`, or a buffer
 that is not densely packed, and those frames never reach the model.
+
+`processing_time_status` reports `WARN` once a cycle exceeds
+`diagnostics.max_allowed_processing_time_ms`, escalating to `ERROR` if it stays over budget for
+longer than `diagnostics.max_acceptable_consecutive_delay_ms`. It reports "waiting" until the
+first inference completes, and carries a per-stage breakdown of the thresholded cycle —
+`preprocess_time_ms`, `inference_time_ms` and `postprocess_time_ms`, mirroring the
+`latency/preprocess`, `latency/inference` and `latency/inference/postprocess` debug topics — so
+an over-budget `processing_time_ms` can be localized without enabling `debug_mode`. The stages
+do not add up to the total: `postprocess_time_ms` is measured inside the `inference_time_ms`
+window, and `preprocess_time_ms` is the cost of a single image rather than the sum over the
+cameras — compare them against their own history instead.
+
+The newest published detection is reported under both clocks, because `processing_time_ms` only
+covers the work done inside the node:
+
+| Key                          | Description                                                                                               |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `last_frame_timestamp`       | Header stamp the detections were computed for (the sensing instant)                                       |
+| `last_published_timestamp`   | Node-clock instant at which they left the node                                                            |
+| `output_latency_ms`          | The difference: end-to-end latency, including the camera transport and the decode queue ahead of the node |
+| `time_since_last_publish_ms` | Age of `last_published_timestamp`, i.e. how long since the node last produced objects                     |
+
+These are observational only — the level is still decided by the processing-time thresholds
+alone. Comparing a node clock against a header stamp requires both to share a time base, so a
+rosbag replay has to publish `/clock` and the node has to run with `use_sim_time` for
+`output_latency_ms` and `time_since_last_publish_ms` to be meaningful.
 
 ## Parameters
 
@@ -169,6 +203,8 @@ Example polygon files: `config/camera9_polygons.yaml`, `config/camera10_polygons
 - `anchor_camera_id`: ID of the anchor camera for synchronization (default: 0)
 - `debug_mode`: Enable debug mode for timing measurements
 - `build_only`: Build TensorRT engines and exit without running inference
+- `diagnostics.max_allowed_processing_time_ms`: Per-cycle processing-time budget; exceeding it raises a `WARN` (default: 200.0)
+- `diagnostics.max_acceptable_consecutive_delay_ms`: How long the processing time may stay over budget before the `WARN` escalates to an `ERROR` (default: 1000.0)
 - `diagnostics.max_image_age_ms`: A camera whose newest frame is older than this is reported as stalled at `ERROR` level (default: 300.0)
 - `diagnostics.validation_callback_interval_ms`: Interval of the diagnostic callbacks (default: 100.0)
 

--- a/perception/autoware_camera_streampetr/README.md
+++ b/perception/autoware_camera_streampetr/README.md
@@ -62,10 +62,10 @@ No                  Yes                                                         
 
 ### Input
 
-| Name                          | Type                                                             | Description                                                     |
-| ----------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------- |
-| `~/input/camera*/image`       | `sensor_msgs::msg::Image` or `sensor_msgs::msg::CompressedImage` | Input image topics (supports both compressed and uncompressed). |
-| `~/input/camera*/camera_info` | `sensor_msgs::msg::CameraInfo`                                   | Input camera info topics, for camera parameters.                |
+| Name                          | Type                           | Description                                                                                                                |
+| ----------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `~/input/camera*/image`       | `sensor_msgs::msg::Image`      | Input image topics, subscribed via `image_transport` (`raw` or `compressed` transport, selected by `is_compressed_image`). |
+| `~/input/camera*/camera_info` | `sensor_msgs::msg::CameraInfo` | Input camera info topics, for camera parameters.                                                                           |
 
 ### Output
 
@@ -124,7 +124,7 @@ Example polygon files: `config/camera9_polygons.yaml`, `config/camera10_polygons
 
 - `max_camera_time_diff`: Maximum allowed time difference between cameras (seconds)
 - `rois_number`: Number of camera ROIs/cameras (default: 6)
-- `is_compressed_image`: Whether input images are compressed
+- `is_compressed_image`: Whether to subscribe with the `compressed` image transport instead of `raw`
 - `is_distorted_image`: Whether input images are distorted
 - `multithreading`: Whether to use multithreading for handling image callbacks
 - `anchor_camera_id`: ID of the anchor camera for synchronization (default: 0)

--- a/perception/autoware_camera_streampetr/config/camera_streampetr.param.yaml
+++ b/perception/autoware_camera_streampetr/config/camera_streampetr.param.yaml
@@ -7,6 +7,11 @@
     is_compressed_image: false # Whether the input images are compressed
     is_distorted_image: false # Whether the input images are distorted
     ego_mask.fill_value_rgb: [0.0, 0.0, 0.0] # RGB order, matching the model input and the rgb8 camera encoding
+    diagnostics:
+      # A camera whose newest frame is older than this raises an ERROR (mid-run stall). Cameras
+      # that have not delivered a first frame yet only raise a WARN (normal during start-up).
+      max_image_age_ms: 300.0
+      validation_callback_interval_ms: 100.0 # Interval of the diagnostic callbacks.
     camera_mask.camera_ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     camera_0_mask:
       enable: false

--- a/perception/autoware_camera_streampetr/config/camera_streampetr.param.yaml
+++ b/perception/autoware_camera_streampetr/config/camera_streampetr.param.yaml
@@ -8,10 +8,14 @@
     is_distorted_image: false # Whether the input images are distorted
     ego_mask.fill_value_rgb: [0.0, 0.0, 0.0] # RGB order, matching the model input and the rgb8 camera encoding
     diagnostics:
+      max_allowed_processing_time_ms: 200.0 # A cycle slower than this raises a WARN.
+      # If the processing time stays above max_allowed_processing_time_ms for longer than
+      # max_acceptable_consecutive_delay_ms, the WARN escalates to an ERROR.
+      max_acceptable_consecutive_delay_ms: 1000.0
       # A camera whose newest frame is older than this raises an ERROR (mid-run stall). Cameras
       # that have not delivered a first frame yet only raise a WARN (normal during start-up).
       max_image_age_ms: 300.0
-      validation_callback_interval_ms: 100.0 # Interval of the diagnostic callbacks.
+      validation_callback_interval_ms: 100.0 # Interval of both diagnostic callbacks.
     camera_mask.camera_ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     camera_0_mask:
       enable: false

--- a/perception/autoware_camera_streampetr/config/camera_streampetr.param.yaml
+++ b/perception/autoware_camera_streampetr/config/camera_streampetr.param.yaml
@@ -6,7 +6,7 @@
     anchor_camera_id: 0 # Camera id of the anchor topic. The forward pass begins once every anchor camera topic reaches.
     is_compressed_image: false # Whether the input images are compressed
     is_distorted_image: false # Whether the input images are distorted
-    ego_mask.fill_value_bgr: [0.0, 0.0, 0.0]
+    ego_mask.fill_value_rgb: [0.0, 0.0, 0.0] # RGB order, matching the model input and the rgb8 camera encoding
     camera_mask.camera_ids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     camera_0_mask:
       enable: false

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_data_store.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_data_store.hpp
@@ -84,8 +84,6 @@ private:
   // Helper methods for update_camera_image
   ImageProcessingParams calculate_image_processing_params(
     const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg) const;
-  // swap_rb tells both of these that the source buffer is BGR, which the ego mask needs in order
-  // to paint its configured fill colour in the right channel order.
   std::unique_ptr<Tensor> process_distorted_image(
     const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg,
     ImageProcessingParams & params, const bool swap_rb);
@@ -105,7 +103,7 @@ private:
 
   // Validates that the message can be fed to the model and reports whether the preprocessing
   // kernel has to swap R/B. Returns false if the frame must be dropped.
-  bool resolve_channel_order(
+  bool validate_channel_order(
     const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg, bool & swap_rb);
 
   const size_t rois_number_;
@@ -117,6 +115,7 @@ private:
   const bool is_distorted_image_;
 
   rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
   std::vector<CameraInfo::ConstSharedPtr> camera_info_list_;
   std::shared_ptr<Tensor> image_input_;
   std::shared_ptr<Tensor> image_input_mean_;
@@ -135,10 +134,6 @@ private:
   std::vector<int> ego_mask_width_;
   std::vector<int> ego_mask_height_;
   std::vector<bool> ego_mask_built_;
-
-  // Drives the throttled errors for images the model cannot consume, which would otherwise be
-  // logged at frame rate. Steady time so throttling is unaffected by simulated or jumping clocks.
-  rclcpp::Clock throttle_clock_{RCL_STEADY_TIME};
 
   // multithreading variables
   mutable std::mutex freeze_mutex_;

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_data_store.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_data_store.hpp
@@ -54,6 +54,7 @@ public:
   bool check_if_all_camera_image_received() const;
   bool check_if_all_camera_info_received() const;
   float check_if_all_images_synced() const;
+  std::string get_missing_camera_status() const;
   float get_preprocess_time_ms() const;
   std::vector<float> get_camera_info_vector() const;
   std::shared_ptr<cuda::Tensor> get_image_input() const;
@@ -83,12 +84,14 @@ private:
   // Helper methods for update_camera_image
   ImageProcessingParams calculate_image_processing_params(
     const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg) const;
+  // swap_rb tells both of these that the source buffer is BGR, which the ego mask needs in order
+  // to paint its configured fill colour in the right channel order.
   std::unique_ptr<Tensor> process_distorted_image(
     const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg,
-    ImageProcessingParams & params);
+    ImageProcessingParams & params, const bool swap_rb);
   std::unique_ptr<Tensor> process_regular_image(
     const Image::ConstSharedPtr & input_camera_image_msg, const ImageProcessingParams & params,
-    const int camera_id);
+    const int camera_id, const bool swap_rb);
   void update_metadata_and_timing(
     const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg,
     const std::chrono::high_resolution_clock::time_point & start_time);
@@ -99,6 +102,11 @@ private:
   void copy_ego_mask_gpu(
     const int camera_id, const std::vector<std::uint8_t> & raster, const int width,
     const int height);
+
+  // Validates that the message can be fed to the model and reports whether the preprocessing
+  // kernel has to swap R/B. Returns false if the frame must be dropped.
+  bool resolve_channel_order(
+    const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg, bool & swap_rb);
 
   const size_t rois_number_;
   const int image_height_;
@@ -127,6 +135,10 @@ private:
   std::vector<int> ego_mask_width_;
   std::vector<int> ego_mask_height_;
   std::vector<bool> ego_mask_built_;
+
+  // Drives the throttled errors for images the model cannot consume, which would otherwise be
+  // logged at frame rate. Steady time so throttling is unaffected by simulated or jumping clocks.
+  rclcpp::Clock throttle_clock_{RCL_STEADY_TIME};
 
   // multithreading variables
   mutable std::mutex freeze_mutex_;

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_data_store.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_data_store.hpp
@@ -54,7 +54,6 @@ public:
   bool check_if_all_camera_image_received() const;
   bool check_if_all_camera_info_received() const;
   float check_if_all_images_synced() const;
-  std::string get_missing_camera_status() const;
   float get_preprocess_time_ms() const;
   std::vector<float> get_camera_info_vector() const;
   std::shared_ptr<cuda::Tensor> get_image_input() const;
@@ -101,9 +100,12 @@ private:
     const int camera_id, const std::vector<std::uint8_t> & raster, const int width,
     const int height);
 
-  // Validates that the message can be fed to the model and reports whether the preprocessing
-  // kernel has to swap R/B. Returns false if the frame must be dropped.
-  bool validate_channel_order(
+  // Entrance check for every incoming frame: validates the encoding (rgb8/bgr8, reporting via
+  // swap_rb whether the preprocessing kernel has to swap R/B) and the buffer geometry. Both
+  // upload paths cudaMemcpyAsync exactly height * width * 3 densely packed bytes out of the
+  // message, so a padded row stride would silently shear the image and a truncated buffer would
+  // be a host-side out-of-bounds read. Returns false if the frame must be dropped.
+  bool validate_image_message(
     const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg, bool & swap_rb);
 
   const size_t rois_number_;

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_data_store.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_data_store.hpp
@@ -23,6 +23,7 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
 #include <memory>
@@ -42,6 +43,21 @@ class CameraDataStore
   using Tensor = cuda::Tensor;
 
 public:
+  // Per-camera health snapshot, consumed by the node's diagnostics publisher.
+  struct CameraStatus
+  {
+    bool camera_info_received{false};
+    bool image_received{false};
+    // The most recent frame was dropped by validate_image_message(): the camera publishes an
+    // encoding or a buffer geometry the preprocessing cannot consume, so it never reaches the
+    // model. Sticky until a valid frame arrives.
+    bool input_rejected{false};
+    // Header stamp of the most recent accepted frame, in epoch seconds; -1.0 until the first
+    // frame arrives. Lets the diagnostics detect a camera that stopped publishing mid-run,
+    // which the sticky image_received flag alone cannot.
+    double last_image_timestamp{-1.0};
+  };
+
   CameraDataStore(
     rclcpp::Node * node, const int rois_number, const int image_height, const int image_width,
     const int anchor_camera_id, const bool is_distorted_image,
@@ -54,6 +70,7 @@ public:
   bool check_if_all_camera_image_received() const;
   bool check_if_all_camera_info_received() const;
   float check_if_all_images_synced() const;
+  std::vector<CameraStatus> get_camera_status() const;
   float get_preprocess_time_ms() const;
   std::vector<float> get_camera_info_vector() const;
   std::shared_ptr<cuda::Tensor> get_image_input() const;
@@ -118,6 +135,9 @@ private:
 
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
+  // Written by validate_image_message() on each camera's own callback thread and read by the
+  // node thread when it publishes diagnostics, so the elements are atomic. One entry per ROI.
+  std::vector<std::atomic<bool>> input_rejected_;
   std::vector<CameraInfo::ConstSharedPtr> camera_info_list_;
   std::shared_ptr<Tensor> image_input_;
   std::shared_ptr<Tensor> image_input_mean_;

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_ego_mask.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/camera_ego_mask.hpp
@@ -35,13 +35,13 @@ struct EgoMaskPolygon
 struct EgoMaskRoiConfig
 {
   std::vector<EgoMaskPolygon> polygons;
-  std::array<std::uint8_t, 3> fill_bgr{0, 0, 0};
+  std::array<std::uint8_t, 3> fill_rgb{0, 0, 0};
 };
 
 struct EgoMaskParams
 {
   bool enabled{false};
-  std::array<std::uint8_t, 3> fill_bgr{0, 0, 0};
+  std::array<std::uint8_t, 3> fill_rgb{0, 0, 0};
   std::vector<std::string> roi_polygons_yaml;
   std::vector<std::optional<EgoMaskRoiConfig>> roi_mask_configs;
 };
@@ -57,9 +57,11 @@ std::vector<EgoMaskPolygon> parsePolygonsYamlText(const std::string & yaml_text)
 std::vector<std::uint8_t> buildEgoMaskRaster(
   const std::vector<EgoMaskPolygon> & polygons, int width, int height);
 
+// The fill is written channel by channel, so it must already be in the same order as the image
+// buffer; see fill_in_source_order() in camera_data_store.cpp.
 cudaError_t applyEgoMask_launch(
-  std::uint8_t * image_bgr, const std::uint8_t * mask, int height, int width, std::uint8_t fill_b,
-  std::uint8_t fill_g, std::uint8_t fill_r, cudaStream_t stream);
+  std::uint8_t * image, const std::uint8_t * mask, int height, int width, std::uint8_t fill_c0,
+  std::uint8_t fill_c1, std::uint8_t fill_c2, cudaStream_t stream);
 
 }  // namespace autoware::camera_streampetr
 

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/network.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/network.hpp
@@ -15,7 +15,6 @@
 #ifndef AUTOWARE__CAMERA_STREAMPETR__NETWORK__NETWORK_HPP_
 #define AUTOWARE__CAMERA_STREAMPETR__NETWORK__NETWORK_HPP_
 
-#include <image_transport/image_transport.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/network.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/network.hpp
@@ -196,10 +196,14 @@ public:
   explicit StreamPetrNetwork(const NetworkConfig & config);
 
   ~StreamPetrNetwork();
-  void inference_detector(
-    const InferenceInputs & inputs,
-    std::vector<autoware_perception_msgs::msg::DetectedObject> & output_objects,
-    std::vector<float> & forward_time_ms);
+
+  // Runs the model only; returns with the stream synchronized. Detections are decoded by the
+  // separate postprocess() so the caller can time the two as disjoint stages.
+  void inference_detector(const InferenceInputs & inputs, std::vector<float> & forward_time_ms);
+
+  // Decodes the head's output bindings into detections. Reads no camera input, so the caller may
+  // unfreeze the camera store before calling this.
+  void postprocess(std::vector<autoware_perception_msgs::msg::DetectedObject> & output_objects);
 
   void wipe_memory();
 
@@ -217,8 +221,6 @@ private:
   void initializePositionEmbedding(const InferenceInputs & inputs);
   void executeBackbone(const InferenceInputs & inputs);
   void executePtsHead(const InferenceInputs & inputs);
-  void executePostprocessing(
-    std::vector<autoware_perception_msgs::msg::DetectedObject> & output_objects);
 
   NetworkConfig config_;
   std::shared_ptr<Logger> logger_;
@@ -230,7 +232,6 @@ private:
   std::unique_ptr<Duration> dur_backbone_;
   std::unique_ptr<Duration> dur_ptshead_;
   std::unique_ptr<Duration> dur_pos_embed_;
-  std::unique_ptr<Duration> dur_postprocess_;
 
   std::unique_ptr<PostprocessCuda> postprocess_cuda_;
   NonMaximumSuppression iou_bev_nms_;

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/preprocess.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/network/preprocess.hpp
@@ -21,12 +21,15 @@ namespace autoware::camera_streampetr
 {
 cudaError_t resizeAndExtractRoi_launch(
   const std::uint8_t * input_img, float * output_img,
-  int camera_offset,         // Camera offset in the input image
-  int H, int W,              // Original image dimensions
-  int H2, int W2,            // Resized image dimensions
-  int H3, int W3,            // ROI dimensions
-  int y_start, int x_start,  // ROI top-left coordinates in resized image
-  const float * channel_wise_mean, const float * channel_wise_std, cudaStream_t stream);
+  int camera_offset,                // Camera offset in the input image
+  int H, int W,                     // Original image dimensions
+  int H2, int W2,                   // Resized image dimensions
+  int H3, int W3,                   // ROI dimensions
+  int y_start, int x_start,         // ROI top-left coordinates in resized image
+  const float * channel_wise_mean,  // 3 floats, RGB order (model channel order)
+  const float * channel_wise_std,   // 3 floats, RGB order (model channel order)
+  bool swap_rb,                     // Source buffer is BGR: exchange channels 0 and 2
+  cudaStream_t stream);
 
 cudaError_t remap_launch(
   const std::uint8_t * input_img, std::uint8_t * output_img, int output_height,

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
@@ -22,13 +22,13 @@
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <image_transport/image_transport.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
-#include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
@@ -58,7 +58,6 @@ namespace autoware::camera_streampetr
 class StreamPetrNode : public rclcpp::Node
 {
   using Image = sensor_msgs::msg::Image;
-  using CompressedImage = sensor_msgs::msg::CompressedImage;
   using CameraInfo = sensor_msgs::msg::CameraInfo;
   using DetectedObjects = autoware_perception_msgs::msg::DetectedObjects;
   using DetectedObject = autoware_perception_msgs::msg::DetectedObject;
@@ -69,8 +68,6 @@ public:
 private:
   void camera_info_callback(CameraInfo::ConstSharedPtr input_camera_info_msg, const int camera_id);
   void camera_image_callback(Image::ConstSharedPtr input_camera_image_msg, const int camera_id);
-  void compressed_image_callback(
-    CompressedImage::ConstSharedPtr input_compressed_image_msg, const int camera_id);
 
   void step(const rclcpp::Time & stamp);
 
@@ -115,8 +112,7 @@ private:
   const bool multithreading_;
   std::vector<rclcpp::CallbackGroup::SharedPtr> camera_callback_groups_;
 
-  std::vector<rclcpp::Subscription<Image>::SharedPtr> camera_image_subs_;
-  std::vector<rclcpp::Subscription<CompressedImage>::SharedPtr> compressed_image_subs_;
+  std::vector<image_transport::Subscriber> camera_image_subs_;
   rclcpp::Publisher<DetectedObjects>::SharedPtr pub_objects_;
 
   tf2_ros::Buffer tf_buffer_;

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
@@ -22,13 +22,13 @@
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
-#include <image_transport/image_transport.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
@@ -58,6 +58,7 @@ namespace autoware::camera_streampetr
 class StreamPetrNode : public rclcpp::Node
 {
   using Image = sensor_msgs::msg::Image;
+  using CompressedImage = sensor_msgs::msg::CompressedImage;
   using CameraInfo = sensor_msgs::msg::CameraInfo;
   using DetectedObjects = autoware_perception_msgs::msg::DetectedObjects;
   using DetectedObject = autoware_perception_msgs::msg::DetectedObject;
@@ -68,6 +69,8 @@ public:
 private:
   void camera_info_callback(CameraInfo::ConstSharedPtr input_camera_info_msg, const int camera_id);
   void camera_image_callback(Image::ConstSharedPtr input_camera_image_msg, const int camera_id);
+  void compressed_image_callback(
+    CompressedImage::ConstSharedPtr input_compressed_image_msg, const int camera_id);
 
   void step(const rclcpp::Time & stamp);
 
@@ -112,7 +115,8 @@ private:
   const bool multithreading_;
   std::vector<rclcpp::CallbackGroup::SharedPtr> camera_callback_groups_;
 
-  std::vector<image_transport::Subscriber> camera_image_subs_;
+  std::vector<rclcpp::Subscription<Image>::SharedPtr> camera_image_subs_;
+  std::vector<rclcpp::Subscription<CompressedImage>::SharedPtr> compressed_image_subs_;
   rclcpp::Publisher<DetectedObjects>::SharedPtr pub_objects_;
 
   tf2_ros::Buffer tf_buffer_;

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
@@ -79,14 +79,23 @@ private:
   void reset_system_state();
   bool prepare_inference_data(const rclcpp::Time & stamp);
   void cleanup_on_failure();
-  std::optional<std::tuple<
-    std::vector<autoware_perception_msgs::msg::DetectedObject>, std::vector<float>, double>>
-  perform_inference();
+  // One cycle's detections and timing. inference_time_ms and postprocess_time_ms are disjoint
+  // stages: the network API splits the two calls, and each gets its own stopwatch window.
+  struct InferenceResult
+  {
+    std::vector<autoware_perception_msgs::msg::DetectedObject> objects;
+    std::vector<float> forward_time_ms;  // per subnetwork: backbone, ptshead, pos_embed
+    double inference_time_ms;
+    double postprocess_time_ms;
+  };
+  std::optional<InferenceResult> perform_inference();
   InferenceInputs create_inference_inputs();
   void publish_detection_results(
     const rclcpp::Time & stamp,
     const std::vector<autoware_perception_msgs::msg::DetectedObject> & output_objects);
-  void publish_debug_metrics(const std::vector<float> & forward_time_ms, double inference_time_ms);
+  void publish_debug_metrics(
+    const std::vector<float> & forward_time_ms, double inference_time_ms,
+    double postprocess_time_ms);
 
   // Per-camera input health (waiting / rejected / stale / active). Timer driven rather than
   // published from a camera callback: a dead camera must not silence the very diagnostic that

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
@@ -93,6 +93,19 @@ private:
   // would report it.
   void diagnose_camera_status(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
+  // Processing-time watchdog, mirroring autoware_bevfusion: WARN once a cycle exceeds the
+  // configured budget, escalating to ERROR if it stays over budget continuously.
+  void diagnose_processing_time(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void add_no_inference_diagnostics(
+    diagnostic_updater::DiagnosticStatusWrapper & stat, std::stringstream & message);
+  diagnostic_msgs::msg::DiagnosticStatus::_level_type check_processing_time_status(
+    diagnostic_updater::DiagnosticStatusWrapper & stat, std::stringstream & message,
+    const rclcpp::Time & timestamp_now);
+  diagnostic_msgs::msg::DiagnosticStatus::_level_type check_consecutive_delays(
+    diagnostic_updater::DiagnosticStatusWrapper & stat, std::stringstream & message,
+    const rclcpp::Time & timestamp_now,
+    diagnostic_msgs::msg::DiagnosticStatus::_level_type current_level);
+
   std::optional<std::pair<std::vector<float>, std::vector<float>>> get_ego_pose_vector(
     const rclcpp::Time & stamp);
   std::optional<std::vector<float>> get_camera_extrinsics_vector();
@@ -144,16 +157,32 @@ private:
   float current_prediction_timestamp_;
 
   // debugger
-  std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{nullptr};
+  // Always on: the processing-time watchdog reads the per-cycle total even when the debug
+  // topics are disabled. Only the publisher stays gated behind debug_mode_.
+  autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
   std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_ptr_{nullptr};
   const bool debug_mode_;
 
-  // diagnostics: timer driven, so the camera status keeps reporting when the cameras stop --
-  // precisely the condition it exists for.
+  // diagnostics: one updater, two tasks (camera_status and processing_time_status), so both
+  // statuses are timer driven and always arrive in the same /diagnostics message.
   diagnostic_updater::Updater diagnostic_updater_{this};
+  double max_allowed_processing_time_ms_;
+  double max_acceptable_consecutive_delay_ms_;
   // A camera whose newest frame is older than this (node clock minus header stamp) is reported
   // as stalled at ERROR level; cameras that have not delivered a first frame yet stay a WARN.
   double max_image_age_ms_;
+  // Unset until the first successful inference, which the watchdog reports as "waiting" rather
+  // than as a violation.
+  std::optional<double> last_processing_time_ms_;
+  // Per-stage breakdown of the cycle behind last_processing_time_ms_, latched together with it.
+  double last_preprocess_time_ms_{0.0};
+  double last_inference_time_ms_{0.0};
+  double last_postprocess_time_ms_{0.0};
+  std::optional<rclcpp::Time> last_in_time_processing_timestamp_;
+  // The most recent published detection under both clocks: the header stamp it was computed for
+  // (the sensing instant) and the node-clock instant it left the node.
+  std::optional<rclcpp::Time> last_output_frame_stamp_;
+  std::optional<rclcpp::Time> last_publish_stamp_;
 };
 
 }  // namespace autoware::camera_streampetr

--- a/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
+++ b/perception/autoware_camera_streampetr/include/autoware/camera_streampetr/node.hpp
@@ -22,10 +22,12 @@
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <image_transport/image_transport.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -47,6 +49,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -85,6 +88,11 @@ private:
     const std::vector<autoware_perception_msgs::msg::DetectedObject> & output_objects);
   void publish_debug_metrics(const std::vector<float> & forward_time_ms, double inference_time_ms);
 
+  // Per-camera input health (waiting / rejected / stale / active). Timer driven rather than
+  // published from a camera callback: a dead camera must not silence the very diagnostic that
+  // would report it.
+  void diagnose_camera_status(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
   std::optional<std::pair<std::vector<float>, std::vector<float>>> get_ego_pose_vector(
     const rclcpp::Time & stamp);
   std::optional<std::vector<float>> get_camera_extrinsics_vector();
@@ -113,6 +121,10 @@ private:
   std::vector<rclcpp::CallbackGroup::SharedPtr> camera_callback_groups_;
 
   std::vector<image_transport::Subscriber> camera_image_subs_;
+  // Resolved image topic per model input index, surfaced by the camera_status diagnostic: the
+  // model index (camera0..N) and the physical camera topic differ on every deployment, and the
+  // mapping otherwise lives only in launch-file remaps.
+  std::vector<std::string> camera_image_topics_;
   rclcpp::Publisher<DetectedObjects>::SharedPtr pub_objects_;
 
   tf2_ros::Buffer tf_buffer_;
@@ -135,6 +147,13 @@ private:
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{nullptr};
   std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_ptr_{nullptr};
   const bool debug_mode_;
+
+  // diagnostics: timer driven, so the camera status keeps reporting when the cameras stop --
+  // precisely the condition it exists for.
+  diagnostic_updater::Updater diagnostic_updater_{this};
+  // A camera whose newest frame is older than this (node clock minus header stamp) is reported
+  // as stalled at ERROR level; cameras that have not delivered a first frame yet stay a WARN.
+  double max_image_age_ms_;
 };
 
 }  // namespace autoware::camera_streampetr

--- a/perception/autoware_camera_streampetr/launch/streampetr.launch.xml
+++ b/perception/autoware_camera_streampetr/launch/streampetr.launch.xml
@@ -7,17 +7,11 @@
 
   <arg name="is_compressed_image" default="false" description="whether the input image is compressed"/>
 
-  <let name="compressed_suffix" value="$(eval &quot;'/compressed' if '$(var is_compressed_image)' == 'true' else ''&quot;)"/>
-  <let name="camera0_topic" value="/sensing/camera/camera0/image_rect_color$(var compressed_suffix)"/>
-  <let name="camera1_topic" value="/sensing/camera/camera1/image_rect_color$(var compressed_suffix)"/>
-  <let name="camera2_topic" value="/sensing/camera/camera2/image_rect_color$(var compressed_suffix)"/>
-  <let name="camera3_topic" value="/sensing/camera/camera3/image_rect_color$(var compressed_suffix)"/>
-  <let name="camera4_topic" value="/sensing/camera/camera4/image_rect_color$(var compressed_suffix)"/>
-
   <node pkg="autoware_camera_streampetr" exec="autoware_camera_streampetr_node" name="stream_petr" output="screen">
     <param from="$(var model_param_path)" allow_substs="true"/>
     <param from="$(var node_param_path)" allow_substs="true"/>
     <param name="build_only" value="$(var build_only)"/>
+    <param name="is_compressed_image" value="$(var is_compressed_image)"/>
 
     <!-- Image of ~/input/camera_i will be the ith image in the model input -->
     <remap from="~/input/camera0/camera_info" to="/sensing/camera/camera0/camera_info"/>
@@ -26,10 +20,13 @@
     <remap from="~/input/camera3/camera_info" to="/sensing/camera/camera3/camera_info"/>
     <remap from="~/input/camera4/camera_info" to="/sensing/camera/camera4/camera_info"/>
 
-    <remap from="~/input/camera0/image$(var compressed_suffix)" to="$(var camera0_topic)"/>
-    <remap from="~/input/camera1/image$(var compressed_suffix)" to="$(var camera1_topic)"/>
-    <remap from="~/input/camera2/image$(var compressed_suffix)" to="$(var camera2_topic)"/>
-    <remap from="~/input/camera3/image$(var compressed_suffix)" to="$(var camera3_topic)"/>
-    <remap from="~/input/camera4/image$(var compressed_suffix)" to="$(var camera4_topic)"/>
+    <!-- Remap only the base image topic; image_transport appends the transport suffix (e.g.
+         /compressed) after the node resolves the remapped base topic, please check
+         https://github.com/ros-perception/image_transport_plugins/issues/155 -->
+    <remap from="~/input/camera0/image" to="/sensing/camera/camera0/image_rect_color"/>
+    <remap from="~/input/camera1/image" to="/sensing/camera/camera1/image_rect_color"/>
+    <remap from="~/input/camera2/image" to="/sensing/camera/camera2/image_rect_color"/>
+    <remap from="~/input/camera3/image" to="/sensing/camera/camera3/image_rect_color"/>
+    <remap from="~/input/camera4/image" to="/sensing/camera/camera4/image_rect_color"/>
   </node>
 </launch>

--- a/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
+++ b/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
@@ -47,20 +47,16 @@ algebra operations. */
 namespace autoware::camera_streampetr
 {
 
-// A camera publishing images the model cannot consume does so on every frame, so the errors are
-// throttled to this period.
-static constexpr int kInvalidInputLogPeriodMs = 5000;
-
 // The ego mask is painted into the raw camera buffer, whose channel order follows the input
-// encoding, while the configured fill colour is always BGR. Reorder it for an RGB source so the
+// encoding, while the configured fill colour is always RGB. Reorder it for a BGR source so the
 // masked region ends up the colour that was actually configured.
 static std::array<std::uint8_t, 3> fill_in_source_order(
-  const std::array<std::uint8_t, 3> & fill_bgr, const bool source_is_bgr)
+  const std::array<std::uint8_t, 3> & fill_rgb, const bool source_is_bgr)
 {
   if (source_is_bgr) {
-    return fill_bgr;
+    return {fill_rgb[2], fill_rgb[1], fill_rgb[0]};
   }
-  return {fill_bgr[2], fill_bgr[1], fill_bgr[0]};
+  return fill_rgb;
 }
 
 // Helper struct for camera matrices (local to this file)
@@ -132,7 +128,8 @@ CameraDataStore::CameraDataStore(
   anchor_camera_id_(anchor_camera_id),
   preprocess_time_ms_(0.0f),
   is_distorted_image_(is_distorted_image),
-  logger_(node->get_logger())
+  logger_(node->get_logger()),
+  clock_(node->get_clock())
 {
   image_input_ = std::make_shared<Tensor>(
     "image_input", nvinfer1::Dims{5, {1, rois_number, 3, image_height, image_width}},
@@ -187,7 +184,7 @@ void CameraDataStore::update_camera_image(
 {
   // Keep this above ++active_updates_ below, so an early return here has no counter to decrement.
   bool swap_rb = false;
-  if (!resolve_channel_order(camera_id, input_camera_image_msg, swap_rb)) {
+  if (!validate_channel_order(camera_id, input_camera_image_msg, swap_rb)) {
     return;
   }
 
@@ -253,7 +250,7 @@ void CameraDataStore::update_camera_image(
   }
 }
 
-bool CameraDataStore::resolve_channel_order(
+bool CameraDataStore::validate_channel_order(
   const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg, bool & swap_rb)
 {
   const std::string & encoding = input_camera_image_msg->encoding;
@@ -266,7 +263,7 @@ bool CameraDataStore::resolve_channel_order(
     // Anything else (mono, bayer, 16-bit, alpha) has a different channel count or stride, so the
     // fixed 3-byte-per-pixel upload below would misread the buffer.
     RCLCPP_ERROR_THROTTLE(
-      logger_, throttle_clock_, kInvalidInputLogPeriodMs,
+      logger_, *clock_, 10000 /* ms */,
       "Camera %d publishes unsupported encoding '%s'. Only 'rgb8' and 'bgr8' can be fed to the "
       "model; dropping frames from this camera.",
       camera_id, encoding.c_str());
@@ -281,7 +278,7 @@ bool CameraDataStore::resolve_channel_order(
     input_camera_image_msg->step != row_bytes ||
     input_camera_image_msg->data.size() < expected_size) {
     RCLCPP_ERROR_THROTTLE(
-      logger_, throttle_clock_, kInvalidInputLogPeriodMs,
+      logger_, *clock_, 10000 /* ms */,
       "Camera %d publishes %ux%u '%s' with step %u and %zu bytes, but a densely packed buffer of "
       "step %zu and %zu bytes is required; dropping frames from this camera.",
       camera_id, input_camera_image_msg->width, input_camera_image_msg->height, encoding.c_str(),
@@ -376,7 +373,7 @@ std::unique_ptr<CameraDataStore::Tensor> CameraDataStore::process_distorted_imag
 
   if (ego_mask_built_[camera_id] && ego_mask_gpu_[camera_id]) {
     const auto & cfg = ego_mask_roi_configs_[camera_id].value();
-    const auto fill = fill_in_source_order(cfg.fill_bgr, swap_rb);
+    const auto fill = fill_in_source_order(cfg.fill_rgb, swap_rb);
     auto err_mask = applyEgoMask_launch(
       static_cast<std::uint8_t *>(image_input_tensor->ptr),
       static_cast<const std::uint8_t *>(ego_mask_gpu_[camera_id]->ptr), original_height,
@@ -405,7 +402,7 @@ std::unique_ptr<CameraDataStore::Tensor> CameraDataStore::process_regular_image(
 
   if (ego_mask_built_[camera_id] && ego_mask_gpu_[camera_id]) {
     const auto & cfg = ego_mask_roi_configs_[camera_id].value();
-    const auto fill = fill_in_source_order(cfg.fill_bgr, swap_rb);
+    const auto fill = fill_in_source_order(cfg.fill_rgb, swap_rb);
     auto err_mask = applyEgoMask_launch(
       static_cast<std::uint8_t *>(image_input_tensor->ptr),
       static_cast<const std::uint8_t *>(ego_mask_gpu_[camera_id]->ptr), params.original_height,

--- a/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
+++ b/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
@@ -184,7 +184,7 @@ void CameraDataStore::update_camera_image(
 {
   // Keep this above ++active_updates_ below, so an early return here has no counter to decrement.
   bool swap_rb = false;
-  if (!validate_channel_order(camera_id, input_camera_image_msg, swap_rb)) {
+  if (!validate_image_message(camera_id, input_camera_image_msg, swap_rb)) {
     return;
   }
 
@@ -250,7 +250,7 @@ void CameraDataStore::update_camera_image(
   }
 }
 
-bool CameraDataStore::validate_channel_order(
+bool CameraDataStore::validate_image_message(
   const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg, bool & swap_rb)
 {
   const std::string & encoding = input_camera_image_msg->encoding;
@@ -270,8 +270,11 @@ bool CameraDataStore::validate_channel_order(
     return false;
   }
 
-  // Both upload paths copy height * width * 3 densely packed bytes straight out of the message,
-  // so a padded row stride would shear the image and a truncated buffer would read out of bounds.
+  // Both upload paths cudaMemcpyAsync exactly height * width * 3 densely packed bytes out of the
+  // message without looking at step, but sensor_msgs/Image permits a padded row stride
+  // (step > width * 3) and does not guarantee data is large enough. A padded stride would
+  // silently shear every row of the model input; a truncated buffer would make the copy a
+  // host-side out-of-bounds read.
   const size_t row_bytes = static_cast<size_t>(input_camera_image_msg->width) * 3;
   const size_t expected_size = static_cast<size_t>(input_camera_image_msg->height) * row_bytes;
   if (
@@ -516,36 +519,6 @@ bool CameraDataStore::check_if_all_camera_image_received() const
     }
   }
   return true;
-}
-
-std::string CameraDataStore::get_missing_camera_status() const
-{
-  std::string missing_camera_info;
-  std::string missing_camera_image;
-  const auto append = [](std::string & list, const std::string & item) {
-    if (!list.empty()) {
-      list += ", ";
-    }
-    list += item;
-  };
-
-  for (size_t camera_id = 0; camera_id < camera_info_list_.size(); ++camera_id) {
-    if (!camera_info_list_[camera_id]) {
-      append(missing_camera_info, std::to_string(camera_id));
-    }
-    if (camera_image_timestamp_[camera_id] < 0) {
-      append(missing_camera_image, std::to_string(camera_id));
-    }
-  }
-
-  std::string status;
-  if (!missing_camera_info.empty()) {
-    append(status, "camera_info not received: [" + missing_camera_info + "]");
-  }
-  if (!missing_camera_image.empty()) {
-    append(status, "image not received: [" + missing_camera_image + "]");
-  }
-  return status.empty() ? "all received" : status;
 }
 
 float CameraDataStore::check_if_all_images_synced() const

--- a/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
+++ b/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
@@ -30,8 +30,12 @@ module provides classes and functions for dense matrices and vectors, as well as
 algebra operations. */
 #include <Eigen/Dense>
 
+#include <sensor_msgs/image_encodings.hpp>
+
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <cstddef>
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
@@ -42,6 +46,22 @@ algebra operations. */
 
 namespace autoware::camera_streampetr
 {
+
+// A camera publishing images the model cannot consume does so on every frame, so the errors are
+// throttled to this period.
+static constexpr int kInvalidInputLogPeriodMs = 5000;
+
+// The ego mask is painted into the raw camera buffer, whose channel order follows the input
+// encoding, while the configured fill colour is always BGR. Reorder it for an RGB source so the
+// masked region ends up the colour that was actually configured.
+static std::array<std::uint8_t, 3> fill_in_source_order(
+  const std::array<std::uint8_t, 3> & fill_bgr, const bool source_is_bgr)
+{
+  if (source_is_bgr) {
+    return fill_bgr;
+  }
+  return {fill_bgr[2], fill_bgr[1], fill_bgr[0]};
+}
 
 // Helper struct for camera matrices (local to this file)
 struct CameraMatrices
@@ -119,12 +139,13 @@ CameraDataStore::CameraDataStore(
     nvinfer1::DataType::kFLOAT);  // {num_dims, batch_size, rois_number, num_channels, height,
                                   // width}
 
+  // RGB order, matching the model's input channel order.
   image_input_mean_ = std::make_shared<Tensor>(
     "image_input_mean", nvinfer1::Dims{1, {3}}, nvinfer1::DataType::kFLOAT);
-  image_input_mean_->load_from_vector({103.530, 116.280, 123.675});
+  image_input_mean_->load_from_vector({123.675, 116.280, 103.530});
   image_input_std_ =
     std::make_shared<Tensor>("image_input_std", nvinfer1::Dims{1, {3}}, nvinfer1::DataType::kFLOAT);
-  image_input_std_->load_from_vector({57.375, 57.120, 58.395});
+  image_input_std_->load_from_vector({58.395, 57.120, 57.375});
 
   camera_image_timestamp_ = std::vector<double>(rois_number, -1.0);
   camera_link_names_ = std::vector<std::string>(rois_number, "");
@@ -164,6 +185,12 @@ CameraDataStore::~CameraDataStore()
 void CameraDataStore::update_camera_image(
   const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg)
 {
+  // Keep this above ++active_updates_ below, so an early return here has no counter to decrement.
+  bool swap_rb = false;
+  if (!resolve_channel_order(camera_id, input_camera_image_msg, swap_rb)) {
+    return;
+  }
+
   {
     std::unique_lock<std::mutex> lock(freeze_mutex_);
     freeze_cv_.wait(lock, [&]() { return !is_frozen_; });  // Wait if frozen
@@ -182,9 +209,10 @@ void CameraDataStore::update_camera_image(
   // Process image based on distortion settings
   std::unique_ptr<Tensor> image_input_tensor;
   if (is_distorted_image_ && camera_info_list_[camera_id]) {
-    image_input_tensor = process_distorted_image(camera_id, input_camera_image_msg, params);
+    image_input_tensor =
+      process_distorted_image(camera_id, input_camera_image_msg, params, swap_rb);
   } else {
-    image_input_tensor = process_regular_image(input_camera_image_msg, params, camera_id);
+    image_input_tensor = process_regular_image(input_camera_image_msg, params, camera_id, swap_rb);
   }
 
   // Check if image processing failed
@@ -206,7 +234,7 @@ void CameraDataStore::update_camera_image(
     params.camera_offset, params.original_height, params.original_width, params.newH, params.newW,
     image_height_, image_width_, params.start_y, params.start_x,
     static_cast<const float *>(image_input_mean_->ptr),
-    static_cast<const float *>(image_input_std_->ptr), streams_.at(camera_id));
+    static_cast<const float *>(image_input_std_->ptr), swap_rb, streams_.at(camera_id));
 
   if (err != cudaSuccess) {
     RCLCPP_ERROR(
@@ -223,6 +251,45 @@ void CameraDataStore::update_camera_image(
       freeze_cv_.notify_all();  // Notify freeze_updates() to continue
     }
   }
+}
+
+bool CameraDataStore::resolve_channel_order(
+  const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg, bool & swap_rb)
+{
+  const std::string & encoding = input_camera_image_msg->encoding;
+
+  if (encoding == sensor_msgs::image_encodings::RGB8) {
+    swap_rb = false;
+  } else if (encoding == sensor_msgs::image_encodings::BGR8) {
+    swap_rb = true;
+  } else {
+    // Anything else (mono, bayer, 16-bit, alpha) has a different channel count or stride, so the
+    // fixed 3-byte-per-pixel upload below would misread the buffer.
+    RCLCPP_ERROR_THROTTLE(
+      logger_, throttle_clock_, kInvalidInputLogPeriodMs,
+      "Camera %d publishes unsupported encoding '%s'. Only 'rgb8' and 'bgr8' can be fed to the "
+      "model; dropping frames from this camera.",
+      camera_id, encoding.c_str());
+    return false;
+  }
+
+  // Both upload paths copy height * width * 3 densely packed bytes straight out of the message,
+  // so a padded row stride would shear the image and a truncated buffer would read out of bounds.
+  const size_t row_bytes = static_cast<size_t>(input_camera_image_msg->width) * 3;
+  const size_t expected_size = static_cast<size_t>(input_camera_image_msg->height) * row_bytes;
+  if (
+    input_camera_image_msg->step != row_bytes ||
+    input_camera_image_msg->data.size() < expected_size) {
+    RCLCPP_ERROR_THROTTLE(
+      logger_, throttle_clock_, kInvalidInputLogPeriodMs,
+      "Camera %d publishes %ux%u '%s' with step %u and %zu bytes, but a densely packed buffer of "
+      "step %zu and %zu bytes is required; dropping frames from this camera.",
+      camera_id, input_camera_image_msg->width, input_camera_image_msg->height, encoding.c_str(),
+      input_camera_image_msg->step, input_camera_image_msg->data.size(), row_bytes, expected_size);
+    return false;
+  }
+
+  return true;
 }
 
 CameraDataStore::ImageProcessingParams CameraDataStore::calculate_image_processing_params(
@@ -258,7 +325,7 @@ CameraDataStore::ImageProcessingParams CameraDataStore::calculate_image_processi
 
 std::unique_ptr<CameraDataStore::Tensor> CameraDataStore::process_distorted_image(
   const int camera_id, const Image::ConstSharedPtr & input_camera_image_msg,
-  ImageProcessingParams & params)
+  ImageProcessingParams & params, const bool swap_rb)
 {
   // Check if undistortion maps are available
   if (
@@ -309,10 +376,11 @@ std::unique_ptr<CameraDataStore::Tensor> CameraDataStore::process_distorted_imag
 
   if (ego_mask_built_[camera_id] && ego_mask_gpu_[camera_id]) {
     const auto & cfg = ego_mask_roi_configs_[camera_id].value();
+    const auto fill = fill_in_source_order(cfg.fill_bgr, swap_rb);
     auto err_mask = applyEgoMask_launch(
       static_cast<std::uint8_t *>(image_input_tensor->ptr),
       static_cast<const std::uint8_t *>(ego_mask_gpu_[camera_id]->ptr), original_height,
-      original_width, cfg.fill_bgr[0], cfg.fill_bgr[1], cfg.fill_bgr[2], streams_[camera_id]);
+      original_width, fill[0], fill[1], fill[2], streams_[camera_id]);
     if (err_mask != cudaSuccess) {
       RCLCPP_ERROR(
         logger_, "applyEgoMask_launch failed for camera %d: %s", camera_id,
@@ -326,7 +394,7 @@ std::unique_ptr<CameraDataStore::Tensor> CameraDataStore::process_distorted_imag
 
 std::unique_ptr<CameraDataStore::Tensor> CameraDataStore::process_regular_image(
   const Image::ConstSharedPtr & input_camera_image_msg, const ImageProcessingParams & params,
-  const int camera_id)
+  const int camera_id, const bool swap_rb)
 {
   auto image_input_tensor = std::make_unique<Tensor>(
     "camera_img", nvinfer1::Dims{3, {params.original_height, params.original_width, 3}},
@@ -337,11 +405,11 @@ std::unique_ptr<CameraDataStore::Tensor> CameraDataStore::process_regular_image(
 
   if (ego_mask_built_[camera_id] && ego_mask_gpu_[camera_id]) {
     const auto & cfg = ego_mask_roi_configs_[camera_id].value();
+    const auto fill = fill_in_source_order(cfg.fill_bgr, swap_rb);
     auto err_mask = applyEgoMask_launch(
       static_cast<std::uint8_t *>(image_input_tensor->ptr),
       static_cast<const std::uint8_t *>(ego_mask_gpu_[camera_id]->ptr), params.original_height,
-      params.original_width, cfg.fill_bgr[0], cfg.fill_bgr[1], cfg.fill_bgr[2],
-      streams_.at(camera_id));
+      params.original_width, fill[0], fill[1], fill[2], streams_.at(camera_id));
     if (err_mask != cudaSuccess) {
       RCLCPP_ERROR(
         logger_, "applyEgoMask_launch failed for camera %d: %s", camera_id,
@@ -451,6 +519,36 @@ bool CameraDataStore::check_if_all_camera_image_received() const
     }
   }
   return true;
+}
+
+std::string CameraDataStore::get_missing_camera_status() const
+{
+  std::string missing_camera_info;
+  std::string missing_camera_image;
+  const auto append = [](std::string & list, const std::string & item) {
+    if (!list.empty()) {
+      list += ", ";
+    }
+    list += item;
+  };
+
+  for (size_t camera_id = 0; camera_id < camera_info_list_.size(); ++camera_id) {
+    if (!camera_info_list_[camera_id]) {
+      append(missing_camera_info, std::to_string(camera_id));
+    }
+    if (camera_image_timestamp_[camera_id] < 0) {
+      append(missing_camera_image, std::to_string(camera_id));
+    }
+  }
+
+  std::string status;
+  if (!missing_camera_info.empty()) {
+    append(status, "camera_info not received: [" + missing_camera_info + "]");
+  }
+  if (!missing_camera_image.empty()) {
+    append(status, "image not received: [" + missing_camera_image + "]");
+  }
+  return status.empty() ? "all received" : status;
 }
 
 float CameraDataStore::check_if_all_images_synced() const

--- a/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
+++ b/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
@@ -129,7 +129,8 @@ CameraDataStore::CameraDataStore(
   preprocess_time_ms_(0.0f),
   is_distorted_image_(is_distorted_image),
   logger_(node->get_logger()),
-  clock_(node->get_clock())
+  clock_(node->get_clock()),
+  input_rejected_(rois_number)
 {
   image_input_ = std::make_shared<Tensor>(
     "image_input", nvinfer1::Dims{5, {1, rois_number, 3, image_height, image_width}},
@@ -267,6 +268,7 @@ bool CameraDataStore::validate_image_message(
       "Camera %d publishes unsupported encoding '%s'. Only 'rgb8' and 'bgr8' can be fed to the "
       "model; dropping frames from this camera.",
       camera_id, encoding.c_str());
+    input_rejected_[camera_id] = true;
     return false;
   }
 
@@ -286,9 +288,11 @@ bool CameraDataStore::validate_image_message(
       "step %zu and %zu bytes is required; dropping frames from this camera.",
       camera_id, input_camera_image_msg->width, input_camera_image_msg->height, encoding.c_str(),
       input_camera_image_msg->step, input_camera_image_msg->data.size(), row_bytes, expected_size);
+    input_rejected_[camera_id] = true;
     return false;
   }
 
+  input_rejected_[camera_id] = false;
   return true;
 }
 
@@ -520,6 +524,18 @@ bool CameraDataStore::check_if_all_camera_image_received() const
     }
   }
   return true;
+}
+
+std::vector<CameraDataStore::CameraStatus> CameraDataStore::get_camera_status() const
+{
+  std::vector<CameraStatus> status(rois_number_);
+  for (size_t camera_id = 0; camera_id < rois_number_; ++camera_id) {
+    status[camera_id].camera_info_received = static_cast<bool>(camera_info_list_[camera_id]);
+    status[camera_id].image_received = camera_image_timestamp_[camera_id] >= 0;
+    status[camera_id].input_rejected = input_rejected_[camera_id];
+    status[camera_id].last_image_timestamp = camera_image_timestamp_[camera_id];
+  }
+  return status;
 }
 
 float CameraDataStore::check_if_all_images_synced() const

--- a/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
+++ b/perception/autoware_camera_streampetr/lib/network/camera_data_store.cpp
@@ -430,8 +430,9 @@ void CameraDataStore::update_metadata_and_timing(
   camera_link_names_[camera_id] = input_camera_image_msg->header.frame_id;
 
   auto end_time = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-  preprocess_time_ms_ = duration.count();
+  // Sub-millisecond precision: preprocessing runs ~2 ms per frame, so a duration_cast to whole
+  // milliseconds would quantize away most of the signal the diagnostics report.
+  preprocess_time_ms_ = std::chrono::duration<double, std::milli>(end_time - start_time).count();
 }
 
 void CameraDataStore::update_camera_info(

--- a/perception/autoware_camera_streampetr/lib/network/camera_ego_mask.cpp
+++ b/perception/autoware_camera_streampetr/lib/network/camera_ego_mask.cpp
@@ -50,11 +50,6 @@ bool trimEmpty(const std::string & s)
   return s.find_first_not_of(" \t\n\r\f\v") == std::string::npos;
 }
 
-std::array<std::uint8_t, 3> clampFillBgr(const std::array<std::uint8_t, 3> & fill)
-{
-  return fill;
-}
-
 YAML::Node parseYamlRoot(const std::string & yaml_text)
 {
   YAML::Node root = YAML::Load(yaml_text);
@@ -231,7 +226,7 @@ std::vector<std::optional<EgoMaskRoiConfig>> loadEgoMaskRoiConfigs(
     return configs;
   }
 
-  const auto fill = clampFillBgr(params.fill_bgr);
+  const auto & fill = params.fill_rgb;
 
   for (std::size_t i = 0; i < rois_number; ++i) {
     if (i >= params.roi_polygons_yaml.size()) {
@@ -244,7 +239,7 @@ std::vector<std::optional<EgoMaskRoiConfig>> loadEgoMaskRoiConfigs(
 
     EgoMaskRoiConfig cfg;
     cfg.polygons = parsePolygonsYamlFile(yaml_path);
-    cfg.fill_bgr = fill;
+    cfg.fill_rgb = fill;
     if (!cfg.polygons.empty()) {
       configs[i] = std::move(cfg);
     }

--- a/perception/autoware_camera_streampetr/lib/network/ego_mask_kernel.cu
+++ b/perception/autoware_camera_streampetr/lib/network/ego_mask_kernel.cu
@@ -21,8 +21,8 @@ namespace autoware::camera_streampetr
 {
 
 __global__ void applyEgoMask_kernel(
-  std::uint8_t * __restrict__ image_bgr, const std::uint8_t * __restrict__ mask, int height,
-  int width, std::uint8_t fill_b, std::uint8_t fill_g, std::uint8_t fill_r)
+  std::uint8_t * __restrict__ image, const std::uint8_t * __restrict__ mask, int height, int width,
+  std::uint8_t fill_c0, std::uint8_t fill_c1, std::uint8_t fill_c2)
 {
   const int x = blockIdx.x * blockDim.x + threadIdx.x;
   const int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -36,19 +36,19 @@ __global__ void applyEgoMask_kernel(
   }
 
   const int img_idx = mask_idx * 3;
-  image_bgr[img_idx] = fill_b;
-  image_bgr[img_idx + 1] = fill_g;
-  image_bgr[img_idx + 2] = fill_r;
+  image[img_idx] = fill_c0;
+  image[img_idx + 1] = fill_c1;
+  image[img_idx + 2] = fill_c2;
 }
 
 cudaError_t applyEgoMask_launch(
-  std::uint8_t * image_bgr, const std::uint8_t * mask, int height, int width, std::uint8_t fill_b,
-  std::uint8_t fill_g, std::uint8_t fill_r, cudaStream_t stream)
+  std::uint8_t * image, const std::uint8_t * mask, int height, int width, std::uint8_t fill_c0,
+  std::uint8_t fill_c1, std::uint8_t fill_c2, cudaStream_t stream)
 {
   dim3 threads(16, 16);
   dim3 blocks(divup(width, threads.x), divup(height, threads.y));
   applyEgoMask_kernel<<<blocks, threads, 0, stream>>>(
-    image_bgr, mask, height, width, fill_b, fill_g, fill_r);
+    image, mask, height, width, fill_c0, fill_c1, fill_c2);
   return cudaGetLastError();
 }
 

--- a/perception/autoware_camera_streampetr/lib/network/network.cpp
+++ b/perception/autoware_camera_streampetr/lib/network/network.cpp
@@ -192,7 +192,6 @@ void StreamPetrNetwork::initializeMemoryAndProfiling()
   dur_backbone_ = std::make_unique<Duration>("backbone", profiler_);
   dur_ptshead_ = std::make_unique<Duration>("ptshead", profiler_);
   dur_pos_embed_ = std::make_unique<Duration>("pos_embed", profiler_);
-  dur_postprocess_ = std::make_unique<Duration>("postprocess", profiler_);
 
   postprocess_cuda_ = std::make_unique<PostprocessCuda>(
     PostProcessingConfig(
@@ -223,9 +222,7 @@ void StreamPetrNetwork::wipe_memory()
 }
 
 void StreamPetrNetwork::inference_detector(
-  const InferenceInputs & inputs,
-  std::vector<autoware_perception_msgs::msg::DetectedObject> & output_objects,
-  std::vector<float> & forward_time_ms)
+  const InferenceInputs & inputs, std::vector<float> & forward_time_ms)
 {
   if (!is_inference_initialized_) {
     initializePositionEmbedding(inputs);
@@ -235,14 +232,13 @@ void StreamPetrNetwork::inference_detector(
   executeBackbone(inputs);
   executePtsHead(inputs);
 
+  // The enqueues above are asynchronous: without this sync the caller's inference time would
+  // only measure the enqueueing, and the GPU wait would leak into whatever it times next.
   cudaStreamSynchronize(stream_);
-
-  executePostprocessing(output_objects);
 
   forward_time_ms.push_back(dur_backbone_->Elapsed());
   forward_time_ms.push_back(dur_ptshead_->Elapsed());
   forward_time_ms.push_back(dur_pos_embed_->Elapsed());
-  forward_time_ms.push_back(dur_postprocess_->Elapsed());
 }
 
 void StreamPetrNetwork::initializePositionEmbedding(const InferenceInputs & inputs)
@@ -303,11 +299,10 @@ void StreamPetrNetwork::executePtsHead(const InferenceInputs & inputs)
   dur_ptshead_->MarkEnd(stream_);
 }
 
-void StreamPetrNetwork::executePostprocessing(
+void StreamPetrNetwork::postprocess(
   std::vector<autoware_perception_msgs::msg::DetectedObject> & output_objects)
 {
   std::vector<Box3D> det_boxes3d;
-  dur_postprocess_->MarkBegin(stream_);
   postprocess_cuda_->generateDetectedBoxes3D_launch(
     static_cast<const float *>(pts_head_->bindings["all_cls_scores"]->ptr),
     static_cast<const float *>(pts_head_->bindings["all_bbox_preds"]->ptr), det_boxes3d, stream_);
@@ -323,7 +318,6 @@ void StreamPetrNetwork::executePostprocessing(
   } else {
     output_objects = std::move(raw_objects);
   }
-  dur_postprocess_->MarkEnd(stream_);
 }
 
 StreamPetrNetwork::~StreamPetrNetwork()

--- a/perception/autoware_camera_streampetr/lib/network/preprocess_kernel.cu
+++ b/perception/autoware_camera_streampetr/lib/network/preprocess_kernel.cu
@@ -38,11 +38,15 @@
 namespace autoware::camera_streampetr
 {
 // -------------------------------------------------------------------------
-// Fused Kernel: Anti-Aliased Resize -> Crop -> Normalize -> CHW Layout
+// Fused Kernel: Anti-Aliased Resize -> Crop -> R/B Swap -> Normalize -> CHW Layout
 // -------------------------------------------------------------------------
 // This kernel mimics PIL's resize (Bilinear/Triangle filter with adaptive support).
 // For downscaling, it expands the kernel window to cover all contributing pixels
 // (Anti-aliasing). For upscaling, it acts as standard bilinear interpolation.
+//
+// The model consumes RGB, so the output planes and `mean`/`std` are in RGB order. A BGR source is
+// handled by `swap_rb`, which exchanges channels 0 and 2 while writing the planar output -- free,
+// because that write is scattered per channel anyway.
 __global__ void resizeAndExtractRoi_kernel(
   const std::uint8_t * __restrict__ input_img, float * __restrict__ output_img,
   int camera_offset,                 // Offset in output buffer (for multi-camera batching)
@@ -50,8 +54,9 @@ __global__ void resizeAndExtractRoi_kernel(
   int resize_h, int resize_w,        // Target resize dimensions (before cropping)
   int roi_h, int roi_w,              // Output ROI dimensions
   int roi_y_start, int roi_x_start,  // Top-left of ROI in the resized coordinate space
-  const float * __restrict__ mean,   // Device pointer to 3 floats
-  const float * __restrict__ std     // Device pointer to 3 floats
+  const float * __restrict__ mean,   // Device pointer to 3 floats, RGB order
+  const float * __restrict__ std,    // Device pointer to 3 floats, RGB order
+  bool swap_rb                       // Source buffer is BGR: exchange channels 0 and 2
 )
 {
   // 1. Calculate thread target pixel in the ROI (Output Image)
@@ -94,10 +99,11 @@ __global__ void resizeAndExtractRoi_kernel(
   y_min = max(0, y_min);
   y_max = min(in_h - 1, y_max);
 
-  // Accumulators
-  float sum_r = 0.0f;
-  float sum_g = 0.0f;
-  float sum_b = 0.0f;
+  // Accumulators, indexed by *source* channel. Which colour each one holds depends on the
+  // input encoding (RGB or BGR); the mapping to model channels happens at write time.
+  float sum_c0 = 0.0f;
+  float sum_c1 = 0.0f;
+  float sum_c2 = 0.0f;
   float sum_weight = 0.0f;
 
   // 7. Convolution Loop (Triangle/Bilinear Filter)
@@ -122,9 +128,9 @@ __global__ void resizeAndExtractRoi_kernel(
       // Skip negligible weights
       if (w > 0.0f) {
         int idx = (row_offset + x) * 3;
-        sum_r += input_img[idx] * w;
-        sum_g += input_img[idx + 1] * w;
-        sum_b += input_img[idx + 2] * w;
+        sum_c0 += input_img[idx] * w;
+        sum_c1 += input_img[idx + 1] * w;
+        sum_c2 += input_img[idx + 2] * w;
         sum_weight += w;
       }
     }
@@ -133,22 +139,24 @@ __global__ void resizeAndExtractRoi_kernel(
   // 8. Normalize Weights and Write Output
   //    Avoid division by zero if weight sum is tiny (shouldn't happen inside valid ROI)
   if (sum_weight > 0.0f) {
-    sum_r /= sum_weight;
-    sum_g /= sum_weight;
-    sum_b /= sum_weight;
+    sum_c0 /= sum_weight;
+    sum_c1 /= sum_weight;
+    sum_c2 /= sum_weight;
   }
 
-  // 9. Normalize (Mean/Std) and Write to Output (Planar CHW)
-  //    Output layout: [Batch/Camera, Channel, Height, Width]
+  // 9. Swap R/B if needed, normalize (Mean/Std) and write to output (Planar CHW)
+  //    Output layout: [Batch/Camera, Channel, Height, Width], always RGB.
+  //    Source channel i lands on model channel (swap_rb ? 2 - i : i); mean/std are indexed
+  //    by the *model* channel so they need no reordering here.
   int area = roi_h * roi_w;
   int out_idx = out_y * roi_w + out_x;
 
-  // Channel 0 (R)
-  output_img[camera_offset + (0 * area + out_idx)] = (sum_r - mean[0]) / std[0];
-  // Channel 1 (G)
-  output_img[camera_offset + (1 * area + out_idx)] = (sum_g - mean[1]) / std[1];
-  // Channel 2 (B)
-  output_img[camera_offset + (2 * area + out_idx)] = (sum_b - mean[2]) / std[2];
+  const int dst_c0 = swap_rb ? 2 : 0;
+  const int dst_c2 = swap_rb ? 0 : 2;
+
+  output_img[camera_offset + (dst_c0 * area + out_idx)] = (sum_c0 - mean[dst_c0]) / std[dst_c0];
+  output_img[camera_offset + (1 * area + out_idx)] = (sum_c1 - mean[1]) / std[1];
+  output_img[camera_offset + (dst_c2 * area + out_idx)] = (sum_c2 - mean[dst_c2]) / std[dst_c2];
 }
 
 cudaError_t resizeAndExtractRoi_launch(
@@ -158,7 +166,8 @@ cudaError_t resizeAndExtractRoi_launch(
   int H2, int W2,            // Resized image dimensions
   int H3, int W3,            // ROI dimensions
   int y_start, int x_start,  // ROI top-left coordinates in resized image
-  const float * channel_wise_mean, const float * channel_wise_std, cudaStream_t stream)
+  const float * channel_wise_mean, const float * channel_wise_std, bool swap_rb,
+  cudaStream_t stream)
 {
   // Define the block and grid dimensions
   dim3 threads(16, 16);
@@ -167,7 +176,7 @@ cudaError_t resizeAndExtractRoi_launch(
   // Launch the kernel
   resizeAndExtractRoi_kernel<<<blocks, threads, 0, stream>>>(
     input_img, output_img, camera_offset, H, W, H2, W2, H3, W3, y_start, x_start, channel_wise_mean,
-    channel_wise_std);
+    channel_wise_std, swap_rb);
 
   // Check for errors
   return cudaGetLastError();

--- a/perception/autoware_camera_streampetr/package.xml
+++ b/perception/autoware_camera_streampetr/package.xml
@@ -5,6 +5,7 @@
   <description>autoware_camera_streampetr</description>
   <maintainer email="samratthapa120@gmail.com">samrat</maintainer>
   <maintainer email="kokseang.tan@tier4.jp">Kok Seang Tan</maintainer>
+  <maintainer email="yihsiang.fang@tier4.jp">Yi-Hsiang Fang</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/perception/autoware_camera_streampetr/package.xml
+++ b/perception/autoware_camera_streampetr/package.xml
@@ -17,6 +17,8 @@
   <depend>autoware_tensorrt_common</depend>
   <depend>autoware_utils</depend>
   <depend>cv_bridge</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>image_transport</depend>

--- a/perception/autoware_camera_streampetr/package.xml
+++ b/perception/autoware_camera_streampetr/package.xml
@@ -18,7 +18,6 @@
   <depend>cv_bridge</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <depend>image_transport</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/autoware_camera_streampetr/package.xml
+++ b/perception/autoware_camera_streampetr/package.xml
@@ -19,6 +19,7 @@
   <depend>cv_bridge</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>image_transport</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -367,9 +367,7 @@ bool StreamPetrNode::validate_camera_sync()
   const float prediction_timestamp = data_store_->get_timestamp();
 
   if (tdiff < 0) {
-    RCLCPP_WARN(
-      rclcpp::get_logger(logger_name_.c_str()), "Not all camera info or image received: %s",
-      data_store_->get_missing_camera_status().c_str());
+    RCLCPP_WARN(rclcpp::get_logger(logger_name_.c_str()), "Not all camera info or image received");
     return false;
   }
 

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -227,14 +227,6 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
       rclcpp::SensorDataQoS{}.keep_last(1), [this, roi_i](const CameraInfo::ConstSharedPtr msg) {
         this->camera_info_callback(msg, static_cast<int>(roi_i));
       });
-    // Both branches subscribe plainly instead of going through image_transport, whose only value
-    // here would be picking the transport at run time -- something this parameter already does.
-    // Its compressed plugin is also unusable for us: CompressedSubscriber::subscribeImpl calls
-    // substr(node_namespace.size()) on the *unresolved* base topic, so it throws
-    // std::out_of_range whenever strlen(base_topic) < strlen(node_namespace). With
-    // "~/input/cameraN/image" (21 chars) under the X2 namespace
-    // "/perception/object_recognition/detection" (40 chars) the node dies at construction.
-    // Reproduced against ros-humble-compressed-image-transport 2.5.5.
     if (is_compressed_image) {
       compressed_image_subs_.at(roi_i) = this->create_subscription<CompressedImage>(
         "~/input/camera" + std::to_string(roi_i) + "/image/compressed", rclcpp::SensorDataQoS(),
@@ -337,10 +329,8 @@ void StreamPetrNode::compressed_image_callback(
 {
   cv_bridge::CvImagePtr cv_ptr;
   try {
-    // Always ask for bgr8, which is exactly what cv::imdecode produces, so cv_bridge hands back
-    // the decoded buffer untouched. Requesting rgb8 would add a full-image CPU cvtColor per
-    // camera per frame on top of the JPEG decode, while the fused preprocessing kernel does the
-    // R/B swap on the GPU for free -- the model still receives RGB either way.
+    // bgr8 is what cv::imdecode already produces; rgb8 would cost a CPU cvtColor per frame while
+    // the preprocessing kernel swaps R/B on the GPU for free.
     cv_ptr = cv_bridge::toCvCopy(input_compressed_image_msg, sensor_msgs::image_encodings::BGR8);
   } catch (const std::exception & e) {
     RCLCPP_ERROR(

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -66,7 +66,7 @@ void validateMaskPoints(const std::vector<double> & mask, const std::string & pa
 }
 
 std::vector<std::optional<EgoMaskRoiConfig>> declareCameraMaskParams(
-  rclcpp::Node & node, const std::size_t rois_number, const std::array<std::uint8_t, 3> & fill_bgr,
+  rclcpp::Node & node, const std::size_t rois_number, const std::array<std::uint8_t, 3> & fill_rgb,
   const std::vector<int64_t> & camera_mask_ids)
 {
   std::vector<std::optional<EgoMaskRoiConfig>> camera_mask_configs(kMaxCameraMaskId + 1);
@@ -84,7 +84,7 @@ std::vector<std::optional<EgoMaskRoiConfig>> declareCameraMaskParams(
 
     EgoMaskRoiConfig config;
     config.polygons.push_back(EgoMaskPolygon{mask, normalized});
-    config.fill_bgr = fill_bgr;
+    config.fill_rgb = fill_rgb;
     camera_mask_configs[camera_id] = std::move(config);
   }
 
@@ -257,16 +257,17 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
 
   EgoMaskParams ego_mask_params;
   ego_mask_params.enabled = declare_parameter<bool>("ego_mask.enabled", false);
-  const auto fill_value_bgr =
-    declare_parameter<std::vector<double>>("ego_mask.fill_value_bgr", {0.0, 0.0, 0.0});
+  // RGB order, matching the model's input channel order and the online cameras' rgb8 encoding.
+  const auto fill_value_rgb =
+    declare_parameter<std::vector<double>>("ego_mask.fill_value_rgb", {0.0, 0.0, 0.0});
   for (std::size_t i = 0; i < 3; ++i) {
-    const double v = i < fill_value_bgr.size() ? fill_value_bgr[i] : 0.0;
-    ego_mask_params.fill_bgr[i] = static_cast<std::uint8_t>(std::clamp(v, 0.0, 255.0));
+    const double v = i < fill_value_rgb.size() ? fill_value_rgb[i] : 0.0;
+    ego_mask_params.fill_rgb[i] = static_cast<std::uint8_t>(std::clamp(v, 0.0, 255.0));
   }
   const auto camera_mask_ids = declare_parameter<std::vector<int64_t>>(
     "camera_mask.camera_ids", makeDefaultCameraMaskIds(rois_number_));
   ego_mask_params.roi_mask_configs =
-    declareCameraMaskParams(*this, rois_number_, ego_mask_params.fill_bgr, camera_mask_ids);
+    declareCameraMaskParams(*this, rois_number_, ego_mask_params.fill_rgb, camera_mask_ids);
   ego_mask_params.roi_polygons_yaml = declare_parameter<std::vector<std::string>>(
     "ego_mask.roi_polygons_yaml", std::vector<std::string>());
 

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -18,9 +18,12 @@
 #include "autoware/camera_streampetr/postprocess/non_maximum_suppression.hpp"
 
 #include <Eigen/Dense>
-#include <image_transport/image_transport.hpp>
 #include <tf2/LinearMath/Transform.hpp>
 #include <tf2/convert.hpp>
+
+#include <sensor_msgs/image_encodings.hpp>
+
+#include <cv_bridge/cv_bridge.h>
 
 #include <algorithm>
 #include <cmath>
@@ -210,6 +213,7 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
   }
   const bool is_compressed_image = declare_parameter<bool>("is_compressed_image");
   camera_image_subs_.resize(rois_number_);
+  compressed_image_subs_.resize(rois_number_);
   for (size_t roi_i = 0; roi_i < rois_number_; ++roi_i) {
     auto sub_options = rclcpp::SubscriptionOptions();
     if (multithreading_) {
@@ -223,12 +227,29 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
       rclcpp::SensorDataQoS{}.keep_last(1), [this, roi_i](const CameraInfo::ConstSharedPtr msg) {
         this->camera_info_callback(msg, static_cast<int>(roi_i));
       });
-    camera_image_subs_.at(roi_i) = image_transport::create_subscription(
-      this, "~/input/camera" + std::to_string(roi_i) + "/image",
-      std::bind(
-        &StreamPetrNode::camera_image_callback, this, std::placeholders::_1,
-        static_cast<int>(roi_i)),
-      is_compressed_image ? "compressed" : "raw", rmw_qos_profile_sensor_data, sub_options);
+    // Both branches subscribe plainly instead of going through image_transport, whose only value
+    // here would be picking the transport at run time -- something this parameter already does.
+    // Its compressed plugin is also unusable for us: CompressedSubscriber::subscribeImpl calls
+    // substr(node_namespace.size()) on the *unresolved* base topic, so it throws
+    // std::out_of_range whenever strlen(base_topic) < strlen(node_namespace). With
+    // "~/input/cameraN/image" (21 chars) under the X2 namespace
+    // "/perception/object_recognition/detection" (40 chars) the node dies at construction.
+    // Reproduced against ros-humble-compressed-image-transport 2.5.5.
+    if (is_compressed_image) {
+      compressed_image_subs_.at(roi_i) = this->create_subscription<CompressedImage>(
+        "~/input/camera" + std::to_string(roi_i) + "/image/compressed", rclcpp::SensorDataQoS(),
+        [this, roi_i](const CompressedImage::ConstSharedPtr msg) {
+          this->compressed_image_callback(msg, static_cast<int>(roi_i));
+        },
+        sub_options);
+    } else {
+      camera_image_subs_.at(roi_i) = this->create_subscription<Image>(
+        "~/input/camera" + std::to_string(roi_i) + "/image", rclcpp::SensorDataQoS(),
+        [this, roi_i](const Image::ConstSharedPtr msg) {
+          this->camera_image_callback(msg, static_cast<int>(roi_i));
+        },
+        sub_options);
+    }
   }
 
   // Publishers
@@ -310,6 +331,25 @@ void StreamPetrNode::camera_image_callback(
   }
 }
 
+void StreamPetrNode::compressed_image_callback(
+  CompressedImage::ConstSharedPtr input_compressed_image_msg, const int camera_id)
+{
+  cv_bridge::CvImagePtr cv_ptr;
+  try {
+    // Always ask for bgr8, which is exactly what cv::imdecode produces, so cv_bridge hands back
+    // the decoded buffer untouched. Requesting rgb8 would add a full-image CPU cvtColor per
+    // camera per frame on top of the JPEG decode, while the fused preprocessing kernel does the
+    // R/B swap on the GPU for free -- the model still receives RGB either way.
+    cv_ptr = cv_bridge::toCvCopy(input_compressed_image_msg, sensor_msgs::image_encodings::BGR8);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger(logger_name_.c_str()),
+      "Failed to decode compressed image of camera %d: %s", camera_id, e.what());
+    return;
+  }
+  camera_image_callback(cv_ptr->toImageMsg(), camera_id);
+}
+
 void StreamPetrNode::step(const rclcpp::Time & stamp)
 {
   if (!validate_camera_sync()) {
@@ -336,7 +376,9 @@ bool StreamPetrNode::validate_camera_sync()
   const float prediction_timestamp = data_store_->get_timestamp();
 
   if (tdiff < 0) {
-    RCLCPP_WARN(rclcpp::get_logger(logger_name_.c_str()), "Not all camera info or image received");
+    RCLCPP_WARN(
+      rclcpp::get_logger(logger_name_.c_str()), "Not all camera info or image received: %s",
+      data_store_->get_missing_camera_status().c_str());
     return false;
   }
 

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -21,10 +21,6 @@
 #include <tf2/LinearMath/Transform.hpp>
 #include <tf2/convert.hpp>
 
-#include <sensor_msgs/image_encodings.hpp>
-
-#include <cv_bridge/cv_bridge.h>
-
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -212,8 +208,8 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
     camera_callback_groups_.resize(rois_number_);
   }
   const bool is_compressed_image = declare_parameter<bool>("is_compressed_image");
+  const std::string image_transport_type = is_compressed_image ? "compressed" : "raw";
   camera_image_subs_.resize(rois_number_);
-  compressed_image_subs_.resize(rois_number_);
   for (size_t roi_i = 0; roi_i < rois_number_; ++roi_i) {
     auto sub_options = rclcpp::SubscriptionOptions();
     if (multithreading_) {
@@ -227,21 +223,18 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
       rclcpp::SensorDataQoS{}.keep_last(1), [this, roi_i](const CameraInfo::ConstSharedPtr msg) {
         this->camera_info_callback(msg, static_cast<int>(roi_i));
       });
-    if (is_compressed_image) {
-      compressed_image_subs_.at(roi_i) = this->create_subscription<CompressedImage>(
-        "~/input/camera" + std::to_string(roi_i) + "/image/compressed", rclcpp::SensorDataQoS(),
-        [this, roi_i](const CompressedImage::ConstSharedPtr msg) {
-          this->compressed_image_callback(msg, static_cast<int>(roi_i));
-        },
-        sub_options);
-    } else {
-      camera_image_subs_.at(roi_i) = this->create_subscription<Image>(
-        "~/input/camera" + std::to_string(roi_i) + "/image", rclcpp::SensorDataQoS(),
-        [this, roi_i](const Image::ConstSharedPtr msg) {
-          this->camera_image_callback(msg, static_cast<int>(roi_i));
-        },
-        sub_options);
-    }
+
+    // Explicitly resolve the topic name so remapping applies to the base topic before
+    // image_transport appends the transport suffix, please check
+    // https://github.com/ros-perception/image_transport_plugins/issues/155
+    const std::string base_topic = this->get_node_topics_interface()->resolve_topic_name(
+      "~/input/camera" + std::to_string(roi_i) + "/image");
+    camera_image_subs_.at(roi_i) = image_transport::create_subscription(
+      this, base_topic,
+      [this, roi_i](const Image::ConstSharedPtr & msg) {
+        this->camera_image_callback(msg, static_cast<int>(roi_i));
+      },
+      image_transport_type, rmw_qos_profile_sensor_data, sub_options);
   }
 
   // Publishers
@@ -322,23 +315,6 @@ void StreamPetrNode::camera_image_callback(
   if (camera_id == anchor_camera_id_) {
     step(input_camera_image_msg->header.stamp);
   }
-}
-
-void StreamPetrNode::compressed_image_callback(
-  CompressedImage::ConstSharedPtr input_compressed_image_msg, const int camera_id)
-{
-  cv_bridge::CvImagePtr cv_ptr;
-  try {
-    // bgr8 is what cv::imdecode already produces; rgb8 would cost a CPU cvtColor per frame while
-    // the preprocessing kernel swaps R/B on the GPU for free.
-    cv_ptr = cv_bridge::toCvCopy(input_compressed_image_msg, sensor_msgs::image_encodings::BGR8);
-  } catch (const std::exception & e) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger(logger_name_.c_str()),
-      "Failed to decode compressed image of camera %d: %s", camera_id, e.what());
-    return;
-  }
-  camera_image_callback(cv_ptr->toImageMsg(), camera_id);
 }
 
 void StreamPetrNode::step(const rclcpp::Time & stamp)

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -40,8 +40,15 @@ namespace
 {
 
 // Fixed-point formatting for /diagnostics values. DiagnosticStatusWrapper's double overload
-// prints large values in scientific notation (1.78461e+09), which is unreadable for long ages;
-// format them as strings instead, like the concatenate node does.
+// prints large values in scientific notation (1.78461e+09), which is unreadable for epoch
+// timestamps and long ages; format them as strings instead, like the concatenate node does.
+std::string format_timestamp(const double seconds)
+{
+  char buffer[32];
+  std::snprintf(buffer, sizeof(buffer), "%.9f", seconds);
+  return std::string(buffer);
+}
+
 std::string format_milliseconds(const double milliseconds)
 {
   char buffer[32];
@@ -291,16 +298,17 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
     this, rois_number_, roi_height, roi_width, anchor_camera_id_,
     declare_parameter<bool>("is_distorted_image"), ego_mask_params);
 
+  stop_watch_.tic("latency/cycle_time_ms");
   if (debug_mode_) {
-    using autoware_utils::DebugPublisher;
-    using autoware_utils::StopWatch;
-    stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
-    debug_publisher_ptr_ = std::make_unique<DebugPublisher>(this, this->get_name());
-    stop_watch_ptr_->tic("latency/cycle_time_ms");
+    debug_publisher_ptr_ = std::make_unique<autoware_utils::DebugPublisher>(this, this->get_name());
   }
 
-  // Diagnostics, always on: the only place where a missing, stalled or rejected camera becomes
-  // visible outside the node's log.
+  // Diagnostics, always on: the only place where a missing camera, a rejected encoding or a
+  // stalled pipeline becomes visible outside the node's log.
+  max_allowed_processing_time_ms_ =
+    declare_parameter<double>("diagnostics.max_allowed_processing_time_ms");
+  max_acceptable_consecutive_delay_ms_ =
+    declare_parameter<double>("diagnostics.max_acceptable_consecutive_delay_ms");
   max_image_age_ms_ = declare_parameter<double>("diagnostics.max_image_age_ms");
   const double validation_callback_interval_ms =
     declare_parameter<double>("diagnostics.validation_callback_interval_ms");
@@ -309,6 +317,8 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
   // their statuses have to stay distinguishable by hardware_id.
   diagnostic_updater_.setHardwareID(this->get_name());
   diagnostic_updater_.add("camera_status", this, &StreamPetrNode::diagnose_camera_status);
+  diagnostic_updater_.add(
+    "processing_time_status", this, &StreamPetrNode::diagnose_processing_time);
   diagnostic_updater_.setPeriod(validation_callback_interval_ms / 1000.0);
 }
 
@@ -321,8 +331,8 @@ void StreamPetrNode::camera_info_callback(
 void StreamPetrNode::camera_image_callback(
   Image::ConstSharedPtr input_camera_image_msg, const int camera_id)
 {
-  if (stop_watch_ptr_ && anchor_camera_id_ == camera_id) {
-    stop_watch_ptr_->tic("latency/total");
+  if (anchor_camera_id_ == camera_id) {
+    stop_watch_.tic("latency/total");
   }
 
   const auto objects_sub_count =
@@ -427,9 +437,7 @@ std::optional<std::tuple<
   std::vector<autoware_perception_msgs::msg::DetectedObject>, std::vector<float>, double>>
 StreamPetrNode::perform_inference()
 {
-  if (stop_watch_ptr_) {
-    stop_watch_ptr_->tic("latency/inference");
-  }
+  stop_watch_.tic("latency/inference");
 
   std::vector<float> forward_time_ms;
   std::vector<autoware_perception_msgs::msg::DetectedObject> output_objects;
@@ -441,10 +449,7 @@ StreamPetrNode::perform_inference()
     data_store_->unfreeze_updates();
   }
 
-  double inference_time_ms = -1.0;
-  if (stop_watch_ptr_) {
-    inference_time_ms = stop_watch_ptr_->toc("latency/inference", true);
-  }
+  const double inference_time_ms = stop_watch_.toc("latency/inference", true);
 
   return std::make_tuple(output_objects, forward_time_ms, inference_time_ms);
 }
@@ -471,17 +476,29 @@ void StreamPetrNode::publish_detection_results(
   output_msg.header.frame_id = "base_link";
   output_msg.header.stamp = stamp;
   pub_objects_->publish(output_msg);
+  // Latched as a pair so the diagnostics can relate the two clocks: stamp is the sensing instant
+  // these detections were computed for, the node clock is when they left the node.
+  last_output_frame_stamp_ = stamp;
+  last_publish_stamp_ = this->get_clock()->now();
 }
 
 void StreamPetrNode::publish_debug_metrics(
   const std::vector<float> & forward_time_ms, double inference_time_ms)
 {
-  if (!debug_publisher_ptr_ || !stop_watch_ptr_) {
+  // Latched before the debug_mode_ gate below: the processing-time watchdog is always active,
+  // and these localize an over-budget total without enabling debug_mode.
+  const double processing_time_ms = stop_watch_.toc("latency/total", true);
+  last_processing_time_ms_ = processing_time_ms;
+  last_preprocess_time_ms_ = data_store_->get_preprocess_time_ms();
+  last_inference_time_ms_ = inference_time_ms;
+  last_postprocess_time_ms_ = forward_time_ms[3];
+
+  if (!debug_publisher_ptr_) {
     return;
   }
 
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
-    "latency/total", stop_watch_ptr_->toc("latency/total", true));
+    "latency/total", processing_time_ms);
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "latency/preprocess", data_store_->get_preprocess_time_ms());
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
@@ -495,8 +512,8 @@ void StreamPetrNode::publish_debug_metrics(
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "latency/inference/postprocess", forward_time_ms[3]);
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
-    "latency/cycle_time_ms", stop_watch_ptr_->toc("latency/cycle_time_ms", true));
-  stop_watch_ptr_->tic("latency/cycle_time_ms");
+    "latency/cycle_time_ms", stop_watch_.toc("latency/cycle_time_ms", true));
+  stop_watch_.tic("latency/cycle_time_ms");
 }
 
 void StreamPetrNode::diagnose_camera_status(diagnostic_updater::DiagnosticStatusWrapper & stat)
@@ -606,6 +623,114 @@ void StreamPetrNode::diagnose_camera_status(diagnostic_updater::DiagnosticStatus
 
   const std::string summary = message.str();
   stat.summary(level, summary.empty() ? "OK" : summary);
+}
+
+void StreamPetrNode::add_no_inference_diagnostics(
+  diagnostic_updater::DiagnosticStatusWrapper & stat, std::stringstream & message)
+{
+  stat.add("is_processing_time_ms_in_expected_range", true);
+  stat.add("processing_time_ms", "n/a");
+  stat.add("preprocess_time_ms", "n/a");
+  stat.add("inference_time_ms", "n/a");
+  stat.add("postprocess_time_ms", "n/a");
+  stat.add("is_consecutive_processing_delay_in_range", true);
+  stat.add("consecutive_processing_delay_ms", "n/a");
+  message << "Waiting for the node to perform inference.";
+}
+
+diagnostic_msgs::msg::DiagnosticStatus::_level_type StreamPetrNode::check_processing_time_status(
+  diagnostic_updater::DiagnosticStatusWrapper & stat, std::stringstream & message,
+  const rclcpp::Time & timestamp_now)
+{
+  const double processing_time_ms = last_processing_time_ms_.value();
+
+  if (processing_time_ms > max_allowed_processing_time_ms_) {
+    stat.add("is_processing_time_ms_in_expected_range", false);
+
+    message << "Processing time exceeds the acceptable limit of " << max_allowed_processing_time_ms_
+            << " ms by " << (processing_time_ms - max_allowed_processing_time_ms_) << " ms.";
+
+    if (!last_in_time_processing_timestamp_) {
+      last_in_time_processing_timestamp_ = timestamp_now;
+    }
+
+    return diagnostic_msgs::msg::DiagnosticStatus::WARN;
+  }
+
+  stat.add("is_processing_time_ms_in_expected_range", true);
+  last_in_time_processing_timestamp_ = timestamp_now;
+  return diagnostic_msgs::msg::DiagnosticStatus::OK;
+}
+
+diagnostic_msgs::msg::DiagnosticStatus::_level_type StreamPetrNode::check_consecutive_delays(
+  diagnostic_updater::DiagnosticStatusWrapper & stat, std::stringstream & message,
+  const rclcpp::Time & timestamp_now,
+  diagnostic_msgs::msg::DiagnosticStatus::_level_type current_level)
+{
+  // check_processing_time_status() ran first and set the timestamp on both of its paths.
+  const double delayed_state_duration_ms =
+    std::chrono::duration<double, std::milli>(
+      std::chrono::nanoseconds(
+        (timestamp_now - last_in_time_processing_timestamp_.value()).nanoseconds()))
+      .count();
+
+  if (delayed_state_duration_ms > max_acceptable_consecutive_delay_ms_) {
+    stat.add("is_consecutive_processing_delay_in_range", false);
+    stat.add("consecutive_processing_delay_ms", format_milliseconds(delayed_state_duration_ms));
+    message << " Processing delay has consecutively exceeded the acceptable limit continuously.";
+    return diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+  }
+
+  stat.add("is_consecutive_processing_delay_in_range", true);
+  stat.add("consecutive_processing_delay_ms", format_milliseconds(delayed_state_duration_ms));
+  return current_level;
+}
+
+// Timer driven, like the camera status above: a node that has stopped inferring altogether still
+// has to report, and that is precisely when step() is no longer running.
+void StreamPetrNode::diagnose_processing_time(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  const rclcpp::Time timestamp_now = this->get_clock()->now();
+  diagnostic_msgs::msg::DiagnosticStatus::_level_type diag_level =
+    diagnostic_msgs::msg::DiagnosticStatus::OK;
+  // Left empty rather than seeded with "OK": a stringstream constructed from a string starts its
+  // put position at 0, so the first << would partially overwrite the seed instead of replacing it.
+  std::stringstream message;
+
+  if (!last_processing_time_ms_) {
+    add_no_inference_diagnostics(stat, message);
+  } else {
+    diag_level = check_processing_time_status(stat, message, timestamp_now);
+    stat.add("processing_time_ms", format_milliseconds(last_processing_time_ms_.value()));
+    // Per-stage breakdown of the same cycle. The watchdog thresholds only the total; these
+    // localize an over-budget cycle to preprocessing, model inference or postprocessing.
+    stat.add("preprocess_time_ms", format_milliseconds(last_preprocess_time_ms_));
+    stat.add("inference_time_ms", format_milliseconds(last_inference_time_ms_));
+    stat.add("postprocess_time_ms", format_milliseconds(last_postprocess_time_ms_));
+    diag_level = check_consecutive_delays(stat, message, timestamp_now, diag_level);
+  }
+  // The newest published detection under both clocks: frame stamp vs publish instant exposes the
+  // end-to-end latency ahead of the node; the age of the publish instant answers "how long since
+  // the node last produced objects". Clamped at zero, like the camera ages: a rosbag loop rewinds
+  // the clock behind the latched stamps.
+  if (last_output_frame_stamp_ && last_publish_stamp_) {
+    const double output_latency_ms = std::max(
+      0.0, (last_publish_stamp_->seconds() - last_output_frame_stamp_->seconds()) * 1000.0);
+    const double time_since_last_publish_ms =
+      std::max(0.0, (timestamp_now.seconds() - last_publish_stamp_->seconds()) * 1000.0);
+    stat.add("last_frame_timestamp", format_timestamp(last_output_frame_stamp_->seconds()));
+    stat.add("last_published_timestamp", format_timestamp(last_publish_stamp_->seconds()));
+    stat.add("output_latency_ms", format_milliseconds(output_latency_ms));
+    stat.add("time_since_last_publish_ms", format_milliseconds(time_since_last_publish_ms));
+  } else {
+    stat.add("last_frame_timestamp", "never");
+    stat.add("last_published_timestamp", "never");
+    stat.add("output_latency_ms", "n/a");
+    stat.add("time_since_last_publish_ms", "n/a");
+  }
+
+  const std::string summary = message.str();
+  stat.summary(diag_level, summary.empty() ? "OK" : summary);
 }
 
 std::optional<std::vector<float>> StreamPetrNode::get_camera_extrinsics_vector()

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -366,9 +366,10 @@ void StreamPetrNode::step(const rclcpp::Time & stamp)
     return;
   }
 
-  const auto [output_objects, forward_time_ms, inference_time_ms] = inference_result.value();
-  publish_detection_results(stamp, output_objects);
-  publish_debug_metrics(forward_time_ms, inference_time_ms);
+  const auto & result = inference_result.value();
+  publish_detection_results(stamp, result.objects);
+  publish_debug_metrics(
+    result.forward_time_ms, result.inference_time_ms, result.postprocess_time_ms);
 }
 
 bool StreamPetrNode::validate_camera_sync()
@@ -433,25 +434,25 @@ void StreamPetrNode::cleanup_on_failure()
   }
 }
 
-std::optional<std::tuple<
-  std::vector<autoware_perception_msgs::msg::DetectedObject>, std::vector<float>, double>>
-StreamPetrNode::perform_inference()
+std::optional<StreamPetrNode::InferenceResult> StreamPetrNode::perform_inference()
 {
+  InferenceResult result;
+
   stop_watch_.tic("latency/inference");
-
-  std::vector<float> forward_time_ms;
-  std::vector<autoware_perception_msgs::msg::DetectedObject> output_objects;
-
   InferenceInputs inputs = create_inference_inputs();
-  network_->inference_detector(inputs, output_objects, forward_time_ms);
+  network_->inference_detector(inputs, result.forward_time_ms);
+  result.inference_time_ms = stop_watch_.toc("latency/inference", true);
 
+  // The decode only reads the head's output bindings, so the cameras can resume before it.
   if (multithreading_) {
     data_store_->unfreeze_updates();
   }
 
-  const double inference_time_ms = stop_watch_.toc("latency/inference", true);
+  stop_watch_.tic("latency/postprocess");
+  network_->postprocess(result.objects);
+  result.postprocess_time_ms = stop_watch_.toc("latency/postprocess", true);
 
-  return std::make_tuple(output_objects, forward_time_ms, inference_time_ms);
+  return result;
 }
 
 InferenceInputs StreamPetrNode::create_inference_inputs()
@@ -483,7 +484,7 @@ void StreamPetrNode::publish_detection_results(
 }
 
 void StreamPetrNode::publish_debug_metrics(
-  const std::vector<float> & forward_time_ms, double inference_time_ms)
+  const std::vector<float> & forward_time_ms, double inference_time_ms, double postprocess_time_ms)
 {
   // Latched before the debug_mode_ gate below: the processing-time watchdog is always active,
   // and these localize an over-budget total without enabling debug_mode.
@@ -491,7 +492,7 @@ void StreamPetrNode::publish_debug_metrics(
   last_processing_time_ms_ = processing_time_ms;
   last_preprocess_time_ms_ = data_store_->get_preprocess_time_ms();
   last_inference_time_ms_ = inference_time_ms;
-  last_postprocess_time_ms_ = forward_time_ms[3];
+  last_postprocess_time_ms_ = postprocess_time_ms;
 
   if (!debug_publisher_ptr_) {
     return;
@@ -510,7 +511,7 @@ void StreamPetrNode::publish_debug_metrics(
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "latency/inference/pos_embed", forward_time_ms[2]);
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
-    "latency/inference/postprocess", forward_time_ms[3]);
+    "latency/postprocess", postprocess_time_ms);
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "latency/cycle_time_ms", stop_watch_.toc("latency/cycle_time_ms", true));
   stop_watch_.tic("latency/cycle_time_ms");

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -37,6 +38,16 @@ namespace autoware::camera_streampetr
 
 namespace
 {
+
+// Fixed-point formatting for /diagnostics values. DiagnosticStatusWrapper's double overload
+// prints large values in scientific notation (1.78461e+09), which is unreadable for long ages;
+// format them as strings instead, like the concatenate node does.
+std::string format_milliseconds(const double milliseconds)
+{
+  char buffer[32];
+  std::snprintf(buffer, sizeof(buffer), "%.3f", milliseconds);
+  return std::string(buffer);
+}
 
 constexpr std::size_t kMaxCameraMaskId = 10;
 
@@ -229,6 +240,7 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
     // https://github.com/ros-perception/image_transport_plugins/issues/155
     const std::string base_topic = this->get_node_topics_interface()->resolve_topic_name(
       "~/input/camera" + std::to_string(roi_i) + "/image");
+    camera_image_topics_.push_back(base_topic);
     camera_image_subs_.at(roi_i) = image_transport::create_subscription(
       this, base_topic,
       [this, roi_i](const Image::ConstSharedPtr & msg) {
@@ -286,6 +298,18 @@ StreamPetrNode::StreamPetrNode(const rclcpp::NodeOptions & node_options)
     debug_publisher_ptr_ = std::make_unique<DebugPublisher>(this, this->get_name());
     stop_watch_ptr_->tic("latency/cycle_time_ms");
   }
+
+  // Diagnostics, always on: the only place where a missing, stalled or rejected camera becomes
+  // visible outside the node's log.
+  max_image_age_ms_ = declare_parameter<double>("diagnostics.max_image_age_ms");
+  const double validation_callback_interval_ms =
+    declare_parameter<double>("diagnostics.validation_callback_interval_ms");
+
+  // The node name, not a fixed string: an A/B deployment runs two instances side by side and
+  // their statuses have to stay distinguishable by hardware_id.
+  diagnostic_updater_.setHardwareID(this->get_name());
+  diagnostic_updater_.add("camera_status", this, &StreamPetrNode::diagnose_camera_status);
+  diagnostic_updater_.setPeriod(validation_callback_interval_ms / 1000.0);
 }
 
 void StreamPetrNode::camera_info_callback(
@@ -473,6 +497,115 @@ void StreamPetrNode::publish_debug_metrics(
   debug_publisher_ptr_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "latency/cycle_time_ms", stop_watch_ptr_->toc("latency/cycle_time_ms", true));
   stop_watch_ptr_->tic("latency/cycle_time_ms");
+}
+
+void StreamPetrNode::diagnose_camera_status(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  const rclcpp::Time now = this->get_clock()->now();
+  const auto camera_status = data_store_->get_camera_status();
+
+  // Every camera collapses into one state, most-specific-cause first:
+  //   rejected            -- the newest frame was dropped by the input validation (ERROR)
+  //   waiting_camera_info -- no camera_info yet, normal during start-up (WARN)
+  //   waiting_image       -- no first frame yet, normal during start-up (WARN)
+  //   stale               -- used to publish, newest frame older than max_image_age_ms (ERROR)
+  //   active              -- healthy
+  std::size_t num_waiting = 0;
+  std::size_t num_stale = 0;
+  std::size_t num_rejected = 0;
+  int stalest_camera_id = -1;
+  double stalest_image_age_ms = 0.0;
+
+  for (std::size_t camera_id = 0; camera_id < camera_status.size(); ++camera_id) {
+    const auto & status = camera_status[camera_id];
+    const std::string prefix = "camera" + std::to_string(camera_id) + "/";
+
+    double age_ms = 0.0;
+    if (status.image_received) {
+      // Clamped at zero: a negative age means the header stamp is ahead of the node clock,
+      // which legitimately happens right after a rosbag loops back, and must not raise a
+      // stall alarm.
+      age_ms = std::max(0.0, (now.seconds() - status.last_image_timestamp) * 1000.0);
+      if (age_ms > stalest_image_age_ms) {
+        stalest_image_age_ms = age_ms;
+        stalest_camera_id = static_cast<int>(camera_id);
+      }
+    }
+
+    std::string state;
+    if (status.input_rejected) {
+      state = "rejected";
+      ++num_rejected;
+    } else if (!status.camera_info_received) {
+      state = "waiting_camera_info";
+      ++num_waiting;
+    } else if (!status.image_received) {
+      state = "waiting_image";
+      ++num_waiting;
+    } else if (age_ms > max_image_age_ms_) {
+      state = "stale";
+      ++num_stale;
+    } else {
+      state = "active";
+    }
+
+    // The model input index (cameraN) and the physical camera differ per deployment; the topic
+    // names the culprit without digging through launch-file remaps.
+    stat.add(prefix + "topic", camera_image_topics_[camera_id]);
+    stat.add(prefix + "state", state);
+    // "n/a" until the first frame: a waiting camera showing 0 ms would read as perfectly fresh.
+    stat.add(prefix + "image_age_ms", status.image_received ? format_milliseconds(age_ms) : "n/a");
+  }
+
+  stat.add("num_cameras", static_cast<int>(camera_status.size()));
+  stat.add("num_waiting", static_cast<int>(num_waiting));
+  stat.add("num_stale", static_cast<int>(num_stale));
+  stat.add("num_rejected", static_cast<int>(num_rejected));
+  stat.add("stalest_camera_id", stalest_camera_id);
+  stat.add(
+    "stalest_image_age_ms",
+    stalest_camera_id >= 0 ? format_milliseconds(stalest_image_age_ms) : "n/a");
+
+  // Subscriber-side stamp spread between the cameras; above max_camera_time_diff the sync check
+  // is skipping prediction cycles. n/a while cameras are still missing.
+  const float inter_camera_diff_s = data_store_->check_if_all_images_synced();
+  stat.add(
+    "max_inter_camera_time_diff_ms",
+    inter_camera_diff_s >= 0.0f ? format_milliseconds(inter_camera_diff_s * 1000.0) : "n/a");
+
+  // The level falls out of the state counts. A rejected or stale camera is an ERROR rather than
+  // a WARN: neither recovers until the publisher is fixed. A camera that simply has not arrived
+  // yet is the normal state during start-up, so it only warrants a WARN, as does a sync spread
+  // that skips cycles.
+  auto level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  std::stringstream message;
+
+  if (num_rejected > 0) {
+    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    message << num_rejected
+            << " camera(s) publish an encoding or buffer geometry the preprocessing cannot "
+               "consume.";
+  }
+  if (num_stale > 0) {
+    level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    message << (message.tellp() > 0 ? " " : "") << num_stale << " camera(s) stale; camera"
+            << stalest_camera_id << " stopped publishing "
+            << format_milliseconds(stalest_image_age_ms) << " ms ago.";
+  }
+  if (level == diagnostic_msgs::msg::DiagnosticStatus::OK) {
+    if (num_waiting > 0) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      message << num_waiting << " camera(s) waiting for camera_info or a first image.";
+    } else if (inter_camera_diff_s > max_camera_time_diff_) {
+      level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      message << "Inter-camera timestamp spread "
+              << format_milliseconds(inter_camera_diff_s * 1000.0)
+              << " ms exceeds max_camera_time_diff; prediction cycles are being skipped.";
+    }
+  }
+
+  const std::string summary = message.str();
+  stat.summary(level, summary.empty() ? "OK" : summary);
 }
 
 std::optional<std::vector<float>> StreamPetrNode::get_camera_extrinsics_vector()


### PR DESCRIPTION
## Description

Depends on https://github.com/autowarefoundation/autoware_universe/pull/13167,
https://github.com/autowarefoundation/autoware_universe/pull/13212,
https://github.com/autowarefoundation/autoware_universe/pull/13213 and
https://github.com/autowarefoundation/autoware_universe/pull/13214.

`inference_detector()` ran the model and then decoded the detections inside the same call, so the
postprocess stage was timed inside the inference window: publishing both invites computing
`total - preprocess - inference - postprocess`, which goes negative. The postprocess `Duration`
was also fragile — its CUDA events are recorded on the stream, but the bbox conversion and NMS
are host work, so the number was only correct while the stream happened to be idle there.

Split the network API into `inference_detector()` (model only, stream synchronized before
returning) and `postprocess()` (bbox decode + NMS):

- The node times each with its own stopwatch window, so `latency/inference` and the new
  `latency/postprocess` topic — previously the nested `latency/inference/postprocess` — are
  disjoint stages, and so are the `inference_time_ms` / `postprocess_time_ms` diagnostics keys.
- The per-cycle results travel as a named `InferenceResult` struct instead of a tuple with two
  adjacent `double`s.
- `postprocess()` only reads the head's output bindings, so the camera store is unfrozen before
  it: with `multithreading:=true` the cameras resume as soon as the forward pass ends instead of
  staying blocked through the decode.

## Related links

None.

## How was this PR tested?

- `colcon build` (Release) with no warnings.
- Replayed an X2 five-camera rosbag: detections unchanged; `latency/inference` +
  `latency/postprocess` sum to slightly less than before-split `latency/inference` (the stages no
  longer overlap), and the diagnostics stage keys match the debug topics.

## Notes for reviewers

Fourth PR of the stack (preprocess-time fix → camera status → processing-time watchdog →
**this** → snake_case rename).

## Interface changes

The debug topic `latency/inference/postprocess` (published only with `debug_mode`) is renamed to
`latency/postprocess`. Plots and analysis scripts subscribing to the old name need updating.

## Effects on system behavior

With `multithreading:=true`, camera preprocessing resumes ~0.4 ms earlier per cycle (it no longer
waits for the decode/NMS). No change to the published detections.
