### PR TITLE
fix(system): declare the dependencies these packages use

### DIFF
--- a/system/autoware_command_mode_decider/package.xml
+++ b/system/autoware_command_mode_decider/package.xml
@@ -13,10 +13,12 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_command_mode_types</depend>
+  <depend>autoware_common_msgs</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_command_mode_decider_plugins/package.xml
+++ b/system/autoware_command_mode_decider_plugins/package.xml
@@ -15,6 +15,7 @@
   <depend>autoware_command_mode_types</depend>
   <depend>autoware_system_msgs</depend>
   <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/system/autoware_command_mode_decider_plugins/package.xml
+++ b/system/autoware_command_mode_decider_plugins/package.xml
@@ -10,8 +10,10 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_command_mode_decider</depend>
   <depend>autoware_command_mode_types</depend>
+  <depend>autoware_system_msgs</depend>
   <depend>pluginlib</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/system/autoware_component_monitor/package.xml
+++ b/system/autoware_component_monitor/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_msgs</depend>
+  <depend>libboost-dev</depend>
   <depend>libboost-filesystem-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/autoware_component_monitor/package.xml
+++ b/system/autoware_component_monitor/package.xml
@@ -18,6 +18,8 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
+  <exec_depend>procps</exec_depend>
+
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/package.xml
+++ b/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/package.xml
@@ -12,6 +12,7 @@
 
   <exec_depend>autoware_adapi_v1_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>tf_transformations</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>

--- a/system/autoware_default_adapi_universe/package.xml
+++ b/system/autoware_default_adapi_universe/package.xml
@@ -48,6 +48,7 @@
   <exec_depend>autoware_default_adapi</exec_depend>
   <exec_depend>autoware_global_parameter_loader</exec_depend>
   <exec_depend>python3-flask</exec_depend>
+  <exec_depend>rclpy</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/system/autoware_default_adapi_universe/package.xml
+++ b/system/autoware_default_adapi_universe/package.xml
@@ -22,6 +22,7 @@
   <depend>autoware_geography_utils</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_qos_utils</depend>
   <depend>autoware_system_msgs</depend>
@@ -29,8 +30,11 @@
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>geographic_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/autoware_dummy_diag_publisher/package.xml
+++ b/system/autoware_dummy_diag_publisher/package.xml
@@ -13,6 +13,7 @@
 
   <depend>diagnostic_msgs</depend>
   <depend>fmt</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/system/autoware_dummy_infrastructure/package.xml
+++ b/system/autoware_dummy_infrastructure/package.xml
@@ -17,6 +17,8 @@
 
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_utils</depend>
+  <depend>nav_msgs</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_v2x_msgs</depend>

--- a/system/autoware_duplicated_node_checker/package.xml
+++ b/system/autoware_duplicated_node_checker/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/autoware_mrm_comfortable_stop_operator/package.xml
+++ b/system/autoware_mrm_comfortable_stop_operator/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_utils</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/system/autoware_mrm_emergency_stop_operator/package.xml
+++ b/system/autoware_mrm_emergency_stop_operator/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_utils</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/system/autoware_mrm_handler/package.xml
+++ b/system/autoware_mrm_handler/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_qos_utils</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/autoware_system_monitor/package.xml
+++ b/system/autoware_system_monitor/package.xml
@@ -17,11 +17,13 @@
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>
+  <depend>libboost-dev</depend>
   <depend>libboost-filesystem-dev</depend>
   <depend>libboost-regex-dev</depend>
   <depend>libboost-serialization-dev</depend>
   <depend>libboost-thread-dev</depend>
   <depend>libnl-3-dev</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/system/autoware_topic_state_monitor/package.xml
+++ b/system/autoware_topic_state_monitor/package.xml
@@ -12,7 +12,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2_msgs</depend>

--- a/system/autoware_velodyne_monitor/package.xml
+++ b/system/autoware_velodyne_monitor/package.xml
@@ -15,6 +15,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>
+  <depend>libboost-dev</depend>
   <depend>libcpprest-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
## Description

Fourteen system packages use headers, symbols, or runtime programs of packages that they never declare. This adds the 25 missing entries: 22 `<depend>` and 3 `<exec_depend>`.

The first commit adds the 21 entries from the checker. A per-package sweep of the same 13 packages ran before this pull request opened. It found two more entries: the `rclpy` import of an installed Python script, and the `rclcpp` logging macro in a plugin library. The checker was then taught the evidence classes of that sweep. It found a third entry in a 14th package: the `numpy` import of a Python program in `autoware_adapi_visualizers`. A review round on the opened pull request added the last entry: the `top` program that `autoware_component_monitor` runs at run time.

These packages build and run today only because another declared dependency re-exports the owner, or because some other package installs the system library.

- Tracking issue: autowarefoundation/autoware_universe#13207
- Parent issue: autowarefoundation/autoware#7263

## The entries

Each entry links to the `package.xml` it goes into, and each example links to a line that uses the dependency, at the commit this branch starts from.

[`autoware_command_mode_decider`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`autoware_common_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider/package.xml) | `<depend>` | [`command_mode_decider_base.hpp:45`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider/src/command_mode_decider_base.hpp#L45) `using autoware_common_msgs::msg::ResponseStatus;` |
| [`diagnostic_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider/package.xml) | `<depend>` | [`command_mode_decider_base.cpp:139`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider/src/command_mode_decider_base.cpp#L139) `status.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "");` |

[`autoware_command_mode_decider_plugins`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider_plugins/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`autoware_adapi_v1_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider_plugins/package.xml) | `<depend>` | [`command_mode_decider.cpp:19`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider_plugins/src/command_mode_decider.cpp#L19) `#include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>` |
| [`autoware_system_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider_plugins/package.xml) | `<depend>` | [`command_mode_decider.cpp:21`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider_plugins/src/command_mode_decider.cpp#L21) `#include <autoware_system_msgs/srv/change_operation_mode.hpp>` |
| [`rclcpp`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider_plugins/package.xml) | `<depend>` | [`command_mode_decider.cpp:119`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_command_mode_decider_plugins/src/command_mode_decider.cpp#L119) `RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 1000, "No mrm available");` |

[`autoware_component_monitor`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_component_monitor/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`libboost-dev`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_component_monitor/package.xml) | `<depend>` | [`component_monitor_node.hpp:22`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_component_monitor/src/component_monitor_node.hpp#L22) `#include <boost/process.hpp>` |
| [`procps`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_component_monitor/package.xml) | `<exec_depend>` | [`component_monitor_node.cpp:44`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_component_monitor/src/component_monitor_node.cpp#L44) `const auto path_top = boost::process::search_path("top");` |

[`autoware_default_adapi_universe`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`autoware_perception_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/package.xml) | `<depend>` | [`perception.hpp:25`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/src/perception.hpp#L25) `#include <autoware_perception_msgs/msg/shape.hpp>` |
| [`builtin_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/package.xml) | `<depend>` | [`operation_mode.cpp:147`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/src/operation_mode.cpp#L147) `state.stamp = builtin_interfaces::msg::Time();` |
| [`diagnostic_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/package.xml) | `<depend>` | [`mrm_request.cpp:35`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/src/mrm_request.cpp#L35) `using diagnostic_msgs::msg::DiagnosticStatus;` |
| [`geometry_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/package.xml) | `<depend>` | [`planning.cpp:260`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/src/planning.cpp#L260) `geometry_msgs::msg::TwistStamped twist;` |
| [`rclpy`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/package.xml) | `<exec_depend>` | [`web_server.py:22`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_universe/script/web_server.py#L22) `import rclpy` |

[`autoware_dummy_diag_publisher`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_dummy_diag_publisher/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`rcl_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_dummy_diag_publisher/package.xml) | `<depend>` | [`dummy_diag_publisher_core.hpp:68`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_dummy_diag_publisher/include/autoware/dummy_diag_publisher/dummy_diag_publisher_core.hpp#L68) `rcl_interfaces::msg::SetParametersResult onSetParams(` |

[`autoware_dummy_infrastructure`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_dummy_infrastructure/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`nav_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_dummy_infrastructure/package.xml) | `<depend>` | [`dummy_infrastructure_node.hpp:23`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_dummy_infrastructure/include/autoware/dummy_infrastructure/dummy_infrastructure_node.hpp#L23) `#include <nav_msgs/msg/odometry.hpp>` |
| [`rcl_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_dummy_infrastructure/package.xml) | `<depend>` | [`dummy_infrastructure_node.hpp:92`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_dummy_infrastructure/include/autoware/dummy_infrastructure/dummy_infrastructure_node.hpp#L92) `rcl_interfaces::msg::SetParametersResult onSetParam(` |

[`autoware_duplicated_node_checker`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_duplicated_node_checker/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`diagnostic_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_duplicated_node_checker/package.xml) | `<depend>` | [`duplicated_node_checker_core.cpp:53`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_duplicated_node_checker/src/duplicated_node_checker_core.cpp#L53) `using diagnostic_msgs::msg::DiagnosticStatus;` |

[`autoware_mrm_comfortable_stop_operator`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_comfortable_stop_operator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`rcl_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_comfortable_stop_operator/package.xml) | `<depend>` | [`mrm_comfortable_stop_operator_core.hpp:68`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator_core.hpp#L68) `rcl_interfaces::msg::SetParametersResult onParameter(` |

[`autoware_mrm_emergency_stop_operator`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_emergency_stop_operator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`rcl_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_emergency_stop_operator/package.xml) | `<depend>` | [`mrm_emergency_stop_operator_core.hpp:61`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_emergency_stop_operator/src/mrm_emergency_stop_operator_core.hpp#L61) `rcl_interfaces::msg::SetParametersResult onParameter(` |

[`autoware_mrm_handler`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_handler/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`diagnostic_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_handler/package.xml) | `<depend>` | [`mrm_handler_core.hpp:42`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_mrm_handler/include/autoware/mrm_handler/mrm_handler_core.hpp#L42) `#include <diagnostic_msgs/msg/diagnostic_array.hpp>` |

[`autoware_topic_state_monitor`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_topic_state_monitor/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`diagnostic_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_topic_state_monitor/package.xml) | `<depend>` | [`topic_state_monitor_core.cpp:128`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp#L128) `using diagnostic_msgs::msg::DiagnosticStatus;` |
| [`rcl_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_topic_state_monitor/package.xml) | `<depend>` | [`topic_state_monitor_core.hpp:58`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp#L58) `rcl_interfaces::msg::SetParametersResult onParameter(` |

[`autoware_velodyne_monitor`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_velodyne_monitor/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`libboost-dev`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_velodyne_monitor/package.xml) | `<depend>` | [`velodyne_monitor.cpp:22`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_velodyne_monitor/src/velodyne_monitor.cpp#L22) `#include <boost/algorithm/string/join.hpp>` |

[`autoware_system_monitor`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_system_monitor/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`libboost-dev`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_system_monitor/package.xml) | `<depend>` | [`system_monitor_utility.hpp:26`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_system_monitor/include/system_monitor/system_monitor_utility.hpp#L26) `#include <boost/range.hpp>` |
| [`rcl_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_system_monitor/package.xml) | `<depend>` | [`cpu_monitor_base.cpp:51`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_system_monitor/src/cpu_monitor/cpu_monitor_base.cpp#L51) `rcl_interfaces::msg::ParameterDescriptor().set__read_only(true).set__description(` |

[`autoware_adapi_visualizers`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`python3-numpy`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/package.xml) | `<exec_depend>` | [`planning_factors.py:8`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/autoware_adapi_visualizers/planning_factors.py#L8) `import numpy` |

## AI usage

**AI usage:** written with Claude Code. The checker from the tracking issue produced the entries of the first commit, and Claude Code verified each entry against its source lines and applied the edits. Thirteen Claude Code sub-agents, one per package, proved the entries again without the checker output. The same sub-agents swept each package for uses that the checker misses. That sweep, and a checker that now knows the same evidence classes, produced the second commit. A review round with 14 fresh Claude Code sub-agents, one per package, ran without the checker and without this body. It confirmed the 24 entries and raised the `procps` finding again. The third commit adds it.

**Self-review:** Done a comprehensive clean context review.

<details>
<summary><strong>Verification:</strong> every entry maps to a real use in the sources, and the 14 packages build cleanly with the new entries.</summary>

### The checker run

On `main` at `f1bb0a617`, in a jazzy workspace.

- `fix_missing_deps.py --repo src/universe/autoware_universe/system --write` reported `packages to edit 13` and `entries to add 21`, all `<depend>`.
- The `system/` tree is unchanged since the measurement in the tracking issue at `4260f35f2`, and the 21 entries are the same 21.

### Per-entry source check, first commit

- One sub-agent per package, 13 in total, each given only the package path and its added entries. Each of the 21 entries mapped to a direct use in the code its tag points to. The use is an `#include` of a header the dependency ships, or a qualified name such as `rcl_interfaces::msg::SetParametersResult`. The tables above link one example per entry.
- Each entry was absent from its `package.xml` before the edit.
- All 25 example links above matched the quoted code at `f1bb0a617`, checked with `git show`.
- `rosdep resolve libboost-dev` returned `apt libboost-dev`.
- `sort-package-xml` and `prettier-package-xml` passed on the 13 manifests.

### Build, first commit

- `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select` for the 13 packages: `Summary: 13 packages finished [1min 59s]`, no errors.
- The only stderr output is the pre-existing `ament_auto_package` notice about the header install destination, and a pre-existing CMake dev warning from `FindFLANN.cmake`.
- Not run at this stage: `colcon test`, and a build of the reverse-dependency closure.

### The sweep and the second commit

- The same 13 sub-agents listed every reference in their package: includes, qualified names, Python imports, launch references, plugin XML base classes, and CMake `find_package` calls. They compared the result with the manifest.
- `autoware_default_adapi_universe`: `CMakeLists.txt` installs `script/web_server.py` to `lib/autoware_default_adapi_universe`, and the script imports `rclpy`. The manifest declared `python3-flask` for the same script, but not `rclpy`. It gets `<exec_depend>rclpy</exec_depend>`.
- `autoware_command_mode_decider_plugins`: `src/command_mode_decider.cpp` expands `RCLCPP_WARN_THROTTLE` and calls `rclcpp::Node` methods on the inherited `node_`. The `rclcpp` header arrives only through `autoware_command_mode_decider/plugin.hpp`. It gets `<depend>rclcpp</depend>`.
- The checker was then taught the evidence classes of the sweep: macros, imports of installed Python programs, launch references, `find_package` calls, and share-directory lookups. On the first commit it reports the two entries above, and one more: `autoware_adapi_visualizers` is an `ament_python` package whose `planning_factors` program imports `numpy`. It gets `<exec_depend>python3-numpy</exec_depend>`. `rosdep resolve python3-numpy` returned `apt python3-numpy`.
- Two findings were left out at this stage. `autoware_mrm_comfortable_stop_operator` imports `yaml` in a launch file, and `launch` itself declares `python3-yaml`, so no package in this repository declares it for a launch file. `autoware_component_monitor` runs the `top` binary at run time, and `procps` is a required Ubuntu package. The third commit reverses the second decision, see below.
- `sort-package-xml` and `prettier-package-xml` passed on the three edited manifests.

### Build, second commit

- `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select autoware_adapi_visualizers autoware_command_mode_decider_plugins autoware_default_adapi_universe`: `Summary: 3 packages finished [5.72s]`, no errors. The only stderr output is a pre-existing `pkg_resources` deprecation warning from `setup.py`.
- Not run: `colcon test`, a build of the reverse-dependency closure, and any check on humble. The repository CI builds the pull request.

### The review round and the third commit

On the pull request head `0cf495c8c`, in the same jazzy workspace.

- 14 fresh sub-agents, one per package, given only the package path and its added entries, mapped all 24 entries to a use again. `git show` matched all 24 example links, `colcon build` of the 14 packages returned `Summary: 14 packages finished [12.7s]`.
- The sweep of `autoware_component_monitor` found the `top` program again. `src/component_monitor_node.cpp:44` looks it up with `boost::process::search_path("top")`. Lines `:44-48` shut the node down when it is absent, and `:80` runs it on every tick. `dpkg -S /usr/bin/top` returns `procps`. The sibling monitors declare their runtime programs, `chrony`, `edac-utils`, `sysstat` in `autoware_system_monitor` and `bluez` in `autoware_bluetooth_monitor`, so `autoware_component_monitor` gets `<exec_depend>procps</exec_depend>`.
- `rosdep resolve procps` returned `apt procps`. `docker run --rm ubuntu:24.04 sh -c 'command -v top'` printed `/usr/bin/top`, and so did `ghcr.io/autowarefoundation/autoware:universe-jazzy`, so the entry changes no image today.
- `sort-package-xml` and `prettier-package-xml` passed on the edited manifest.
- `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select autoware_component_monitor`: `Summary: 1 package finished [3.34s]`, no errors. An `<exec_depend>` cannot change the build, so this only shows that the manifest still parses.
- Not run: `colcon test`, and any check on humble.

</details>
