### PR TITLE
fix(evaluator): declare the dependencies these packages use

### DIFF
--- a/evaluator/autoware_control_evaluator/package.xml
+++ b/evaluator/autoware_control_evaluator/package.xml
@@ -18,8 +18,10 @@
 
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_deprecated_boundary_departure_checker</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
@@ -28,8 +30,12 @@
   <depend>autoware_route_handler</depend>
   <depend>autoware_test_utils</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_math</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>libboost-dev</depend>
   <depend>nav_msgs</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>pluginlib</depend>
@@ -40,6 +46,7 @@
   <depend>tier4_metric_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/evaluator/autoware_kinematic_evaluator/package.xml
+++ b/evaluator/autoware_kinematic_evaluator/package.xml
@@ -32,6 +32,7 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/evaluator/autoware_kinematic_evaluator/package.xml
+++ b/evaluator/autoware_kinematic_evaluator/package.xml
@@ -24,6 +24,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>libboost-dev</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/evaluator/autoware_localization_evaluator/package.xml
+++ b/evaluator/autoware_localization_evaluator/package.xml
@@ -30,6 +30,7 @@
   <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/evaluator/autoware_localization_evaluator/package.xml
+++ b/evaluator/autoware_localization_evaluator/package.xml
@@ -21,6 +21,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>libboost-dev</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/evaluator/autoware_perception_online_evaluator/package.xml
+++ b/evaluator/autoware_perception_online_evaluator/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_agnocast_wrapper</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
@@ -25,13 +26,21 @@
   <depend>autoware_vehicle_info_utils</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
+  <depend>libboost-dev</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>std_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_metric_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_cpp</test_depend>

--- a/evaluator/autoware_planning_evaluator/package.xml
+++ b/evaluator/autoware_planning_evaluator/package.xml
@@ -31,6 +31,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
   <depend>libboost-dev</depend>
   <depend>nav_msgs</depend>
   <depend>nlohmann-json-dev</depend>
@@ -47,6 +48,7 @@
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>autoware_test_utils</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/evaluator/autoware_planning_evaluator/package.xml
+++ b/evaluator/autoware_planning_evaluator/package.xml
@@ -16,7 +16,10 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_agnocast_wrapper</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_lanelet2_utils</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
@@ -25,16 +28,20 @@
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
+  <depend>libboost-dev</depend>
   <depend>nav_msgs</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_metric_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_cpp</test_depend>

--- a/evaluator/autoware_scenario_simulator_v2_adapter/package.xml
+++ b/evaluator/autoware_scenario_simulator_v2_adapter/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <depend>diagnostic_msgs</depend>
   <depend>pluginlib</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_metric_msgs</depend>


### PR DESCRIPTION
## Description

Six evaluator packages use headers or symbols of packages that they never declare. This adds the 30 missing entries: 26 `<depend>` and 4 `<test_depend>`.

The first commit adds the 26 entries from the checker. A per-package sweep of the same six packages ran before this pull request opened. It found four more entries. Two are an undeclared `find_package` in a test block. One is a `lanelet::ConstLanelet` use in library code. One is a test that reads parameter files from another package.

These packages build today only because another declared dependency re-exports the owner, or because some other package installs the system library.

- Tracking issue: autowarefoundation/autoware_universe#13207
- Parent issue: autowarefoundation/autoware#7263

## The entries

Each entry links to the `package.xml` it goes into, and each example links to a line that uses the dependency, at the commit this branch starts from.

[`autoware_control_evaluator`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`autoware_internal_debug_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/package.xml) | `<depend>` | [`control_evaluator_node.hpp:33`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp#L33) `#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>` |
| [`autoware_map_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/package.xml) | `<depend>` | [`control_evaluator_node.hpp:64`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp#L64) `using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;` |
| [`autoware_utils_math`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/package.xml) | `<depend>` | [`control_evaluator_node.hpp:27`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp#L27) `#include <autoware_utils_math/accumulator.hpp>` |
| [`geometry_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/package.xml) | `<depend>` | [`control_evaluator_node.hpp:32`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp#L32) `#include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"` |
| [`lanelet2_core`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/package.xml) | `<depend>` | [`metrics_utils.cpp:23`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/src/metrics/metrics_utils.cpp#L23) `#include <lanelet2_core/Forward.h>` |
| [`libboost-dev`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/package.xml) | `<depend>` | [`control_evaluator_node.cpp:28`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp#L28) `#include <boost/geometry.hpp>` |
| [`ament_index_cpp`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/package.xml) | `<test_depend>` | [`test_control_evaluator_node.cpp:15`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp#L15) `#include "ament_index_cpp/get_package_share_directory.hpp"` |

[`autoware_kinematic_evaluator`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_kinematic_evaluator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`libboost-dev`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_kinematic_evaluator/package.xml) | `<depend>` | [`kinematic_evaluator_node.cpp:17`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_kinematic_evaluator/src/kinematic_evaluator_node.cpp#L17) `#include "boost/lexical_cast.hpp"` |
| [`ament_cmake_ros`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_kinematic_evaluator/package.xml) | `<test_depend>` | [`CMakeLists.txt:32`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_kinematic_evaluator/CMakeLists.txt#L32) `find_package(ament_cmake_ros REQUIRED)` |

[`autoware_localization_evaluator`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_localization_evaluator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`libboost-dev`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_localization_evaluator/package.xml) | `<depend>` | [`localization_evaluator_node.cpp:17`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_localization_evaluator/src/localization_evaluator_node.cpp#L17) `#include "boost/lexical_cast.hpp"` |
| [`ament_cmake_ros`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_localization_evaluator/package.xml) | `<test_depend>` | [`CMakeLists.txt:32`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_localization_evaluator/CMakeLists.txt#L32) `find_package(ament_cmake_ros REQUIRED)` |

[`autoware_perception_online_evaluator`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`autoware_internal_debug_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`perception_analytics_publisher_node.hpp:28`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_analytics_publisher_node.hpp#L28) `#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>` |
| [`lanelet2_core`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`marker_utils.hpp:25`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/utils/marker_utils.hpp#L25) `#include <lanelet2_core/Forward.h>` |
| [`libboost-dev`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`perception_online_evaluator_node.cpp:24`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/src/perception_online_evaluator_node.cpp#L24) `#include "boost/lexical_cast.hpp"` |
| [`rcl_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`perception_online_evaluator_node.hpp:99`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_online_evaluator_node.hpp#L99) `rcl_interfaces::msg::SetParametersResult onParameter(` |
| [`std_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`marker_utils.hpp:71`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/utils/marker_utils.hpp#L71) `std_msgs::msg::ColorRGBA createColorFromString(const std::string & str);` |
| [`tf2_geometry_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`perception_analytics_calculator.cpp:21`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/src/perception_analytics_calculator.cpp#L21) `#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"` |
| [`tf2_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`perception_online_evaluator_node.hpp:43`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/perception_online_evaluator_node.hpp#L43) `using TFMessage = tf2_msgs::msg::TFMessage;` |
| [`unique_identifier_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`metrics_calculator.hpp:30`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/metrics_calculator.hpp#L30) `#include <unique_identifier_msgs/msg/uuid.hpp>` |
| [`visualization_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/package.xml) | `<depend>` | [`marker_utils.hpp:23`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_perception_online_evaluator/include/autoware/perception_online_evaluator/utils/marker_utils.hpp#L23) `#include <visualization_msgs/msg/marker_array.hpp>` |

[`autoware_planning_evaluator`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`autoware_internal_debug_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<depend>` | [`planning_evaluator_node.hpp:34`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp#L34) `#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>` |
| [`autoware_lanelet2_utils`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<depend>` | [`planning_evaluator_node.cpp:20`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp#L20) `#include <autoware/lanelet2_utils/geometry.hpp>` |
| [`autoware_map_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<depend>` | [`planning_evaluator_node.hpp:70`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp#L70) `using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;` |
| [`diagnostic_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<depend>` | [`planning_evaluator_node.cpp:25`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp#L25) `#include <diagnostic_msgs/msg/detail/diagnostic_status__struct.hpp>` |
| [`lanelet2_core`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<depend>` | [`planning_evaluator_node.cpp:226`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp#L226) `lanelet::ConstLanelet closest_route_lanelet;` |
| [`libboost-dev`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<depend>` | [`obstacle_metrics_calculator.hpp:31`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/obstacle_metrics_calculator.hpp#L31) `#include <boost/geometry.hpp>` |
| [`tf2_geometry_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<depend>` | [`obstacle_metrics_calculator.hpp:29`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/obstacle_metrics_calculator.hpp#L29) `#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>` |
| [`unique_identifier_msgs`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<depend>` | [`metrics_utils.hpp:25`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metrics/metrics_utils.hpp#L25) `#include "unique_identifier_msgs/msg/uuid.hpp"` |
| [`autoware_test_utils`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/package.xml) | `<test_depend>` | [`test_planning_evaluator_node.cpp:68`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_planning_evaluator/test/test_planning_evaluator_node.cpp#L68) `ament_index_cpp::get_package_share_directory("autoware_test_utils");` |

[`autoware_scenario_simulator_v2_adapter`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_scenario_simulator_v2_adapter/package.xml)

| Entry | Tag | Example use |
|---|---|---|
| [`rcl_interfaces`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_scenario_simulator_v2_adapter/package.xml) | `<depend>` | [`converter_node.cpp:17`](https://github.com/autowarefoundation/autoware_universe/blob/f1bb0a617e93fa55d71a38da8cca78725fa40c8a/evaluator/autoware_scenario_simulator_v2_adapter/src/converter_node.cpp#L17) `#include <rcl_interfaces/msg/list_parameters_result.hpp>` |

## Why the count differs from the tracking issue

The tracking issue lists 25 entries for `evaluator`. The sweep found a defect in the checker. The checker blanks string literals before it scans, so that a Doxygen example does not count as a use. A quoted include such as `#include "boost/lexical_cast.hpp"` is a string literal too, so every quoted include was invisible to it. With that fixed, the checker reports 26 entries. It now sees `tf2_geometry_msgs` in `autoware_perception_online_evaluator`, and it moves `libboost-dev` in the same package from `<test_depend>` to `<depend>`. The first commit carries the fixed output. For `system`, the fix changes nothing.

The sweep also taught the checker the evidence classes it did not have. These are macros, imports of installed Python programs, launch references, `find_package` calls, share-directory lookups, and qualified names whose namespace is not the package name. On the first commit of this branch, the improved checker reports the four entries of the second commit, and nothing else. The counts in the tracking issue come from the old checker, so they are a lower bound.

## AI usage

**AI usage:** written with Claude Code. The checker from the tracking issue produced the entries of the first commit, and Claude Code verified each entry against its source lines and applied the edits. Six Claude Code sub-agents, one per package, proved the entries again without the checker output. The same sub-agents swept each package for uses that the checker misses, and that sweep produced the second commit and the checker fixes.

**Self-review:** Done a comprehensive clean context review 👍

<details>
<summary><strong>Verification:</strong> every entry maps to a real use in the sources, and the six packages build cleanly with the new entries.</summary>

### The checker run

On `main` at `f1bb0a617`, in a jazzy workspace.

- The old checker, `fix_missing_deps.py --repo src/universe/autoware_universe/evaluator --write`, reported `packages to edit 6` and `entries to add 25`: 23 `<depend>` and 2 `<test_depend>`. These are the 25 entries of the tracking issue.
- The `evaluator/` tree is unchanged since the measurement in the tracking issue at `4260f35f2`.
- The fixed checker, on the clean tree, reported `entries to add 26`: 25 `<depend>` and 1 `<test_depend>`. The difference is `tf2_geometry_msgs` in `autoware_perception_online_evaluator`, and the tag of `libboost-dev` in the same package. The first commit is this output.

### Per-entry source check, first commit

- One sub-agent per package, six in total, each given only the package path and its added entries. Each of the 26 entries mapped to a direct use in the code its tag points to. The use is an `#include` of a header the dependency ships, or a qualified name such as `autoware_map_msgs::msg::LaneletMapBin`. The tables above link one example per entry.
- The sub-agent for `autoware_perception_online_evaluator` rejected the old tag of `libboost-dev`, because `src/perception_online_evaluator_node.cpp:24` includes `boost/lexical_cast.hpp`, and it found the missing `tf2_geometry_msgs`. That is what exposed the checker defect.
- Each entry was absent from its `package.xml` before the edit.
- All 30 example links above matched the quoted code at `f1bb0a617`, checked with `git show`.
- `rosdep resolve libboost-dev` returned `apt libboost-dev`.
- `colcon list --packages-above autoware_control_evaluator` and `--packages-above autoware_planning_evaluator` list only the launch packages, so no added workspace entry creates a cycle.
- `sort-package-xml` and `prettier-package-xml` passed on the six manifests.

### Build, first commit

- `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select` for the six packages, on the 25-entry tree: `Summary: 6 packages finished [1min 12s]`, no errors.
- The same command on the committed 26-entry tree: `Summary: 6 packages finished [29.9s]`, no errors.
- The stderr output is the pre-existing `ament_auto_package` notice about the header install destination, the `tl_expected` deprecation note, and a CMake dev warning from `FindFLANN.cmake`.
- Not run at this stage: `colcon test`, and a build of the reverse-dependency closure.

### The sweep and the second commit

- The same six sub-agents listed every reference in their package: includes, qualified names, Python imports, launch references, plugin XML base classes, and CMake `find_package` calls. They compared the result with the manifest.
- `autoware_kinematic_evaluator` and `autoware_localization_evaluator`: `CMakeLists.txt` calls `find_package(ament_cmake_ros REQUIRED)` under `BUILD_TESTING`, and no tag declares it. The three other evaluators declare it as `<test_depend>`, and so do 94 other packages of this repository. Both get `<test_depend>ament_cmake_ros</test_depend>`.
- `autoware_planning_evaluator`: `src/planning_evaluator_node.cpp:226` uses `lanelet::ConstLanelet`, which `lanelet2_core` defines, and the header arrives only through `autoware_lanelet2_utils`. It gets `<depend>lanelet2_core</depend>`. Its test calls `get_package_share_directory("autoware_test_utils")` and loads two parameter files from that directory, so the test fails without that package. It gets `<test_depend>autoware_test_utils</test_depend>`, the tag 17 packages of this repository use for it.
- One finding was left out on purpose. The test of `autoware_planning_evaluator` calls `rcutils_logging_set_logger_level`, and no package of this repository declares `rcutils`.
- The checker was then taught the evidence classes of the sweep. On the first commit of this branch, `fix_missing_deps.py --repo src/universe/autoware_universe/evaluator` reports the four entries above and nothing else. On the second commit it reports `entries to add 0`.
- `sort-package-xml` and `prettier-package-xml` passed on the three edited manifests.

### Build, second commit

- `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-select autoware_kinematic_evaluator autoware_localization_evaluator autoware_planning_evaluator`: `Summary: 3 packages finished [13.5s]`, no errors.
- Not run: `colcon test`, a build of the reverse-dependency closure, and any check on humble. The repository CI builds the pull request.

</details>
