### PR TITLE
docs(mkdocs_macros): render README interfaces and parameters from node design files

### DIFF
--- a/mkdocs_macros.py
+++ b/mkdocs_macros.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import urllib
 
 from tabulate import tabulate
@@ -16,9 +17,15 @@ def format_param_type(param_type):
         return param_type
 
 
-def format_param_name(param_name):
-    # Names carry no space or hyphen: mark the separators as line-break opportunities.
-    return param_name.replace(".", ".<wbr>").replace("_", "_<wbr>")
+# Identifiers (parameter names, topic paths, message types, file paths) carry no
+# space or hyphen: their separators are the only line-break opportunities. A
+# separator followed by a digit is kept unbreakable so numeric values stay intact.
+SEPARATOR_BREAK_PATTERN = re.compile(r"([._/])(?!\d)")
+
+
+def add_break_opportunities(text):
+    """Mark the separators of an unbreakable identifier as line-break opportunities."""
+    return SEPARATOR_BREAK_PATTERN.sub(r"\1<wbr>", text)
 
 
 def format_param_range(param):
@@ -112,10 +119,10 @@ def extract_parameter_info(parameters, doc, base_dir, cache, namespace="", seen_
             )
         else:
             param = {}
-            param["Name"] = format_param_name(namespace + k)
+            param["Name"] = add_break_opportunities(namespace + k)
             param["Type"] = format_param_type(resolved.get("type", "N/A"))
             param["Description"] = resolved.get("description", "")
-            param["Default"] = resolved.get("default", "")
+            param["Default"] = add_break_opportunities(format_cell(resolved.get("default")))
             param["Range"] = format_param_range(resolved)
             params.append(param)
     return params
@@ -190,6 +197,14 @@ def format_qos(qos):
     return "<br/>".join(f"{k}: {format_cell(v)}" for k, v in qos.items())
 
 
+def format_code(value):
+    """Format an identifier as inline code, breakable at its separators."""
+    text = format_cell(value)
+    if not text:
+        return ""
+    return f"<code>{add_break_opportunities(text)}</code>"
+
+
 def build_table(rows, columns):
     """Build a GitHub Markdown table for the given column spec.
 
@@ -213,11 +228,11 @@ def extract_interface_rows(entries):
     for entry in entries or []:
         rows.append(
             {
-                "Name": f"`{entry['name']}`",
-                "Type": f"`{entry['message_type']}`",
+                "Name": format_code(entry["name"]),
+                "Type": format_code(entry["message_type"]),
                 "Description": format_cell(entry.get("description")),
-                "Topic": f"`{entry['global']}`" if entry.get("global") else "",
-                "Remap": f"`{entry['remap_target']}`" if entry.get("remap_target") else "",
+                "Topic": format_code(entry.get("global")),
+                "Remap": format_code(entry.get("remap_target")),
                 "QoS": format_qos(entry.get("qos")),
             }
         )
@@ -243,9 +258,9 @@ def format_param_values_table(param_values):
     for param in param_values or []:
         rows.append(
             {
-                "Name": f"`{param['name']}`",
+                "Name": format_code(param["name"]),
                 "Type": format_param_type(param.get("type", "")),
-                "Default": format_cell(param.get("default")),
+                "Default": format_code(param.get("default")),
                 "Description": format_cell(param.get("description")),
             }
         )
@@ -268,9 +283,9 @@ def format_param_files_table(param_files):
     for entry in param_files or []:
         rows.append(
             {
-                "Name": f"`{entry['name']}`",
-                "Default": format_cell(entry.get("default")),
-                "Schema": f"`{entry['schema']}`" if entry.get("schema") else "",
+                "Name": format_code(entry["name"]),
+                "Default": format_code(entry.get("default")),
+                "Schema": format_code(entry.get("schema")),
                 "Description": format_cell(entry.get("description")),
             }
         )

--- a/mkdocs_macros.py
+++ b/mkdocs_macros.py
@@ -3,6 +3,7 @@ import os
 import urllib
 
 from tabulate import tabulate
+import yaml
 
 # This file is for defining macros for mkdocs-macros plugin
 # Check https://mkdocs-macros-plugin.readthedocs.io/en/latest/macros/ for the details
@@ -158,12 +159,194 @@ def format_json(json_data, base_dir=""):
     return markdown_table
 
 
+# ---------------------------------------------------------------------------
+# autoware_system_design_format `*.node.yaml` rendering
+#
+# Renders the interface and parameter sections of a node design file
+# (see schema autoware_system_designer/schema/<version>/node.json) into
+# Markdown tables, the same way json_to_markdown renders a JSON schema.
+# ---------------------------------------------------------------------------
+
+
+def format_cell(value):
+    """Format a YAML scalar/collection into a single Markdown table cell."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (list, dict)):
+        # render nested qos/structures compactly without breaking the table
+        text = json.dumps(value)
+    else:
+        text = str(value)
+    # escape pipe so it does not break the Markdown table, keep on one line
+    return text.replace("|", "\\|").replace("\n", "<br/>")
+
+
+def format_qos(qos):
+    """Render a qos mapping as a compact, readable cell."""
+    if not qos:
+        return ""
+    return "<br/>".join(f"{k}: {format_cell(v)}" for k, v in qos.items())
+
+
+def build_table(rows, columns):
+    """Build a GitHub Markdown table for the given column spec.
+
+    ``columns`` is a list of ``(header, key)`` tuples. A column is dropped
+    entirely when none of the rows provide a value for it, so optional fields
+    (description, qos, global, ...) only appear when actually used.
+    """
+    used = [(header, key) for header, key in columns if any(r.get(key) for r in rows)]
+    table = []
+    for row in rows:
+        table.append({header: row.get(key, "") for header, key in used})
+    if not table:
+        return ""
+    # cspell: ignore tablefmt
+    return tabulate(table, headers="keys", tablefmt="github")
+
+
+def extract_interface_rows(entries):
+    """Normalize subscriber/publisher/server/client entries into table rows."""
+    rows = []
+    for entry in entries or []:
+        rows.append(
+            {
+                "Name": f"`{entry['name']}`",
+                "Type": f"`{entry['message_type']}`",
+                "Description": format_cell(entry.get("description")),
+                "Topic": f"`{entry['global']}`" if entry.get("global") else "",
+                "Remap": f"`{entry['remap_target']}`" if entry.get("remap_target") else "",
+                "QoS": format_qos(entry.get("qos")),
+            }
+        )
+    return rows
+
+
+INTERFACE_COLUMNS = [
+    ("Name", "Name"),
+    ("Type", "Type"),
+    ("Description", "Description"),
+    ("Topic (global)", "Topic"),
+    ("Remap", "Remap"),
+    ("QoS", "QoS"),
+]
+
+
+def format_interface_table(entries):
+    return build_table(extract_interface_rows(entries), INTERFACE_COLUMNS)
+
+
+def format_param_values_table(param_values):
+    rows = []
+    for param in param_values or []:
+        rows.append(
+            {
+                "Name": f"`{param['name']}`",
+                "Type": format_param_type(param.get("type", "")),
+                "Default": format_cell(param.get("default")),
+                "Description": format_cell(param.get("description")),
+            }
+        )
+    return build_table(
+        rows,
+        [
+            ("Name", "Name"),
+            ("Type", "Type"),
+            ("Default", "Default"),
+            ("Description", "Description"),
+        ],
+    )
+
+
+def format_param_files_table(param_files):
+    # param_files may be a mapping (legacy) or a list of entries
+    if isinstance(param_files, dict):
+        param_files = [{"name": k, "default": v} for k, v in param_files.items()]
+    rows = []
+    for entry in param_files or []:
+        rows.append(
+            {
+                "Name": f"`{entry['name']}`",
+                "Default": format_cell(entry.get("default")),
+                "Schema": f"`{entry['schema']}`" if entry.get("schema") else "",
+                "Description": format_cell(entry.get("description")),
+            }
+        )
+    return build_table(
+        rows,
+        [
+            ("Name", "Name"),
+            ("Default", "Default"),
+            ("Schema", "Schema"),
+            ("Description", "Description"),
+        ],
+    )
+
+
+def format_node_yaml(data):
+    """Render the interface and parameter sections of a node design file."""
+    sections = []
+
+    def add_section(title, body):
+        if body:
+            sections.append(f"#### {title}\n\n{body}")
+
+    add_section("Subscribers", format_interface_table(data.get("subscribers")))
+    add_section("Publishers", format_interface_table(data.get("publishers")))
+    add_section("Service servers", format_interface_table(data.get("servers")))
+    add_section("Service clients", format_interface_table(data.get("clients")))
+    add_section("Parameter files", format_param_files_table(data.get("param_files")))
+    add_section("Parameters", format_param_values_table(data.get("param_values")))
+
+    return "\n\n".join(sections)
+
+
 def define_env(env):
     @env.macro
     def json_to_markdown(json_schema_file_path):
         with open(json_schema_file_path) as f:
             data = json.load(f)
             return format_json(data, os.path.dirname(json_schema_file_path))
+
+    @env.macro
+    def node_to_markdown(node_yaml_file_path):
+        """Render all interface + parameter tables of a `*.node.yaml` file."""
+        with open(node_yaml_file_path) as f:
+            data = yaml.safe_load(f)
+        return format_node_yaml(data)
+
+    @env.macro
+    def node_interfaces_to_markdown(node_yaml_file_path):
+        """Render only the subscriber/publisher/server/client tables."""
+        with open(node_yaml_file_path) as f:
+            data = yaml.safe_load(f)
+        sections = []
+        for title, key in [
+            ("Subscribers", "subscribers"),
+            ("Publishers", "publishers"),
+            ("Service servers", "servers"),
+            ("Service clients", "clients"),
+        ]:
+            table = format_interface_table(data.get(key))
+            if table:
+                sections.append(f"#### {title}\n\n{table}")
+        return "\n\n".join(sections)
+
+    @env.macro
+    def node_param_values_to_markdown(node_yaml_file_path):
+        """Render only the `param_values` table of a `*.node.yaml` file."""
+        with open(node_yaml_file_path) as f:
+            data = yaml.safe_load(f)
+        return format_param_values_table(data.get("param_values"))
+
+    @env.macro
+    def node_param_files_to_markdown(node_yaml_file_path):
+        """Render only the `param_files` table of a `*.node.yaml` file."""
+        with open(node_yaml_file_path) as f:
+            data = yaml.safe_load(f)
+        return format_param_files_table(data.get("param_files"))
 
     @env.macro
     def drawio(image_path):

--- a/mkdocs_macros.py
+++ b/mkdocs_macros.py
@@ -285,13 +285,14 @@ def format_param_files_table(param_files):
     )
 
 
-def format_node_yaml(data):
+def format_node_yaml(data, heading_level=3):
     """Render the interface and parameter sections of a node design file."""
     sections = []
+    heading = "#" * heading_level
 
     def add_section(title, body):
         if body:
-            sections.append(f"#### {title}\n\n{body}")
+            sections.append(f"{heading} {title}\n\n{body}")
 
     add_section("Subscribers", format_interface_table(data.get("subscribers")))
     add_section("Publishers", format_interface_table(data.get("publishers")))
@@ -311,17 +312,18 @@ def define_env(env):
             return format_json(data, os.path.dirname(json_schema_file_path))
 
     @env.macro
-    def node_to_markdown(node_yaml_file_path):
+    def node_to_markdown(node_yaml_file_path, heading_level=3):
         """Render all interface + parameter tables of a `*.node.yaml` file."""
         with open(node_yaml_file_path) as f:
             data = yaml.safe_load(f)
-        return format_node_yaml(data)
+        return format_node_yaml(data, heading_level)
 
     @env.macro
-    def node_interfaces_to_markdown(node_yaml_file_path):
+    def node_interfaces_to_markdown(node_yaml_file_path, heading_level=3):
         """Render only the subscriber/publisher/server/client tables."""
         with open(node_yaml_file_path) as f:
             data = yaml.safe_load(f)
+        heading = "#" * heading_level
         sections = []
         for title, key in [
             ("Subscribers", "subscribers"),
@@ -331,7 +333,7 @@ def define_env(env):
         ]:
             table = format_interface_table(data.get(key))
             if table:
-                sections.append(f"#### {title}\n\n{table}")
+                sections.append(f"{heading} {title}\n\n{table}")
         return "\n\n".join(sections)
 
     @env.macro

--- a/perception/autoware_multi_object_tracker/README.md
+++ b/perception/autoware_multi_object_tracker/README.md
@@ -24,14 +24,14 @@ For big vehicles such as trucks and buses, we have separate models for passenger
 
 ## Inputs / Outputs
 
-### Input
+The interfaces below are generated from the node design file
+[`design/MultiObjectTracker.node.yaml`](design/MultiObjectTracker.node.yaml).
 
-Multiple inputs are pre-defined in the input channel parameters (described below) and the inputs can be configured
+{{ node_interfaces_to_markdown("perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml") }}
 
-| Name                        | Type          | Description                 |
-| --------------------------- | ------------- | --------------------------- |
-| `input/detection**/objects` | `std::string` | input topic                 |
-| `input/detection**/channel` | `std::string` | input channel configuration |
+### Input channel configuration
+
+Multiple inputs are pre-defined in the input channel parameters (described below) and the inputs can be configured.
 
 rule of the channel configuration
 
@@ -85,13 +85,14 @@ input/detection07/channel: none # Disabled
 
 Up to 12 detection inputs can be configured (detection01 through detection12). Each input consists of an objects topic and its corresponding channel configuration.
 
-### Output
-
-| Name       | Type                                            | Description     |
-| ---------- | ----------------------------------------------- | --------------- |
-| `~/output` | `autoware_perception_msgs::msg::TrackedObjects` | tracked objects |
-
 ## Parameters
+
+### Node parameters
+
+The node launch parameters below are generated from the node design file
+[`design/MultiObjectTracker.node.yaml`](design/MultiObjectTracker.node.yaml).
+
+{{ node_param_values_to_markdown("perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml") }}
 
 ### Input Channel parameters
 

--- a/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
+++ b/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
@@ -15,40 +15,40 @@ launch:
 subscribers:
   - name: detection01/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 1
+    description: the detected objects input for channel 1
   - name: detection02/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 2
+    description: the detected objects input for channel 2
   - name: detection03/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 3
+    description: the detected objects input for channel 3
   - name: detection04/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 4
+    description: the detected objects input for channel 4
   - name: detection05/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 5
+    description: the detected objects input for channel 5
   - name: detection06/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 6
+    description: the detected objects input for channel 6
   - name: detection07/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 7
+    description: the detected objects input for channel 7
   - name: detection08/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 8
+    description: the detected objects input for channel 8
   - name: detection09/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 9
+    description: the detected objects input for channel 9
   - name: detection10/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 10
+    description: the detected objects input for channel 10
   - name: detection11/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 11
+    description: the detected objects input for channel 11
   - name: detection12/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
-    description: the detected objects input fo channel 12
+    description: the detected objects input for channel 12
   - name: input/odometry
     message_type: nav_msgs/msg/Odometry
     description: the odometry input for ego vehicle state estimation

--- a/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
+++ b/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
@@ -1,4 +1,4 @@
-autoware_system_design_format: 0.3.0
+autoware_system_design_format: 0.4.0
 
 # node information
 name: MultiObjectTracker.node

--- a/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
+++ b/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
@@ -13,44 +13,60 @@ launch:
 
 # interfaces
 subscribers:
-  - name: ros_transform
-    message_type: tf2_msgs/msg/TFMessage
-    global: /tf
   - name: detection01/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 1
   - name: detection02/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 2
   - name: detection03/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 3
   - name: detection04/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 4
   - name: detection05/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 5
   - name: detection06/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 6
   - name: detection07/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 7
   - name: detection08/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 8
   - name: detection09/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 9
   - name: detection10/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 10
   - name: detection11/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 11
   - name: detection12/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the detected objects input fo channel 12
   - name: input/odometry
     message_type: nav_msgs/msg/Odometry
+    description: the odometry input for ego vehicle state estimation
+  - name: ros_transform
+    message_type: tf2_msgs/msg/TFMessage
+    description: the ros transform input for ego vehicle state estimation
+    global: /tf
 
 publishers:
   - name: objects
     message_type: autoware_perception_msgs/msg/TrackedObjects
+    description: the tracked objects output from the multi-object tracker
     qos:
       reliability: reliable
       durability: transient_local
   - name: merged_objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+    description: the merged detected objects output from the multi-object tracker
     qos:
       reliability: reliable
       durability: transient_local
@@ -59,54 +75,71 @@ publishers:
 param_files:
   - name: tracker_setting_path
     default: config/multi_object_tracker_node.param.yaml
+    description: Parameters for the multi-object tracker node
   - name: data_association_matrix_path
     default: config/data_association_matrix.param.yaml
+    description: Parameters for Data Association
   - name: input_channels_path
     default: config/input_channels.param.yaml
+    description: Parameters for Input Channels. the channel names are set in this file. The channel names are used to subscribe to the detected objects from each channel.
 
 param_values:
   - name: input/detection01/channel
     type: string
     default: none
+    description: the channel name for channel 1
   - name: input/detection02/channel
     type: string
     default: none
+    description: the channel name for channel 2
   - name: input/detection03/channel
     type: string
     default: none
+    description: the channel name for channel 3
   - name: input/detection04/channel
     type: string
     default: none
+    description: the channel name for channel 4
   - name: input/detection05/channel
     type: string
     default: none
+    description: the channel name for channel 5
   - name: input/detection06/channel
     type: string
     default: none
+    description: the channel name for channel 6
   - name: input/detection07/channel
     type: string
     default: none
+    description: the channel name for channel 7
   - name: input/detection08/channel
     type: string
     default: none
+    description: the channel name for channel 8
   - name: input/detection09/channel
     type: string
     default: none
+    description: the channel name for channel 9
   - name: input/detection10/channel
     type: string
     default: none
+    description: the channel name for channel 10
   - name: input/detection11/channel
     type: string
     default: none
+    description: the channel name for channel 11
   - name: input/detection12/channel
     type: string
     default: none
+    description: the channel name for channel 12
   - name: publish_merged_objects
     type: boolean
     default: false
+    description: switch to publish the merged detected objects output
   - name: ego_source
     type: string
     default: tf
+    description: the source of ego vehicle state estimation. "tf" or "odometry" are supported. If "tf" is selected, the ego vehicle state is estimated from the ros transform input. If "odometry" is selected, the ego vehicle state is estimated from the odometry input.
 
 # processes
 processes:


### PR DESCRIPTION
## Description

Renders the "Inputs / Outputs" and node parameter sections of a package README directly from its `*.node.yaml` node design file (autoware_system_design_format), so the documented interfaces stay in sync with the design file instead of being maintained as hand-written tables.

Changes:

- `mkdocs_macros.py`
  - Adds macros to render a node design file into Markdown: `node_to_markdown`, `node_interfaces_to_markdown`, `node_param_values_to_markdown`, `node_param_files_to_markdown`.
  - Adds local `$ref` resolution and improved parameter extraction for JSON schema rendering (with fallback handling).
- `perception/autoware_multi_object_tracker` (first adoption example)
  - `README.md`: replaces the hand-written input/output tables with the generated interface and parameter tables.
  - `design/MultiObjectTracker.node.yaml`: updates to `autoware_system_design_format: 0.4.0` and adds interface/parameter descriptions used by the generated tables.

## Related links

Issue https://github.com/autowarefoundation/autoware_universe/issues/13226

Requirement: sync file after https://github.com/autowarefoundation/sync-file-templates/pull/97, update version https://github.com/autowarefoundation/autoware/pull/7278

## How was this PR tested?

- Rendered the macros locally against `MultiObjectTracker.node.yaml`: interface, `param_values`, and `param_files` tables generate as expected (headings at h3 under the README's h2 sections).
- Regression-checked `json_to_markdown` against all 179 `schema/*.schema.json` files in the repo: every schema renders a non-empty parameter table with no errors, including schemas that inline `ros__parameters` without a `$ref`.
- `pre-commit` passes on the changed files (markdownlint, prettier, yamllint, flake8, isort, black, design-format lint).
- Full docs-site rendering will be verified by the documentation CI job once the system designer version update lands.

## Notes for reviewers

The `autoware_multi_object_tracker` README is a template example of the design-file-driven interface documentation; other packages can adopt the same macros incrementally.

## Interface changes

None. (Documentation and node design file only; no runtime topic or parameter changes.)

## Effects on system behavior

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

