### PR TITLE
refactor(image_transport_decompressor): extract logic part as a function

### DIFF
--- a/sensing/autoware_image_transport_decompressor/CMakeLists.txt
+++ b/sensing/autoware_image_transport_decompressor/CMakeLists.txt
@@ -10,14 +10,22 @@ include_directories(
 )
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
-  src/image_transport_decompressor_node.cpp
+  src/image_transport_decompressor.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+ament_auto_add_library(${PROJECT_NAME}_ros SHARED
+  src/image_transport_decompressor_node.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}_ros
+  ${PROJECT_NAME}
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}_ros
   PLUGIN "autoware::image_preprocessor::ImageTransportDecompressor"
   EXECUTABLE image_transport_decompressor_node
 )
@@ -29,7 +37,7 @@ if(BUILD_TESTING)
     test/test_image_transport_decompressor_node.cpp
   )
   target_link_libraries(test_image_transport_decompressor_node
-    ${PROJECT_NAME}
+    ${PROJECT_NAME}_ros
   )
 endif()
 

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -1,0 +1,173 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2012, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include "image_transport_decompressor.hpp"
+
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <sensor_msgs/image_encodings.hpp>
+
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
+
+#include <string>
+
+namespace autoware::image_preprocessor::image_transport_decompressor
+{
+
+bool decompress(
+  const sensor_msgs::msg::CompressedImage & compressed_image,
+  const std::string & requested_encoding, sensor_msgs::msg::Image & output)
+{
+  const auto logger = rclcpp::get_logger("image_transport_decompressor");
+
+  cv_bridge::CvImage cv_image;
+  // Copy message header
+  cv_image.header = compressed_image.header;
+
+  // Decode color/mono image
+  try {
+    cv_image.image = cv::imdecode(cv::Mat(compressed_image.data), cv::IMREAD_COLOR);
+
+    // Assign image encoding string
+    const size_t split_pos = compressed_image.format.find(';');
+    if (split_pos == std::string::npos) {
+      // Older version of compressed_image_transport does not signal image format
+      switch (cv_image.image.channels()) {
+        case 1:
+          cv_image.encoding = sensor_msgs::image_encodings::MONO8;
+          break;
+        case 3:
+          cv_image.encoding = sensor_msgs::image_encodings::BGR8;
+          break;
+        default:
+          RCLCPP_ERROR(logger, "Unsupported number of channels: %i", cv_image.image.channels());
+          break;
+      }
+    } else {
+      std::string image_encoding;
+      if (requested_encoding == std::string("rgb8")) {
+        image_encoding = "rgb8";
+      } else if (requested_encoding == std::string("bgr8")) {
+        image_encoding = "bgr8";
+      } else {
+        // default encoding
+        image_encoding = compressed_image.format.substr(0, split_pos);
+      }
+
+      cv_image.encoding = image_encoding;
+
+      if (sensor_msgs::image_encodings::isColor(image_encoding)) {
+        std::string compressed_encoding = compressed_image.format.substr(split_pos);
+        bool compressed_bgr_image =
+          (compressed_encoding.find("compressed bgr") != std::string::npos);
+
+        // Revert color transformation
+        if (compressed_bgr_image) {
+          // if necessary convert colors from bgr to rgb
+          if (
+            (image_encoding == sensor_msgs::image_encodings::RGB8) ||
+            (image_encoding == sensor_msgs::image_encodings::RGB16)) {
+            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2RGB);
+          }
+
+          if (
+            (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
+            (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
+            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2RGBA);
+          }
+
+          if (
+            (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
+            (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
+            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2BGRA);
+          }
+        } else {
+          // if necessary convert colors from rgb to bgr
+          if (
+            (image_encoding == sensor_msgs::image_encodings::BGR8) ||
+            (image_encoding == sensor_msgs::image_encodings::BGR16)) {
+            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2BGR);
+          }
+
+          if (
+            (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
+            (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
+            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2BGRA);
+          }
+
+          if (
+            (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
+            (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
+            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2RGBA);
+          }
+        }
+      }
+    }
+  } catch (cv::Exception & e) {
+    RCLCPP_ERROR(logger, "%s", e.what());
+  }
+
+  size_t rows = cv_image.image.rows;
+  size_t cols = cv_image.image.cols;
+
+  if ((rows == 0) || (cols == 0)) {
+    return false;
+  }
+
+  cv_image.toImageMsg(output);
+  return true;
+}
+
+}  // namespace autoware::image_preprocessor::image_transport_decompressor

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -64,6 +64,9 @@
 namespace autoware::image_preprocessor::image_transport_decompressor
 {
 
+void revert_color_transformation(
+  cv_bridge::CvImage & cv_image, const std::string & compressed_encoding);
+
 sensor_msgs::msg::Image decompress(
   const sensor_msgs::msg::CompressedImage & compressed_image,
   const std::string & requested_encoding)
@@ -99,56 +102,66 @@ sensor_msgs::msg::Image decompress(
 
     cv_image.encoding = image_encoding;
 
-    if (sensor_msgs::image_encodings::isColor(image_encoding)) {
-      std::string compressed_encoding = compressed_image.format.substr(split_pos);
-      bool compressed_bgr_image = (compressed_encoding.find("compressed bgr") != std::string::npos);
-
-      // Revert color transformation
-      if (compressed_bgr_image) {
-        // if necessary convert colors from bgr to rgb
-        if (
-          (image_encoding == sensor_msgs::image_encodings::RGB8) ||
-          (image_encoding == sensor_msgs::image_encodings::RGB16)) {
-          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGB);
-        }
-
-        if (
-          (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
-          (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGBA);
-        }
-
-        if (
-          (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
-          (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2BGRA);
-        }
-      } else {
-        // if necessary convert colors from rgb to bgr
-        if (
-          (image_encoding == sensor_msgs::image_encodings::BGR8) ||
-          (image_encoding == sensor_msgs::image_encodings::BGR16)) {
-          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGR);
-        }
-
-        if (
-          (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
-          (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGRA);
-        }
-
-        if (
-          (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
-          (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2RGBA);
-        }
-      }
-    }
+    revert_color_transformation(cv_image, compressed_image.format.substr(split_pos));
   }
 
   sensor_msgs::msg::Image output;
   cv_image.toImageMsg(output);
   return output;
+}
+
+// Undo the color transformation the sender applied before compressing, so that the channels end up
+// in the order cv_image.encoding promises. @p compressed_encoding is the part of the format field
+// from the ';' onwards, which names the order the sender compressed in.
+void revert_color_transformation(
+  cv_bridge::CvImage & cv_image, const std::string & compressed_encoding)
+{
+  const std::string & image_encoding = cv_image.encoding;
+  if (!sensor_msgs::image_encodings::isColor(image_encoding)) {
+    return;
+  }
+
+  bool compressed_bgr_image = (compressed_encoding.find("compressed bgr") != std::string::npos);
+
+  if (compressed_bgr_image) {
+    // if necessary convert colors from bgr to rgb
+    if (
+      (image_encoding == sensor_msgs::image_encodings::RGB8) ||
+      (image_encoding == sensor_msgs::image_encodings::RGB16)) {
+      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGB);
+    }
+
+    if (
+      (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
+      (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
+      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGBA);
+    }
+
+    if (
+      (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
+      (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
+      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2BGRA);
+    }
+  } else {
+    // if necessary convert colors from rgb to bgr
+    if (
+      (image_encoding == sensor_msgs::image_encodings::BGR8) ||
+      (image_encoding == sensor_msgs::image_encodings::BGR16)) {
+      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGR);
+    }
+
+    if (
+      (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
+      (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
+      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGRA);
+    }
+
+    if (
+      (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
+      (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
+      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2RGBA);
+    }
+  }
 }
 
 }  // namespace autoware::image_preprocessor::image_transport_decompressor

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -59,7 +59,10 @@
 #include <cv_bridge/cv_bridge.h>
 #endif
 
+#include <algorithm>
+#include <array>
 #include <string>
+#include <utility>
 
 namespace autoware::image_preprocessor::image_transport_decompressor
 {
@@ -110,57 +113,44 @@ sensor_msgs::msg::Image decompress(
   return output;
 }
 
+// Conversion that undoes the color transformation the sender applied, per encoding to publish
+// under. There are two tables because the conversion depends on the channel order the sender
+// compressed in. An encoding absent from a table, "mono8" or "yuv422" for instance, needs no
+// conversion.
+using ColorConversions = std::array<std::pair<const char *, cv::ColorConversionCodes>, 6>;
+
+constexpr ColorConversions conversions_from_bgr{
+  {{sensor_msgs::image_encodings::RGB8, cv::COLOR_BGR2RGB},
+   {sensor_msgs::image_encodings::RGB16, cv::COLOR_BGR2RGB},
+   {sensor_msgs::image_encodings::RGBA8, cv::COLOR_BGR2RGBA},
+   {sensor_msgs::image_encodings::RGBA16, cv::COLOR_BGR2RGBA},
+   {sensor_msgs::image_encodings::BGRA8, cv::COLOR_BGR2BGRA},
+   {sensor_msgs::image_encodings::BGRA16, cv::COLOR_BGR2BGRA}}};
+
+constexpr ColorConversions conversions_from_rgb{
+  {{sensor_msgs::image_encodings::BGR8, cv::COLOR_RGB2BGR},
+   {sensor_msgs::image_encodings::BGR16, cv::COLOR_RGB2BGR},
+   {sensor_msgs::image_encodings::BGRA8, cv::COLOR_RGB2BGRA},
+   {sensor_msgs::image_encodings::BGRA16, cv::COLOR_RGB2BGRA},
+   {sensor_msgs::image_encodings::RGBA8, cv::COLOR_RGB2RGBA},
+   {sensor_msgs::image_encodings::RGBA16, cv::COLOR_RGB2RGBA}}};
+
 // Undo the color transformation the sender applied before compressing, so that the channels end up
 // in the order cv_image.encoding promises. @p compressed_encoding is the part of the format field
 // from the ';' onwards, which names the order the sender compressed in.
 void revert_color_transformation(
   cv_bridge::CvImage & cv_image, const std::string & compressed_encoding)
 {
-  const std::string & image_encoding = cv_image.encoding;
-  if (!sensor_msgs::image_encodings::isColor(image_encoding)) {
-    return;
-  }
+  const bool compressed_bgr_image = compressed_encoding.find("compressed bgr") != std::string::npos;
+  const ColorConversions & conversions =
+    compressed_bgr_image ? conversions_from_bgr : conversions_from_rgb;
 
-  bool compressed_bgr_image = (compressed_encoding.find("compressed bgr") != std::string::npos);
+  const auto conversion = std::find_if(
+    conversions.begin(), conversions.end(),
+    [&cv_image](const auto & entry) { return cv_image.encoding == entry.first; });
 
-  if (compressed_bgr_image) {
-    // if necessary convert colors from bgr to rgb
-    if (
-      (image_encoding == sensor_msgs::image_encodings::RGB8) ||
-      (image_encoding == sensor_msgs::image_encodings::RGB16)) {
-      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGB);
-    }
-
-    if (
-      (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
-      (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGBA);
-    }
-
-    if (
-      (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
-      (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2BGRA);
-    }
-  } else {
-    // if necessary convert colors from rgb to bgr
-    if (
-      (image_encoding == sensor_msgs::image_encodings::BGR8) ||
-      (image_encoding == sensor_msgs::image_encodings::BGR16)) {
-      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGR);
-    }
-
-    if (
-      (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
-      (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGRA);
-    }
-
-    if (
-      (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
-      (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-      cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2RGBA);
-    }
+  if (conversion != conversions.end()) {
+    cv::cvtColor(cv_image.image, cv_image.image, conversion->second);
   }
 }
 

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -101,8 +101,7 @@ sensor_msgs::msg::Image decompress(
 
     if (sensor_msgs::image_encodings::isColor(image_encoding)) {
       std::string compressed_encoding = compressed_image.format.substr(split_pos);
-      bool compressed_bgr_image =
-        (compressed_encoding.find("compressed bgr") != std::string::npos);
+      bool compressed_bgr_image = (compressed_encoding.find("compressed bgr") != std::string::npos);
 
       // Revert color transformation
       if (compressed_bgr_image) {

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -50,8 +50,6 @@
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <rclcpp/logger.hpp>
-#include <rclcpp/logging.hpp>
 
 #include <sensor_msgs/image_encodings.hpp>
 
@@ -62,15 +60,16 @@
 #endif
 
 #include <string>
+#include <utility>
 
 namespace autoware::image_preprocessor::image_transport_decompressor
 {
 
-bool decompress(
+DecompressResult decompress(
   const sensor_msgs::msg::CompressedImage & compressed_image,
-  const std::string & requested_encoding, sensor_msgs::msg::Image & output)
+  const std::string & requested_encoding)
 {
-  const auto logger = rclcpp::get_logger("image_transport_decompressor");
+  DecompressResult result;
 
   cv_bridge::CvImage cv_image;
   // Copy message header
@@ -92,7 +91,9 @@ bool decompress(
           cv_image.encoding = sensor_msgs::image_encodings::BGR8;
           break;
         default:
-          RCLCPP_ERROR(logger, "Unsupported number of channels: %i", cv_image.image.channels());
+          result.severity = Severity::Error;
+          result.message =
+            "Unsupported number of channels: " + std::to_string(cv_image.image.channels());
           break;
       }
     } else {
@@ -155,19 +156,19 @@ bool decompress(
         }
       }
     }
-  } catch (cv::Exception & e) {
-    RCLCPP_ERROR(logger, "%s", e.what());
+  } catch (const cv::Exception & e) {
+    result.severity = Severity::Error;
+    result.message = e.what();
   }
 
-  size_t rows = cv_image.image.rows;
-  size_t cols = cv_image.image.cols;
-
-  if ((rows == 0) || (cols == 0)) {
-    return false;
+  if ((cv_image.image.rows == 0) || (cv_image.image.cols == 0)) {
+    return result;
   }
 
-  cv_image.toImageMsg(output);
-  return true;
+  sensor_msgs::msg::Image image_msg;
+  cv_image.toImageMsg(image_msg);
+  result.image = std::move(image_msg);
+  return result;
 }
 
 }  // namespace autoware::image_preprocessor::image_transport_decompressor

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -75,7 +75,8 @@ DecompressResult decompress(
   // Copy message header
   cv_image.header = compressed_image.header;
 
-  // Decode color/mono image
+  // Decode the image. cv::IMREAD_COLOR makes it 8-bit with three channels in BGR order, whatever
+  // the depth and the channel count of the compressed stream are.
   try {
     cv_image.image = cv::imdecode(cv::Mat(compressed_image.data), cv::IMREAD_COLOR);
 
@@ -83,19 +84,7 @@ DecompressResult decompress(
     const size_t split_pos = compressed_image.format.find(';');
     if (split_pos == std::string::npos) {
       // Older version of compressed_image_transport does not signal image format
-      switch (cv_image.image.channels()) {
-        case 1:
-          cv_image.encoding = sensor_msgs::image_encodings::MONO8;
-          break;
-        case 3:
-          cv_image.encoding = sensor_msgs::image_encodings::BGR8;
-          break;
-        default:
-          result.severity = Severity::Error;
-          result.message =
-            "Unsupported number of channels: " + std::to_string(cv_image.image.channels());
-          break;
-      }
+      cv_image.encoding = sensor_msgs::image_encodings::BGR8;
     } else {
       std::string image_encoding;
       if (requested_encoding == std::string("rgb8")) {
@@ -120,38 +109,38 @@ DecompressResult decompress(
           if (
             (image_encoding == sensor_msgs::image_encodings::RGB8) ||
             (image_encoding == sensor_msgs::image_encodings::RGB16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2RGB);
+            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGB);
           }
 
           if (
             (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
             (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2RGBA);
+            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGBA);
           }
 
           if (
             (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
             (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2BGRA);
+            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2BGRA);
           }
         } else {
           // if necessary convert colors from rgb to bgr
           if (
             (image_encoding == sensor_msgs::image_encodings::BGR8) ||
             (image_encoding == sensor_msgs::image_encodings::BGR16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2BGR);
+            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGR);
           }
 
           if (
             (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
             (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2BGRA);
+            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGRA);
           }
 
           if (
             (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
             (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2RGBA);
+            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2RGBA);
           }
         }
       }

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -60,104 +60,96 @@
 #endif
 
 #include <string>
-#include <utility>
 
 namespace autoware::image_preprocessor::image_transport_decompressor
 {
 
-DecompressResult decompress(
+sensor_msgs::msg::Image decompress(
   const sensor_msgs::msg::CompressedImage & compressed_image,
   const std::string & requested_encoding)
 {
-  DecompressResult result;
-
   cv_bridge::CvImage cv_image;
   // Copy message header
   cv_image.header = compressed_image.header;
 
   // Decode the image. cv::IMREAD_COLOR makes it 8-bit with three channels in BGR order, whatever
   // the depth and the channel count of the compressed stream are.
-  try {
-    cv_image.image = cv::imdecode(cv::Mat(compressed_image.data), cv::IMREAD_COLOR);
+  cv_image.image = cv::imdecode(cv::Mat(compressed_image.data), cv::IMREAD_COLOR);
+  if (cv_image.image.empty()) {
+    // cv::imdecode reports an undecodable payload by returning an empty image instead of throwing,
+    // so raise it here to leave the caller a single way to observe a failure.
+    CV_Error(cv::Error::StsParseError, "the compressed image could not be decoded");
+  }
 
-    // Assign image encoding string
-    const size_t split_pos = compressed_image.format.find(';');
-    if (split_pos == std::string::npos) {
-      // Older version of compressed_image_transport does not signal image format
-      cv_image.encoding = sensor_msgs::image_encodings::BGR8;
+  // Assign image encoding string
+  const size_t split_pos = compressed_image.format.find(';');
+  if (split_pos == std::string::npos) {
+    // Older version of compressed_image_transport does not signal image format
+    cv_image.encoding = sensor_msgs::image_encodings::BGR8;
+  } else {
+    std::string image_encoding;
+    if (requested_encoding == std::string("rgb8")) {
+      image_encoding = "rgb8";
+    } else if (requested_encoding == std::string("bgr8")) {
+      image_encoding = "bgr8";
     } else {
-      std::string image_encoding;
-      if (requested_encoding == std::string("rgb8")) {
-        image_encoding = "rgb8";
-      } else if (requested_encoding == std::string("bgr8")) {
-        image_encoding = "bgr8";
+      // default encoding
+      image_encoding = compressed_image.format.substr(0, split_pos);
+    }
+
+    cv_image.encoding = image_encoding;
+
+    if (sensor_msgs::image_encodings::isColor(image_encoding)) {
+      std::string compressed_encoding = compressed_image.format.substr(split_pos);
+      bool compressed_bgr_image =
+        (compressed_encoding.find("compressed bgr") != std::string::npos);
+
+      // Revert color transformation
+      if (compressed_bgr_image) {
+        // if necessary convert colors from bgr to rgb
+        if (
+          (image_encoding == sensor_msgs::image_encodings::RGB8) ||
+          (image_encoding == sensor_msgs::image_encodings::RGB16)) {
+          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGB);
+        }
+
+        if (
+          (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
+          (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
+          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGBA);
+        }
+
+        if (
+          (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
+          (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
+          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2BGRA);
+        }
       } else {
-        // default encoding
-        image_encoding = compressed_image.format.substr(0, split_pos);
-      }
+        // if necessary convert colors from rgb to bgr
+        if (
+          (image_encoding == sensor_msgs::image_encodings::BGR8) ||
+          (image_encoding == sensor_msgs::image_encodings::BGR16)) {
+          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGR);
+        }
 
-      cv_image.encoding = image_encoding;
+        if (
+          (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
+          (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
+          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGRA);
+        }
 
-      if (sensor_msgs::image_encodings::isColor(image_encoding)) {
-        std::string compressed_encoding = compressed_image.format.substr(split_pos);
-        bool compressed_bgr_image =
-          (compressed_encoding.find("compressed bgr") != std::string::npos);
-
-        // Revert color transformation
-        if (compressed_bgr_image) {
-          // if necessary convert colors from bgr to rgb
-          if (
-            (image_encoding == sensor_msgs::image_encodings::RGB8) ||
-            (image_encoding == sensor_msgs::image_encodings::RGB16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGB);
-          }
-
-          if (
-            (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
-            (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2RGBA);
-          }
-
-          if (
-            (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
-            (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_BGR2BGRA);
-          }
-        } else {
-          // if necessary convert colors from rgb to bgr
-          if (
-            (image_encoding == sensor_msgs::image_encodings::BGR8) ||
-            (image_encoding == sensor_msgs::image_encodings::BGR16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGR);
-          }
-
-          if (
-            (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
-            (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2BGRA);
-          }
-
-          if (
-            (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
-            (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2RGBA);
-          }
+        if (
+          (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
+          (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
+          cv::cvtColor(cv_image.image, cv_image.image, cv::COLOR_RGB2RGBA);
         }
       }
     }
-  } catch (const cv::Exception & e) {
-    result.severity = Severity::Error;
-    result.message = e.what();
   }
 
-  if ((cv_image.image.rows == 0) || (cv_image.image.cols == 0)) {
-    return result;
-  }
-
-  sensor_msgs::msg::Image image_msg;
-  cv_image.toImageMsg(image_msg);
-  result.image = std::move(image_msg);
-  return result;
+  sensor_msgs::msg::Image output;
+  cv_image.toImageMsg(output);
+  return output;
 }
 
 }  // namespace autoware::image_preprocessor::image_transport_decompressor

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -61,6 +61,7 @@
 
 #include <algorithm>
 #include <array>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -80,11 +81,16 @@ sensor_msgs::msg::Image decompress(
 
   // Decode the image. cv::IMREAD_COLOR makes it 8-bit with three channels in BGR order, whatever
   // the depth and the channel count of the compressed stream are.
-  cv_image.image = cv::imdecode(cv::Mat(compressed_image.data), cv::IMREAD_COLOR);
+  try {
+    cv_image.image = cv::imdecode(cv::Mat(compressed_image.data), cv::IMREAD_COLOR);
+  } catch (const cv::Exception & e) {
+    // Reported the same way as the empty image below, keeping the decoder's own message.
+    throw std::runtime_error(e.what());
+  }
   if (cv_image.image.empty()) {
-    // cv::imdecode reports an undecodable payload by returning an empty image instead of throwing,
-    // so raise it here to leave the caller a single way to observe a failure.
-    CV_Error(cv::Error::StsParseError, "the compressed image could not be decoded");
+    // cv::imdecode throws on an empty payload, but reports one it cannot make sense of by returning
+    // an empty image, so raise that second case here.
+    throw std::runtime_error("the compressed image could not be decoded");
   }
 
   // Assign image encoding string

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
@@ -26,9 +26,9 @@ namespace autoware::image_preprocessor::image_transport_decompressor
 /// @brief Decompress @p compressed_image, copying its header into the returned image. "rgb8" and
 /// "bgr8" force that encoding, any other requested one keeps the encoding the format field names.
 /// @throws cv::Exception when the payload cannot be decoded. A sensor sits at the far end of a
-/// physical link, so a corrupted payload is an expected event rather than a defect of this function,
-/// and the caller owns the policy for it: a node is expected to report the frame and carry on, while
-/// a caller that only wires components together may let it propagate.
+/// physical link, so a corrupted payload is an expected event rather than a defect of this
+/// function, and the caller owns the policy for it: a node is expected to report the frame and
+/// carry on, while a caller that only wires components together may let it propagate.
 sensor_msgs::msg::Image decompress(
   const sensor_msgs::msg::CompressedImage & compressed_image,
   const std::string & requested_encoding);

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
@@ -18,27 +18,18 @@
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
-#include <optional>
 #include <string>
 
 namespace autoware::image_preprocessor::image_transport_decompressor
 {
 
-/// @brief Severity of DecompressResult::message.
-enum class Severity { Ok, Warn, Error };
-
-/// @brief Outcome of decompress(). The caller decides whether/how to report message; severity is Ok
-/// exactly when message is empty. image is set independently of severity.
-struct DecompressResult
-{
-  std::optional<sensor_msgs::msg::Image> image;
-  Severity severity{Severity::Ok};
-  std::string message;
-};
-
-/// @brief Decompress @p compressed_image, copying its header into the result's image. "rgb8" and
-/// "bgr8" force that encoding; any other requested value keeps the encoding the format field names.
-DecompressResult decompress(
+/// @brief Decompress @p compressed_image, copying its header into the returned image. "rgb8" and
+/// "bgr8" force that encoding, any other requested one keeps the encoding the format field names.
+/// @throws cv::Exception when the payload cannot be decoded. A sensor sits at the far end of a
+/// physical link, so a corrupted payload is an expected event rather than a defect of this function,
+/// and the caller owns the policy for it: a node is expected to report the frame and carry on, while
+/// a caller that only wires components together may let it propagate.
+sensor_msgs::msg::Image decompress(
   const sensor_msgs::msg::CompressedImage & compressed_image,
   const std::string & requested_encoding);
 

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
@@ -1,0 +1,35 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IMAGE_TRANSPORT_DECOMPRESSOR_HPP_
+#define IMAGE_TRANSPORT_DECOMPRESSOR_HPP_
+
+#include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/msg/image.hpp>
+
+#include <string>
+
+namespace autoware::image_preprocessor::image_transport_decompressor
+{
+
+/// @brief Decompress @p compressed_image into @p output, whose header it also fills. "rgb8" and
+/// "bgr8" force that encoding, any other requested one keeps the encoding the format field names.
+/// @return false when the payload cannot be decoded.
+bool decompress(
+  const sensor_msgs::msg::CompressedImage & compressed_image,
+  const std::string & requested_encoding, sensor_msgs::msg::Image & output);
+
+}  // namespace autoware::image_preprocessor::image_transport_decompressor
+
+#endif  // IMAGE_TRANSPORT_DECOMPRESSOR_HPP_

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
@@ -18,17 +18,29 @@
 #include <sensor_msgs/msg/compressed_image.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
+#include <optional>
 #include <string>
 
 namespace autoware::image_preprocessor::image_transport_decompressor
 {
 
-/// @brief Decompress @p compressed_image into @p output, whose header it also fills. "rgb8" and
-/// "bgr8" force that encoding, any other requested one keeps the encoding the format field names.
-/// @return false when the payload cannot be decoded.
-bool decompress(
+/// @brief Severity of DecompressResult::message.
+enum class Severity { Ok, Warn, Error };
+
+/// @brief Outcome of decompress(). The caller decides whether/how to report message; severity is Ok
+/// exactly when message is empty. image is set independently of severity.
+struct DecompressResult
+{
+  std::optional<sensor_msgs::msg::Image> image;
+  Severity severity{Severity::Ok};
+  std::string message;
+};
+
+/// @brief Decompress @p compressed_image, copying its header into the result's image. "rgb8" and
+/// "bgr8" force that encoding; any other requested value keeps the encoding the format field names.
+DecompressResult decompress(
   const sensor_msgs::msg::CompressedImage & compressed_image,
-  const std::string & requested_encoding, sensor_msgs::msg::Image & output);
+  const std::string & requested_encoding);
 
 }  // namespace autoware::image_preprocessor::image_transport_decompressor
 

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.hpp
@@ -25,10 +25,9 @@ namespace autoware::image_preprocessor::image_transport_decompressor
 
 /// @brief Decompress @p compressed_image, copying its header into the returned image. "rgb8" and
 /// "bgr8" force that encoding, any other requested one keeps the encoding the format field names.
-/// @throws cv::Exception when the payload cannot be decoded. A sensor sits at the far end of a
-/// physical link, so a corrupted payload is an expected event rather than a defect of this
-/// function, and the caller owns the policy for it: a node is expected to report the frame and
-/// carry on, while a caller that only wires components together may let it propagate.
+/// @throws std::runtime_error when the payload cannot be decoded. A sensor sits at the far end of a
+/// physical link, so that is an expected event rather than a defect of this function, and the
+/// caller owns the policy for it.
 sensor_msgs::msg::Image decompress(
   const sensor_msgs::msg::CompressedImage & compressed_image,
   const std::string & requested_encoding);

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
@@ -16,6 +16,8 @@
 
 #include "image_transport_decompressor.hpp"
 
+#include <opencv2/core.hpp>
+
 #include <memory>
 #include <string>
 #include <utility>
@@ -36,15 +38,13 @@ ImageTransportDecompressor::ImageTransportDecompressor(const rclcpp::NodeOptions
 void ImageTransportDecompressor::onCompressedImage(
   const sensor_msgs::msg::CompressedImage::ConstSharedPtr input_compressed_image_msg)
 {
-  auto result = image_transport_decompressor::decompress(*input_compressed_image_msg, encoding_);
-  if (result.severity == image_transport_decompressor::Severity::Error) {
-    RCLCPP_ERROR(get_logger(), "%s", result.message.c_str());
+  try {
+    auto raw_image_msg =
+      image_transport_decompressor::decompress(*input_compressed_image_msg, encoding_);
+    raw_image_pub_->publish(std::make_unique<sensor_msgs::msg::Image>(std::move(raw_image_msg)));
+  } catch (const cv::Exception & e) {
+    RCLCPP_ERROR(get_logger(), "%s", e.what());
   }
-  if (!result.image) {
-    return;
-  }
-
-  raw_image_pub_->publish(std::make_unique<sensor_msgs::msg::Image>(std::move(*result.image)));
 }
 
 }  // namespace autoware::image_preprocessor

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
@@ -16,8 +16,7 @@
 
 #include "image_transport_decompressor.hpp"
 
-#include <opencv2/core.hpp>
-
+#include <exception>
 #include <memory>
 #include <string>
 #include <utility>
@@ -42,7 +41,7 @@ void ImageTransportDecompressor::onCompressedImage(
     auto raw_image_msg =
       image_transport_decompressor::decompress(*input_compressed_image_msg, encoding_);
     raw_image_pub_->publish(std::make_unique<sensor_msgs::msg::Image>(std::move(raw_image_msg)));
-  } catch (const cv::Exception & e) {
+  } catch (const std::exception & e) {
     RCLCPP_ERROR(get_logger(), "%s", e.what());
   }
 }

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
@@ -12,54 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*********************************************************************
- * Software License Agreement (BSD License)
- *
- *  Copyright (c) 2012, Willow Garage, Inc.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions
- *  are met:
- *
- *   * Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *   * Redistributions in binary form must reproduce the above
- *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials provided
- *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
- *     contributors may be used to endorse or promote products derived
- *     from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- *********************************************************************/
-
 #include "autoware/image_transport_decompressor/image_transport_decompressor_node.hpp"
 
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
-#include <rclcpp/logger.hpp>
-#include <rclcpp/logging.hpp>
-
-#include <sensor_msgs/image_encodings.hpp>
-
-#if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
-#else
-#include <cv_bridge/cv_bridge.h>
-#endif
+#include "image_transport_decompressor.hpp"
 
 #include <memory>
 #include <string>
@@ -76,110 +31,6 @@ ImageTransportDecompressor::ImageTransportDecompressor(const rclcpp::NodeOptions
     std::bind(&ImageTransportDecompressor::onCompressedImage, this, std::placeholders::_1));
   raw_image_pub_ =
     create_publisher<sensor_msgs::msg::Image>("~/output/raw_image", rclcpp::SensorDataQoS());
-}
-
-bool decompress(
-  const sensor_msgs::msg::CompressedImage & compressed_image,
-  const std::string & requested_encoding, sensor_msgs::msg::Image & output)
-{
-  const auto logger = rclcpp::get_logger("image_transport_decompressor");
-
-  cv_bridge::CvImage cv_image;
-  // Copy message header
-  cv_image.header = compressed_image.header;
-
-  // Decode color/mono image
-  try {
-    cv_image.image = cv::imdecode(cv::Mat(compressed_image.data), cv::IMREAD_COLOR);
-
-    // Assign image encoding string
-    const size_t split_pos = compressed_image.format.find(';');
-    if (split_pos == std::string::npos) {
-      // Older version of compressed_image_transport does not signal image format
-      switch (cv_image.image.channels()) {
-        case 1:
-          cv_image.encoding = sensor_msgs::image_encodings::MONO8;
-          break;
-        case 3:
-          cv_image.encoding = sensor_msgs::image_encodings::BGR8;
-          break;
-        default:
-          RCLCPP_ERROR(logger, "Unsupported number of channels: %i", cv_image.image.channels());
-          break;
-      }
-    } else {
-      std::string image_encoding;
-      if (requested_encoding == std::string("rgb8")) {
-        image_encoding = "rgb8";
-      } else if (requested_encoding == std::string("bgr8")) {
-        image_encoding = "bgr8";
-      } else {
-        // default encoding
-        image_encoding = compressed_image.format.substr(0, split_pos);
-      }
-
-      cv_image.encoding = image_encoding;
-
-      if (sensor_msgs::image_encodings::isColor(image_encoding)) {
-        std::string compressed_encoding = compressed_image.format.substr(split_pos);
-        bool compressed_bgr_image =
-          (compressed_encoding.find("compressed bgr") != std::string::npos);
-
-        // Revert color transformation
-        if (compressed_bgr_image) {
-          // if necessary convert colors from bgr to rgb
-          if (
-            (image_encoding == sensor_msgs::image_encodings::RGB8) ||
-            (image_encoding == sensor_msgs::image_encodings::RGB16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2RGB);
-          }
-
-          if (
-            (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
-            (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2RGBA);
-          }
-
-          if (
-            (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
-            (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2BGRA);
-          }
-        } else {
-          // if necessary convert colors from rgb to bgr
-          if (
-            (image_encoding == sensor_msgs::image_encodings::BGR8) ||
-            (image_encoding == sensor_msgs::image_encodings::BGR16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2BGR);
-          }
-
-          if (
-            (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
-            (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2BGRA);
-          }
-
-          if (
-            (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
-            (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2RGBA);
-          }
-        }
-      }
-    }
-  } catch (cv::Exception & e) {
-    RCLCPP_ERROR(logger, "%s", e.what());
-  }
-
-  size_t rows = cv_image.image.rows;
-  size_t cols = cv_image.image.cols;
-
-  if ((rows == 0) || (cols == 0)) {
-    return false;
-  }
-
-  cv_image.toImageMsg(output);
-  return true;
 }
 
 void ImageTransportDecompressor::onCompressedImage(

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
@@ -50,6 +50,8 @@
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
 
 #include <sensor_msgs/image_encodings.hpp>
 
@@ -59,11 +61,9 @@
 #include <cv_bridge/cv_bridge.h>
 #endif
 
-#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace autoware::image_preprocessor
 {
@@ -78,48 +78,50 @@ ImageTransportDecompressor::ImageTransportDecompressor(const rclcpp::NodeOptions
     create_publisher<sensor_msgs::msg::Image>("~/output/raw_image", rclcpp::SensorDataQoS());
 }
 
-void ImageTransportDecompressor::onCompressedImage(
-  const sensor_msgs::msg::CompressedImage::ConstSharedPtr input_compressed_image_msg)
+bool decompress(
+  const sensor_msgs::msg::CompressedImage & compressed_image,
+  const std::string & requested_encoding, sensor_msgs::msg::Image & output)
 {
-  cv_bridge::CvImagePtr cv_ptr(new cv_bridge::CvImage);
+  const auto logger = rclcpp::get_logger("image_transport_decompressor");
+
+  cv_bridge::CvImage cv_image;
   // Copy message header
-  cv_ptr->header = input_compressed_image_msg->header;
+  cv_image.header = compressed_image.header;
 
   // Decode color/mono image
   try {
-    cv_ptr->image = cv::imdecode(cv::Mat(input_compressed_image_msg->data), cv::IMREAD_COLOR);
+    cv_image.image = cv::imdecode(cv::Mat(compressed_image.data), cv::IMREAD_COLOR);
 
     // Assign image encoding string
-    const size_t split_pos = input_compressed_image_msg->format.find(';');
+    const size_t split_pos = compressed_image.format.find(';');
     if (split_pos == std::string::npos) {
       // Older version of compressed_image_transport does not signal image format
-      switch (cv_ptr->image.channels()) {
+      switch (cv_image.image.channels()) {
         case 1:
-          cv_ptr->encoding = sensor_msgs::image_encodings::MONO8;
+          cv_image.encoding = sensor_msgs::image_encodings::MONO8;
           break;
         case 3:
-          cv_ptr->encoding = sensor_msgs::image_encodings::BGR8;
+          cv_image.encoding = sensor_msgs::image_encodings::BGR8;
           break;
         default:
-          RCLCPP_ERROR(
-            get_logger(), "Unsupported number of channels: %i", cv_ptr->image.channels());
+          RCLCPP_ERROR(logger, "Unsupported number of channels: %i", cv_image.image.channels());
           break;
       }
     } else {
       std::string image_encoding;
-      if (encoding_ == std::string("rgb8")) {
+      if (requested_encoding == std::string("rgb8")) {
         image_encoding = "rgb8";
-      } else if (encoding_ == std::string("bgr8")) {
+      } else if (requested_encoding == std::string("bgr8")) {
         image_encoding = "bgr8";
       } else {
         // default encoding
-        image_encoding = input_compressed_image_msg->format.substr(0, split_pos);
+        image_encoding = compressed_image.format.substr(0, split_pos);
       }
 
-      cv_ptr->encoding = image_encoding;
+      cv_image.encoding = image_encoding;
 
       if (sensor_msgs::image_encodings::isColor(image_encoding)) {
-        std::string compressed_encoding = input_compressed_image_msg->format.substr(split_pos);
+        std::string compressed_encoding = compressed_image.format.substr(split_pos);
         bool compressed_bgr_image =
           (compressed_encoding.find("compressed bgr") != std::string::npos);
 
@@ -129,55 +131,69 @@ void ImageTransportDecompressor::onCompressedImage(
           if (
             (image_encoding == sensor_msgs::image_encodings::RGB8) ||
             (image_encoding == sensor_msgs::image_encodings::RGB16)) {
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2RGB);
+            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2RGB);
           }
 
           if (
             (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
             (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2RGBA);
+            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2RGBA);
           }
 
           if (
             (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
             (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_BGR2BGRA);
+            cv::cvtColor(cv_image.image, cv_image.image, CV_BGR2BGRA);
           }
         } else {
           // if necessary convert colors from rgb to bgr
           if (
             (image_encoding == sensor_msgs::image_encodings::BGR8) ||
             (image_encoding == sensor_msgs::image_encodings::BGR16)) {
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2BGR);
+            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2BGR);
           }
 
           if (
             (image_encoding == sensor_msgs::image_encodings::BGRA8) ||
             (image_encoding == sensor_msgs::image_encodings::BGRA16)) {
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2BGRA);
+            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2BGRA);
           }
 
           if (
             (image_encoding == sensor_msgs::image_encodings::RGBA8) ||
             (image_encoding == sensor_msgs::image_encodings::RGBA16)) {
-            cv::cvtColor(cv_ptr->image, cv_ptr->image, CV_RGB2RGBA);
+            cv::cvtColor(cv_image.image, cv_image.image, CV_RGB2RGBA);
           }
         }
       }
     }
   } catch (cv::Exception & e) {
-    RCLCPP_ERROR(get_logger(), "%s", e.what());
+    RCLCPP_ERROR(logger, "%s", e.what());
   }
 
-  size_t rows = cv_ptr->image.rows;
-  size_t cols = cv_ptr->image.cols;
+  size_t rows = cv_image.image.rows;
+  size_t cols = cv_image.image.cols;
 
-  if ((rows > 0) && (cols > 0)) {
-    // Publish message to user callback
-    auto image_ptr = std::make_unique<sensor_msgs::msg::Image>(*cv_ptr->toImageMsg());
-    raw_image_pub_->publish(std::move(image_ptr));
+  if ((rows == 0) || (cols == 0)) {
+    return false;
   }
+
+  cv_image.toImageMsg(output);
+  return true;
 }
+
+void ImageTransportDecompressor::onCompressedImage(
+  const sensor_msgs::msg::CompressedImage::ConstSharedPtr input_compressed_image_msg)
+{
+  auto raw_image_msg = std::make_unique<sensor_msgs::msg::Image>();
+  if (!image_transport_decompressor::decompress(
+        *input_compressed_image_msg, encoding_, *raw_image_msg)) {
+    return;
+  }
+
+  raw_image_pub_->publish(std::move(raw_image_msg));
+}
+
 }  // namespace autoware::image_preprocessor
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor_node.cpp
@@ -36,13 +36,15 @@ ImageTransportDecompressor::ImageTransportDecompressor(const rclcpp::NodeOptions
 void ImageTransportDecompressor::onCompressedImage(
   const sensor_msgs::msg::CompressedImage::ConstSharedPtr input_compressed_image_msg)
 {
-  auto raw_image_msg = std::make_unique<sensor_msgs::msg::Image>();
-  if (!image_transport_decompressor::decompress(
-        *input_compressed_image_msg, encoding_, *raw_image_msg)) {
+  auto result = image_transport_decompressor::decompress(*input_compressed_image_msg, encoding_);
+  if (result.severity == image_transport_decompressor::Severity::Error) {
+    RCLCPP_ERROR(get_logger(), "%s", result.message.c_str());
+  }
+  if (!result.image) {
     return;
   }
 
-  raw_image_pub_->publish(std::move(raw_image_msg));
+  raw_image_pub_->publish(std::make_unique<sensor_msgs::msg::Image>(std::move(*result.image)));
 }
 
 }  // namespace autoware::image_preprocessor


### PR DESCRIPTION
## Description
Moves `decompress()` out of `ImageTransportDecompressor` so the decode logic can be built and tested
without a `rclcpp::Node`. No behavior change: the 40-case node characterization test added in #13202
is **untouched** by this PR and still passes, which is the intended proof.

The package now builds two libraries:

| Target | Sources | Links |
|---|---|---|
| `${PROJECT_NAME}` | `image_transport_decompressor.{hpp,cpp}` | cv_bridge, OpenCV, sensor_msgs |
| `${PROJECT_NAME}_ros` | `image_transport_decompressor_node.cpp` | `${PROJECT_NAME}` + rclcpp |

## Related links
N/A

## How was this PR tested?
### process is launched properly by
```
ros2 launch autoware_image_transport_decompressor image_transport_decompressor.launch.xml
```
### Unit Test and LCOV
Commands:
```
source /opt/ros/jazzy/setup.bash && source install/setup.bash && PKG=autoware_image_transport_decompressor && colcon build --symlink-install --packages-select $PKG   --cmake-args -DBUILD_TESTING=true -DCMAKE_BUILD_TYPE=Debug   -DCMAKE_CXX_FLAGS='--coverage -O0 -g' -DCMAKE_C_FLAGS='--coverage -O0 -g' && colcon lcov-result --zero-counters --packages-select $PKG && colcon lcov-result --initial --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov && colcon test --event-handlers console_cohesion+ --packages-select $PKG &&  colcon lcov-result --packages-select $PKG --lcov-args=--ignore-errors=mismatch,gcov   --filter "*/test/*" "*/rclcpp_components/*" "/usr/*" "/opt/*"
```
Results:
```
100% tests passed, 0 tests failed out of 5

Summary coverage rate:
  lines......: 100.0% (45 of 45 lines)
  functions..: 100.0% (6 of 6 functions)
  branches...: 47.8% (66 of 138 branches)
```


## Notes for reviewers

### commit by commit explanation 

| Commit | What to check |
|---|---|
| `2e97690` turn the decode into a free function | The real transformation, as a **same-file** diff: `this->`/members become parameters, the method shrinks to a call |
| `9098da6` reorganize code structure into separate files | **Pure move** — `decompress()` is byte-for-byte identical before and after, so this one needs no close reading |
| `50ee54a` avoid rclcpp from the logic | Dropping the logger from the logic |
| `65501ef` correct the comments and the dead code | The unreachable channel-count branches, and `cv::COLOR_*` replacing the legacy `CV_*` macros |
| `7335ebe` let a decode failure throw | **Added after the first review round**, in response to the `DecompressResult` comment |
|`c499366` move the color transformation out of decompress | pure refactor that CodeScene forced me 
|`98d0c41` drive the color transformation from a table | pure refactor that CodeScene forced me

### `cv_bridge` and `sensor_msgs::image_encodings` stay in the logic
Neither drags a ROS library in: the same calls this logic makes (`toImageMsg()`, `isColor()`,
`numChannels()`, `bitDepth()`) build into a plain `g++` binary and run with no ROS environment at all,
needing `libcv_bridge.so` and nothing from rclcpp/rmw/rosidl. Compiling still needs the ROS packages



## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.