### PR TITLE
perf(map_based_prediction): vru path-cut follow-up optimizations

### DIFF
--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/fence.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/fence.hpp
@@ -31,10 +31,14 @@ public:
 
   void buildFromMap(std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr);
 
+  /// @p predicted_path_ls holds the path positions up to the crosswalk arrival index.
   [[nodiscard]] bool doesPathCrossAnyFenceBeforeCrosswalk(
-    const PredictedPathWithArrivalIndex & predicted_path) const;
+    const lanelet::BasicLineString2d & predicted_path_ls) const;
 
-  [[nodiscard]] PredictedPath cutPathBeforeFences(const PredictedPath & predicted_path) const;
+  /// @p predicted_path_ls holds all path positions of @p predicted_path.
+  [[nodiscard]] PredictedPath cutPathBeforeFences(
+    const PredictedPath & predicted_path,
+    const lanelet::BasicLineString2d & predicted_path_ls) const;
 
 private:
   lanelet::LaneletMapUPtr fence_layer_{nullptr};

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/road_boundary.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/road_boundary.hpp
@@ -25,6 +25,7 @@
 
 #include <functional>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::map_based_prediction
@@ -48,6 +49,9 @@ public:
   /// Predicate returning true when the given crosswalk / walkway lanelet has a red signal.
   using CrosswalkSignalRedFn = std::function<bool(const lanelet::ConstLanelet &)>;
 
+  /// Crosswalk rings converted once at map load, keyed by the lanelet id.
+  using CrosswalkPolygonMap = std::unordered_map<lanelet::Id, lanelet::BasicPolygon2d>;
+
   /// Return the object's predicted paths trimmed where they first cross a road boundary.
   /// When @p object_within_road is true the paths are returned unchanged. A path is cut only when
   /// the object can decelerate to a stop before the boundary; otherwise the jump-out is treated as
@@ -65,6 +69,7 @@ private:
   // Crosswalk / walkway lanelets. A boundary crossing that falls inside one of these is treated as
   // a legitimate crosswalk crossing and is not cut.
   lanelet::LaneletMapConstUPtr crosswalk_layer_{nullptr};
+  CrosswalkPolygonMap crosswalk_polygons_;
   utils::ObjectDecelerationParams object_deceleration_params_{};
 };
 

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/vegetation.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/vegetation.hpp
@@ -38,12 +38,15 @@ public:
 
   void buildFromMap(std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr);
 
+  /// @p predicted_path_ls holds the path positions up to the crosswalk arrival index.
   [[nodiscard]] bool doesPathCrossAnyVegetationBeforeCrosswalk(
     const PredictedPathWithArrivalIndex & predicted_path,
+    const lanelet::BasicLineString2d & predicted_path_ls,
     const autoware_perception_msgs::msg::Shape & object_shape) const;
 
+  /// @p predicted_path_ls holds all path positions of @p predicted_path.
   [[nodiscard]] PredictedPath cutPathsCrossingVegetation(
-    const PredictedPath & predicted_path,
+    const PredictedPath & predicted_path, const lanelet::BasicLineString2d & predicted_path_ls,
     const autoware_perception_msgs::msg::Shape & object_shape) const;
 
 private:

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/vegetation.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/vegetation.hpp
@@ -17,12 +17,15 @@
 
 #include "autoware/map_based_prediction/path_generator/path_generator.hpp"
 
+#include <autoware_utils_geometry/boost_geometry.hpp>
+
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/shape.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::map_based_prediction
@@ -44,7 +47,13 @@ public:
     const autoware_perception_msgs::msg::Shape & object_shape) const;
 
 private:
+  [[nodiscard]] std::vector<const autoware_utils_geometry::Polygon2d *> lookupCachedPolygons(
+    const lanelet::ConstPolygons3d & candidates) const;
+
+  // Non-null only when the map holds at least one valid vegetation polygon.
   lanelet::LaneletMapConstUPtr vegetation_layer_{nullptr};
+  // Boost polygons converted once at map load, keyed by the id of the layer entry.
+  std::unordered_map<lanelet::Id, autoware_utils_geometry::Polygon2d> polygons_2d_;
 };
 
 }  // namespace autoware::map_based_prediction

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/utils.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/utils.hpp
@@ -141,6 +141,10 @@ struct ObjectDecelerationParams
 /// i.e. when the object cannot stop at all.
 double distance_to_stop_with_deceleration(double speed, double deceleration);
 
+/// 2D linestring over the path positions up to and including @p last_idx.
+lanelet::BasicLineString2d to_linestring_2d(
+  const std::vector<geometry_msgs::msg::Pose> & path, size_t last_idx);
+
 }  // namespace utils
 
 }  // namespace autoware::map_based_prediction

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/fence.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/fence.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::map_based_prediction
@@ -54,17 +55,10 @@ void FenceModule::buildFromMap(std::shared_ptr<lanelet::LaneletMap> lanelet_map_
 }
 
 bool FenceModule::doesPathCrossAnyFenceBeforeCrosswalk(
-  const PredictedPathWithArrivalIndex & predicted_path) const
+  const lanelet::BasicLineString2d & predicted_path_ls) const
 {
-  if (!fence_layer_) {
+  if (!fence_layer_ || predicted_path_ls.size() < 2) {
     return false;
-  }
-  if (predicted_path.path.empty()) return false;
-  const size_t last_idx = std::min(predicted_path.arrival_index, predicted_path.path.size() - 1);
-  lanelet::BasicLineString2d predicted_path_ls;
-  for (auto i = 0UL; i <= last_idx; ++i) {
-    const auto & pt = predicted_path.path[i];
-    predicted_path_ls.emplace_back(pt.position.x, pt.position.y);
   }
   const auto candidates =
     fence_layer_->lineStringLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));
@@ -76,25 +70,19 @@ bool FenceModule::doesPathCrossAnyFenceBeforeCrosswalk(
   return false;
 }
 
-PredictedPath FenceModule::cutPathBeforeFences(const PredictedPath & predicted_path) const
+PredictedPath FenceModule::cutPathBeforeFences(
+  const PredictedPath & predicted_path, const lanelet::BasicLineString2d & predicted_path_ls) const
 {
-  if (!fence_layer_) {
+  if (!fence_layer_ || predicted_path_ls.size() < 2) {
     return predicted_path;
-  }
-  const auto & path = predicted_path.path;
-  if (path.size() < 2) {
-    return predicted_path;
-  }
-  lanelet::BasicLineString2d predicted_path_ls;
-  for (const auto & pt : path) {
-    predicted_path_ls.emplace_back(pt.position.x, pt.position.y);
   }
   const auto candidates =
     fence_layer_->lineStringLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));
-  std::vector<lanelet::ConstLineString3d> crossed_fences{};
+  std::vector<lanelet::BasicLineString2d> crossed_fences{};
   for (const auto & candidate : candidates) {
-    if (doesPathCrossFence(predicted_path_ls, candidate)) {
-      crossed_fences.push_back(candidate);
+    auto fence_2d = lanelet::utils::to2D(candidate.basicLineString());
+    if (boost::geometry::intersects(predicted_path_ls, fence_2d)) {
+      crossed_fences.push_back(std::move(fence_2d));
     }
   }
   if (crossed_fences.empty()) {
@@ -103,11 +91,10 @@ PredictedPath FenceModule::cutPathBeforeFences(const PredictedPath & predicted_p
 
   std::optional<size_t> closest_cross_index{};
   for (auto i = 0UL; i + 1 < predicted_path_ls.size() && !closest_cross_index.has_value(); ++i) {
-    lanelet::BasicLineString2d path_segment(
+    const lanelet::BasicLineString2d path_segment(
       lanelet::BasicPoints2d{predicted_path_ls[i], predicted_path_ls[i + 1]});
-    for (const auto & fence : crossed_fences) {
-      if (
-        boost::geometry::intersects(path_segment, lanelet::utils::to2D(fence).basicLineString())) {
+    for (const auto & fence_2d : crossed_fences) {
+      if (boost::geometry::intersects(path_segment, fence_2d)) {
         closest_cross_index = i;
       }
     }

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/fence.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/fence.cpp
@@ -95,7 +95,6 @@ PredictedPath FenceModule::cutPathBeforeFences(const PredictedPath & predicted_p
   for (const auto & candidate : candidates) {
     if (doesPathCrossFence(predicted_path_ls, candidate)) {
       crossed_fences.push_back(candidate);
-      break;
     }
   }
   if (crossed_fences.empty()) {
@@ -118,10 +117,7 @@ PredictedPath FenceModule::cutPathBeforeFences(const PredictedPath & predicted_p
     return predicted_path;
   }
   auto trimmed_path = predicted_path;
-  trimmed_path.path.clear();
-  for (unsigned i = 0; i <= closest_cross_index.value(); ++i) {
-    trimmed_path.path.push_back(path.at(i));
-  }
+  trimmed_path.path.resize(closest_cross_index.value() + 1);
   return trimmed_path;
 }
 

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/predictor_vru.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/predictor_vru.cpp
@@ -244,11 +244,15 @@ PredictedObject PredictorVru::getPredictedObjectAsCrosswalkUser(const TrackedObj
       mutable_object, params_.prediction_time_horizon);
     predicted_path.confidence = 1.0;
 
+    // One linestring per path, shared by the cut modules; cuts only shorten it.
+    auto predicted_path_ls = utils::to_linestring_2d(
+      predicted_path.path, predicted_path.path.empty() ? 0 : predicted_path.path.size() - 1);
     const PredictedPath predicted_path_cut_with_fences =
-      fence_module_.cutPathBeforeFences(predicted_path);
+      fence_module_.cutPathBeforeFences(predicted_path, predicted_path_ls);
+    predicted_path_ls.resize(predicted_path_cut_with_fences.path.size());
     predicted_object.kinematics.predicted_paths.push_back(
       vegetation_module_.cutPathsCrossingVegetation(
-        predicted_path_cut_with_fences, mutable_object.shape));
+        predicted_path_cut_with_fences, predicted_path_ls, mutable_object.shape));
   }
 
   boost::optional<lanelet::ConstLanelet> crossing_crosswalk{boost::none};
@@ -390,12 +394,14 @@ PredictedObject PredictorVru::getPredictedObjectAsCrosswalkUser(const TrackedObj
     if (predicted_path.path.empty()) {
       continue;
     }
-    if (fence_module_.doesPathCrossAnyFenceBeforeCrosswalk(predicted_path)) {
+    const auto predicted_path_ls = utils::to_linestring_2d(
+      predicted_path.path, std::min(predicted_path.arrival_index, predicted_path.path.size() - 1));
+    if (fence_module_.doesPathCrossAnyFenceBeforeCrosswalk(predicted_path_ls)) {
       continue;
     }
     if (
       vegetation_module_.doesPathCrossAnyVegetationBeforeCrosswalk(
-        predicted_path, mutable_object.shape)) {
+        predicted_path, predicted_path_ls, mutable_object.shape)) {
       continue;
     }
     predicted_object.kinematics.predicted_paths.push_back(predicted_path);

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
@@ -75,14 +75,12 @@ bool segment_has_cuttable_crossing(
   const RoadBoundaryModule::CrosswalkPolygonMap & crosswalk_polygons,
   const RoadBoundaryModule::CrosswalkSignalRedFn & is_crosswalk_signal_red)
 {
-  if (!boost::geometry::intersects(path_segment, boundary_2d)) {
-    return false;
-  }
   lanelet::BasicPoints2d intersections;
   boost::geometry::intersection(path_segment, boundary_2d, intersections);
-  // Fall back to cutting when the intersection points cannot be resolved (e.g. collinear overlap).
+  // No points either for a disjoint segment or for a collinear overlap that cannot be resolved
+  // into points; the latter falls back to cutting.
   if (intersections.empty()) {
-    return true;
+    return boost::geometry::intersects(path_segment, boundary_2d);
   }
   for (const auto & intersection : intersections) {
     const auto crosswalk = find_crosswalk_at_point(crosswalk_layer, crosswalk_polygons, intersection);

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
@@ -30,7 +30,8 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_set>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::map_based_prediction
@@ -42,16 +43,10 @@ namespace
 // points lying exactly on (or just outside) the crosswalk edge are still recognised as inside.
 constexpr double kCrosswalkContainmentMargin = 0.5;  // [m]
 
-bool does_path_cross_boundary(
-  const lanelet::BasicLineString2d & predicted_path,
-  const lanelet::ConstLineString3d & boundary_line)
-{
-  return boost::geometry::intersects(
-    predicted_path, lanelet::utils::to2D(boundary_line.basicLineString()));
-}
-
 std::optional<lanelet::ConstLanelet> find_crosswalk_at_point(
-  const lanelet::LaneletMap * crosswalk_layer, const lanelet::BasicPoint2d & point)
+  const lanelet::LaneletMap * crosswalk_layer,
+  const RoadBoundaryModule::CrosswalkPolygonMap & crosswalk_polygons,
+  const lanelet::BasicPoint2d & point)
 {
   if (!crosswalk_layer) {
     return std::nullopt;
@@ -62,7 +57,7 @@ std::optional<lanelet::ConstLanelet> find_crosswalk_at_point(
     // distance() is 0 when the point is inside the polygon and the gap to the edge otherwise, so
     // this is equivalent to a within() test against a polygon expanded by the margin.
     if (
-      boost::geometry::distance(point, crosswalk.polygon2d().basicPolygon()) <=
+      boost::geometry::distance(point, crosswalk_polygons.at(crosswalk.id())) <=
       kCrosswalkContainmentMargin) {
       return crosswalk;
     }
@@ -75,11 +70,11 @@ std::optional<lanelet::ConstLanelet> find_crosswalk_at_point(
 // red (no signal or non-red) i.e. a legitimate crossing. An intersection outside any crosswalk, or
 // inside a crosswalk with a red signal, is a cuttable jump-out.
 bool segment_has_cuttable_crossing(
-  const lanelet::BasicLineString2d & path_segment, const lanelet::ConstLineString3d & boundary,
+  const lanelet::BasicLineString2d & path_segment, const lanelet::BasicLineString2d & boundary_2d,
   const lanelet::LaneletMap * crosswalk_layer,
+  const RoadBoundaryModule::CrosswalkPolygonMap & crosswalk_polygons,
   const RoadBoundaryModule::CrosswalkSignalRedFn & is_crosswalk_signal_red)
 {
-  const auto boundary_2d = lanelet::utils::to2D(boundary).basicLineString();
   if (!boost::geometry::intersects(path_segment, boundary_2d)) {
     return false;
   }
@@ -90,7 +85,7 @@ bool segment_has_cuttable_crossing(
     return true;
   }
   for (const auto & intersection : intersections) {
-    const auto crosswalk = find_crosswalk_at_point(crosswalk_layer, intersection);
+    const auto crosswalk = find_crosswalk_at_point(crosswalk_layer, crosswalk_polygons, intersection);
     const bool exempt = crosswalk.has_value() && !is_crosswalk_signal_red(crosswalk.value());
     if (!exempt) {
       return true;
@@ -101,6 +96,7 @@ bool segment_has_cuttable_crossing(
 
 std::optional<size_t> find_road_boundary_crossing_index(
   const lanelet::LaneletMap & road_boundary_layer, const lanelet::LaneletMap * crosswalk_layer,
+  const RoadBoundaryModule::CrosswalkPolygonMap & crosswalk_polygons,
   const RoadBoundaryModule::CrosswalkSignalRedFn & is_crosswalk_signal_red,
   const PredictedPath & predicted_path)
 {
@@ -117,10 +113,11 @@ std::optional<size_t> find_road_boundary_crossing_index(
 
   const auto candidates =
     road_boundary_layer.lineStringLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));
-  std::vector<lanelet::ConstLineString3d> crossed_boundaries{};
+  std::vector<lanelet::BasicLineString2d> crossed_boundaries{};
   for (const auto & candidate : candidates) {
-    if (does_path_cross_boundary(predicted_path_ls, candidate)) {
-      crossed_boundaries.push_back(candidate);
+    auto boundary_2d = lanelet::utils::to2D(candidate.basicLineString());
+    if (boost::geometry::intersects(predicted_path_ls, boundary_2d)) {
+      crossed_boundaries.push_back(std::move(boundary_2d));
     }
   }
   if (crossed_boundaries.empty()) {
@@ -130,10 +127,11 @@ std::optional<size_t> find_road_boundary_crossing_index(
   for (auto i = 0UL; i + 1 < predicted_path_ls.size(); ++i) {
     const lanelet::BasicLineString2d path_segment(
       lanelet::BasicPoints2d{predicted_path_ls.at(i), predicted_path_ls.at(i + 1)});
-    for (const auto & boundary : crossed_boundaries) {
+    for (const auto & boundary_2d : crossed_boundaries) {
       if (
         segment_has_cuttable_crossing(
-          path_segment, boundary, crosswalk_layer, is_crosswalk_signal_red)) {
+          path_segment, boundary_2d, crosswalk_layer, crosswalk_polygons,
+          is_crosswalk_signal_red)) {
         return i;
       }
     }
@@ -144,14 +142,14 @@ std::optional<size_t> find_road_boundary_crossing_index(
 
 void RoadBoundaryModule::build_from_map(std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr)
 {
+  road_boundary_layer_ = nullptr;
+  crosswalk_layer_ = nullptr;
+  crosswalk_polygons_.clear();
   if (!lanelet_map_ptr) {
-    road_boundary_layer_ = nullptr;
-    crosswalk_layer_ = nullptr;
     return;
   }
 
-  lanelet::LineStrings3d boundaries;
-  std::unordered_set<lanelet::Id> added_ids;
+  std::unordered_map<lanelet::Id, std::pair<lanelet::LineString3d, size_t>> bound_usage;
   lanelet::ConstLanelets crosswalks;
   for (const auto & lanelet : lanelet_map_ptr->laneletLayer) {
     const std::string subtype = lanelet.attributeOr(lanelet::AttributeName::Subtype, "none");
@@ -165,14 +163,27 @@ void RoadBoundaryModule::build_from_map(std::shared_ptr<lanelet::LaneletMap> lan
       continue;
     }
     for (const auto & bound : {lanelet.leftBound(), lanelet.rightBound()}) {
-      if (added_ids.insert(bound.id()).second) {
-        boundaries.emplace_back(
-          std::const_pointer_cast<lanelet::LineStringData>(bound.constData()));
-      }
+      auto [it, inserted] = bound_usage.try_emplace(
+        bound.id(),
+        lanelet::LineString3d(std::const_pointer_cast<lanelet::LineStringData>(bound.constData())),
+        0UL);
+      ++it->second.second;
+    }
+  }
+  // A bound shared by two road-subtype lanelets is an interior lane divider; a path coming from
+  // outside the road always reaches an outer edge first, so dividers are never the first crossing
+  // and are left out of the layer.
+  lanelet::LineStrings3d boundaries;
+  for (auto & [id, bound_with_usage] : bound_usage) {
+    if (bound_with_usage.second == 1) {
+      boundaries.push_back(bound_with_usage.first);
     }
   }
   road_boundary_layer_ = lanelet::utils::createMap(boundaries);
   crosswalk_layer_ = lanelet::utils::createConstMap(crosswalks, {});
+  for (const auto & crosswalk : crosswalks) {
+    crosswalk_polygons_.emplace(crosswalk.id(), crosswalk.polygon2d().basicPolygon());
+  }
 }
 
 std::vector<PredictedPath> RoadBoundaryModule::cut_paths_crossing_road_boundary(
@@ -194,7 +205,8 @@ std::vector<PredictedPath> RoadBoundaryModule::cut_paths_crossing_road_boundary(
 
   for (PredictedPath & predicted_path : cut_paths) {
     const std::optional<size_t> crossing_index = find_road_boundary_crossing_index(
-      *road_boundary_layer_, crosswalk_layer_.get(), is_crosswalk_signal_red, predicted_path);
+      *road_boundary_layer_, crosswalk_layer_.get(), crosswalk_polygons_, is_crosswalk_signal_red,
+      predicted_path);
     if (!crossing_index) {
       continue;
     }

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
@@ -83,7 +83,8 @@ bool segment_has_cuttable_crossing(
     return boost::geometry::intersects(path_segment, boundary_2d);
   }
   for (const auto & intersection : intersections) {
-    const auto crosswalk = find_crosswalk_at_point(crosswalk_layer, crosswalk_polygons, intersection);
+    const auto crosswalk =
+      find_crosswalk_at_point(crosswalk_layer, crosswalk_polygons, intersection);
     const bool exempt = crosswalk.has_value() && !is_crosswalk_signal_red(crosswalk.value());
     if (!exempt) {
       return true;
@@ -103,11 +104,7 @@ std::optional<size_t> find_road_boundary_crossing_index(
     return std::nullopt;
   }
 
-  lanelet::BasicLineString2d predicted_path_ls;
-  predicted_path_ls.reserve(path.size());
-  for (const auto & pt : path) {
-    predicted_path_ls.emplace_back(pt.position.x, pt.position.y);
-  }
+  const auto predicted_path_ls = utils::to_linestring_2d(path, path.size() - 1);
 
   const auto candidates =
     road_boundary_layer.lineStringLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/vegetation.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/vegetation.cpp
@@ -20,6 +20,8 @@
 
 #include <autoware_perception_msgs/msg/shape.hpp>
 
+#include <rclcpp/logging.hpp>
+
 #include <boost/geometry.hpp>
 
 #include <lanelet2_core/geometry/LineString.h>
@@ -30,6 +32,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::map_based_prediction
@@ -86,7 +89,7 @@ Box2d buildPathFootprintBBox(
 
 std::optional<size_t> findVegetationCrossingIndex(
   const PredictedPath & predicted_path, const autoware_perception_msgs::msg::Shape & object_shape,
-  const lanelet::ConstPolygons3d & vegetation_polygons, const size_t last_idx)
+  const std::vector<const Polygon2d *> & vegetation_polygons, const size_t last_idx)
 {
   const auto & path = predicted_path.path;
   if (path.size() < 2 || vegetation_polygons.empty()) {
@@ -96,17 +99,16 @@ std::optional<size_t> findVegetationCrossingIndex(
   const auto path_bbox = buildPathFootprintBBox(path, object_shape, last_idx);
   const auto initial_footprint = autoware_utils_geometry::to_polygon2d(path.front(), object_shape);
 
-  std::vector<Polygon2d> candidate_polygons;
-  for (const auto & vegetation_polygon : vegetation_polygons) {
-    const auto vegetation_polygon_2d = toPolygon2d(vegetation_polygon);
-    if (!boost::geometry::intersects(path_bbox, vegetation_polygon_2d)) {
+  std::vector<const Polygon2d *> candidate_polygons;
+  for (const auto * vegetation_polygon : vegetation_polygons) {
+    if (!boost::geometry::intersects(path_bbox, *vegetation_polygon)) {
       continue;
     }
     // Object already overlapping vegetation: its path leaves the area, so no crossing is reported.
-    if (boost::geometry::intersects(initial_footprint, vegetation_polygon_2d)) {
+    if (boost::geometry::intersects(initial_footprint, *vegetation_polygon)) {
       return std::nullopt;
     }
-    candidate_polygons.push_back(vegetation_polygon_2d);
+    candidate_polygons.push_back(vegetation_polygon);
   }
   if (candidate_polygons.empty()) {
     return std::nullopt;
@@ -116,8 +118,8 @@ std::optional<size_t> findVegetationCrossingIndex(
   for (auto i = 0UL; i + 1 <= last_idx; ++i) {
     const auto swept_polygon =
       convexPolygonCoveringSegmentFootprints(path.at(i), path.at(i + 1), object_shape);
-    for (const auto & candidate_polygon : candidate_polygons) {
-      if (boost::geometry::intersects(swept_polygon, candidate_polygon)) {
+    for (const auto * candidate_polygon : candidate_polygons) {
+      if (boost::geometry::intersects(swept_polygon, *candidate_polygon)) {
         return i;
       }
     }
@@ -128,7 +130,7 @@ std::optional<size_t> findVegetationCrossingIndex(
 bool doesPathCrossVegetation(
   const PredictedPathWithArrivalIndex & predicted_path,
   const autoware_perception_msgs::msg::Shape & object_shape,
-  const lanelet::ConstPolygons3d & vegetation_polygons)
+  const std::vector<const Polygon2d *> & vegetation_polygons)
 {
   if (predicted_path.path.size() < 2) {
     return false;
@@ -141,8 +143,9 @@ bool doesPathCrossVegetation(
 
 void VegetationModule::buildFromMap(std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr)
 {
+  vegetation_layer_ = nullptr;
+  polygons_2d_.clear();
   if (!lanelet_map_ptr) {
-    vegetation_layer_ = nullptr;
     return;
   }
 
@@ -150,12 +153,36 @@ void VegetationModule::buildFromMap(std::shared_ptr<lanelet::LaneletMap> lanelet
   for (const auto & polygon : lanelet_map_ptr->polygonLayer) {
     const std::string type = polygon.attributeOr(lanelet::AttributeName::Type, "none");
     const std::string subtype = polygon.attributeOr(lanelet::AttributeName::Subtype, "none");
-    if (type == "area" && subtype == "vegetation") {
-      vegetations.emplace_back(
-        std::const_pointer_cast<lanelet::LineStringData>(polygon.constData()));
+    if (type != "area" || subtype != "vegetation") {
+      continue;
     }
+    auto polygon_2d = toPolygon2d(polygon);
+    boost::geometry::unique(polygon_2d);
+    // A closed outer ring needs three distinct vertices plus the closing point.
+    if (polygon_2d.outer().size() < 4 || !boost::geometry::is_valid(polygon_2d)) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("map_based_prediction.vegetation"),
+        "Skipping invalid vegetation polygon %ld in the lanelet map", polygon.id());
+      continue;
+    }
+    polygons_2d_.emplace(polygon.id(), std::move(polygon_2d));
+    vegetations.emplace_back(std::const_pointer_cast<lanelet::LineStringData>(polygon.constData()));
   }
-  vegetation_layer_ = lanelet::utils::createMap(vegetations);
+  // The layer stays null when nothing is left, so per-path queries short-circuit.
+  if (!vegetations.empty()) {
+    vegetation_layer_ = lanelet::utils::createMap(vegetations);
+  }
+}
+
+std::vector<const Polygon2d *> VegetationModule::lookupCachedPolygons(
+  const lanelet::ConstPolygons3d & candidates) const
+{
+  std::vector<const Polygon2d *> polygons;
+  polygons.reserve(candidates.size());
+  for (const auto & candidate : candidates) {
+    polygons.push_back(&polygons_2d_.at(candidate.id()));
+  }
+  return polygons;
 }
 
 bool VegetationModule::doesPathCrossAnyVegetationBeforeCrosswalk(
@@ -176,7 +203,8 @@ bool VegetationModule::doesPathCrossAnyVegetationBeforeCrosswalk(
   }
   const auto candidates =
     vegetation_layer_->polygonLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));
-  return doesPathCrossVegetation(predicted_path, object_shape, candidates);
+  return doesPathCrossVegetation(
+    predicted_path, object_shape, lookupCachedPolygons(candidates));
 }
 
 PredictedPath VegetationModule::cutPathsCrossingVegetation(
@@ -195,7 +223,8 @@ PredictedPath VegetationModule::cutPathsCrossingVegetation(
   const auto candidates =
     vegetation_layer_->polygonLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));
   const std::optional<size_t> crossing_index = findVegetationCrossingIndex(
-    predicted_path, object_shape, candidates, predicted_path.path.size() - 1);
+    predicted_path, object_shape, lookupCachedPolygons(candidates),
+    predicted_path.path.size() - 1);
   if (crossing_index) {
     cut_path.path.resize(std::min(*crossing_index + 1, cut_path.path.size()));
   }

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/vegetation.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/vegetation.cpp
@@ -17,10 +17,9 @@
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
+#include <rclcpp/logging.hpp>
 
 #include <autoware_perception_msgs/msg/shape.hpp>
-
-#include <rclcpp/logging.hpp>
 
 #include <boost/geometry.hpp>
 
@@ -110,8 +109,7 @@ std::optional<size_t> findVegetationCrossingIndex(
   }
 
   const double footprint_radius = footprintRadius(object_shape);
-  const bool is_cylinder =
-    object_shape.type == autoware_perception_msgs::msg::Shape::CYLINDER;
+  const bool is_cylinder = object_shape.type == autoware_perception_msgs::msg::Shape::CYLINDER;
   // The swept footprint of a cylinder is the centerline buffered by its radius, so distance
   // tests against the centerline are exact; other shapes use them as a conservative gate.
   const auto initial_footprint =
@@ -124,10 +122,9 @@ std::optional<size_t> findVegetationCrossingIndex(
     }
     // Object already overlapping vegetation: its path leaves the area, so no crossing is reported.
     const bool initially_overlapping =
-      is_cylinder
-        ? boost::geometry::distance(predicted_path_ls.front(), *vegetation_polygon) <=
-            footprint_radius
-        : boost::geometry::intersects(initial_footprint, *vegetation_polygon);
+      is_cylinder ? boost::geometry::distance(predicted_path_ls.front(), *vegetation_polygon) <=
+                      footprint_radius
+                  : boost::geometry::intersects(initial_footprint, *vegetation_polygon);
     if (initially_overlapping) {
       return std::nullopt;
     }
@@ -229,19 +226,11 @@ std::vector<const Polygon2d *> VegetationModule::lookupCachedPolygons(
 
 bool VegetationModule::doesPathCrossAnyVegetationBeforeCrosswalk(
   const PredictedPathWithArrivalIndex & predicted_path,
+  const lanelet::BasicLineString2d & predicted_path_ls,
   const autoware_perception_msgs::msg::Shape & object_shape) const
 {
-  if (!vegetation_layer_) {
+  if (!vegetation_layer_ || predicted_path_ls.empty()) {
     return false;
-  }
-  if (predicted_path.path.empty()) {
-    return false;
-  }
-  lanelet::BasicLineString2d predicted_path_ls;
-  const size_t last_idx = std::min(predicted_path.arrival_index, predicted_path.path.size() - 1);
-  for (auto i = 0UL; i <= last_idx; ++i) {
-    const auto & pt = predicted_path.path.at(i);
-    predicted_path_ls.emplace_back(pt.position.x, pt.position.y);
   }
   const auto candidates =
     vegetation_layer_->polygonLayer.search(searchBox(predicted_path_ls, object_shape));
@@ -250,7 +239,7 @@ bool VegetationModule::doesPathCrossAnyVegetationBeforeCrosswalk(
 }
 
 PredictedPath VegetationModule::cutPathsCrossingVegetation(
-  const PredictedPath & predicted_path,
+  const PredictedPath & predicted_path, const lanelet::BasicLineString2d & predicted_path_ls,
   const autoware_perception_msgs::msg::Shape & object_shape) const
 {
   PredictedPath cut_path = predicted_path;
@@ -258,10 +247,6 @@ PredictedPath VegetationModule::cutPathsCrossingVegetation(
     return cut_path;
   }
 
-  lanelet::BasicLineString2d predicted_path_ls;
-  for (const auto & pt : predicted_path.path) {
-    predicted_path_ls.emplace_back(pt.position.x, pt.position.y);
-  }
   const auto candidates =
     vegetation_layer_->polygonLayer.search(searchBox(predicted_path_ls, object_shape));
   const std::optional<size_t> crossing_index = findVegetationCrossingIndex(

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/vegetation.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/vegetation.cpp
@@ -29,6 +29,7 @@
 #include <lanelet2_core/primitives/Polygon.h>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <optional>
 #include <string>
@@ -42,7 +43,6 @@ namespace
 {
 using Point2d = autoware_utils_geometry::Point2d;
 using Polygon2d = autoware_utils_geometry::Polygon2d;
-using Box2d = autoware_utils_geometry::Box2d;
 
 autoware_utils_geometry::Polygon2d toPolygon2d(const lanelet::ConstPolygon3d & lanelet_polygon)
 {
@@ -52,13 +52,26 @@ autoware_utils_geometry::Polygon2d toPolygon2d(const lanelet::ConstPolygon3d & l
   return polygon;
 }
 
-Polygon2d convexPolygonCoveringSegmentFootprints(
-  const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & end_pose,
-  const autoware_perception_msgs::msg::Shape & shape)
+// Radius of the smallest origin-centred circle covering the footprint.
+double footprintRadius(const autoware_perception_msgs::msg::Shape & shape)
 {
-  const auto start_polygon = autoware_utils_geometry::to_polygon2d(start_pose, shape);
-  const auto end_polygon = autoware_utils_geometry::to_polygon2d(end_pose, shape);
+  using autoware_perception_msgs::msg::Shape;
+  if (shape.type == Shape::CYLINDER) {
+    return shape.dimensions.x * 0.5;
+  }
+  if (shape.type == Shape::POLYGON) {
+    double radius = 0.0;
+    for (const auto & point : shape.footprint.points) {
+      radius = std::max(radius, static_cast<double>(std::hypot(point.x, point.y)));
+    }
+    return radius;
+  }
+  return std::hypot(shape.dimensions.x, shape.dimensions.y) * 0.5;
+}
 
+Polygon2d convexPolygonCoveringFootprints(
+  const Polygon2d & start_polygon, const Polygon2d & end_polygon)
+{
   boost::geometry::model::multi_point<Point2d> points;
   for (const auto & point : start_polygon.outer()) {
     points.push_back(point);
@@ -73,22 +86,22 @@ Polygon2d convexPolygonCoveringSegmentFootprints(
   return hull;
 }
 
-Box2d buildPathFootprintBBox(
-  const std::vector<geometry_msgs::msg::Pose> & path,
-  const autoware_perception_msgs::msg::Shape & object_shape, const size_t last_idx)
+// Centerline bounding box grown by the footprint radius, so every polygon the swept footprint
+// can reach is inside the queried area.
+lanelet::BoundingBox2d searchBox(
+  const lanelet::BasicLineString2d & predicted_path_ls,
+  const autoware_perception_msgs::msg::Shape & object_shape)
 {
-  boost::geometry::model::multi_point<Point2d> path_footprint_points;
-  for (auto i = 0UL; i <= last_idx; ++i) {
-    const auto footprint = autoware_utils_geometry::to_polygon2d(path.at(i), object_shape);
-    for (const auto & point : footprint.outer()) {
-      path_footprint_points.push_back(point);
-    }
-  }
-  return boost::geometry::return_envelope<Box2d>(path_footprint_points);
+  const auto bbox = lanelet::geometry::boundingBox2d(predicted_path_ls);
+  const double radius = footprintRadius(object_shape);
+  const lanelet::BasicPoint2d margin(radius, radius);
+  return {bbox.min() - margin, bbox.max() + margin};
 }
 
+// The linestring holds the path positions up to and including last_idx.
 std::optional<size_t> findVegetationCrossingIndex(
-  const PredictedPath & predicted_path, const autoware_perception_msgs::msg::Shape & object_shape,
+  const PredictedPath & predicted_path, const lanelet::BasicLineString2d & predicted_path_ls,
+  const autoware_perception_msgs::msg::Shape & object_shape,
   const std::vector<const Polygon2d *> & vegetation_polygons, const size_t last_idx)
 {
   const auto & path = predicted_path.path;
@@ -96,16 +109,26 @@ std::optional<size_t> findVegetationCrossingIndex(
     return std::nullopt;
   }
 
-  const auto path_bbox = buildPathFootprintBBox(path, object_shape, last_idx);
-  const auto initial_footprint = autoware_utils_geometry::to_polygon2d(path.front(), object_shape);
+  const double footprint_radius = footprintRadius(object_shape);
+  const bool is_cylinder =
+    object_shape.type == autoware_perception_msgs::msg::Shape::CYLINDER;
+  // The swept footprint of a cylinder is the centerline buffered by its radius, so distance
+  // tests against the centerline are exact; other shapes use them as a conservative gate.
+  const auto initial_footprint =
+    is_cylinder ? Polygon2d{} : autoware_utils_geometry::to_polygon2d(path.front(), object_shape);
 
   std::vector<const Polygon2d *> candidate_polygons;
   for (const auto * vegetation_polygon : vegetation_polygons) {
-    if (!boost::geometry::intersects(path_bbox, *vegetation_polygon)) {
+    if (boost::geometry::distance(predicted_path_ls, *vegetation_polygon) > footprint_radius) {
       continue;
     }
     // Object already overlapping vegetation: its path leaves the area, so no crossing is reported.
-    if (boost::geometry::intersects(initial_footprint, *vegetation_polygon)) {
+    const bool initially_overlapping =
+      is_cylinder
+        ? boost::geometry::distance(predicted_path_ls.front(), *vegetation_polygon) <=
+            footprint_radius
+        : boost::geometry::intersects(initial_footprint, *vegetation_polygon);
+    if (initially_overlapping) {
       return std::nullopt;
     }
     candidate_polygons.push_back(vegetation_polygon);
@@ -115,20 +138,38 @@ std::optional<size_t> findVegetationCrossingIndex(
   }
 
   // Segment loop outermost so the crossing closest to the object is the one reported.
+  if (is_cylinder) {
+    for (auto i = 0UL; i + 1 <= last_idx; ++i) {
+      const lanelet::BasicLineString2d segment(
+        lanelet::BasicPoints2d{predicted_path_ls.at(i), predicted_path_ls.at(i + 1)});
+      for (const auto * candidate_polygon : candidate_polygons) {
+        if (boost::geometry::distance(segment, *candidate_polygon) <= footprint_radius) {
+          return i;
+        }
+      }
+    }
+    return std::nullopt;
+  }
+
+  auto segment_start_footprint = initial_footprint;
   for (auto i = 0UL; i + 1 <= last_idx; ++i) {
+    auto segment_end_footprint =
+      autoware_utils_geometry::to_polygon2d(path.at(i + 1), object_shape);
     const auto swept_polygon =
-      convexPolygonCoveringSegmentFootprints(path.at(i), path.at(i + 1), object_shape);
+      convexPolygonCoveringFootprints(segment_start_footprint, segment_end_footprint);
     for (const auto * candidate_polygon : candidate_polygons) {
       if (boost::geometry::intersects(swept_polygon, *candidate_polygon)) {
         return i;
       }
     }
+    segment_start_footprint = std::move(segment_end_footprint);
   }
   return std::nullopt;
 }
 
 bool doesPathCrossVegetation(
   const PredictedPathWithArrivalIndex & predicted_path,
+  const lanelet::BasicLineString2d & predicted_path_ls,
   const autoware_perception_msgs::msg::Shape & object_shape,
   const std::vector<const Polygon2d *> & vegetation_polygons)
 {
@@ -136,7 +177,8 @@ bool doesPathCrossVegetation(
     return false;
   }
   const size_t last_idx = std::min(predicted_path.arrival_index, predicted_path.path.size() - 1);
-  return findVegetationCrossingIndex(predicted_path, object_shape, vegetation_polygons, last_idx)
+  return findVegetationCrossingIndex(
+           predicted_path, predicted_path_ls, object_shape, vegetation_polygons, last_idx)
     .has_value();
 }
 }  // namespace
@@ -202,9 +244,9 @@ bool VegetationModule::doesPathCrossAnyVegetationBeforeCrosswalk(
     predicted_path_ls.emplace_back(pt.position.x, pt.position.y);
   }
   const auto candidates =
-    vegetation_layer_->polygonLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));
+    vegetation_layer_->polygonLayer.search(searchBox(predicted_path_ls, object_shape));
   return doesPathCrossVegetation(
-    predicted_path, object_shape, lookupCachedPolygons(candidates));
+    predicted_path, predicted_path_ls, object_shape, lookupCachedPolygons(candidates));
 }
 
 PredictedPath VegetationModule::cutPathsCrossingVegetation(
@@ -221,9 +263,9 @@ PredictedPath VegetationModule::cutPathsCrossingVegetation(
     predicted_path_ls.emplace_back(pt.position.x, pt.position.y);
   }
   const auto candidates =
-    vegetation_layer_->polygonLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));
+    vegetation_layer_->polygonLayer.search(searchBox(predicted_path_ls, object_shape));
   const std::optional<size_t> crossing_index = findVegetationCrossingIndex(
-    predicted_path, object_shape, lookupCachedPolygons(candidates),
+    predicted_path, predicted_path_ls, object_shape, lookupCachedPolygons(candidates),
     predicted_path.path.size() - 1);
   if (crossing_index) {
     cut_path.path.resize(std::min(*crossing_index + 1, cut_path.path.size()));

--- a/perception/autoware_map_based_prediction/lib/utils.cpp
+++ b/perception/autoware_map_based_prediction/lib/utils.cpp
@@ -561,5 +561,17 @@ double distance_to_stop_with_deceleration(const double speed, const double decel
   return (speed * speed) / (2.0 * -deceleration);
 }
 
+lanelet::BasicLineString2d to_linestring_2d(
+  const std::vector<geometry_msgs::msg::Pose> & path, const size_t last_idx)
+{
+  lanelet::BasicLineString2d linestring;
+  linestring.reserve(std::min(last_idx + 1, path.size()));
+  for (auto i = 0UL; i <= last_idx && i < path.size(); ++i) {
+    const auto & position = path.at(i).position;
+    linestring.emplace_back(position.x, position.y);
+  }
+  return linestring;
+}
+
 }  // namespace utils
 }  // namespace autoware::map_based_prediction

--- a/perception/autoware_map_based_prediction/test/map_based_prediction/test_vru_path_cut_modules.cpp
+++ b/perception/autoware_map_based_prediction/test/map_based_prediction/test_vru_path_cut_modules.cpp
@@ -1,0 +1,321 @@
+// Copyright 2026 TIER IV, inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_based_prediction/predictor_vru/fence.hpp"
+#include "autoware/map_based_prediction/predictor_vru/road_boundary.hpp"
+#include "autoware/map_based_prediction/predictor_vru/vegetation.hpp"
+#include "autoware/map_based_prediction/utils.hpp"
+
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Polygon.h>
+#include <lanelet2_core/utility/Utilities.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::map_based_prediction
+{
+namespace
+{
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::Shape;
+
+lanelet::Point3d make_point(const double x, const double y)
+{
+  return lanelet::Point3d(lanelet::utils::getId(), x, y, 0.0);
+}
+
+lanelet::LineString3d make_linestring(
+  const std::vector<std::pair<double, double>> & points, const std::string & type = "")
+{
+  lanelet::LineString3d linestring(lanelet::utils::getId());
+  for (const auto & [x, y] : points) {
+    linestring.push_back(make_point(x, y));
+  }
+  if (!type.empty()) {
+    linestring.attributes()[lanelet::AttributeName::Type] = type;
+  }
+  return linestring;
+}
+
+lanelet::Polygon3d make_vegetation_polygon(const std::vector<std::pair<double, double>> & points)
+{
+  lanelet::Polygon3d polygon(lanelet::utils::getId());
+  for (const auto & [x, y] : points) {
+    polygon.push_back(make_point(x, y));
+  }
+  polygon.attributes()[lanelet::AttributeName::Type] = "area";
+  polygon.attributes()[lanelet::AttributeName::Subtype] = "vegetation";
+  return polygon;
+}
+
+lanelet::Lanelet make_lanelet(
+  const lanelet::LineString3d & left, const lanelet::LineString3d & right,
+  const std::string & subtype)
+{
+  lanelet::Lanelet lanelet(lanelet::utils::getId(), left, right);
+  lanelet.attributes()[lanelet::AttributeName::Subtype] = subtype;
+  return lanelet;
+}
+
+// Straight path along the x-axis with 1 m spacing, poses at x = 0 .. n_poses - 1.
+PredictedPath make_straight_path(const size_t n_poses)
+{
+  PredictedPath path;
+  for (auto i = 0UL; i < n_poses; ++i) {
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = static_cast<double>(i);
+    pose.orientation.w = 1.0;
+    path.path.push_back(pose);
+  }
+  return path;
+}
+
+Shape cylinder_shape(const double diameter)
+{
+  Shape shape;
+  shape.type = Shape::CYLINDER;
+  shape.dimensions.x = diameter;
+  return shape;
+}
+
+Shape bounding_box_shape(const double length, const double width)
+{
+  Shape shape;
+  shape.type = Shape::BOUNDING_BOX;
+  shape.dimensions.x = length;
+  shape.dimensions.y = width;
+  return shape;
+}
+
+lanelet::BasicLineString2d full_linestring(const PredictedPath & path)
+{
+  return utils::to_linestring_2d(path.path, path.path.size() - 1);
+}
+
+class VegetationModuleTest : public ::testing::Test
+{
+protected:
+  VegetationModule build_module(const std::vector<lanelet::Polygon3d> & polygons)
+  {
+    auto map = std::make_shared<lanelet::LaneletMap>();
+    for (const auto & polygon : polygons) {
+      map->add(polygon);
+    }
+    VegetationModule module;
+    module.buildFromMap(map);
+    return module;
+  }
+};
+
+TEST_F(VegetationModuleTest, EarliestCrossingWins)
+{
+  // Two polygons over the path; the cut belongs to the nearer one at x in [2.2, 3].
+  const auto module = build_module(
+    {make_vegetation_polygon({{6.2, -1.0}, {7.0, -1.0}, {7.0, 1.0}, {6.2, 1.0}}),
+     make_vegetation_polygon({{2.2, -1.0}, {3.0, -1.0}, {3.0, 1.0}, {2.2, 1.0}})});
+  const auto path = make_straight_path(11);
+  const auto cut =
+    module.cutPathsCrossingVegetation(path, full_linestring(path), cylinder_shape(1.0));
+  // Segment (1,0)-(2,0) is the first within 0.5 m of the nearer polygon.
+  ASSERT_EQ(cut.path.size(), 2UL);
+}
+
+TEST_F(VegetationModuleTest, InitialOverlapIsNotACrossing)
+{
+  const auto module =
+    build_module({make_vegetation_polygon({{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}})});
+  const auto path = make_straight_path(11);
+  const auto cut =
+    module.cutPathsCrossingVegetation(path, full_linestring(path), cylinder_shape(1.0));
+  ASSERT_EQ(cut.path.size(), 11UL);
+}
+
+TEST_F(VegetationModuleTest, PolygonWithinFootprintRadiusOfCenterlineIsDetected)
+{
+  // The polygon never touches the centerline (y >= 0.3) but the 0.5 m footprint sweeps into it.
+  const auto module =
+    build_module({make_vegetation_polygon({{4.0, 0.3}, {5.0, 0.3}, {5.0, 1.0}, {4.0, 1.0}})});
+  const auto path = make_straight_path(11);
+  const auto cut =
+    module.cutPathsCrossingVegetation(path, full_linestring(path), cylinder_shape(1.0));
+  ASSERT_EQ(cut.path.size(), 4UL);
+}
+
+TEST_F(VegetationModuleTest, BoundingBoxShapeCuts)
+{
+  const auto module =
+    build_module({make_vegetation_polygon({{4.2, -1.0}, {5.0, -1.0}, {5.0, 1.0}, {4.2, 1.0}})});
+  const auto path = make_straight_path(11);
+  const auto cut =
+    module.cutPathsCrossingVegetation(path, full_linestring(path), bounding_box_shape(1.0, 0.6));
+  ASSERT_EQ(cut.path.size(), 4UL);
+}
+
+TEST_F(VegetationModuleTest, VegetationFreeMapLeavesPathUntouched)
+{
+  const auto module = build_module({});
+  const auto path = make_straight_path(11);
+  const auto cut =
+    module.cutPathsCrossingVegetation(path, full_linestring(path), cylinder_shape(1.0));
+  ASSERT_EQ(cut.path.size(), 11UL);
+}
+
+TEST_F(VegetationModuleTest, InvalidPolygonIsSkippedWithoutDisablingValidOnes)
+{
+  // The degenerate two-point polygon is rejected at load; the valid one still cuts.
+  const auto module = build_module(
+    {make_vegetation_polygon({{2.2, -1.0}, {3.0, -1.0}}),
+     make_vegetation_polygon({{6.2, -1.0}, {7.0, -1.0}, {7.0, 1.0}, {6.2, 1.0}})});
+  const auto path = make_straight_path(11);
+  const auto cut =
+    module.cutPathsCrossingVegetation(path, full_linestring(path), cylinder_shape(1.0));
+  ASSERT_EQ(cut.path.size(), 6UL);
+}
+
+TEST_F(VegetationModuleTest, CrossingBeyondArrivalIndexIsIgnored)
+{
+  const auto module =
+    build_module({make_vegetation_polygon({{6.2, -1.0}, {7.0, -1.0}, {7.0, 1.0}, {6.2, 1.0}})});
+  PredictedPathWithArrivalIndex path;
+  static_cast<PredictedPath &>(path) = make_straight_path(11);
+  path.arrival_index = 4;
+  const auto path_ls = utils::to_linestring_2d(path.path, path.arrival_index);
+  EXPECT_FALSE(
+    module.doesPathCrossAnyVegetationBeforeCrosswalk(path, path_ls, cylinder_shape(1.0)));
+  path.arrival_index = 10;
+  const auto full_ls = utils::to_linestring_2d(path.path, path.arrival_index);
+  EXPECT_TRUE(module.doesPathCrossAnyVegetationBeforeCrosswalk(path, full_ls, cylinder_shape(1.0)));
+}
+
+TEST(FenceModuleTest, EarliestFenceCrossingWins)
+{
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  map->add(make_linestring({{6.5, -1.0}, {6.5, 1.0}}, "fence"));
+  map->add(make_linestring({{2.5, -1.0}, {2.5, 1.0}}, "fence"));
+  FenceModule module;
+  module.buildFromMap(map);
+
+  const auto path = make_straight_path(11);
+  const auto cut = module.cutPathBeforeFences(path, full_linestring(path));
+  // Segment (2,0)-(3,0) crosses the nearer fence at x = 2.5.
+  ASSERT_EQ(cut.path.size(), 3UL);
+}
+
+class RoadBoundaryModuleTest : public ::testing::Test
+{
+protected:
+  // One road lanelet with outer bounds at x = 2.5 and x = 4, and an adjacent one sharing the
+  // bound at x = 4 with its own outer bound at x = 6. All bounds run along the y-axis.
+  void SetUp() override
+  {
+    map_ = std::make_shared<lanelet::LaneletMap>();
+    const auto bound_a = make_linestring({{2.5, -10.0}, {2.5, 10.0}});
+    const auto bound_shared = make_linestring({{4.0, -10.0}, {4.0, 10.0}});
+    const auto bound_b = make_linestring({{6.0, -10.0}, {6.0, 10.0}});
+    map_->add(make_lanelet(bound_a, bound_shared, "road"));
+    map_->add(make_lanelet(bound_shared, bound_b, "road"));
+  }
+
+  RoadBoundaryModule build_module()
+  {
+    RoadBoundaryModule module;
+    module.build_from_map(map_);
+    utils::ObjectDecelerationParams deceleration_params;
+    deceleration_params.per_label.emplace(ObjectClassification::PEDESTRIAN, -0.5);
+    module.set_object_deceleration(deceleration_params);
+    return module;
+  }
+
+  static PredictedObject make_pedestrian(const double speed, PredictedPath path)
+  {
+    PredictedObject object;
+    ObjectClassification classification;
+    classification.label = ObjectClassification::PEDESTRIAN;
+    classification.probability = 1.0;
+    object.classification.push_back(classification);
+    object.kinematics.initial_twist_with_covariance.twist.linear.x = speed;
+    object.kinematics.predicted_paths.push_back(std::move(path));
+    return object;
+  }
+
+  static bool never_red(const lanelet::ConstLanelet &) { return false; }
+  static bool always_red(const lanelet::ConstLanelet &) { return true; }
+
+  std::shared_ptr<lanelet::LaneletMap> map_;
+};
+
+TEST_F(RoadBoundaryModuleTest, SlowObjectIsCutAtOuterBoundary)
+{
+  const auto module = build_module();
+  const auto object = make_pedestrian(0.5, make_straight_path(11));
+  const auto cut_paths = module.cut_paths_crossing_road_boundary(object, false, never_red);
+  ASSERT_EQ(cut_paths.size(), 1UL);
+  // Segment (2,0)-(3,0) crosses the outer bound at x = 2.5.
+  ASSERT_EQ(cut_paths.front().path.size(), 3UL);
+}
+
+TEST_F(RoadBoundaryModuleTest, InteriorDividerIsNotABoundary)
+{
+  const auto module = build_module();
+  // Path from x = 3 to x = 3.9: inside the first lanelet, reaching toward the shared bound only.
+  PredictedPath path;
+  for (const auto x : {3.0, 3.5, 3.9}) {
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = x;
+    pose.orientation.w = 1.0;
+    path.path.push_back(pose);
+  }
+  // Extend across the shared bound at x = 4 but short of the outer bound at x = 6.
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 5.0;
+  pose.orientation.w = 1.0;
+  path.path.push_back(pose);
+  const auto object = make_pedestrian(0.5, path);
+  const auto cut_paths = module.cut_paths_crossing_road_boundary(object, false, never_red);
+  ASSERT_EQ(cut_paths.front().path.size(), 4UL);
+}
+
+TEST_F(RoadBoundaryModuleTest, CrosswalkCrossingIsExemptUnlessRed)
+{
+  const auto left = make_linestring({{2.0, -1.0}, {3.0, -1.0}});
+  const auto right = make_linestring({{2.0, 1.0}, {3.0, 1.0}});
+  map_->add(make_lanelet(left, right, "crosswalk"));
+  const auto module = build_module();
+
+  // Six poses so the exempt crossing at x = 2.5 is the only boundary the path reaches.
+  const auto object = make_pedestrian(0.5, make_straight_path(6));
+  const auto kept = module.cut_paths_crossing_road_boundary(object, false, never_red);
+  ASSERT_EQ(kept.front().path.size(), 6UL);
+  const auto cut = module.cut_paths_crossing_road_boundary(object, false, always_red);
+  ASSERT_EQ(cut.front().path.size(), 3UL);
+}
+
+TEST_F(RoadBoundaryModuleTest, UnstoppableObjectKeepsItsPath)
+{
+  const auto module = build_module();
+  const auto object = make_pedestrian(5.0, make_straight_path(11));
+  const auto cut_paths = module.cut_paths_crossing_road_boundary(object, false, never_red);
+  ASSERT_EQ(cut_paths.front().path.size(), 11UL);
+}
+
+}  // namespace
+}  // namespace autoware::map_based_prediction


### PR DESCRIPTION
## Description

Follow-up performance PR deferred from the reviews of #13190 (vegetation path cutting) and #13203 (road-boundary path cutting), implementing the items listed there in one PR as agreed, plus one same-class bug fix and unit tests for the three VRU path-cut modules.

### Load-time conversion of map geometry

- Vegetation polygons are converted to boost polygons **once** in `buildFromMap` and validated there (`bg::is_valid` + three distinct vertices); an invalid map polygon is skipped with a warning instead of silently disabling the area. Previously the same polygon was re-converted `M × (1+K) × n_objects` times per cycle.
- A vegetation-free map leaves the layer null, so per-path queries short-circuit (`createMap({})` is non-null).
- Road boundaries are converted to 2D once per crossed boundary (`basicLineString()` returns by value, previously paid per segment per boundary), and crosswalk rings are cached at load instead of being rebuilt per intersection point.
- **Interior lane dividers are dropped from the boundary layer**: a bound shared by two road-subtype lanelets separates two road areas, and a path coming from outside the road always reaches an outer edge first, so a divider can never be the first crossing. On `sample-map-rosbag` this removes 26 of 112 bound linestrings (23 %) that every query had to consider.

### Cheaper per-path tests

- For `CYLINDER` shapes (every pedestrian) the swept footprint of a segment *is* the segment buffered by the radius, so `bg::distance(segment, polygon) <= r` replaces the per-segment convex hulls — and is exact, unlike the 6-gon circle approximation the hulls were built from. Box/polygon shapes keep the hulls but reuse each segment's end footprint as the next start (halving footprint construction).
- The N-footprint `buildPathFootprintBBox` prefilter is replaced by one centerline-to-polygon distance test per candidate.
- The vegetation R-tree query box is grown by the footprint circumradius. This also closes a search gap: the old query used the bare centerline box, so a polygon reachable only by the swept footprint (e.g. a hedge 0.3 m beside the walking line) could be missed.
- The road-boundary segment test resolves intersection points in a single `bg::intersection` sweep; `bg::intersects` remains only as the collinear-overlap fallback.

### One linestring per path

The caller converts each predicted path to a 2D linestring once and hands it to the fence and vegetation modules (the fence-cut prefix is reused for the vegetation cut); fences crossed by a path are converted to 2D once instead of per segment.

### Bug fix

`FenceModule::cutPathBeforeFences` stopped at the first crossed fence in R-tree order, so a different fence crossing **earlier** along the path was never examined and the cut landed too late. All crossed fences are now collected; the segment loop already returns the earliest crossing.

## Related links

- Deferred from the review threads of #13190 and #13203.

**Parent Issue:**

- N/A

## How was this PR tested?

- `colcon test --packages-select autoware_map_based_prediction` — 18 tests pass, including 12 new module tests on synthetic in-memory lanelet maps pinning: earliest-crossing cut index, initial-overlap exemption, detection of polygons reachable only by the swept footprint, invalid-polygon rejection at load, interior-divider exclusion, crosswalk signal exemption, and the can-stop gate.
- Release build clean; `pre-commit` clean on all changed files.
- Ran Planning simulation and confirmed VRU behaviors

## Notes for reviewers

The commits are split so each is reviewable on its own: fence fix → load-time conversion → per-path test cheapening → linestring hoist → tests.

## Interface changes

None (module-internal APIs in `predictor_vru/` gained a prebuilt-linestring parameter; no topic or parameter changes).

## Effects on system behavior

Three deliberate behavior changes, all narrowing false cuts or closing detection gaps:

1. A predicted path is now cut at the **earliest** fence crossing when multiple fences cross it (previously R-tree order could pick a later one).
2. Vegetation polygons reachable only by the object's swept footprint (not by its centerline) are now detected, and degenerate/invalid vegetation polygons in the map are ignored with a warning.
3. Crossings of interior lane dividers no longer cut paths; only outer road edges do. Reachable in practice only when a path enters the road through an exempt crosswalk and then crosses a divider outside the crosswalk polygon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
