### PR TITLE
fix(control_command_gate): ignore invalid control command

### DIFF
--- a/control/autoware_control_command_gate/src/command/source.hpp
+++ b/control/autoware_control_command_gate/src/command/source.hpp
@@ -42,10 +42,10 @@ protected:
   void send_gear(const GearCommand & msg);
   void send_turn_indicators(const TurnIndicatorsCommand & msg);
   void send_hazard_lights(const HazardLightsCommand & msg);
-
-private:
   const uint16_t source_id_;
   const std::string source_name_;
+
+private:
   CommandOutput * output_;
   std::unique_ptr<TimeoutDiag> timeout_;
 };

--- a/control/autoware_control_command_gate/src/command/subscription.cpp
+++ b/control/autoware_control_command_gate/src/command/subscription.cpp
@@ -19,8 +19,18 @@
 namespace autoware::control_command_gate
 {
 
+bool validate_command(const Control & msg)
+{
+  if (!std::isfinite(msg.longitudinal.velocity)) return false;
+  if (!std::isfinite(msg.longitudinal.acceleration)) return false;
+  if (!std::isfinite(msg.longitudinal.jerk)) return false;
+  if (!std::isfinite(msg.lateral.steering_tire_angle)) return false;
+  if (!std::isfinite(msg.lateral.steering_tire_rotation_rate)) return false;
+  return true;
+}
+
 CommandSubscription::CommandSubscription(uint16_t id, const std::string & name, rclcpp::Node & node)
-: CommandSource(id, name)
+: CommandSource(id, name), clock_(node.get_clock()), logger_(node.get_logger())
 {
   using std::placeholders::_1;
   const auto control_qos = rclcpp::QoS(5);
@@ -41,6 +51,12 @@ CommandSubscription::CommandSubscription(uint16_t id, const std::string & name, 
 
 void CommandSubscription::on_control(const Control & msg)
 {
+  // NOTE: The control command filter does not handle NaN.
+  if (!validate_command(msg)) {
+    RCLCPP_ERROR_STREAM_THROTTLE(logger_, *clock_, 1000, "invalid control from " + source_name_);
+    return;
+  }
+
   // NOTE: Control does not need to be saved because it is sent periodically.
   send_control(msg);
 }

--- a/control/autoware_control_command_gate/src/command/subscription.hpp
+++ b/control/autoware_control_command_gate/src/command/subscription.hpp
@@ -36,6 +36,8 @@ private:
   void on_turn_indicators(const TurnIndicatorsCommand & msg);
   void on_hazard_lights(const HazardLightsCommand & msg);
 
+  rclcpp::Clock::SharedPtr clock_;
+  rclcpp::Logger logger_;
   rclcpp::Subscription<Control>::SharedPtr sub_control_;
   rclcpp::Subscription<GearCommand>::SharedPtr sub_gear_;
   rclcpp::Subscription<TurnIndicatorsCommand>::SharedPtr sub_turn_indicators_;


### PR DESCRIPTION
## Description

Fix an issue where the output would get stuck at NaN if the input command contained NaN.

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/T4DEV-58293)

## How was this PR tested?

1. Launch planning simulation with `use_control_command_gate:=true`
2. Change to autonomous mode.
3. Execute following command.
    ```bash
    ros2 topic pub -r 10 /control/trajectory_follower/control_cmd autoware_control_msgs/msg/Control "{stamp: now, longitudinal: {stamp: now, is_defined_acceleration: true, is_defined_jerk: true, velocity: nan, acceleration: nan, jerk: nan}}"
    ```
4. Check that the vehicle is driving normally.
5. Check `ros2 topic echo /control/command/control_cmd`.



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
