### PR TITLE
refactor(autoware_traffic_light_classifier): pass ROS 2 message types through classify() and make_debug_image()

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.cpp
@@ -18,8 +18,16 @@
 
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 
+#include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/region_of_interest.hpp>
 #include <tier4_perception_msgs/msg/traffic_light.hpp>
+
+// cppcheck-suppress preprocessorErrorDirective
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <cstddef>
 #include <memory>
@@ -39,9 +47,22 @@ TrafficLightClassifier::TrafficLightClassifier(
 }
 
 std::optional<TrafficLightClassifier::Result> TrafficLightClassifier::classify(
-  const cv::Mat & image, const tier4_perception_msgs::msg::TrafficLightRoiArray & rois) const
+  const sensor_msgs::msg::Image & image_msg,
+  const tier4_perception_msgs::msg::TrafficLightRoiArray & rois) const
 {
   Result result;
+  if (rois.rois.empty()) {
+    result.signals.header = image_msg.header;
+    return result;
+  }
+
+  cv_bridge::CvImagePtr cv_ptr;
+  try {
+    cv_ptr = cv_bridge::toCvCopy(image_msg, sensor_msgs::image_encodings::RGB8);
+  } catch (const cv_bridge::Exception &) {
+    return std::nullopt;
+  }
+  const cv::Mat & image = cv_ptr->image;
 
   std::vector<cv::Mat> images;
   // Valid ROIs in classification order (parallel to `images`). The classifier returns elements
@@ -118,6 +139,7 @@ std::optional<TrafficLightClassifier::Result> TrafficLightClassifier::classify(
     traffic_light_utils::setSignalUnknown(signal, 0.0);
   }
 
+  result.signals.header = image_msg.header;
   return result;
 }
 

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.cpp
@@ -143,9 +143,15 @@ std::optional<TrafficLightClassifier::Result> TrafficLightClassifier::classify(
   return result;
 }
 
-cv::Mat TrafficLightClassifier::make_debug_image(const std::vector<cv::Mat> & roi_images) const
+sensor_msgs::msg::Image::ConstSharedPtr TrafficLightClassifier::make_debug_image(
+  const Result & result) const
 {
-  return classifier_->make_debug_image(roi_images);
+  const cv::Mat debug_image = classifier_->make_debug_image(result.roi_images);
+  if (debug_image.empty()) {
+    return nullptr;
+  }
+  return cv_bridge::CvImage(result.signals.header, sensor_msgs::image_encodings::RGB8, debug_image)
+    .toImageMsg();
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
@@ -19,6 +19,7 @@
 
 #include <opencv2/core/core.hpp>
 
+#include <sensor_msgs/msg/image.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
@@ -37,8 +38,7 @@ class TrafficLightClassifier
 public:
   struct Result
   {
-    // Classification output. The header is intentionally left unset: the node stamps
-    // it from the input image before publishing.
+    // Classification output, stamped with the input image's header.
     tier4_perception_msgs::msg::TrafficLightArray signals;
     bool detected_over_exposure = false;
     bool detected_under_exposure = false;
@@ -51,12 +51,14 @@ public:
     std::shared_ptr<ClassifierInterface> classifier, uint8_t classify_traffic_light_type,
     double over_exposure_threshold, double under_exposure_threshold);
 
-  // Pure orchestration over an already-decoded RGB image and its ROIs: filter ROIs by type,
-  // crop and classify the valid ones, append undetected (zero-sized) ROIs as UNKNOWN, and
-  // overwrite over/under-exposed slots with UNKNOWN. Returns std::nullopt when the classifier
+  // Returns an empty, header-stamped Result without decoding the image when `rois` is empty.
+  // Otherwise decodes the ROS image message, then filters ROIs by type, crops and classifies
+  // the valid ones, appends undetected (zero-sized) ROIs as UNKNOWN, and overwrites
+  // over/under-exposed slots with UNKNOWN. Returns std::nullopt when decoding or the classifier
   // backend fails, so the caller can skip publishing.
   std::optional<Result> classify(
-    const cv::Mat & image, const tier4_perception_msgs::msg::TrafficLightRoiArray & rois) const;
+    const sensor_msgs::msg::Image & image_msg,
+    const tier4_perception_msgs::msg::TrafficLightRoiArray & rois) const;
 
   // Composite debug view for the most recent classify() call, built from its returned
   // roi_images. Empty when there is nothing to render. Off the hot path: the node calls this

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
@@ -60,10 +60,10 @@ public:
     const sensor_msgs::msg::Image & image_msg,
     const tier4_perception_msgs::msg::TrafficLightRoiArray & rois) const;
 
-  // Composite debug view for the most recent classify() call, built from its returned
-  // roi_images. Empty when there is nothing to render. Off the hot path: the node calls this
-  // only when a debug consumer is attached.
-  cv::Mat make_debug_image(const std::vector<cv::Mat> & roi_images) const;
+  // Composite debug view for a classify() result, built from its roi_images and stamped with
+  // its signals' header. Returns nullptr when there is nothing to render. Off the hot path: the
+  // node calls this only when a debug consumer is attached.
+  sensor_msgs::msg::Image::ConstSharedPtr make_debug_image(const Result & result) const;
 
 private:
   std::shared_ptr<ClassifierInterface> classifier_;

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -16,7 +16,13 @@
 #include "classifier_params.hpp"
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
-#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
+
+// cppcheck-suppress preprocessorErrorDirective
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <memory>
 #include <string>
@@ -124,31 +130,19 @@ void TrafficLightClassifierNode::image_roi_callback(
   if (!classifier_) {
     return;
   }
-  tier4_perception_msgs::msg::TrafficLightArray output_msg;
-  if (input_rois_msg->rois.empty()) {
-    output_msg.header = input_image_msg->header;
-    traffic_signal_array_pub_->publish(output_msg);
-    return;
-  }
-
-  cv_bridge::CvImagePtr cv_ptr;
-  try {
-    cv_ptr = cv_bridge::toCvCopy(input_image_msg, sensor_msgs::image_encodings::RGB8);
-  } catch (cv_bridge::Exception & e) {
-    RCLCPP_ERROR(
-      this->get_logger(), "Could not convert from '%s' to 'rgb8'.",
-      input_image_msg->encoding.c_str());
-  }
-
-  auto result = classifier_->classify(cv_ptr->image, *input_rois_msg);
+  auto result = classifier_->classify(*input_image_msg, *input_rois_msg);
   if (!result) {
     RCLCPP_ERROR(this->get_logger(), "failed classify image, abort callback");
     return;
   }
 
-  output_msg = std::move(result->signals);
-  output_msg.header = input_image_msg->header;
-  traffic_signal_array_pub_->publish(output_msg);
+  traffic_signal_array_pub_->publish(result->signals);
+
+  // No rois means classify took its empty-input short-circuit: nothing was classified,
+  // so there is nothing to report diagnostics or a debug view for.
+  if (input_rois_msg->rois.empty()) {
+    return;
+  }
 
   // publish diagnostics
   diagnostics_interface_ptr_->clear();
@@ -162,7 +156,7 @@ void TrafficLightClassifierNode::image_roi_callback(
       diagnostic_msgs::msg::DiagnosticStatus::WARN,
       "Detected out-of-range exposure in ROI. Corresponding ROI was overwritten with UNKNOWN.");
   }
-  diagnostics_interface_ptr_->publish(output_msg.header.stamp);
+  diagnostics_interface_ptr_->publish(result->signals.header.stamp);
 
   // Publish the debug view last, and only when a consumer is attached (building it is a cold path),
   // so a debug-rendering failure cannot skip the primary signal output or diagnostics above.

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -17,13 +17,6 @@
 
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
-// cppcheck-suppress preprocessorErrorDirective
-#if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
-#else
-#include <cv_bridge/cv_bridge.h>
-#endif
-
 #include <memory>
 #include <string>
 #include <utility>
@@ -161,10 +154,8 @@ void TrafficLightClassifierNode::image_roi_callback(
   // Publish the debug view last, and only when a consumer is attached (building it is a cold path),
   // so a debug-rendering failure cannot skip the primary signal output or diagnostics above.
   if (debug_image_pub_.getNumSubscribers() > 0) {
-    const cv::Mat debug_image = classifier_->make_debug_image(result->roi_images);
-    if (!debug_image.empty()) {
-      const auto debug_image_msg =
-        cv_bridge::CvImage(std_msgs::msg::Header(), "rgb8", debug_image).toImageMsg();
+    const auto debug_image_msg = classifier_->make_debug_image(*result);
+    if (debug_image_msg) {
       debug_image_pub_.publish(debug_image_msg);
     }
   }

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
@@ -22,20 +22,11 @@
 #include <image_transport/subscriber_filter.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/header.hpp>
-#include <tier4_perception_msgs/msg/traffic_light.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
-#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
-// cppcheck-suppress preprocessorErrorDirective
-#if __has_include(<cv_bridge/cv_bridge.hpp>)
-#include <cv_bridge/cv_bridge.hpp>
-#else
-#include <cv_bridge/cv_bridge.h>
-#endif
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>

--- a/perception/autoware_traffic_light_classifier/test/test_traffic_light_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_traffic_light_classifier.cpp
@@ -254,7 +254,7 @@ TEST_F(TrafficLightClassifierTest, RoiImagesAreClassifiedSubsetForwardedToDebug)
   // Act
   const auto result = classifier.classify(image, rois);
   ASSERT_TRUE(result.has_value());
-  classifier.make_debug_image(result->roi_images);
+  classifier.make_debug_image(*result);
 
   // Assert: roi_images holds only the 1 classified ROI -- distinct from both the 3
   // inputs and the 2 output signals (classified + appended-UNKNOWN) -- and that same

--- a/perception/autoware_traffic_light_classifier/test/test_traffic_light_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/test/test_traffic_light_classifier.cpp
@@ -15,7 +15,7 @@
 //
 // Unit tests for the ROS-free classification core (TrafficLightClassifier).
 //
-// classify() is exercised directly over an in-memory cv::Mat and a
+// classify() is exercised directly over an in-memory sensor_msgs::msg::Image and a
 // TrafficLightRoiArray, with a hand-written FakeClassifier standing in for the
 // real backend. This isolates the per-ROI orchestration (type filtering,
 // cropping, exposure handling, UNKNOWN-append, ordering, the classifier-failure
@@ -27,7 +27,7 @@
 //   * The concrete lamp color/shape a real backend assigns -- the fake stamps a
 //     fixed color, so only the slots/ids/exposure structure is pinned.
 //   * compute_brightness on real camera frames -- covered by test_utils.
-//   * Node wiring (pub/sub, diagnostics, header stamping, sync) -- covered by
+//   * Node wiring (pub/sub, diagnostics, sync) -- covered by
 //     test_traffic_light_classifier_integration.
 //
 
@@ -36,10 +36,18 @@
 
 #include <opencv2/core/core.hpp>
 
+#include <sensor_msgs/msg/image.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
+
+// cppcheck-suppress preprocessorErrorDirective
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#include <cv_bridge/cv_bridge.h>
+#endif
 
 #include <gtest/gtest.h>
 
@@ -128,19 +136,27 @@ public:
   }
 };
 
-cv::Mat make_solid_image(const cv::Scalar & color, int width = 16, int height = 16)
+// The rgb8 image message classify() consumes directly. frame_id is fixed to
+// "camera_frame" for every test; the header-propagation tests assert against that constant.
+sensor_msgs::msg::Image make_image_message(
+  const cv::Scalar & color, int width = 16, int height = 16)
 {
-  return cv::Mat(height, width, CV_8UC3, color);
+  std_msgs::msg::Header header;
+  header.frame_id = "camera_frame";
+  return *cv_bridge::CvImage(header, "rgb8", cv::Mat(height, width, CV_8UC3, color)).toImageMsg();
 }
 
-// A 32x16 image split into two 16x16 halves: left painted `left`, right painted
-// `right`. Pairs with two side-by-side ROIs (x=0 and x=16) so each ROI crops a
-// distinctly colored region.
-cv::Mat make_left_right_image(const cv::Scalar & left, const cv::Scalar & right)
+// A 32x16 image message split into two 16x16 halves: left painted `left`, right painted
+// `right`. Pairs with two side-by-side ROIs (x=0 and x=16) so each ROI crops a distinctly
+// colored region. frame_id is fixed to "camera_frame", as in make_image_message.
+sensor_msgs::msg::Image make_left_right_image_message(
+  const cv::Scalar & left, const cv::Scalar & right)
 {
   cv::Mat mat(/*rows=*/16, /*cols=*/32, CV_8UC3, left);
   mat(cv::Rect(/*x=*/16, /*y=*/0, /*width=*/16, /*height=*/16)).setTo(right);
-  return mat;
+  std_msgs::msg::Header header;
+  header.frame_id = "camera_frame";
+  return *cv_bridge::CvImage(header, "rgb8", mat).toImageMsg();
 }
 
 TrafficLightRoi make_roi(
@@ -229,7 +245,7 @@ TEST_F(TrafficLightClassifierTest, RoiImagesAreClassifiedSubsetForwardedToDebug)
   //   id=2 zero-sized car  -> appended to signals as UNKNOWN, NOT in roi_images
   //   id=3 pedestrian type -> dropped entirely (in neither)
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
-  const auto image = make_solid_image(gray);
+  const auto image = make_image_message(gray);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));
   rois.rois.push_back(make_zero_sized_roi(/*id=*/2));
@@ -257,7 +273,7 @@ TEST_F(TrafficLightClassifierTest, RejectsBackendSignalCountMismatch)
   // Arrange -- one valid ROI, but the backend is rigged to return one more signal than images.
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
   fake_classifier_->extra_signals = 1;
-  const auto image = make_solid_image(gray);
+  const auto image = make_image_message(gray);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));
 
@@ -269,14 +285,15 @@ TEST_F(TrafficLightClassifierTest, RejectsBackendSignalCountMismatch)
 }
 
 // --------------------------------------------------------------------------
-// No ROIs -> empty result, no exposure flags, and the backend is never invoked
-// (the images batch is empty, so classify() skips it).
+// No ROIs -> classify() takes its empty-input short-circuit: empty result,
+// no exposure flags, the backend is never invoked, and the image is never
+// decoded -- yet the header is still stamped from the input image message.
 // --------------------------------------------------------------------------
 TEST_F(TrafficLightClassifierTest, EmptyRoisYieldEmptyResult)
 {
   // Arrange
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
-  const auto image = make_solid_image(gray);
+  const auto image = make_image_message(gray);
   const TrafficLightRoiArray rois;  // no rois
 
   // Act
@@ -288,6 +305,7 @@ TEST_F(TrafficLightClassifierTest, EmptyRoisYieldEmptyResult)
   EXPECT_FALSE(result->detected_over_exposure);
   EXPECT_FALSE(result->detected_under_exposure);
   EXPECT_EQ(fake_classifier_->call_count, 0);
+  EXPECT_EQ(result->signals.header.frame_id, "camera_frame");
 }
 
 // --------------------------------------------------------------------------
@@ -298,7 +316,7 @@ TEST_F(TrafficLightClassifierTest, NonMatchingTypeRoiIsDropped)
 {
   // Arrange
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
-  const auto image = make_solid_image(gray);
+  const auto image = make_image_message(gray);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_roi(/*id=*/1, pedestrian_type, 0, 0, 16, 16));
 
@@ -319,7 +337,7 @@ TEST_F(TrafficLightClassifierTest, ZeroSizedMatchingRoiAppendedAsUnknown)
 {
   // Arrange
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
-  const auto image = make_solid_image(gray);
+  const auto image = make_image_message(gray);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_zero_sized_roi(/*id=*/1));
 
@@ -338,14 +356,13 @@ TEST_F(TrafficLightClassifierTest, ZeroSizedMatchingRoiAppendedAsUnknown)
 
 // --------------------------------------------------------------------------
 // A valid ROI is classified into exactly one element with id/type propagated.
-// The result header is left default-constructed: stamping it is the node's job,
-// and classify() must not touch it.
+// The result header is stamped from the input image message's header.
 // --------------------------------------------------------------------------
-TEST_F(TrafficLightClassifierTest, ValidRoiIsClassifiedAndHeaderLeftUnset)
+TEST_F(TrafficLightClassifierTest, ValidRoiIsClassifiedAndHeaderPropagatedFromImage)
 {
   // Arrange
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
-  const auto image = make_solid_image(gray);
+  const auto image = make_image_message(gray);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/7));
 
@@ -361,8 +378,7 @@ TEST_F(TrafficLightClassifierTest, ValidRoiIsClassifiedAndHeaderLeftUnset)
   ASSERT_EQ(signal.elements.size(), 1u);
   EXPECT_EQ(signal.elements[0].color, TrafficLightElement::GREEN);  // backend result preserved
   EXPECT_EQ(fake_classifier_->call_count, 1);
-  // Header intentionally untouched by the core.
-  EXPECT_EQ(result->signals.header, std_msgs::msg::Header{});
+  EXPECT_EQ(result->signals.header.frame_id, "camera_frame");
 }
 
 // --------------------------------------------------------------------------
@@ -373,7 +389,7 @@ TEST_F(TrafficLightClassifierTest, MultipleValidRoisMapToOrderedSlots)
 {
   // Arrange
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
-  const auto image = make_solid_image(gray, /*width=*/32);
+  const auto image = make_image_message(gray, /*width=*/32);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));
   rois.rois.push_back(make_valid_roi(/*id=*/2, /*x=*/16));
@@ -400,7 +416,7 @@ TEST_F(TrafficLightClassifierTest, ValidThenZeroSizedRoiOrdering)
 {
   // Arrange
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
-  const auto image = make_solid_image(gray);
+  const auto image = make_image_message(gray);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_zero_sized_roi(/*id=*/1));  // appended last as UNKNOWN
   rois.rois.push_back(make_valid_roi(/*id=*/2));       // classified, leads the output
@@ -427,7 +443,7 @@ TEST_F(TrafficLightClassifierTest, CropHandedToBackendMatchesRoiGeometry)
 {
   // Arrange
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
-  const auto image = make_left_right_image(red, blue);
+  const auto image = make_left_right_image_message(red, blue);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));            // left half (red)
   rois.rois.push_back(make_valid_roi(/*id=*/2, /*x=*/16));  // right half (blue)
@@ -454,7 +470,7 @@ TEST_F(TrafficLightClassifierTest, OverExposedRoiOverwrittenWithUnknownAndFlagge
 {
   // Arrange
   auto classifier = make_classifier(/*over=*/0.85, no_under_threshold);
-  const auto image = make_solid_image(white);
+  const auto image = make_image_message(white);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));
 
@@ -479,7 +495,7 @@ TEST_F(TrafficLightClassifierTest, UnderExposedRoiOverwrittenWithUnknownAndFlagg
 {
   // Arrange
   auto classifier = make_classifier(no_over_threshold, /*under=*/-0.85);
-  const auto image = make_solid_image(black);
+  const auto image = make_image_message(black);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));
 
@@ -504,7 +520,7 @@ TEST_F(TrafficLightClassifierTest, OnlyExposedSlotIsOverwritten)
 {
   // Arrange
   auto classifier = make_classifier(/*over=*/0.85, no_under_threshold);
-  const auto image = make_left_right_image(gray, white);  // left normal, right over-exposed
+  const auto image = make_left_right_image_message(gray, white);  // left normal, right over-exposed
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));            // normal (left half)
   rois.rois.push_back(make_valid_roi(/*id=*/2, /*x=*/16));  // over-exposed (right half)
@@ -536,7 +552,7 @@ TEST_F(TrafficLightClassifierTest, OverAndUnderExposureInSameCall)
 {
   // Arrange
   auto classifier = make_classifier(/*over=*/0.85, /*under=*/-0.85);
-  const auto image = make_left_right_image(white, black);  // left over, right under
+  const auto image = make_left_right_image_message(white, black);  // left over, right under
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));            // over-exposed (left half)
   rois.rois.push_back(make_valid_roi(/*id=*/2, /*x=*/16));  // under-exposed (right half)
@@ -563,7 +579,7 @@ TEST_F(TrafficLightClassifierTest, BackendFailureReturnsNullopt)
   // Arrange
   auto classifier = make_classifier(no_over_threshold, no_under_threshold);
   fake_classifier_->succeed = false;
-  const auto image = make_solid_image(gray);
+  const auto image = make_image_message(gray);
   TrafficLightRoiArray rois;
   rois.rois.push_back(make_valid_roi(/*id=*/1));
 


### PR DESCRIPTION
## Description

1. `TrafficLightClassifier::classify()` now takes the raw `sensor_msgs::msg::Image` directly.
2. The empty-ROI-array short-circuit is now handled inside `classify()`, instead of the node checking for it separately.
3. `TrafficLightClassifier::make_debug_image()` now returns a `sensor_msgs::msg::Image::ConstSharedPtr` directly,.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

`colcon build --packages-select autoware_traffic_light_classifier` and `colcon test --packages-select autoware_traffic_light_classifier --event-handlers console_cohesion+` were run; all 6 test executables pass (100%).


## Notes for reviewers

As a side effect of point 3, the debug image message's header was previously left default-constructed (empty `stamp`/`frame_id`), since the node built it itself without setting one. It is now stamped with the same header as the input image, matching the published signals' header.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
