### PR TITLE
feat(autoware_trajectory_processor): support agnocast_wrapper::Node

### DIFF
--- a/planning/autoware_path_optimizer/CMakeLists.txt
+++ b/planning/autoware_path_optimizer/CMakeLists.txt
@@ -66,6 +66,8 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/utils/geometry_utils.cpp
 )
 
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
+
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR})
 target_link_libraries(${PROJECT_NAME} acados_interface)
 

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/common_structs.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/common_structs.hpp
@@ -61,11 +61,13 @@ struct DebugData
 struct TrajectoryParam
 {
   TrajectoryParam() = default;
-  explicit TrajectoryParam(rclcpp::Node * node)
+  template <typename NodeT>
+  explicit TrajectoryParam(NodeT * node)
   {
     output_backward_traj_length =
-      node->declare_parameter<double>("common.output_backward_traj_length");
-    output_delta_arc_length = node->declare_parameter<double>("common.output_delta_arc_length");
+      node->template declare_parameter<double>("common.output_backward_traj_length");
+    output_delta_arc_length =
+      node->template declare_parameter<double>("common.output_delta_arc_length");
   }
 
   void onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -85,10 +87,11 @@ struct TrajectoryParam
 struct EgoNearestParam
 {
   EgoNearestParam() = default;
-  explicit EgoNearestParam(rclcpp::Node * node)
+  template <typename NodeT>
+  explicit EgoNearestParam(NodeT * node)
   {
-    dist_threshold = node->declare_parameter<double>("ego_nearest_dist_threshold");
-    yaw_threshold = node->declare_parameter<double>("ego_nearest_yaw_threshold");
+    dist_threshold = node->template declare_parameter<double>("ego_nearest_dist_threshold");
+    yaw_threshold = node->template declare_parameter<double>("ego_nearest_yaw_threshold");
   }
 
   void onParam(const std::vector<rclcpp::Parameter> & parameters)

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/mpt_optimizer.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/mpt_optimizer.hpp
@@ -35,11 +35,17 @@
 #include <std_msgs/msg/multi_array_dimension.hpp>
 #include <std_msgs/msg/multi_array_layout.hpp>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace autoware::agnocast_wrapper
+{
+class Node;
+}  // namespace autoware::agnocast_wrapper
 
 namespace autoware::path_optimizer
 {
@@ -182,6 +188,12 @@ public:
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
     const TrajectoryParam & traj_param, const std::shared_ptr<DebugData> debug_data_ptr,
     const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_);
+  MPTOptimizer(
+    autoware::agnocast_wrapper::Node * node, const bool enable_debug_info,
+    const EgoNearestParam ego_nearest_param,
+    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+    const TrajectoryParam & traj_param, const std::shared_ptr<DebugData> debug_data_ptr,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_);
 
   std::optional<std::vector<TrajectoryPoint>> optimizeTrajectory(const PlannerData & planner_data);
   std::optional<std::vector<TrajectoryPoint>> getPrevOptimizedTrajectoryPoints() const;
@@ -244,8 +256,8 @@ private:
 
   struct MPTParam
   {
-    explicit MPTParam(
-      rclcpp::Node * node, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
+    template <typename NodeT>
+    explicit MPTParam(NodeT * node, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info);
     MPTParam() = default;
     void onParam(const std::vector<rclcpp::Parameter> & parameters);
 
@@ -319,18 +331,27 @@ private:
   };
 
   // publisher
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_fixed_traj_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_ref_traj_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_mpt_traj_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_acados_mpt_traj_pub_;
+  using TrajectoryPublishFunc = std::function<void(const Trajectory &)>;
+  using Float32MultiArrayPublishFunc =
+    std::function<void(const std_msgs::msg::Float32MultiArray &)>;
+
+  TrajectoryPublishFunc debug_fixed_traj_pub_;
+  TrajectoryPublishFunc debug_ref_traj_pub_;
+  TrajectoryPublishFunc debug_mpt_traj_pub_;
+  TrajectoryPublishFunc debug_acados_mpt_traj_pub_;
 
   // Add new publishers for spline coefficients and curvatures
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr debug_optimised_steering_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr
-    debug_acados_optimised_steering_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr debug_optimised_states_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr debug_acados_optimised_states_pub_;
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr debug_ref_steering_pub_;
+  Float32MultiArrayPublishFunc debug_optimised_steering_pub_;
+  Float32MultiArrayPublishFunc debug_acados_optimised_steering_pub_;
+  Float32MultiArrayPublishFunc debug_optimised_states_pub_;
+  Float32MultiArrayPublishFunc debug_acados_optimised_states_pub_;
+  Float32MultiArrayPublishFunc debug_ref_steering_pub_;
+
+  template <typename NodeT>
+  void setUpPublishers(NodeT * node);
+
+  template <typename NodeT>
+  void initializeCommon(NodeT * node);
 
   // argument
   bool enable_debug_info_;

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/replan_checker.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/replan_checker.hpp
@@ -24,12 +24,19 @@
 #include <memory>
 #include <vector>
 
+namespace autoware::agnocast_wrapper
+{
+class Node;
+}  // namespace autoware::agnocast_wrapper
+
 namespace autoware::path_optimizer
 {
 class ReplanChecker
 {
 public:
   explicit ReplanChecker(rclcpp::Node * node, const EgoNearestParam & ego_nearest_param);
+  explicit ReplanChecker(
+    autoware::agnocast_wrapper::Node * node, const EgoNearestParam & ego_nearest_param);
   void onParam(const std::vector<rclcpp::Parameter> & parameters);
 
   bool isResetRequired(const PlannerData & planner_data) const;
@@ -41,6 +48,9 @@ public:
     const rclcpp::Time & current_time);
 
 private:
+  template <typename NodeT>
+  void declareParams(NodeT * node);
+
   EgoNearestParam ego_nearest_param_;
   rclcpp::Logger logger_;
 

--- a/planning/autoware_path_optimizer/package.xml
+++ b/planning/autoware_path_optimizer/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_export_link_flags</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>

--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -21,6 +21,7 @@
 #include "autoware/path_optimizer/utils/geometry_utils.hpp"
 #include "autoware/path_optimizer/utils/trajectory_utils.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <rclcpp/logging.hpp>
 #include <tf2/utils.hpp>
@@ -174,28 +175,32 @@ double calcLateralDistToBounds(
 }
 }  // namespace
 
+template <typename NodeT>
 MPTOptimizer::MPTParam::MPTParam(
-  rclcpp::Node * node, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
+  NodeT * node, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info)
 {
   {  // option
-    steer_limit_constraint = node->declare_parameter<bool>("mpt.option.steer_limit_constraint");
-    enable_warm_start = node->declare_parameter<bool>("mpt.option.enable_warm_start");
-    enable_manual_warm_start = node->declare_parameter<bool>("mpt.option.enable_manual_warm_start");
+    steer_limit_constraint =
+      node->template declare_parameter<bool>("mpt.option.steer_limit_constraint");
+    enable_warm_start = node->template declare_parameter<bool>("mpt.option.enable_warm_start");
+    enable_manual_warm_start =
+      node->template declare_parameter<bool>("mpt.option.enable_manual_warm_start");
     enable_optimization_validation =
-      node->declare_parameter<bool>("mpt.option.enable_optimization_validation");
-    mpt_visualize_sampling_num = node->declare_parameter<int>("mpt.option.visualize_sampling_num");
+      node->template declare_parameter<bool>("mpt.option.enable_optimization_validation");
+    mpt_visualize_sampling_num =
+      node->template declare_parameter<int>("mpt.option.visualize_sampling_num");
   }
 
   {  // common
-    num_points = node->declare_parameter<int>("mpt.common.num_points");
-    delta_arc_length = node->declare_parameter<double>("mpt.common.delta_arc_length");
+    num_points = node->template declare_parameter<int>("mpt.common.num_points");
+    delta_arc_length = node->template declare_parameter<double>("mpt.common.delta_arc_length");
   }
 
-  use_acados = node->declare_parameter<bool>("mpt.use_acados");
+  use_acados = node->template declare_parameter<bool>("mpt.use_acados");
   // Enable/disable the new MPT-style circle road-bound constraints in acados.
   // Default false so we can A/B test behavior safely.
   use_acados_circle_constraints =
-    node->declare_parameter<bool>("mpt.use_acados_circle_constraints", false);
+    node->template declare_parameter<bool>("mpt.use_acados_circle_constraints", false);
 
   // kinematics
   max_steer_rad = vehicle_info.max_steer_angle_rad;
@@ -203,93 +208,103 @@ MPTOptimizer::MPTParam::MPTParam(
   // NOTE: By default, optimization_center_offset will be vehicle_info.wheel_base * 0.8
   //       The 0.8 scale is adopted as it performed the best.
   constexpr double default_wheel_base_ratio = 0.8;
-  optimization_center_offset = node->declare_parameter<double>(
+  optimization_center_offset = node->template declare_parameter<double>(
     "mpt.kinematics.optimization_center_offset",
     vehicle_info.wheel_base_m * default_wheel_base_ratio);
 
   {  // clearance
     hard_clearance_from_road =
-      node->declare_parameter<double>("mpt.clearance.hard_clearance_from_road");
+      node->template declare_parameter<double>("mpt.clearance.hard_clearance_from_road");
     soft_clearance_from_road =
-      node->declare_parameter<double>("mpt.clearance.soft_clearance_from_road");
+      node->template declare_parameter<double>("mpt.clearance.soft_clearance_from_road");
   }
 
   {  // weight
     soft_collision_free_weight =
-      node->declare_parameter<double>("mpt.weight.soft_collision_free_weight");
+      node->template declare_parameter<double>("mpt.weight.soft_collision_free_weight");
 
-    lat_error_weight = node->declare_parameter<double>("mpt.weight.lat_error_weight");
-    yaw_error_weight = node->declare_parameter<double>("mpt.weight.yaw_error_weight");
-    yaw_error_rate_weight = node->declare_parameter<double>("mpt.weight.yaw_error_rate_weight");
-    steer_input_weight = node->declare_parameter<double>("mpt.weight.steer_input_weight");
-    steer_rate_weight = node->declare_parameter<double>("mpt.weight.steer_rate_weight");
+    lat_error_weight = node->template declare_parameter<double>("mpt.weight.lat_error_weight");
+    yaw_error_weight = node->template declare_parameter<double>("mpt.weight.yaw_error_weight");
+    yaw_error_rate_weight =
+      node->template declare_parameter<double>("mpt.weight.yaw_error_rate_weight");
+    steer_input_weight = node->template declare_parameter<double>("mpt.weight.steer_input_weight");
+    steer_rate_weight = node->template declare_parameter<double>("mpt.weight.steer_rate_weight");
 
     terminal_lat_error_weight =
-      node->declare_parameter<double>("mpt.weight.terminal_lat_error_weight");
+      node->template declare_parameter<double>("mpt.weight.terminal_lat_error_weight");
     terminal_yaw_error_weight =
-      node->declare_parameter<double>("mpt.weight.terminal_yaw_error_weight");
-    goal_lat_error_weight = node->declare_parameter<double>("mpt.weight.goal_lat_error_weight");
-    goal_yaw_error_weight = node->declare_parameter<double>("mpt.weight.goal_yaw_error_weight");
+      node->template declare_parameter<double>("mpt.weight.terminal_yaw_error_weight");
+    goal_lat_error_weight =
+      node->template declare_parameter<double>("mpt.weight.goal_lat_error_weight");
+    goal_yaw_error_weight =
+      node->template declare_parameter<double>("mpt.weight.goal_yaw_error_weight");
   }
 
   {  // avoidance
-    max_longitudinal_margin_for_bound_violation =
-      node->declare_parameter<double>("mpt.avoidance.max_longitudinal_margin_for_bound_violation");
-    max_bound_fixing_time = node->declare_parameter<double>("mpt.avoidance.max_bound_fixing_time");
-    max_avoidance_cost = node->declare_parameter<double>("mpt.avoidance.max_avoidance_cost");
-    avoidance_cost_margin = node->declare_parameter<double>("mpt.avoidance.avoidance_cost_margin");
+    max_longitudinal_margin_for_bound_violation = node->template declare_parameter<double>(
+      "mpt.avoidance.max_longitudinal_margin_for_bound_violation");
+    max_bound_fixing_time =
+      node->template declare_parameter<double>("mpt.avoidance.max_bound_fixing_time");
+    max_avoidance_cost =
+      node->template declare_parameter<double>("mpt.avoidance.max_avoidance_cost");
+    avoidance_cost_margin =
+      node->template declare_parameter<double>("mpt.avoidance.avoidance_cost_margin");
     avoidance_cost_band_length =
-      node->declare_parameter<double>("mpt.avoidance.avoidance_cost_band_length");
+      node->template declare_parameter<double>("mpt.avoidance.avoidance_cost_band_length");
     avoidance_cost_decrease_rate =
-      node->declare_parameter<double>("mpt.avoidance.avoidance_cost_decrease_rate");
-    min_drivable_width = node->declare_parameter<double>("mpt.avoidance.min_drivable_width");
+      node->template declare_parameter<double>("mpt.avoidance.avoidance_cost_decrease_rate");
+    min_drivable_width =
+      node->template declare_parameter<double>("mpt.avoidance.min_drivable_width");
 
     avoidance_lat_error_weight =
-      node->declare_parameter<double>("mpt.avoidance.weight.lat_error_weight");
+      node->template declare_parameter<double>("mpt.avoidance.weight.lat_error_weight");
     avoidance_yaw_error_weight =
-      node->declare_parameter<double>("mpt.avoidance.weight.yaw_error_weight");
+      node->template declare_parameter<double>("mpt.avoidance.weight.yaw_error_weight");
     avoidance_steer_input_weight =
-      node->declare_parameter<double>("mpt.avoidance.weight.steer_input_weight");
+      node->template declare_parameter<double>("mpt.avoidance.weight.steer_input_weight");
   }
 
   {  // collision free constraints
-    l_inf_norm = node->declare_parameter<bool>("mpt.collision_free_constraints.option.l_inf_norm");
-    soft_constraint =
-      node->declare_parameter<bool>("mpt.collision_free_constraints.option.soft_constraint");
-    hard_constraint =
-      node->declare_parameter<bool>("mpt.collision_free_constraints.option.hard_constraint");
+    l_inf_norm =
+      node->template declare_parameter<bool>("mpt.collision_free_constraints.option.l_inf_norm");
+    soft_constraint = node->template declare_parameter<bool>(
+      "mpt.collision_free_constraints.option.soft_constraint");
+    hard_constraint = node->template declare_parameter<bool>(
+      "mpt.collision_free_constraints.option.hard_constraint");
   }
 
   {  // vehicle_circles
     // NOTE: Vehicle shape for collision free constraints is considered as a set of circles
-    vehicle_circles_method =
-      node->declare_parameter<std::string>("mpt.collision_free_constraints.vehicle_circles.method");
+    vehicle_circles_method = node->template declare_parameter<std::string>(
+      "mpt.collision_free_constraints.vehicle_circles.method");
 
     // uniform circles
-    vehicle_circles_uniform_circle_num = node->declare_parameter<int>(
+    vehicle_circles_uniform_circle_num = node->template declare_parameter<int>(
       "mpt.collision_free_constraints.vehicle_circles.uniform_circle.num");
-    vehicle_circles_uniform_circle_radius_ratio = node->declare_parameter<double>(
+    vehicle_circles_uniform_circle_radius_ratio = node->template declare_parameter<double>(
       "mpt.collision_free_constraints.vehicle_circles.uniform_circle.radius_ratio");
 
     // bicycle model
-    vehicle_circles_bicycle_model_num = node->declare_parameter<int>(
+    vehicle_circles_bicycle_model_num = node->template declare_parameter<int>(
       "mpt.collision_free_constraints.vehicle_circles.bicycle_model.num_for_"
       "calculation");
-    vehicle_circles_bicycle_model_rear_radius_ratio = node->declare_parameter<double>(
+    vehicle_circles_bicycle_model_rear_radius_ratio = node->template declare_parameter<double>(
       "mpt.collision_free_constraints.vehicle_circles."
       "bicycle_model.rear_radius_ratio");
-    vehicle_circles_bicycle_model_front_radius_ratio = node->declare_parameter<double>(
+    vehicle_circles_bicycle_model_front_radius_ratio = node->template declare_parameter<double>(
       "mpt.collision_free_constraints.vehicle_circles."
       "bicycle_model.front_radius_ratio");
 
     // fitting uniform circles
-    vehicle_circles_fitting_uniform_circle_num = node->declare_parameter<int>(
+    vehicle_circles_fitting_uniform_circle_num = node->template declare_parameter<int>(
       "mpt.collision_free_constraints.vehicle_circles.fitting_uniform_circle.num");
   }
 
   {  // validation
-    max_validation_lat_error = node->declare_parameter<double>("mpt.validation.max_lat_error");
-    max_validation_yaw_error = node->declare_parameter<double>("mpt.validation.max_yaw_error");
+    max_validation_lat_error =
+      node->template declare_parameter<double>("mpt.validation.max_lat_error");
+    max_validation_yaw_error =
+      node->template declare_parameter<double>("mpt.validation.max_yaw_error");
   }
 }
 
@@ -407,6 +422,45 @@ void MPTOptimizer::MPTParam::onParam(const std::vector<rclcpp::Parameter> & para
   }
 }
 
+template <typename NodeT>
+void MPTOptimizer::setUpPublishers(NodeT * node)
+{
+  const auto make_traj_pub = [&](const std::string & topic) {
+    return [publisher = node->template create_publisher<Trajectory>(topic, 1)](
+             const Trajectory & msg) { publisher->publish(msg); };
+  };
+  const auto make_array_pub = [&](const std::string & topic) {
+    return [publisher = node->template create_publisher<std_msgs::msg::Float32MultiArray>(
+              topic, 1)](const std_msgs::msg::Float32MultiArray & msg) { publisher->publish(msg); };
+  };
+
+  debug_fixed_traj_pub_ = make_traj_pub("~/debug/mpt_fixed_traj");
+  debug_ref_traj_pub_ = make_traj_pub("~/debug/mpt_ref_traj");
+  debug_mpt_traj_pub_ = make_traj_pub("~/debug/mpt_traj");
+  debug_optimised_steering_pub_ = make_array_pub("~/debug/optimised_steering");
+
+  debug_acados_mpt_traj_pub_ = make_traj_pub("~/debug/acados_mpt_traj");
+  debug_acados_optimised_steering_pub_ = make_array_pub("~/debug/acados_optimised_steering");
+  debug_optimised_states_pub_ = make_array_pub("~/debug/optimised_states");
+  debug_acados_optimised_states_pub_ = make_array_pub("~/debug/acados_optimised_states");
+  debug_ref_steering_pub_ = make_array_pub("~/debug/ref_steering");
+}
+
+template <typename NodeT>
+void MPTOptimizer::initializeCommon(NodeT * node)
+{
+  mpt_param_ = MPTParam(node, vehicle_info_);
+  updateVehicleCircles();
+  debug_data_ptr_->mpt_visualize_sampling_num = mpt_param_.mpt_visualize_sampling_num;
+
+  state_equation_generator_ =
+    StateEquationGenerator(vehicle_info_.wheel_base_m, mpt_param_.max_steer_rad, time_keeper_);
+
+  osqp_solver_ptr_ = std::make_unique<autoware::osqp_interface::OSQPInterface>(osqp_epsilon_);
+
+  setUpPublishers(node);
+}
+
 MPTOptimizer::MPTOptimizer(
   rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
@@ -420,34 +474,24 @@ MPTOptimizer::MPTOptimizer(
   time_keeper_(time_keeper),
   logger_(node->get_logger().get_child("mpt_optimizer"))
 {
-  // initialize mpt param
-  mpt_param_ = MPTParam(node, vehicle_info);
-  updateVehicleCircles();
-  debug_data_ptr_->mpt_visualize_sampling_num = mpt_param_.mpt_visualize_sampling_num;
+  initializeCommon(node);
+}
 
-  // state equation generator
-  state_equation_generator_ =
-    StateEquationGenerator(vehicle_info_.wheel_base_m, mpt_param_.max_steer_rad, time_keeper_);
-
-  // osqp solver
-  osqp_solver_ptr_ = std::make_unique<autoware::osqp_interface::OSQPInterface>(osqp_epsilon_);
-
-  // publisher
-  debug_fixed_traj_pub_ = node->create_publisher<Trajectory>("~/debug/mpt_fixed_traj", 1);
-  debug_ref_traj_pub_ = node->create_publisher<Trajectory>("~/debug/mpt_ref_traj", 1);
-  debug_mpt_traj_pub_ = node->create_publisher<Trajectory>("~/debug/mpt_traj", 1);
-  debug_optimised_steering_pub_ =
-    node->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/optimised_steering", 1);
-
-  debug_acados_mpt_traj_pub_ = node->create_publisher<Trajectory>("~/debug/acados_mpt_traj", 1);
-  debug_acados_optimised_steering_pub_ = node->create_publisher<std_msgs::msg::Float32MultiArray>(
-    "~/debug/acados_optimised_steering", 1);
-  debug_optimised_states_pub_ =
-    node->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/optimised_states", 1);
-  debug_acados_optimised_states_pub_ =
-    node->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/acados_optimised_states", 1);
-  debug_ref_steering_pub_ =
-    node->create_publisher<std_msgs::msg::Float32MultiArray>("~/debug/ref_steering", 1);
+MPTOptimizer::MPTOptimizer(
+  autoware::agnocast_wrapper::Node * node, const bool enable_debug_info,
+  const EgoNearestParam ego_nearest_param,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const TrajectoryParam & traj_param, const std::shared_ptr<DebugData> debug_data_ptr,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
+: enable_debug_info_(enable_debug_info),
+  ego_nearest_param_(ego_nearest_param),
+  vehicle_info_(vehicle_info),
+  traj_param_(traj_param),
+  debug_data_ptr_(debug_data_ptr),
+  time_keeper_(time_keeper),
+  logger_(node->get_logger().get_child("mpt_optimizer"))
+{
+  initializeCommon(node);
 }
 
 void MPTOptimizer::updateVehicleCircles()
@@ -620,7 +664,7 @@ void MPTOptimizer::publishOptimizedSteering(const Eigen::VectorXd & optimized_va
     msg.data.push_back(static_cast<float>(optimized_variables(i)));
   }
 
-  debug_optimised_steering_pub_->publish(msg);
+  debug_optimised_steering_pub_(msg);
 }
 
 void MPTOptimizer::publishOptimizedStates(const Eigen::VectorXd & states, const size_t N) const
@@ -631,7 +675,7 @@ void MPTOptimizer::publishOptimizedStates(const Eigen::VectorXd & states, const 
     msg.data.push_back(static_cast<float>(states(2 * i)));      // eY
     msg.data.push_back(static_cast<float>(states(2 * i + 1)));  // ePsi
   }
-  debug_optimised_states_pub_->publish(msg);
+  debug_optimised_states_pub_(msg);
 }
 
 void MPTOptimizer::updateDebugDataAndPublishAcadosSteering(
@@ -654,7 +698,7 @@ void MPTOptimizer::updateDebugDataAndPublishAcadosSteering(
     acados_steering_msg.data.push_back(static_cast<float>(delta[0]));
   }
 
-  debug_acados_optimised_steering_pub_->publish(acados_steering_msg);
+  debug_acados_optimised_steering_pub_(acados_steering_msg);
 }
 
 void MPTOptimizer::publishAcadosTrajectory(
@@ -663,7 +707,7 @@ void MPTOptimizer::publishAcadosTrajectory(
 {
   // Publish acados trajectory to separate topic for comparison
   const auto acados_traj = autoware::motion_utils::convertToTrajectory(acados_traj_points, header);
-  debug_acados_mpt_traj_pub_->publish(acados_traj);
+  debug_acados_mpt_traj_pub_(acados_traj);
 }
 
 void MPTOptimizer::publishAcadosStates(const AcadosSolution & acados_result) const
@@ -676,7 +720,7 @@ void MPTOptimizer::publishAcadosStates(const AcadosSolution & acados_result) con
     acados_states_msg.data.push_back(static_cast<float>(acados_states[i][0]));  // eY
     acados_states_msg.data.push_back(static_cast<float>(acados_states[i][1]));  // ePsi
   }
-  debug_acados_optimised_states_pub_->publish(acados_states_msg);
+  debug_acados_optimised_states_pub_(acados_states_msg);
 }
 
 void MPTOptimizer::publishReferenceTrajectory(
@@ -685,7 +729,7 @@ void MPTOptimizer::publishReferenceTrajectory(
   // Publish reference trajectory for comparison
   const auto ref_traj = autoware::motion_utils::convertToTrajectory(
     trajectory_utils::convertToTrajectoryPoints(ref_points), header);
-  debug_ref_traj_pub_->publish(ref_traj);
+  debug_ref_traj_pub_(ref_traj);
 }
 
 void MPTOptimizer::publishReferenceSteeringAngles(
@@ -732,7 +776,7 @@ void MPTOptimizer::publishReferenceSteeringAngles(
       }
     }
   }
-  debug_ref_steering_pub_->publish(ref_steering_msg);
+  debug_ref_steering_pub_(ref_steering_msg);
 }
 
 geometry_msgs::msg::Point getCorner(const geometry_msgs::msg::Pose & ego_pose, double dx, double dy)
@@ -2207,16 +2251,16 @@ void MPTOptimizer::publishDebugTrajectories(
   // reference points
   const auto ref_traj = autoware::motion_utils::convertToTrajectory(
     trajectory_utils::convertToTrajectoryPoints(ref_points), header);
-  debug_ref_traj_pub_->publish(ref_traj);
+  debug_ref_traj_pub_(ref_traj);
 
   // fixed reference points
   const auto fixed_traj_points = extractFixedPoints(ref_points);
   const auto fixed_traj = autoware::motion_utils::convertToTrajectory(fixed_traj_points, header);
-  debug_fixed_traj_pub_->publish(fixed_traj);
+  debug_fixed_traj_pub_(fixed_traj);
 
   // mpt points
   const auto mpt_traj = autoware::motion_utils::convertToTrajectory(mpt_traj_points, header);
-  debug_mpt_traj_pub_->publish(mpt_traj);
+  debug_mpt_traj_pub_(mpt_traj);
 }
 
 std::vector<TrajectoryPoint> MPTOptimizer::extractFixedPoints(

--- a/planning/autoware_path_optimizer/src/replan_checker.cpp
+++ b/planning/autoware_path_optimizer/src/replan_checker.cpp
@@ -19,23 +19,38 @@
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+
 #include <memory>
 #include <vector>
 
 namespace autoware::path_optimizer
 {
+template <typename NodeT>
+void ReplanChecker::declareParams(NodeT * node)
+{
+  max_path_shape_around_ego_lat_dist_ =
+    node->template declare_parameter<double>("replan.max_path_shape_around_ego_lat_dist");
+  max_path_shape_forward_lat_dist_ =
+    node->template declare_parameter<double>("replan.max_path_shape_forward_lat_dist");
+  max_path_shape_forward_lon_dist_ =
+    node->template declare_parameter<double>("replan.max_path_shape_forward_lon_dist");
+  max_ego_moving_dist_ = node->template declare_parameter<double>("replan.max_ego_moving_dist");
+  max_goal_moving_dist_ = node->template declare_parameter<double>("replan.max_goal_moving_dist");
+  max_delta_time_sec_ = node->template declare_parameter<double>("replan.max_delta_time_sec");
+}
+
 ReplanChecker::ReplanChecker(rclcpp::Node * node, const EgoNearestParam & ego_nearest_param)
 : ego_nearest_param_(ego_nearest_param), logger_(node->get_logger().get_child("replan_checker"))
 {
-  max_path_shape_around_ego_lat_dist_ =
-    node->declare_parameter<double>("replan.max_path_shape_around_ego_lat_dist");
-  max_path_shape_forward_lat_dist_ =
-    node->declare_parameter<double>("replan.max_path_shape_forward_lat_dist");
-  max_path_shape_forward_lon_dist_ =
-    node->declare_parameter<double>("replan.max_path_shape_forward_lon_dist");
-  max_ego_moving_dist_ = node->declare_parameter<double>("replan.max_ego_moving_dist");
-  max_goal_moving_dist_ = node->declare_parameter<double>("replan.max_goal_moving_dist");
-  max_delta_time_sec_ = node->declare_parameter<double>("replan.max_delta_time_sec");
+  declareParams(node);
+}
+
+ReplanChecker::ReplanChecker(
+  autoware::agnocast_wrapper::Node * node, const EgoNearestParam & ego_nearest_param)
+: ego_nearest_param_(ego_nearest_param), logger_(node->get_logger().get_child("replan_checker"))
+{
+  declareParams(node);
 }
 
 void ReplanChecker::onParam(const std::vector<rclcpp::Parameter> & parameters)

--- a/planning/autoware_path_smoother/CMakeLists.txt
+++ b/planning/autoware_path_smoother/CMakeLists.txt
@@ -10,6 +10,8 @@ ament_auto_add_library(autoware_path_smoother SHARED
   DIRECTORY src
 )
 
+autoware_agnocast_wrapper_setup(autoware_path_smoother)
+
 target_include_directories(autoware_path_smoother
   SYSTEM PUBLIC
     ${EIGEN3_INCLUDE_DIR}

--- a/planning/autoware_path_smoother/include/autoware/path_smoother/common_structs.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/common_structs.hpp
@@ -91,11 +91,13 @@ struct TimeKeeper
 struct CommonParam
 {
   CommonParam() = default;
-  explicit CommonParam(rclcpp::Node * node)
+  template <typename NodeT>
+  explicit CommonParam(NodeT * node)
   {
     output_backward_traj_length =
-      node->declare_parameter<double>("common.output_backward_traj_length");
-    output_delta_arc_length = node->declare_parameter<double>("common.output_delta_arc_length");
+      node->template declare_parameter<double>("common.output_backward_traj_length");
+    output_delta_arc_length =
+      node->template declare_parameter<double>("common.output_delta_arc_length");
   }
 
   void onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -115,10 +117,11 @@ struct CommonParam
 struct EgoNearestParam
 {
   EgoNearestParam() = default;
-  explicit EgoNearestParam(rclcpp::Node * node)
+  template <typename NodeT>
+  explicit EgoNearestParam(NodeT * node)
   {
-    dist_threshold = node->declare_parameter<double>("ego_nearest_dist_threshold");
-    yaw_threshold = node->declare_parameter<double>("ego_nearest_yaw_threshold");
+    dist_threshold = node->template declare_parameter<double>("ego_nearest_dist_threshold");
+    yaw_threshold = node->template declare_parameter<double>("ego_nearest_yaw_threshold");
   }
 
   void onParam(const std::vector<rclcpp::Parameter> & parameters)

--- a/planning/autoware_path_smoother/include/autoware/path_smoother/elastic_band.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/elastic_band.hpp
@@ -21,11 +21,17 @@
 
 #include <Eigen/Core>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>
+
+namespace autoware::agnocast_wrapper
+{
+class Node;
+}  // namespace autoware::agnocast_wrapper
 
 namespace autoware::path_smoother
 {
@@ -35,6 +41,10 @@ public:
   EBPathSmoother(
     rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
     const CommonParam & common_param, const std::shared_ptr<TimeKeeper> time_keeper_ptr);
+  EBPathSmoother(
+    autoware::agnocast_wrapper::Node * node, const bool enable_debug_info,
+    const EgoNearestParam ego_nearest_param, const CommonParam & common_param,
+    const std::shared_ptr<TimeKeeper> time_keeper_ptr);
 
   std::vector<TrajectoryPoint> smoothTrajectory(
     const std::vector<TrajectoryPoint> & traj_points, const geometry_msgs::msg::Pose & ego_pose);
@@ -55,7 +65,8 @@ private:
     };
 
     EBParam() = default;
-    explicit EBParam(rclcpp::Node * node);
+    template <typename NodeT>
+    explicit EBParam(NodeT * node);
     void onParam(const std::vector<rclcpp::Parameter> & parameters);
 
     // option
@@ -106,8 +117,11 @@ private:
   rclcpp::Clock clock_;
 
   // publisher
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_traj_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr debug_eb_fixed_traj_pub_;
+  std::function<void(const Trajectory &)> debug_eb_traj_pub_;
+  std::function<void(const Trajectory &)> debug_eb_fixed_traj_pub_;
+
+  template <typename NodeT>
+  void setUpPublishers(NodeT * node);
 
   std::unique_ptr<autoware::osqp_interface::OSQPInterface> osqp_solver_ptr_;
   std::shared_ptr<std::vector<TrajectoryPoint>> prev_eb_traj_points_ptr_{nullptr};

--- a/planning/autoware_path_smoother/include/autoware/path_smoother/replan_checker.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/replan_checker.hpp
@@ -23,12 +23,19 @@
 #include <memory>
 #include <vector>
 
+namespace autoware::agnocast_wrapper
+{
+class Node;
+}  // namespace autoware::agnocast_wrapper
+
 namespace autoware::path_smoother
 {
 class ReplanChecker
 {
 public:
   explicit ReplanChecker(rclcpp::Node * node, const EgoNearestParam & ego_nearest_param);
+  explicit ReplanChecker(
+    autoware::agnocast_wrapper::Node * node, const EgoNearestParam & ego_nearest_param);
   void onParam(const std::vector<rclcpp::Parameter> & parameters);
 
   bool isResetRequired(const PlannerData & planner_data) const;
@@ -40,6 +47,9 @@ public:
     const rclcpp::Time & current_time);
 
 private:
+  template <typename NodeT>
+  void declareParams(NodeT * node);
+
   EgoNearestParam ego_nearest_param_;
   rclcpp::Logger logger_;
 

--- a/planning/autoware_path_smoother/package.xml
+++ b/planning/autoware_path_smoother/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>

--- a/planning/autoware_path_smoother/src/elastic_band.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band.cpp
@@ -22,6 +22,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Sparse>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <tf2/utils.hpp>
 
 #include <algorithm>
@@ -87,41 +88,48 @@ std_msgs::msg::Header createHeader(const rclcpp::Time & now)
 
 namespace autoware::path_smoother
 {
-EBPathSmoother::EBParam::EBParam(rclcpp::Node * node)
+template <typename NodeT>
+EBPathSmoother::EBParam::EBParam(NodeT * node)
 {
   {  // option
-    enable_warm_start = node->declare_parameter<bool>("elastic_band.option.enable_warm_start");
+    enable_warm_start =
+      node->template declare_parameter<bool>("elastic_band.option.enable_warm_start");
     enable_optimization_validation =
-      node->declare_parameter<bool>("elastic_band.option.enable_optimization_validation");
+      node->template declare_parameter<bool>("elastic_band.option.enable_optimization_validation");
   }
 
   {  // common
-    delta_arc_length = node->declare_parameter<double>("elastic_band.common.delta_arc_length");
-    num_points = node->declare_parameter<int>("elastic_band.common.num_points");
+    delta_arc_length =
+      node->template declare_parameter<double>("elastic_band.common.delta_arc_length");
+    num_points = node->template declare_parameter<int>("elastic_band.common.num_points");
   }
 
   {  // clearance
-    num_joint_points = node->declare_parameter<int>("elastic_band.clearance.num_joint_points");
-    clearance_for_fix = node->declare_parameter<double>("elastic_band.clearance.clearance_for_fix");
+    num_joint_points =
+      node->template declare_parameter<int>("elastic_band.clearance.num_joint_points");
+    clearance_for_fix =
+      node->template declare_parameter<double>("elastic_band.clearance.clearance_for_fix");
     clearance_for_joint =
-      node->declare_parameter<double>("elastic_band.clearance.clearance_for_joint");
+      node->template declare_parameter<double>("elastic_band.clearance.clearance_for_joint");
     clearance_for_smooth =
-      node->declare_parameter<double>("elastic_band.clearance.clearance_for_smooth");
+      node->template declare_parameter<double>("elastic_band.clearance.clearance_for_smooth");
   }
 
   {  // weight
-    smooth_weight = node->declare_parameter<double>("elastic_band.weight.smooth_weight");
-    lat_error_weight = node->declare_parameter<double>("elastic_band.weight.lat_error_weight");
+    smooth_weight = node->template declare_parameter<double>("elastic_band.weight.smooth_weight");
+    lat_error_weight =
+      node->template declare_parameter<double>("elastic_band.weight.lat_error_weight");
   }
 
   {  // qp
-    qp_param.max_iteration = node->declare_parameter<int>("elastic_band.qp.max_iteration");
-    qp_param.eps_abs = node->declare_parameter<double>("elastic_band.qp.eps_abs");
-    qp_param.eps_rel = node->declare_parameter<double>("elastic_band.qp.eps_rel");
+    qp_param.max_iteration = node->template declare_parameter<int>("elastic_band.qp.max_iteration");
+    qp_param.eps_abs = node->template declare_parameter<double>("elastic_band.qp.eps_abs");
+    qp_param.eps_rel = node->template declare_parameter<double>("elastic_band.qp.eps_rel");
   }
 
   // validation
-  max_validation_error = node->declare_parameter<double>("elastic_band.validation.max_error");
+  max_validation_error =
+    node->template declare_parameter<double>("elastic_band.validation.max_error");
 }
 
 void EBPathSmoother::EBParam::onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -161,6 +169,18 @@ void EBPathSmoother::EBParam::onParam(const std::vector<rclcpp::Parameter> & par
   }
 }
 
+template <typename NodeT>
+void EBPathSmoother::setUpPublishers(NodeT * node)
+{
+  debug_eb_traj_pub_ = [publisher =
+                          node->template create_publisher<Trajectory>("~/debug/eb_traj", 1)](
+                         const Trajectory & msg) { publisher->publish(msg); };
+  debug_eb_fixed_traj_pub_ = [publisher = node->template create_publisher<Trajectory>(
+                                "~/debug/eb_fixed_traj", 1)](const Trajectory & msg) {
+    publisher->publish(msg);
+  };
+}
+
 EBPathSmoother::EBPathSmoother(
   rclcpp::Node * node, const bool enable_debug_info, const EgoNearestParam ego_nearest_param,
   const CommonParam & common_param, const std::shared_ptr<TimeKeeper> time_keeper_ptr)
@@ -171,12 +191,23 @@ EBPathSmoother::EBPathSmoother(
   logger_(node->get_logger().get_child("elastic_band_smoother")),
   clock_(*node->get_clock())
 {
-  // eb param
   eb_param_ = EBParam(node);
+  setUpPublishers(node);
+}
 
-  // publisher
-  debug_eb_traj_pub_ = node->create_publisher<Trajectory>("~/debug/eb_traj", 1);
-  debug_eb_fixed_traj_pub_ = node->create_publisher<Trajectory>("~/debug/eb_fixed_traj", 1);
+EBPathSmoother::EBPathSmoother(
+  autoware::agnocast_wrapper::Node * node, const bool enable_debug_info,
+  const EgoNearestParam ego_nearest_param, const CommonParam & common_param,
+  const std::shared_ptr<TimeKeeper> time_keeper_ptr)
+: enable_debug_info_(enable_debug_info),
+  ego_nearest_param_(ego_nearest_param),
+  common_param_(common_param),
+  time_keeper_ptr_(time_keeper_ptr),
+  logger_(node->get_logger().get_child("elastic_band_smoother")),
+  clock_(*node->get_clock())
+{
+  eb_param_ = EBParam(node);
+  setUpPublishers(node);
 }
 
 void EBPathSmoother::onParam(const std::vector<rclcpp::Parameter> & parameters)
@@ -265,7 +296,7 @@ std::vector<TrajectoryPoint> EBPathSmoother::smoothTrajectory(
   // 8. publish eb trajectory
   const auto eb_traj =
     autoware::motion_utils::convertToTrajectory(*eb_traj_points, createHeader(clock_.now()));
-  debug_eb_traj_pub_->publish(eb_traj);
+  debug_eb_traj_pub_(eb_traj);
 
   time_keeper_ptr_->toc(__func__, "      ");
   return *eb_traj_points;
@@ -392,7 +423,7 @@ void EBPathSmoother::updateConstraint(
   // publish fixed trajectory
   const auto eb_fixed_traj = autoware::motion_utils::convertToTrajectory(
     debug_fixed_traj_points, createHeader(clock_.now()));
-  debug_eb_fixed_traj_pub_->publish(eb_fixed_traj);
+  debug_eb_fixed_traj_pub_(eb_fixed_traj);
 
   time_keeper_ptr_->toc(__func__, "        ");
 }

--- a/planning/autoware_path_smoother/src/replan_checker.cpp
+++ b/planning/autoware_path_smoother/src/replan_checker.cpp
@@ -19,24 +19,39 @@
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+
 #include <memory>
 #include <vector>
 
 namespace autoware::path_smoother
 {
+template <typename NodeT>
+void ReplanChecker::declareParams(NodeT * node)
+{
+  enable_ = node->template declare_parameter<bool>("replan.enable");
+  max_path_shape_around_ego_lat_dist_ =
+    node->template declare_parameter<double>("replan.max_path_shape_around_ego_lat_dist");
+  max_path_shape_forward_lat_dist_ =
+    node->template declare_parameter<double>("replan.max_path_shape_forward_lat_dist");
+  max_path_shape_forward_lon_dist_ =
+    node->template declare_parameter<double>("replan.max_path_shape_forward_lon_dist");
+  max_ego_moving_dist_ = node->template declare_parameter<double>("replan.max_ego_moving_dist");
+  max_goal_moving_dist_ = node->template declare_parameter<double>("replan.max_goal_moving_dist");
+  max_delta_time_sec_ = node->template declare_parameter<double>("replan.max_delta_time_sec");
+}
+
 ReplanChecker::ReplanChecker(rclcpp::Node * node, const EgoNearestParam & ego_nearest_param)
 : ego_nearest_param_(ego_nearest_param), logger_(node->get_logger().get_child("replan_checker"))
 {
-  enable_ = node->declare_parameter<bool>("replan.enable");
-  max_path_shape_around_ego_lat_dist_ =
-    node->declare_parameter<double>("replan.max_path_shape_around_ego_lat_dist");
-  max_path_shape_forward_lat_dist_ =
-    node->declare_parameter<double>("replan.max_path_shape_forward_lat_dist");
-  max_path_shape_forward_lon_dist_ =
-    node->declare_parameter<double>("replan.max_path_shape_forward_lon_dist");
-  max_ego_moving_dist_ = node->declare_parameter<double>("replan.max_ego_moving_dist");
-  max_goal_moving_dist_ = node->declare_parameter<double>("replan.max_goal_moving_dist");
-  max_delta_time_sec_ = node->declare_parameter<double>("replan.max_delta_time_sec");
+  declareParams(node);
+}
+
+ReplanChecker::ReplanChecker(
+  autoware::agnocast_wrapper::Node * node, const EgoNearestParam & ego_nearest_param)
+: ego_nearest_param_(ego_nearest_param), logger_(node->get_logger().get_child("replan_checker"))
+{
+  declareParams(node);
 }
 
 void ReplanChecker::onParam(const std::vector<rclcpp::Parameter> & parameters)


### PR DESCRIPTION
## Description
Add `agnocast_wrapper::Node` support to the shared classes in `autoware_path_smoother` and `autoware_path_optimizer`, so that a node derived from `agnocast_wrapper::Node` can use them.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR.

This PR converts no node. It is the library half of the `trajectory_processor` conversion (see "Related links"), split out because it is backward compatible on its own and can be reviewed independently.

`EBPathSmoother`, `MPTOptimizer` and both `ReplanChecker`s currently take an `rclcpp::Node *` in order to declare parameters and create debug publishers. Each of them gains a second, non-template constructor overload taking `autoware::agnocast_wrapper::Node *`, following the pattern established in autowarefoundation/autoware_core#1264:

- The parameter declaration bodies are shared as private templates (`declareParams<NodeT>()`, the `CommonParam` / `EgoNearestParam` / `EBParam` / `MPTParam` constructors), so the two overloads do not duplicate any logic. `declare_parameter` is called as `node->template declare_parameter<T>(...)`.
- The debug publishers inside `EBPathSmoother` and `MPTOptimizer` are injected as `std::function` (`TrajectoryPublishFunc`, `Float32MultiArrayPublishFunc`) instead of being created from the node pointer, so neither class stores a node type.
- `agnocast_wrapper::Node` is forward declared in the headers, so the wrapper header is only included in the `.cpp` files.
- `autoware_agnocast_wrapper_setup()` is added to both library targets, so `USE_AGNOCAST_ENABLED` is defined consistently and the ABI matches the wrapper.

The constructor overloads are non-template on purpose. A template constructor on a non-template class cannot be explicitly instantiated for the wrapper type, and a derived node then fails to link; two plain overloads accept a derived node through the usual derived-to-base conversion.
## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7007
- https://github.com/orgs/autowarefoundation/discussions/6804
- Constructor overload pattern: https://github.com/autowarefoundation/autoware_core/pull/1264
- Follow-up PR that uses these overloads: https://github.com/autowarefoundation/autoware_universe/pull/13242

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- **Build**: Confirmed `autoware_path_smoother` and `autoware_path_optimizer` build with `ENABLE_AGNOCAST=1`, together with `autoware_trajectory_processor` taken unmodified from `main`, which confirms the existing callers are unaffected. `ENABLE_AGNOCAST=0` is left to CI.
- **Unit tests**: With `ENABLE_AGNOCAST=1`, the existing tests of both packages pass. No test logic is changed by this PR.
- **Regression (LSim)**: The logging simulator with the sample rosbag runs to completion with no `process has died` while playing. `ElasticBandSmoother` and `PathOptimizer` run inside `motion_planning_container` and behave as before.

## Notes for reviewers

- The new overloads have no caller in this PR. They are exercised by the follow-up `trajectory_processor` PR, which was verified end to end with the same library code.
- Debug topic names and QoS are unchanged. Passing a null `std::function` disables the corresponding debug publication, which is what the existing `enable_debug_info` path already does.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
