### PR TITLE
perf(autoware_freespace_planning_algorithms): carry neighbor distances into RRT* best-parent selection

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/rrtstar_core.hpp
+++ b/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/rrtstar_core.hpp
@@ -90,6 +90,12 @@ using NodeSharedPtr = std::shared_ptr<Node>;
 using NodeConstSharedPtr = std::shared_ptr<const Node>;
 using NodeWeakPtr = std::weak_ptr<Node>;
 
+struct NeighborCandidate
+{
+  NodeConstSharedPtr node;
+  double distance_to_new;
+};
+
 struct Node
 {
   Pose pose;
@@ -135,15 +141,15 @@ public:
 
 private:
   NodeConstSharedPtr findNearestNode(const Pose & x_rand) const;
-  std::vector<NodeConstSharedPtr> findNeighborNodes(const Pose & pose) const;
+  std::vector<NeighborCandidate> findNeighborNodes(const Pose & pose) const;
   NodeSharedPtr addNewNode(const Pose & pose, NodeSharedPtr node_parent);
   NodeConstSharedPtr getBestParentNode(
     const Pose & pose_new, const NodeConstSharedPtr & node_nearest,
-    const std::vector<NodeConstSharedPtr> & neighbor_nodes) const;
+    const std::vector<NeighborCandidate> & neighbor_nodes) const;
   void reconnect(const NodeSharedPtr & node_new, const NodeSharedPtr & node_reconnect);
   NodeConstSharedPtr getReconnectTargeNode(
     const NodeConstSharedPtr node_new,
-    const std::vector<NodeConstSharedPtr> & neighbor_nodes) const;
+    const std::vector<NeighborCandidate> & neighbor_nodes) const;
 
   NodeSharedPtr node_start_;
   NodeSharedPtr node_goal_;

--- a/planning/autoware_freespace_planning_algorithms/src/rrtstar_core.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/rrtstar_core.cpp
@@ -347,7 +347,7 @@ NodeConstSharedPtr RRTStar::findNearestNode(const Pose & x_rand) const
   return node_nearest;
 }
 
-std::vector<NodeConstSharedPtr> RRTStar::findNeighborNodes(const Pose & x_new) const
+std::vector<NeighborCandidate> RRTStar::findNeighborNodes(const Pose & x_new) const
 {
   // In the original paper of rrtstar, radius is shrinking over time.
   // However, because we use reeds-shepp distance metric instead of Euclidean metric,
@@ -362,12 +362,13 @@ std::vector<NodeConstSharedPtr> RRTStar::findNeighborNodes(const Pose & x_new) c
 
   const double radius_neighbor = mu_;
 
-  std::vector<NodeConstSharedPtr> nodes;
+  std::vector<NeighborCandidate> nodes;
   for (auto & node : nodes_) {
     if (cspace_.distanceLowerBound(node->pose, x_new) > radius_neighbor) continue;
-    const bool is_neighbor = (cspace_.distance(node->pose, x_new) < radius_neighbor);
+    const double distance_to_new = cspace_.distance(node->pose, x_new);
+    const bool is_neighbor = (distance_to_new < radius_neighbor);
     if (is_neighbor) {
-      nodes.push_back(node);
+      nodes.push_back(NeighborCandidate{node, distance_to_new});
     }
   }
   return nodes;
@@ -385,11 +386,12 @@ NodeSharedPtr RRTStar::addNewNode(const Pose & pose, NodeSharedPtr node_parent)
 }
 
 NodeConstSharedPtr RRTStar::getReconnectTargeNode(
-  const NodeConstSharedPtr node_new, const std::vector<NodeConstSharedPtr> & neighbor_nodes) const
+  const NodeConstSharedPtr node_new, const std::vector<NeighborCandidate> & neighbor_nodes) const
 {
   NodeConstSharedPtr node_reconnect = nullptr;
 
-  for (const auto & node_neighbor : neighbor_nodes) {
+  for (const auto & candidate : neighbor_nodes) {
+    const auto & node_neighbor = candidate.node;
     if (
       cspace_.isValidPath_child2parent(
         node_neighbor->pose, node_new->pose, collision_check_resolution_)) {
@@ -406,14 +408,15 @@ NodeConstSharedPtr RRTStar::getReconnectTargeNode(
 
 NodeConstSharedPtr RRTStar::getBestParentNode(
   const Pose & pose_new, const NodeConstSharedPtr & node_nearest,
-  const std::vector<NodeConstSharedPtr> & neighbor_nodes) const
+  const std::vector<NeighborCandidate> & neighbor_nodes) const
 {
   NodeConstSharedPtr node_best = node_nearest;
   double cost_min =
     *(node_nearest->cost_from_start) + cspace_.distance(node_nearest->pose, pose_new);
-  for (const auto & node : neighbor_nodes) {
+  for (const auto & candidate : neighbor_nodes) {
+    const auto & node = candidate.node;
     const double cost_start_to_new =
-      *(node->cost_from_start) + cspace_.distance(node->pose, pose_new);
+      *(node->cost_from_start) + candidate.distance_to_new;
     if (cost_start_to_new < cost_min) {
       if (cspace_.isValidPath_child2parent(pose_new, node->pose, collision_check_resolution_)) {
         node_best = node;


### PR DESCRIPTION
## Description
`findNeighborNodes` computes each candidate's Reeds-Shepp distance to the new pose to decide neighborhood membership, discards it, and `getBestParentNode` recomputes the same distance for the cost comparison. This PR returns a small `NeighborCandidate {node, distance_to_new}` struct from the radius search and reuses the stored distance in parent selection. Reeds-Shepp distance is a pure function of the two poses, so the reuse is exact. In a focused fixture (100,000 iterations over the pair), distance evaluations drop from 700k to 400k per sample and the median improves ~36% (519 ms → 333 ms).

## How was this PR tested?
- `colcon test` for the package: all tests pass, unchanged (including `rrtstar_core_informed-test`).
- Deterministic 600-extension trees are bit-identical vs baseline — tree hash and solution cost equal — on two platforms (arm64/Apple-clang, x86_64/gcc).
- Focused fixture: identical parent selection on directed collinear-node cases.
- ASan + UBSan: clean.

- Downstream parity: the dependent-package tree (`--packages-above-and-dependencies`, including `autoware_freespace_planner` and the behavior-path modules) was built and tested with and without this change — the per-test failure diff is empty.

## Notes for reviewers
`getReconnectTargeNode` iterates the same vector and only needs the node; it unpacks the struct without using the distance.

## Interface changes
None (types changed are in the file-private `rrtstar_core` implementation namespace).

## AI usage disclosure
This optimization was found via the AI Performance Engineer
[Zynoptes](https://www.zynoptes.com). Correctness was established by
differential testing against the baseline implementation, the package's testing
suite, and ASan+UBSan runs. I have reviewed every line of this diff personally
and will respond to review comments myself.
