### PR TITLE
feat(euclidean_cluster): add support of filtering clusters regarding size

### DIFF
--- a/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
+++ b/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
@@ -59,8 +59,8 @@
 
     # Post-clustering merge for confusable label pairs (e.g. truck/trailer over-segmentation).
     confusable_label_groups:
-      truck_trailer:
-        labels: ["truck", "trailer"]
+      truck_trailer_car:
+        labels: ["truck", "trailer", "car"]
         cross_label_tolerance_m: 0.5
         max_merged_size_m: 25.0
 

--- a/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
+++ b/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
@@ -19,6 +19,7 @@
         large_cluster_voxel_count_threshold: 5
         large_cluster_max_points_per_voxel: 30
         max_voxels_per_cluster: 200
+        min_cluster_size_m: 0.0
       bicycle:
         tolerance_m: 0.4
         voxel_leaf_size_m: 0.15
@@ -27,6 +28,7 @@
         large_cluster_voxel_count_threshold: 5
         large_cluster_max_points_per_voxel: 50
         max_voxels_per_cluster: 300
+        min_cluster_size_m: 0.0
       hazard:
         tolerance_m: 0.3
         voxel_leaf_size_m: 0.1
@@ -35,6 +37,7 @@
         large_cluster_voxel_count_threshold: 5
         large_cluster_max_points_per_voxel: 30
         max_voxels_per_cluster: 200
+        min_cluster_size_m: 0.0
 
     # Post-clustering merge for confusable label pairs (e.g. truck/trailer over-segmentation).
     confusable_label_groups:
@@ -45,7 +48,8 @@
 
     # Point filtering by semantic confidence
     min_probability: 0.3
-
+    # Minimum XY bounding-circle diameter for a clustered object (0 disables filtering).
+    min_cluster_size_m: 1.5
     # Shape estimation behavior
     use_shape_estimation_corrector: false
     use_shape_estimation_filter: false

--- a/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
+++ b/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
@@ -20,6 +20,15 @@
         large_cluster_max_points_per_voxel: 30
         max_voxels_per_cluster: 200
         min_cluster_size_m: 0.0
+      motorcycle:
+        tolerance_m: 0.4
+        voxel_leaf_size_m: 0.15
+        min_points_per_voxel: 1
+        min_points_per_cluster: 5
+        large_cluster_voxel_count_threshold: 5
+        large_cluster_max_points_per_voxel: 50
+        max_voxels_per_cluster: 300
+        min_cluster_size_m: 0.0
       bicycle:
         tolerance_m: 0.4
         voxel_leaf_size_m: 0.15
@@ -28,6 +37,15 @@
         large_cluster_voxel_count_threshold: 5
         large_cluster_max_points_per_voxel: 50
         max_voxels_per_cluster: 300
+        min_cluster_size_m: 0.0
+      animal:
+        tolerance_m: 0.3
+        voxel_leaf_size_m: 0.1
+        min_points_per_voxel: 1
+        min_points_per_cluster: 3
+        large_cluster_voxel_count_threshold: 5
+        large_cluster_max_points_per_voxel: 30
+        max_voxels_per_cluster: 200
         min_cluster_size_m: 0.0
       hazard:
         tolerance_m: 0.3

--- a/perception/autoware_euclidean_cluster/docs/label-based-euclidean-cluster.md
+++ b/perception/autoware_euclidean_cluster/docs/label-based-euclidean-cluster.md
@@ -48,6 +48,14 @@ a throttled warning.
 9. Estimate a shape and pose for each cluster with `ShapeEstimator`.
 10. If shape estimation does not produce a usable shape, fall back to an axis-aligned bounding shape computed from the clustered points.
 
+### Filtering Clusters
+
+Clusters can optionally be filtered by their physical size after label-based clustering.
+The size is the diameter of an XY bounding circle around the cluster, which is independent of object heading.
+`min_cluster_size_m: 0.0` disables the global filter.
+A value under `label_cluster_params.<label>.min_cluster_size_m` overrides it for that label; setting the override to `0.0` disables filtering for that label.
+This allows large-object labels such as `truck` to reject implausibly small false positives while leaving small `hazard` objects unfiltered.
+
 ## Shape Estimation Behavior
 
 After clustering, the node converts each cluster into a `DetectedObject`.
@@ -87,6 +95,7 @@ hazards need a tighter tolerance and finer voxels than cars or trucks.
 - Each override block accepts the same keys as the global clustering parameters.
 - Any key omitted inside an override block falls back to the corresponding global value, so a block
   only needs to list the parameters that differ.
+- `min_cluster_size_m` is also accepted in an override block and is evaluated after clustering.
 - A label with no override block (or an empty one) keeps using the global default cluster.
 - When a label-specific cluster is created, the node logs `Using custom cluster params for label '<label>'` at startup.
 

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp
@@ -43,18 +43,18 @@ public:
   EuclideanClusterInterface() = default;
   EuclideanClusterInterface(
     bool use_height, int min_points_per_cluster, int max_cluster_size,
-    float min_cluster_size_m = 0.0F)
+    float min_cluster_size = 0.0F)
   : use_height_(use_height),
     min_points_per_cluster_(min_points_per_cluster),
     max_cluster_size_(max_cluster_size),
-    min_cluster_size_m_(min_cluster_size_m)
+    min_cluster_size_(min_cluster_size)
   {
   }
   virtual ~EuclideanClusterInterface() = default;
   void setUseHeight(bool use_height) { use_height_ = use_height; }
   void setMinClusterSize(int size) { min_points_per_cluster_ = size; }
   void setMaxClusterSize(int size) { max_cluster_size_ = size; }
-  void setMinClusterSizeM(float size) { min_cluster_size_m_ = size; }
+  void setMinClusterSize(float size) { min_cluster_size_ = size; }
 
   /// @brief Cluster a point cloud and return only point copies for each cluster.
   /// @details This legacy overload preserves the existing interface for callers that do not need
@@ -78,7 +78,7 @@ protected:
   /// @details A zero threshold disables this filter.
   bool isClusterLargeEnough(const pcl::PointCloud<pcl::PointXYZ> & cluster) const
   {
-    if (min_cluster_size_m_ <= 0.0F || cluster.empty()) {
+    if (min_cluster_size_ <= 0.0F || cluster.empty()) {
       return true;
     }
 
@@ -95,13 +95,13 @@ protected:
     for (const auto & point : cluster) {
       radius = std::max(radius, std::hypot(point.x - center_x, point.y - center_y));
     }
-    return 2.0F * radius >= min_cluster_size_m_;
+    return 2.0F * radius >= min_cluster_size_;
   }
 
   bool use_height_ = true;
   int min_points_per_cluster_;
   int max_cluster_size_;
-  float min_cluster_size_m_ = 0.0F;
+  float min_cluster_size_ = 0.0F;
 };
 
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp
@@ -78,8 +78,11 @@ protected:
   /// @details A zero threshold disables this filter.
   bool isClusterLargeEnough(const pcl::PointCloud<pcl::PointXYZ> & cluster) const
   {
-    if (min_cluster_size_ <= 0.0F || cluster.empty()) {
+    if (min_cluster_size_ <= 0.0F) {
       return true;
+    }
+    if (cluster.empty()) {
+      return false;
     }
 
     float center_x = 0.0F;

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp
@@ -23,6 +23,7 @@
 #include <pcl/point_types.h>
 #include <pcl/types.h>
 
+#include <algorithm>
 #include <vector>
 
 namespace autoware::euclidean_cluster
@@ -40,16 +41,20 @@ class EuclideanClusterInterface
 {
 public:
   EuclideanClusterInterface() = default;
-  EuclideanClusterInterface(bool use_height, int min_points_per_cluster, int max_cluster_size)
+  EuclideanClusterInterface(
+    bool use_height, int min_points_per_cluster, int max_cluster_size,
+    float min_cluster_size_m = 0.0F)
   : use_height_(use_height),
     min_points_per_cluster_(min_points_per_cluster),
-    max_cluster_size_(max_cluster_size)
+    max_cluster_size_(max_cluster_size),
+    min_cluster_size_m_(min_cluster_size_m)
   {
   }
   virtual ~EuclideanClusterInterface() = default;
   void setUseHeight(bool use_height) { use_height_ = use_height; }
   void setMinClusterSize(int size) { min_points_per_cluster_ = size; }
   void setMaxClusterSize(int size) { max_cluster_size_ = size; }
+  void setMinClusterSizeM(float size) { min_cluster_size_m_ = size; }
 
   /// @brief Cluster a point cloud and return only point copies for each cluster.
   /// @details This legacy overload preserves the existing interface for callers that do not need
@@ -69,9 +74,34 @@ public:
     tier4_perception_msgs::msg::DetectedObjectsWithFeature & output_clusters) = 0;
 
 protected:
+  /// @brief Return whether a cluster meets the configured XY physical-size threshold.
+  /// @details A zero threshold disables this filter.
+  bool isClusterLargeEnough(const pcl::PointCloud<pcl::PointXYZ> & cluster) const
+  {
+    if (min_cluster_size_m_ <= 0.0F || cluster.empty()) {
+      return true;
+    }
+
+    float center_x = 0.0F;
+    float center_y = 0.0F;
+    for (const auto & point : cluster) {
+      center_x += point.x;
+      center_y += point.y;
+    }
+    center_x /= static_cast<float>(cluster.size());
+    center_y /= static_cast<float>(cluster.size());
+
+    float radius = 0.0F;
+    for (const auto & point : cluster) {
+      radius = std::max(radius, std::hypot(point.x - center_x, point.y - center_y));
+    }
+    return 2.0F * radius >= min_cluster_size_m_;
+  }
+
   bool use_height_ = true;
   int min_points_per_cluster_;
   int max_cluster_size_;
+  float min_cluster_size_m_ = 0.0F;
 };
 
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
@@ -33,7 +33,8 @@ public:
   VoxelGridBasedEuclideanCluster(
     bool use_height, int min_points_per_cluster, float tolerance, float voxel_leaf_size,
     int min_points_per_voxel, int large_cluster_voxel_count_threshold,
-    int large_cluster_max_points_per_voxel, int max_voxels_per_cluster);
+    int large_cluster_max_points_per_voxel, int max_voxels_per_cluster,
+    float min_cluster_size_m = 0.0F);
   bool cluster(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) override;

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
@@ -34,7 +34,7 @@ public:
     bool use_height, int min_points_per_cluster, float tolerance, float voxel_leaf_size,
     int min_points_per_voxel, int large_cluster_voxel_count_threshold,
     int large_cluster_max_points_per_voxel, int max_voxels_per_cluster,
-    float min_cluster_size_m = 0.0F);
+    float min_cluster_size = 0.0F);
   bool cluster(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) override;

--- a/perception/autoware_euclidean_cluster/lib/euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/euclidean_cluster.cpp
@@ -113,7 +113,9 @@ bool EuclideanCluster::cluster(
       indexed_cluster.cloud.width = indexed_cluster.cloud.points.size();
       indexed_cluster.cloud.height = 1;
       indexed_cluster.cloud.is_dense = false;
-      clusters.push_back(std::move(indexed_cluster));
+      if (isClusterLargeEnough(indexed_cluster.cloud)) {
+        clusters.push_back(std::move(indexed_cluster));
+      }
     }
   }
   return true;

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -213,7 +213,6 @@ LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
   if (!shape_estimator_) {
     throw std::invalid_argument("LabelBasedEuclideanCluster: shape_estimator is null");
   }
-
   // Build label-to-group index for confusable merging
   for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
     for (const auto label : confusable_groups_[g].labels) {

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -213,6 +213,7 @@ LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
   if (!shape_estimator_) {
     throw std::invalid_argument("LabelBasedEuclideanCluster: shape_estimator is null");
   }
+
   // Build label-to-group index for confusable merging
   for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
     for (const auto label : confusable_groups_[g].labels) {

--- a/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -32,9 +32,9 @@ namespace autoware::euclidean_cluster
 VoxelGridBasedEuclideanCluster::VoxelGridBasedEuclideanCluster(
   bool use_height, int min_points_per_cluster, float tolerance, float voxel_leaf_size,
   int min_points_per_voxel, int large_cluster_voxel_count_threshold,
-  int large_cluster_max_points_per_voxel, int max_voxels_per_cluster, float min_cluster_size_m)
+  int large_cluster_max_points_per_voxel, int max_voxels_per_cluster, float min_cluster_size)
 // max cluster size is unused by this cluster executer (oversized groups are split, not dropped).
-: EuclideanClusterInterface(use_height, min_points_per_cluster, 0, min_cluster_size_m),
+: EuclideanClusterInterface(use_height, min_points_per_cluster, 0, min_cluster_size),
   tolerance_(tolerance),
   voxel_leaf_size_(voxel_leaf_size),
   min_points_per_voxel_(min_points_per_voxel),

--- a/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -32,9 +32,9 @@ namespace autoware::euclidean_cluster
 VoxelGridBasedEuclideanCluster::VoxelGridBasedEuclideanCluster(
   bool use_height, int min_points_per_cluster, float tolerance, float voxel_leaf_size,
   int min_points_per_voxel, int large_cluster_voxel_count_threshold,
-  int large_cluster_max_points_per_voxel, int max_voxels_per_cluster)
+  int large_cluster_max_points_per_voxel, int max_voxels_per_cluster, float min_cluster_size_m)
 // max cluster size is unused by this cluster executer (oversized groups are split, not dropped).
-: EuclideanClusterInterface(use_height, min_points_per_cluster, 0),
+: EuclideanClusterInterface(use_height, min_points_per_cluster, 0, min_cluster_size_m),
   tolerance_(tolerance),
   voxel_leaf_size_(voxel_leaf_size),
   min_points_per_voxel_(min_points_per_voxel),
@@ -246,7 +246,8 @@ bool VoxelGridBasedEuclideanCluster::cluster(
     std::remove_if(
       clusters.begin(), clusters.end(),
       [this](const IndexedCluster & cluster) {
-        return static_cast<int>(cluster.cloud.size()) < min_points_per_cluster_;
+        return static_cast<int>(cluster.cloud.size()) < min_points_per_cluster_ ||
+               !isClusterLargeEnough(cluster.cloud);
       }),
     clusters.end());
 

--- a/perception/autoware_euclidean_cluster/schema/label_based_euclidean_cluster.schema.json
+++ b/perception/autoware_euclidean_cluster/schema/label_based_euclidean_cluster.schema.json
@@ -52,6 +52,12 @@
           "description": "Minimum semantic probability required for a point to be used.",
           "default": 0.3
         },
+        "min_cluster_size_m": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Minimum XY bounding-circle diameter for an output cluster in meters. Zero disables size filtering.",
+          "default": 0
+        },
         "use_shape_estimation_corrector": {
           "type": "boolean",
           "description": "Enable the shape estimation corrector.",
@@ -107,7 +113,8 @@
         "use_shape_estimation_corrector",
         "use_shape_estimation_filter",
         "use_boost_bbox_optimizer",
-        "shape_policy"
+        "shape_policy",
+        "min_cluster_size_m"
       ],
       "additionalProperties": false
     },
@@ -122,7 +129,12 @@
         "min_points_per_voxel": { "type": "integer" },
         "large_cluster_voxel_count_threshold": { "type": "integer" },
         "large_cluster_max_points_per_voxel": { "type": "integer" },
-        "max_voxels_per_cluster": { "type": "integer", "minimum": 1 }
+        "max_voxels_per_cluster": { "type": "integer", "minimum": 1 },
+        "min_cluster_size_m": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Optional per-label minimum XY bounding-circle diameter in meters. Overrides the global value; zero disables filtering for this label."
+        }
       },
       "additionalProperties": false
     },

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -166,6 +166,8 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
   // Load parameters
   const auto min_probability = static_cast<float>(
     autoware_utils_rclcpp::get_or_declare_parameter<double>(*this, "min_probability"));
+  const auto min_cluster_size_m = static_cast<float>(
+    autoware_utils_rclcpp::get_or_declare_parameter<double>(*this, "min_cluster_size_m"));
   const auto shape_policy = to_shape_policy(
     autoware_utils_rclcpp::get_or_declare_parameter<uint8_t>(*this, "shape_policy"));
 
@@ -191,8 +193,8 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
 
   auto default_cluster = std::make_shared<VoxelGridBasedEuclideanCluster>(
     use_height, min_points_per_cluster, tolerance, voxel_leaf_size, min_points_per_voxel,
-    large_cluster_voxel_count_threshold, large_cluster_max_points_per_voxel,
-    max_voxels_per_cluster);
+    large_cluster_voxel_count_threshold, large_cluster_max_points_per_voxel, max_voxels_per_cluster,
+    min_cluster_size_m);
 
   // Build per-label cluster overrides from label_cluster_params.<label_name>.* parameters
   std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>>
@@ -202,11 +204,12 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
       const auto & label_name = entry.first;
       const auto & label_prefix = entry.second;
       auto has = [&](const std::string & key) { return this->has_parameter(label_prefix + key); };
+
       if (
         !has("tolerance_m") && !has("min_points_per_cluster") && !has("use_height") &&
         !has("voxel_leaf_size_m") && !has("min_points_per_voxel") &&
         !has("large_cluster_voxel_count_threshold") && !has("large_cluster_max_points_per_voxel") &&
-        !has("max_voxels_per_cluster")) {
+        !has("max_voxels_per_cluster") && !has("min_cluster_size_m")) {
         continue;
       }
 
@@ -240,7 +243,8 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
         get_int("min_points_per_voxel", min_points_per_voxel),
         get_int("large_cluster_voxel_count_threshold", large_cluster_voxel_count_threshold),
         get_int("large_cluster_max_points_per_voxel", large_cluster_max_points_per_voxel),
-        get_int("max_voxels_per_cluster", max_voxels_per_cluster));
+        get_int("max_voxels_per_cluster", max_voxels_per_cluster),
+        get_float("min_cluster_size_m", min_cluster_size_m));
 
       RCLCPP_INFO(get_logger(), "Using custom cluster params for label '%s'", label_name.c_str());
     }

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
@@ -194,6 +194,46 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsAreGroupedByLabel)
   EXPECT_TRUE(has_ped);
 }
 
+TEST_F(LabelBasedEuclideanClusterTest, PerLabelMinimumSizeFiltersTinyTruckButKeepsHazard)
+{
+  const auto truck_point_label = static_cast<std::uint8_t>(PointCloudClassification::TRUCK);
+  const auto hazard_point_label = static_cast<std::uint8_t>(PointCloudClassification::HAZARD);
+
+  const auto truck_object_label = static_cast<std::uint8_t>(ObjectClassification::TRUCK);
+  const auto hazard_object_label = static_cast<std::uint8_t>(ObjectClassification::HAZARD);
+
+  auto truck_cluster =
+    std::make_shared<VoxelGridBasedEuclideanCluster>(false, 2, 1.0, 0.1, 1, 10, 100, 10000, 1.0F);
+  auto hazard_cluster =
+    std::make_shared<VoxelGridBasedEuclideanCluster>(false, 2, 1.0, 0.1, 1, 10, 100, 10000, 0.0F);
+  LabelBasedEuclideanCluster cluster(
+    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{
+      {truck_object_label, truck_cluster},
+      {hazard_object_label, hazard_cluster},
+    },
+    shape_estimator_);
+
+  auto pc = create_pointcloud(
+    {0.0F, 0.05F, 0.10F, 5.0F, 5.05F, 5.10F}, {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F},
+    {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F},
+    {
+      truck_point_label,
+      truck_point_label,
+      truck_point_label,
+      hazard_point_label,
+      hazard_point_label,
+      hazard_point_label,
+    });
+
+  const auto result = cluster.process(pc);
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->objects.objects.size(), 1U);
+  EXPECT_EQ(
+    result->objects.objects.front().classification.front().label, ObjectClassification::HAZARD);
+}
+
 // ============================================================================
 // Probability Filtering Tests
 // ============================================================================

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
@@ -75,7 +75,7 @@ protected:
       rclcpp::Parameter("use_shape_estimation_corrector", false),
       rclcpp::Parameter("use_shape_estimation_filter", false),
       rclcpp::Parameter("use_boost_bbox_optimizer", false),
-    };
+      rclcpp::Parameter("min_cluster_size_m", 0.0)};
 
     parameters.insert(parameters.end(), extra_parameters.begin(), extra_parameters.end());
 


### PR DESCRIPTION
## Description

This pull request adds physical-size filtering for clustered object in `EuclideanClusterInterface`  to reduce false-positive detection caused by implausibly small segmentation clusters.

**Changes**

- Add min_cluster_size_m to `EuclideanClusterInterface`.
  - Default: 1.5 (disabled if the value is 0.0)
  - Uses the XY bounding-circle diameter of each cluster.

- Apply the filter in `EuclideanCluster` and `VoxelGridBasedEuclideanCluster`.
- Support global and per-label configuration.
- Keep HAZARD unfiltered to preserve detection of small hazard objects.

**Configuration**

```yaml
min_cluster_size_m: 1.5 # default threshold

label_cluster_params:
  hazard:
      min_cluster_size_m: 0.0 # disable not to filter small objects
```

## Related links

**Parent Issue:**

- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RDDR-1044?focusedCommentId=327724&sourceType=mention&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&xpis=eyJicmlkZ2UiOiJub3RpZmljYXRpb25EcmF3ZXIiLCJpZCI6IjE3ODcyOTc4MjE4NjUiLCJzb3VyY2UiOiJjb25mbHVlbmNlIn0%3D#comment-327724)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Package build succeeded.
- `test_label_based_euclidean_cluster` / `test_label_based_euclidean_cluster_node` passed.
- JSON and YAML configuration validation passed.

I confirmed this feature worked as expected:

- Before...Tiny truck (pink) appears behind the ego
- After...No truck appears

| Before | After |
|-----------|-------|
|<img width="3840" height="2160" alt="Screenshot from 2026-08-26 16-14-50" src="https://github.com/user-attachments/assets/b1545163-e3c2-481d-8869-5551bef1635f" /> |  <img width="3840" height="2160" alt="Screenshot from 2026-08-26 16-15-02" src="https://github.com/user-attachments/assets/6f7117cf-b6d6-4f7e-8e9d-b56dbed690c6" /> |


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

🔴⬆️ -->

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `min_cluster_size_m`   | `double` | `1.5`         | Minimum XY bounding-circle diameter for an output cluster in meters. Zero disables size filtering. |

<!-- ⬇️🔴

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
