### PR TITLE
chore(trajectory_gate): add remap args

### DIFF
--- a/planning/autoware_trajectory_gate/config/trajectory_gate.param.yaml
+++ b/planning/autoware_trajectory_gate/config/trajectory_gate.param.yaml
@@ -3,8 +3,8 @@
     trajectory_warn_duration: 0.3
     trajectory_error_duration: 0.5
 
-    source_ids: [100, 200, 300]
+    source_ids: [101, 102, 103]
     source:
-      100: { name: main }
-      200: { name: mrm1 }
-      300: { name: mrm2 }
+      101: { name: main }
+      102: { name: mrm1 }
+      103: { name: mrm2 }

--- a/planning/autoware_trajectory_gate/launch/trajectory_gate.launch.xml
+++ b/planning/autoware_trajectory_gate/launch/trajectory_gate.launch.xml
@@ -1,7 +1,13 @@
 <launch>
   <arg name="config" default="$(find-pkg-share autoware_trajectory_gate)/config/trajectory_gate.param.yaml"/>
+  <arg name="output/trajectory" default="output/trajectory"/>
+
+  <!-- Enabled if "main" is listed in config source name -->
+  <arg name="inputs/main/trajectory" default="inputs/main/trajectory"/>
 
   <node pkg="autoware_trajectory_gate" exec="trajectory_gate_node">
     <param from="$(var config)"/>
+    <remap from="~/output/trajectory" to="$(var output/trajectory)"/>
+    <remap from="~/inputs/main/trajectory" to="$(var inputs/main/trajectory)"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

Add argument to remap input and ouput trajectory name. And modify sample source IDs.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/12497

## How was this PR tested?

The real vehicle evaluation was performed with all PRs in https://github.com/autowarefoundation/autoware_universe/issues/12497.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
