### PR TITLE
feat(operation_mode_transition_manager): add driving mode interface

### DIFF
--- a/control/autoware_operation_mode_transition_manager/package.xml
+++ b/control/autoware_operation_mode_transition_manager/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/control/autoware_operation_mode_transition_manager/src/autonomous_mode_transition_flag_node.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/autonomous_mode_transition_flag_node.cpp
@@ -15,6 +15,7 @@
 #include "autonomous_mode_transition_flag_node.hpp"
 
 #include <memory>
+#include <string>
 
 namespace autoware::operation_mode_transition_manager
 {
@@ -30,6 +31,12 @@ AutonomousModeTransitionFlagNode::AutonomousModeTransitionFlagNode(
     create_publisher<ModeChangeAvailable>("/system/command_mode/transition/available", 1);
   pub_transition_completed_ =
     create_publisher<ModeChangeAvailable>("/system/command_mode/transition/completed", 1);
+
+  pub_driving_mode_available_ = create_publisher<DiagnosticArray>("/diagnostics", 1);
+  pub_driving_mode_stable_ = create_publisher<DrivingModeFlag>("/system/driving_mode/stable", 1);
+  sub_driving_mode_info_ = create_subscription<DrivingModeInfo>(
+    "/system/driving_mode/info", rclcpp::QoS(1).transient_local(),
+    [this](const DrivingModeInfo & msg) { on_driving_mode_info(msg); });
 
   pub_debug_ = create_publisher<ModeChangeBase::DebugInfo>("~/debug_info", 1);
 
@@ -53,6 +60,8 @@ void AutonomousModeTransitionFlagNode::on_timer()
   const auto stamp = get_clock()->now();
   publish(pub_transition_available_, stamp, is_available);
   publish(pub_transition_completed_, stamp, is_completed);
+  publish_driving_mode_available(is_available);
+  publish_driving_mode_stable(is_completed);
 
   ModeChangeBase::DebugInfo debug = autonomous_mode_->getDebugInfo();
   debug.stamp = stamp;
@@ -84,6 +93,46 @@ InputData AutonomousModeTransitionFlagNode::take_data()
   }
 
   return data;
+}
+
+void AutonomousModeTransitionFlagNode::on_driving_mode_info(const DrivingModeInfo & msg)
+{
+  for (const auto & item : msg.items) {
+    if (item.name == "autonomous") {
+      driving_mode_id_ = item.mode;
+      break;
+    }
+  }
+}
+
+void AutonomousModeTransitionFlagNode::publish_driving_mode_stable(bool flag) const
+{
+  if (!driving_mode_id_) {
+    return;
+  }
+
+  tier4_system_msgs::msg::DrivingModeFlagItem item;
+  item.mode = driving_mode_id_.value();
+  item.flag = flag;
+
+  DrivingModeFlag msg;
+  msg.stamp = now();
+  msg.items = {item};
+  pub_driving_mode_stable_->publish(msg);
+}
+
+void AutonomousModeTransitionFlagNode::publish_driving_mode_available(bool flag) const
+{
+  using diagnostic_msgs::msg::DiagnosticStatus;
+
+  DiagnosticStatus status;
+  status.level = flag ? DiagnosticStatus::OK : DiagnosticStatus::ERROR;
+  status.name = std::string(get_name()) + ": mode_change_available";
+
+  DiagnosticArray msg;
+  msg.header.stamp = now();
+  msg.status = {status};
+  pub_driving_mode_available_->publish(msg);
 }
 
 }  // namespace autoware::operation_mode_transition_manager

--- a/control/autoware_operation_mode_transition_manager/src/autonomous_mode_transition_flag_node.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/autonomous_mode_transition_flag_node.hpp
@@ -20,6 +20,9 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <tier4_system_msgs/msg/driving_mode_flag.hpp>
+#include <tier4_system_msgs/msg/driving_mode_info.hpp>
 #include <tier4_system_msgs/msg/mode_change_available.hpp>
 
 #include <memory>
@@ -34,6 +37,9 @@ public:
 
 private:
   using ModeChangeAvailable = tier4_system_msgs::msg::ModeChangeAvailable;
+  using DrivingModeFlag = tier4_system_msgs::msg::DrivingModeFlag;
+  using DrivingModeInfo = tier4_system_msgs::msg::DrivingModeInfo;
+  using DiagnosticArray = diagnostic_msgs::msg::DiagnosticArray;
   void on_timer();
   InputData take_data();
 
@@ -51,6 +57,15 @@ private:
     this, "trajectory_follower_control_cmd"};
 
   std::unique_ptr<ModeChangeBase> autonomous_mode_;
+
+  // Driving mode interface
+  rclcpp::Subscription<DrivingModeInfo>::SharedPtr sub_driving_mode_info_;
+  rclcpp::Publisher<DrivingModeFlag>::SharedPtr pub_driving_mode_stable_;
+  rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_driving_mode_available_;
+  void on_driving_mode_info(const DrivingModeInfo & msg);
+  void publish_driving_mode_stable(bool flag) const;
+  void publish_driving_mode_available(bool flag) const;
+  std::optional<uint32_t> driving_mode_id_;  // Refer to the driving_mode_manager for this ID.
 };
 
 }  // namespace autoware::operation_mode_transition_manager


### PR DESCRIPTION
## Description

Add interface for driving mode management. Publishes the transition available and transition complete (stable) flag for autonomous mode. 

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/12497

## How was this PR tested?

The vehicle evaluation was performed with all PRs in https://github.com/autowarefoundation/autoware_universe/issues/12497.

## Notes for reviewers

None.

## Interface changes

None.

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `/diagnostics` | `diagnostic_msgs/msg/DiagnosticArray` | transition available flag |
| Added | Pub | `/system/driving_mode/stable` | `tier4_system_msgs/msg/DrivingModeFlag` | transition complete flag |
| Added | Sub | `/system/driving_mode/info` | `tier4_system_msgs/msg/DrivingModeInfo` | to get autonomous mode ID |

## Effects on system behavior

None.
