### PR TITLE
fix(perception): complete node design files for label-based euclidean cluster and PTv3

### DIFF
--- a/perception/autoware_detected_object_feature_remover/design/DetectedObjectFeatureRemover.node.yaml
+++ b/perception/autoware_detected_object_feature_remover/design/DetectedObjectFeatureRemover.node.yaml
@@ -8,7 +8,7 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::detected_object_feature_remover::DetectedObjectFeatureRemoverNode
+  plugin: autoware::detected_object_feature_remover::DetectedObjectFeatureRemover
   executable: detected_object_feature_remover_node
   node_output: screen
 

--- a/perception/autoware_euclidean_cluster/design/LabelBasedEuclideanCluster.node.yaml
+++ b/perception/autoware_euclidean_cluster/design/LabelBasedEuclideanCluster.node.yaml
@@ -1,0 +1,45 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: LabelBasedEuclideanCluster.node
+
+package:
+  name: autoware_euclidean_cluster
+  provider: autoware
+
+launch:
+  plugin: autoware::euclidean_cluster::LabelBasedEuclideanClusterNode
+  executable: label_based_euclidean_cluster_node
+  node_output: screen
+
+# interfaces
+# the input cloud carries per-point semantic labels; clustering and shape estimation run per label
+subscribers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: input/pointcloud
+
+publishers:
+  - name: objects
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: output/objects
+  - name: clustered_pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: output/pointcloud
+
+# parameters
+param_files:
+  - name: param_path
+    schema: schema/label_based_euclidean_cluster.schema.json
+    default: config/label_based_euclidean_cluster.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: cluster
+    trigger_conditions:
+      - on_input: pointcloud
+    outcomes:
+      - to_output: objects
+      - to_output: clustered_pointcloud

--- a/perception/autoware_ptv3/design/PTv3.node.yaml
+++ b/perception/autoware_ptv3/design/PTv3.node.yaml
@@ -39,17 +39,42 @@ publishers:
 
 # parameters
 param_files:
-  - name: model_param
+  - name: model_param_path
+    schema: schema/ptv3.schema.json
     default: config/ptv3.param.yaml
-  - name: backbone_ml_package_param
-    default: ml_package_backbone_ptv3.param.yaml
-  - name: d_head_ml_package_param
-    default: ml_package_d_head_ptv3.param.yaml
+    allow_substs: true
+  - name: encoder_ml_package_param_path
+    schema: schema/ml_package_ptv3.schema.json
+    default: config/ml_package_ptv3_encoder.param.yaml
+  - name: seg3d_head_ml_package_param_path
+    schema: schema/ml_package_ptv3.schema.json
+    default: config/ml_package_ptv3_seg3d_head.param.yaml
+  - name: det3d_head_ml_package_param_path
+    schema: schema/ml_package_ptv3.schema.json
+    default: config/ml_package_ptv3_det3d_head.param.yaml
 
+# launch-arg scope: the model param file resolves its artifact paths and head switches against these
 param_values:
   - name: build_only
     type: bool
     default: false
+    description: If true, the node will only build the model and exit.
+  - name: model_path
+    type: str
+    default: $(var data_path)/ptv3
+    description: The directory containing the model artifacts.
+  - name: model_variant
+    type: str
+    default: ptv3
+    description: The model variant selecting the artifact file names.
+  - name: use_seg3d_head
+    type: bool
+    default: true
+    description: Enable the segmentation 3D head.
+  - name: use_det3d_head
+    type: bool
+    default: true
+    description: Enable the detection 3D head.
 
 # processes
 processes:
@@ -59,3 +84,4 @@ processes:
     outcomes:
       - to_output: objects
       - to_output: pointcloud_segmentation
+      - to_output: pointcloud_filtered


### PR DESCRIPTION
## Description

Node design files for perception nodes.

- `autoware_euclidean_cluster`: `LabelBasedEuclideanCluster.node.yaml`. Subscribes the label-carrying pointcloud, publishes detected objects and the clustered pointcloud.
- `autoware_ptv3`: per-head ml_package param files (`encoder`, `seg3d_head`, `det3d_head`), `model_param_path` with substitutions enabled, schema references, the `pointcloud_filtered` output, and the `model_path` / `model_variant` / `use_seg3d_head` / `use_det3d_head` launch args that `config/ptv3.param.yaml` resolves against.
- `autoware_detected_object_feature_remover`: plugin name `autoware::detected_object_feature_remover::DetectedObjectFeatureRemover`, as registered by `RCLCPP_COMPONENTS_REGISTER_NODE`.

Design files only.

## Related links

**Parent Issue:**

- <https://github.com/autowarefoundation/autoware_universe/issues/13093>

- <https://github.com/autowarefoundation/autoware_universe/pull/13254>

## How was this PR tested?

Plugin names, executables, topic names, param file names and schema paths checked against `CMakeLists.txt`, the node constructors and the `config/` and `schema/` directories. `pre-commit` passes.

## Notes for reviewers

The PTv3 launch args are what the substitutions in `config/ptv3.param.yaml` (`$(var model_path)`, `$(var model_variant)`, `$(var use_*_head)`) resolve against, so a generated launcher needs them declared in the design.

## Interface changes

None.

## Effects on system behavior

None.
