### PR TITLE
feat(simulator): add node design file for dummy traffic light publisher

### DIFF
--- a/simulator/autoware_dummy_traffic_light_publisher/design/DummyTrafficLightPublisher.node.yaml
+++ b/simulator/autoware_dummy_traffic_light_publisher/design/DummyTrafficLightPublisher.node.yaml
@@ -1,0 +1,39 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: DummyTrafficLightPublisher.node
+
+package:
+  name: autoware_dummy_traffic_light_publisher
+  provider: autoware
+
+launch:
+  executable: autoware_dummy_traffic_light_publisher_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+  - name: traffic_signals
+    message_type: autoware_perception_msgs/msg/TrafficLightGroupArray
+    global: /simulator/input/traffic_signals
+
+publishers:
+  - name: traffic_signals
+    message_type: autoware_perception_msgs/msg/TrafficLightGroupArray
+
+# parameters
+param_files:
+  - name: dummy_traffic_light_publisher_param_file
+    default: config/dummy_traffic_light_publisher.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: publish
+    trigger_conditions:
+      - periodic: 10.0
+    outcomes:
+      - to_output: traffic_signals


### PR DESCRIPTION
## Description

Node design file for `autoware_dummy_traffic_light_publisher`.

Subscribes `~/input/vector_map` and the traffic signal input pinned to the global topic `/simulator/input/traffic_signals`, publishes `~/output/traffic_signals` on a 10 Hz timer, and carries `config/dummy_traffic_light_publisher.param.yaml`.

Design file only.

## Related links

**Parent Issue:**

- <https://github.com/autowarefoundation/autoware_universe/issues/13093>

- <https://github.com/autowarefoundation/autoware_universe/pull/13253>

## How was this PR tested?

Executable name, topic names and param file checked against `CMakeLists.txt` and the node constructor. `pre-commit` passes.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
