### PR TITLE
feat(trajectory_modifier, minimum_rule_based_planner): improve obstacle stop feature

### DIFF
--- a/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
+++ b/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
@@ -37,6 +37,8 @@ struct ObstacleTypeParameters
   double surround_check_front_distance{0.0};
   double surround_check_side_distance{0.0};
   double surround_check_back_distance{0.0};
+  bool enable_bbox_check{true};
+  bool enable_polygon_check{true};
 };
 
 struct Parameters

--- a/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
@@ -187,6 +187,21 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByDynamicOb
     return std::nullopt;
   }
 
+  auto is_enabled = [&](const auto & object, const std::string & label) {
+    const auto enable_check_iter = parameters_.object_type_enable_check.find(label);
+    if (
+      enable_check_iter == parameters_.object_type_enable_check.end() ||
+      !enable_check_iter->second) {
+      return false;
+    }
+    const auto & object_param = parameters_.obstacle_types_map.at(label);
+    if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX)
+      return object_param.enable_bbox_check;
+    if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON)
+      return object_param.enable_polygon_check;
+    return false;
+  };
+
   autoware_perception_msgs::msg::PredictedObject nearest_object;
   double minimum_distance = std::numeric_limits<double>::max();
   bool was_minimum_distance_updated = false;
@@ -199,12 +214,7 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByDynamicOb
     }
 
     const auto & str_label = label_iter->second;
-    const auto enable_check_iter = parameters_.object_type_enable_check.find(str_label);
-    if (
-      enable_check_iter == parameters_.object_type_enable_check.end() ||
-      !enable_check_iter->second) {
-      continue;
-    }
+    if (!is_enabled(object, str_label)) continue;
 
     const auto & object_param = parameters_.obstacle_types_map.at(str_label);
     const double front_margin = object_param.surround_check_front_distance;

--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -5,7 +5,6 @@ The `traffic_light_compliance_checker` package provides a deterministic validati
 ## Core Features
 
 1. **Signal State Tracking (`TrafficLightStatusTracker`)**
-
    - Eliminates perception jitter and signal flickering by maintaining a temporal state history for each traffic light group ID.
    - Leverages stable duration thresholds before validating a transition to `RED` or `AMBER`.
    - Utilizes a hysteresis buffer to sustain known states during transient object occlusions.

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -51,7 +51,6 @@
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
-        max_velocity_th: 3.0     # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
         safety_buffer: 0.1       # safety buffer to expand object shape [m]
@@ -73,16 +72,16 @@
       rss_params:
         enable: true
         object_decel:
-          car: 1.5
-          truck: 1.5
-          bus: 1.5
-          trailer: 1.5
+          car: 1.6
+          truck: 1.6
+          bus: 1.6
+          trailer: 1.6
           motorcycle: 2.0
           bicycle: 3.0
           pedestrian: 5.0
-        ego_decel: 2.5           # [m/s^2]
-        reaction_time: 0.2       # [s]
-        safety_margin: 2.0       # [m]
+        ego_decel: 2.0           # [m/s^2]
+        reaction_time: 0.4       # [s]
+        safety_margin: 3.0       # [m]
         lookahead_horizon: 1.5   # [s]
 
     surround_obstacle_stop:

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -50,7 +50,9 @@
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       objects:
-        object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
+        target_objects:
+          bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"]
+          polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"]
         stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
         safety_buffer: 0.1       # safety buffer to expand object shape [m]
@@ -88,7 +90,9 @@
       enable: true
       use_objects: true
       use_pointcloud: false
-      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"] # object types to consider for surround obstacle stop
+      target_objects:
+        bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
+        polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"]
       front_distance_th:
         car: 0.5
         truck: 0.5

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -160,10 +160,18 @@ minimum_rule_based_planner:
       validation:
         bounds<>: [0.0, 10.0]
     objects:
-      object_types:
-        type: string_array
-        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
-        description: object types to consider for obstacle stop
+      target_objects:
+        bbox:
+          type: string_array
+          default_value:
+            [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, unknown]
+          description: types of bounding box shaped objects to consider for obstacle stop
+          read_only: false
+        polygon:
+          type: string_array
+          default_value: [car, truck, bus, trailer, pedestrian, hazard, unknown]
+          description: types of polygon shaped objects to consider for obstacle stop
+          read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.3
@@ -332,12 +340,18 @@ minimum_rule_based_planner:
       default_value: false
       description: enable the use of pointcloud for surround obstacle stop
       read_only: false
-    object_types:
-      type: string_array
-      default_value:
-        [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
-      description: types of objects to consider for surround obstacle stop
-      read_only: false
+    target_objects:
+      bbox:
+        type: string_array
+        default_value:
+          [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
+        description: types of bounding box shaped objects to consider for surround obstacle stop
+        read_only: false
+      polygon:
+        type: string_array
+        default_value: [car, truck, bus, trailer, pedestrian, hazard, animal, unknown]
+        description: types of polygon shaped objects to consider for surround obstacle stop
+        read_only: false
     base_distance_th:
       &distance_th_template {
         type: double,

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -164,10 +164,6 @@ minimum_rule_based_planner:
         type: string_array
         default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
         description: object types to consider for obstacle stop
-      max_velocity_th:
-        type: double
-        default_value: 3.0
-        description: maximum velocity threshold for target object [m/s]
       stopped_velocity_th:
         type: double
         default_value: 0.3
@@ -255,25 +251,25 @@ minimum_rule_based_planner:
       object_decel:
         car:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: deceleration for car type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
         truck:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: deceleration for truck type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
         bus:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: deceleration for bus type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
         trailer:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: deceleration for trailer type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
@@ -297,19 +293,19 @@ minimum_rule_based_planner:
             bounds<>: [0.0, 10.0]
       ego_decel:
         type: double
-        default_value: 2.5
+        default_value: 2.0
         description: deceleration for ego vehicle used in RSS calculation [m/s^2]
         validation:
           bounds<>: [0.0, 10.0]
       reaction_time:
         type: double
-        default_value: 0.2
+        default_value: 0.4
         description: reaction time used in RSS calculation [s]
         validation:
           bounds<>: [0.0, 10.0]
       safety_margin:
         type: double
-        default_value: 2.0
+        default_value: 3.0
         description: safety margin used in RSS calculation [m]
         validation:
           bounds<>: [0.0, 10.0]

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -194,18 +194,11 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
-  // TODO(Quda): Port the latest modifier logic
-  std::optional<CollisionPoint> collision_point;
-  if (params_.rss_params.enable) {
-    collision_point = get_nearest_object_collision(
-      traj_points, context_->vehicle_info, predicted_objects, object_decel_map_,
-      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
-      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-      params_.rss_params.lookahead_horizon, colliding_object);
-  } else {
-    collision_point =
-      get_nearest_object_collision(traj_points, predicted_objects, colliding_object);
-  }
+  auto collision_point = get_nearest_object_collision(
+    traj_points, context_->vehicle_info, active_objects, object_decel_map_,
+    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
 
   if (collision_point) debug_data_.colliding_object = colliding_object;
   return collision_point;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -33,6 +33,7 @@ namespace autoware::minimum_rule_based_planner::plugin
 {
 using autoware::trajectory_processor::utils::clamp_stop_point_arc_length;
 using autoware::trajectory_processor::utils::insert_stop_point;
+using autoware::trajectory_processor::utils::replace_trajectory_with_stop_point;
 using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_object_collision;
 using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_pcd_collision;
 using autoware::trajectory_processor::utils::obstacle_stop::get_trajectory_shape;
@@ -161,22 +162,10 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const Modifier
     data.acceleration_ptr->accel.accel.linear.x, params_.nominal_stopping_decel,
     params_.stopping_jerk);
 
-  if (!insert_stop_point(
-        traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length))
-    return;
-
   if (
     target_stop_point_arc_length < params_.arrived_distance_threshold ||
-    !insert_stop_point(
-      traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
-    auto p = traj_points.front();
-    traj_points.clear();
-    p.longitudinal_velocity_mps = 0.0;
-    p.acceleration_mps2 = 0.0;
-    p.time_from_start = rclcpp::Duration::from_seconds(0.0);
-    traj_points.push_back(p);
-    p.time_from_start = rclcpp::Duration::from_seconds(0.1);
-    traj_points.push_back(p);
+    !insert_stop_point(traj_points, target_stop_point_arc_length)) {
+    replace_trajectory_with_stop_point(traj_points, data.odometry_ptr->pose.pose);
   }
 
   const auto & stop_pose = traj_points.back().pose;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -55,8 +55,9 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
       params_.pointcloud.clustering.max_size);
 
   object_filter_ = std::make_unique<trajectory_processor::utils::obstacle_stop::ObjectFilter>(
-    params_.objects.object_types, params_.objects.stopped_velocity_th,
-    params_.objects.max_lateral_velocity_th, params_.objects.safety_buffer);
+    params_.objects.target_objects.bbox, params_.objects.target_objects.polygon,
+    params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th,
+    params_.objects.safety_buffer);
 
   pub_clustered_pointcloud_ =
     get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -55,9 +55,8 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
       params_.pointcloud.clustering.max_size);
 
   object_filter_ = std::make_unique<trajectory_processor::utils::obstacle_stop::ObjectFilter>(
-    params_.objects.object_types, params_.objects.max_velocity_th,
-    params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th,
-    params_.objects.safety_buffer);
+    params_.objects.object_types, params_.objects.stopped_velocity_th,
+    params_.objects.max_lateral_velocity_th, params_.objects.safety_buffer);
 
   pub_clustered_pointcloud_ =
     get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);
@@ -195,7 +194,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
-    traj_points, context_->vehicle_info, active_objects, object_decel_map_,
+    traj_points, context_->vehicle_info, predicted_objects, object_decel_map_,
     params_.rss_params.ego_decel, params_.rss_params.reaction_time,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
     params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -59,7 +59,8 @@ public:
     {
       const auto & p = params_.objects;
       object_filter_->set_params(
-        p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+        p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
+        p.max_lateral_velocity_th, p.safety_buffer);
     }
 
     {

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -59,8 +59,7 @@ public:
     {
       const auto & p = params_.objects;
       object_filter_->set_params(
-        p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
-        p.safety_buffer);
+        p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
     }
 
     {

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -37,12 +37,15 @@ using SurroundObstacleStopParams =
   autoware::minimum_rule_based_planner::plugin::MinimumRuleBasedPlannerParams::SurroundObstacleStop;
 
 ObstacleTypeParameters to_obstacle_type_parameters(
-  const double front_distance, const double side_distance, const double back_distance)
+  const double front_distance, const double side_distance, const double back_distance,
+  const bool enable_bbox_check = true, const bool enable_polygon_check = true)
 {
   ObstacleTypeParameters parameters;
   parameters.surround_check_front_distance = front_distance;
   parameters.surround_check_side_distance = side_distance;
   parameters.surround_check_back_distance = back_distance;
+  parameters.enable_bbox_check = enable_bbox_check;
+  parameters.enable_polygon_check = enable_polygon_check;
   return parameters;
 }
 
@@ -51,48 +54,57 @@ Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & pa
   Parameters parameters;
   parameters.pointcloud_enable_check = params.use_pointcloud;
 
-  const std::unordered_set<std::string> enabled_object_types(
-    params.object_types.begin(), params.object_types.end());
+  const std::unordered_set<std::string> bbox_enabled_object_types(
+    params.target_objects.bbox.begin(), params.target_objects.bbox.end());
+  const std::unordered_set<std::string> polygon_enabled_object_types(
+    params.target_objects.polygon.begin(), params.target_objects.polygon.end());
 
-  const auto set_object_enable = [&](const std::string & label) {
-    parameters.object_type_enable_check[label] = enabled_object_types.count(label) > 0;
+  auto is_bbox_enabled = [&](const std::string & label) {
+    return bbox_enabled_object_types.count(label) > 0;
   };
-  set_object_enable("unknown");
-  set_object_enable("car");
-  set_object_enable("truck");
-  set_object_enable("bus");
-  set_object_enable("trailer");
-  set_object_enable("motorcycle");
-  set_object_enable("bicycle");
-  set_object_enable("pedestrian");
-  set_object_enable("hazard");
-  set_object_enable("animal");
+  auto is_polygon_enabled = [&](const std::string & label) {
+    return polygon_enabled_object_types.count(label) > 0;
+  };
 
   const auto & front = params.front_distance_th;
   const auto & side = params.side_distance_th;
   const auto & back = params.back_distance_th;
+  auto get_object_distance_thresholds = [&](const std::string & label) {
+    if (label == "car") return std::make_tuple(front.car, side.car, back.car);
+    if (label == "truck") return std::make_tuple(front.truck, side.truck, back.truck);
+    if (label == "bus") return std::make_tuple(front.bus, side.bus, back.bus);
+    if (label == "trailer") return std::make_tuple(front.trailer, side.trailer, back.trailer);
+    if (label == "motorcycle")
+      return std::make_tuple(front.motorcycle, side.motorcycle, back.motorcycle);
+    if (label == "bicycle") return std::make_tuple(front.bicycle, side.bicycle, back.bicycle);
+    if (label == "pedestrian")
+      return std::make_tuple(front.pedestrian, side.pedestrian, back.pedestrian);
+    if (label == "hazard") return std::make_tuple(front.hazard, side.hazard, back.hazard);
+    if (label == "animal") return std::make_tuple(front.animal, side.animal, back.animal);
+    return std::make_tuple(front.unknown, side.unknown, back.unknown);
+  };
+
+  const auto set_object_params = [&](const std::string & label) {
+    const auto bbox_enabled = is_bbox_enabled(label);
+    const auto polygon_enabled = is_polygon_enabled(label);
+    const auto [front, side, back] = get_object_distance_thresholds(label);
+    parameters.object_type_enable_check[label] = bbox_enabled || polygon_enabled;
+    parameters.obstacle_types_map[label] =
+      to_obstacle_type_parameters(front, side, back, bbox_enabled, polygon_enabled);
+  };
+  set_object_params("unknown");
+  set_object_params("car");
+  set_object_params("truck");
+  set_object_params("bus");
+  set_object_params("trailer");
+  set_object_params("motorcycle");
+  set_object_params("bicycle");
+  set_object_params("pedestrian");
+  set_object_params("hazard");
+  set_object_params("animal");
 
   parameters.obstacle_types_map["pointcloud"] =
     to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
-  parameters.obstacle_types_map["unknown"] =
-    to_obstacle_type_parameters(front.unknown, side.unknown, back.unknown);
-  parameters.obstacle_types_map["car"] = to_obstacle_type_parameters(front.car, side.car, back.car);
-  parameters.obstacle_types_map["truck"] =
-    to_obstacle_type_parameters(front.truck, side.truck, back.truck);
-  parameters.obstacle_types_map["bus"] = to_obstacle_type_parameters(front.bus, side.bus, back.bus);
-  parameters.obstacle_types_map["trailer"] =
-    to_obstacle_type_parameters(front.trailer, side.trailer, back.trailer);
-  parameters.obstacle_types_map["motorcycle"] =
-    to_obstacle_type_parameters(front.motorcycle, side.motorcycle, back.motorcycle);
-  parameters.obstacle_types_map["bicycle"] =
-    to_obstacle_type_parameters(front.bicycle, side.bicycle, back.bicycle);
-  parameters.obstacle_types_map["pedestrian"] =
-    to_obstacle_type_parameters(front.pedestrian, side.pedestrian, back.pedestrian);
-  parameters.obstacle_types_map["hazard"] =
-    to_obstacle_type_parameters(front.hazard, side.hazard, back.hazard);
-  parameters.obstacle_types_map["animal"] =
-    to_obstacle_type_parameters(front.animal, side.animal, back.animal);
-
   return parameters;
 }
 }  // namespace

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -240,22 +240,46 @@
             "objects": {
               "type": "object",
               "properties": {
-                "object_types": {
-                  "type": "array",
-                  "description": "Object types",
-                  "default": [
-                    "car",
-                    "truck",
-                    "bus",
-                    "trailer",
-                    "motorcycle",
-                    "bicycle",
-                    "pedestrian",
-                    "hazard"
-                  ],
-                  "items": {
-                    "type": "string"
-                  }
+                "target_objects": {
+                  "type": "object",
+                  "properties": {
+                    "bbox": {
+                      "type": "array",
+                      "description": "Types of bounding box shaped objects to consider for obstacle stop",
+                      "default": [
+                        "car",
+                        "truck",
+                        "bus",
+                        "trailer",
+                        "motorcycle",
+                        "bicycle",
+                        "pedestrian",
+                        "hazard",
+                        "unknown"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "polygon": {
+                      "type": "array",
+                      "description": "Types of polygon shaped objects to consider for obstacle stop",
+                      "default": [
+                        "car",
+                        "truck",
+                        "bus",
+                        "trailer",
+                        "pedestrian",
+                        "hazard",
+                        "unknown"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
                 },
                 "stopped_velocity_th": {
                   "type": "number",
@@ -475,24 +499,48 @@
               "description": "Enable the use of pointcloud for surround obstacle stop",
               "default": false
             },
-            "object_types": {
-              "type": "array",
-              "description": "Types of objects to consider for surround obstacle stop",
-              "default": [
-                "car",
-                "truck",
-                "bus",
-                "trailer",
-                "motorcycle",
-                "bicycle",
-                "pedestrian",
-                "hazard",
-                "animal",
-                "unknown"
-              ],
-              "items": {
-                "type": "string"
-              }
+            "target_objects": {
+              "type": "object",
+              "properties": {
+                "bbox": {
+                  "type": "array",
+                  "description": "Types of bounding box shaped objects to consider for surround obstacle stop",
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "motorcycle",
+                    "bicycle",
+                    "pedestrian",
+                    "hazard",
+                    "animal",
+                    "unknown"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "polygon": {
+                  "type": "array",
+                  "description": "Types of polygon shaped objects to consider for surround obstacle stop",
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "pedestrian",
+                    "hazard",
+                    "animal",
+                    "unknown"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [],
+              "additionalProperties": false
             },
             "front_distance_th": {
               "type": "object",

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -257,12 +257,6 @@
                     "type": "string"
                   }
                 },
-                "max_velocity_th": {
-                  "type": "number",
-                  "description": "Max velocity threshold [m/s]",
-                  "default": 1.0,
-                  "minimum": 0.0
-                },
                 "stopped_velocity_th": {
                   "type": "number",
                   "description": "Velocity threshold for target object to be considered as stopped [m/s]",

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -55,6 +55,7 @@
       enable_stop_for_objects: true
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
+      minimum_stop_margin: 3.0 # [m]
       lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
 

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -68,7 +68,9 @@
         grace_period: 0.2 # [s]
 
       objects:
-        object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
+        target_objects:
+          bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"]
+          polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"]
         stopped_velocity_th: 0.3 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
         safety_buffer: 0.1 # [m] safety buffer to expand object shape
@@ -107,7 +109,9 @@
     surround_obstacle_stop:
       use_objects: true
       use_pointcloud: false
-      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
+      target_objects:
+        bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
+        polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"]
       front_distance_th:
         car: 0.5
         truck: 0.5

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -69,7 +69,6 @@
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
-        max_velocity_th: 3.0      # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.3 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
         safety_buffer: 0.1 # [m] safety buffer to expand object shape
@@ -91,17 +90,17 @@
       rss_params:
         enable: true
         object_decel:
-          car: 1.5
-          truck: 1.5
-          bus: 1.5
-          trailer: 1.5
+          car: 1.6
+          truck: 1.6
+          bus: 1.6
+          trailer: 1.6
           motorcycle: 2.0
           bicycle: 3.0
           pedestrian: 5.0
           animal: 5.0
-        ego_decel: 2.5 # [m/s^2]
-        reaction_time: 0.2 # [s]
-        safety_margin: 2.0 # [m]
+        ego_decel: 2.0 # [m/s^2]
+        reaction_time: 0.4 # [s]
+        safety_margin: 3.0 # [m]
         lookahead_horizon: 1.5 # [s]
 
     # Surround Obstacle Stop Plugin Parameters

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -141,6 +141,8 @@ struct TrajectoryShape
   autoware_utils_geometry::Box2d bounding_box;
   double trajectory_length;
   double forward_traj_length;
+
+  [[nodiscard]] double ego_arc_length() const { return trajectory_length - forward_traj_length; }
 };
 
 struct DebugData

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -21,6 +21,7 @@
 #include <rclcpp/time.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -55,6 +56,7 @@ using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using autoware_utils_geometry::MultiPolygon2d;
@@ -251,15 +253,20 @@ struct ObjectFilter
    * @param safety_buffer Safety buffer to expand object shape [m].
    */
   ObjectFilter(
-    const std::vector<std::string> & object_type_strings, const double stopped_velocity_th,
+    const std::vector<std::string> & bbox_object_type_strings,
+    const std::vector<std::string> & polygon_object_type_strings, const double stopped_velocity_th,
     const double max_lateral_velocity_th, const double safety_buffer)
   : stopped_velocity_th_(stopped_velocity_th),
     max_lateral_velocity_th_(max_lateral_velocity_th),
     safety_buffer_(safety_buffer)
   {
-    for (const auto & object_type_string : object_type_strings) {
+    for (const auto & object_type_string : bbox_object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
-      object_types_.emplace(string_to_object_type.at(object_type_string));
+      bbox_object_types_.emplace(string_to_object_type.at(object_type_string));
+    }
+    for (const auto & object_type_string : polygon_object_type_strings) {
+      if (string_to_object_type.count(object_type_string) == 0) continue;
+      polygon_object_types_.emplace(string_to_object_type.at(object_type_string));
     }
   }
 
@@ -278,7 +285,11 @@ struct ObjectFilter
               ? ObjectClassification::UNKNOWN
               : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
           if (classification_to_object_type.count(label) == 0) return true;
-          return object_types_.count(classification_to_object_type.at(label)) == 0;
+          if (object.shape.type == Shape::BOUNDING_BOX)
+            return bbox_object_types_.count(classification_to_object_type.at(label)) == 0;
+          if (object.shape.type == Shape::POLYGON)
+            return polygon_object_types_.count(classification_to_object_type.at(label)) == 0;
+          return true;
         }),
       objects.objects.end());
   }
@@ -302,13 +313,19 @@ struct ObjectFilter
    * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
    */
   void set_params(
-    const std::vector<std::string> & object_type_strings, const double stopped_velocity_th,
+    const std::vector<std::string> & bbox_object_type_strings,
+    const std::vector<std::string> & polygon_object_type_strings, const double stopped_velocity_th,
     const double max_lateral_velocity_th, const double safety_buffer)
   {
-    object_types_.clear();
-    for (const auto & object_type_string : object_type_strings) {
+    bbox_object_types_.clear();
+    polygon_object_types_.clear();
+    for (const auto & object_type_string : bbox_object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
-      object_types_.emplace(string_to_object_type.at(object_type_string));
+      bbox_object_types_.emplace(string_to_object_type.at(object_type_string));
+    }
+    for (const auto & object_type_string : polygon_object_type_strings) {
+      if (string_to_object_type.count(object_type_string) == 0) continue;
+      polygon_object_types_.emplace(string_to_object_type.at(object_type_string));
     }
     stopped_velocity_th_ = stopped_velocity_th;
     max_lateral_velocity_th_ = max_lateral_velocity_th;
@@ -316,7 +333,8 @@ struct ObjectFilter
   }
 
 private:
-  std::unordered_set<ObjectType> object_types_;
+  std::unordered_set<ObjectType> bbox_object_types_;
+  std::unordered_set<ObjectType> polygon_object_types_;
   double stopped_velocity_th_;
   double max_lateral_velocity_th_;
   double safety_buffer_;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -246,17 +246,14 @@ struct ObjectFilter
   /**
    * @brief Construct a filter from allowed type names and speed thresholds.
    * @param object_type_strings Allowed object classes (see string_to_object_type).
-   * @param max_velocity_th Remove objects with longitudinal twist.x above this [m/s].
    * @param stopped_velocity_th Used when filtering by target area for "moving" vs stopped.
    * @param max_lateral_velocity_th Lateral speed threshold for the exiting-object heuristic [m/s].
    * @param safety_buffer Safety buffer to expand object shape [m].
    */
   ObjectFilter(
-    const std::vector<std::string> & object_type_strings, const double max_velocity_th,
-    const double stopped_velocity_th, const double max_lateral_velocity_th,
-    const double safety_buffer)
-  : max_velocity_th_(max_velocity_th),
-    stopped_velocity_th_(stopped_velocity_th),
+    const std::vector<std::string> & object_type_strings, const double stopped_velocity_th,
+    const double max_lateral_velocity_th, const double safety_buffer)
+  : stopped_velocity_th_(stopped_velocity_th),
     max_lateral_velocity_th_(max_lateral_velocity_th),
     safety_buffer_(safety_buffer)
   {
@@ -276,8 +273,6 @@ struct ObjectFilter
       std::remove_if(
         objects.objects.begin(), objects.objects.end(),
         [&](const auto & object) {
-          if (object.kinematics.initial_twist_with_covariance.twist.linear.x > max_velocity_th_)
-            return true;
           const auto label =
             object.classification.empty()
               ? ObjectClassification::UNKNOWN
@@ -307,16 +302,14 @@ struct ObjectFilter
    * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
    */
   void set_params(
-    const std::vector<std::string> & object_type_strings, const double max_velocity_th,
-    const double stopped_velocity_th, const double max_lateral_velocity_th,
-    const double safety_buffer)
+    const std::vector<std::string> & object_type_strings, const double stopped_velocity_th,
+    const double max_lateral_velocity_th, const double safety_buffer)
   {
     object_types_.clear();
     for (const auto & object_type_string : object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
       object_types_.emplace(string_to_object_type.at(object_type_string));
     }
-    max_velocity_th_ = max_velocity_th;
     stopped_velocity_th_ = stopped_velocity_th;
     max_lateral_velocity_th_ = max_lateral_velocity_th;
     safety_buffer_ = safety_buffer;
@@ -324,7 +317,6 @@ struct ObjectFilter
 
 private:
   std::unordered_set<ObjectType> object_types_;
-  double max_velocity_th_;
   double stopped_velocity_th_;
   double max_lateral_velocity_th_;
   double safety_buffer_;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -205,20 +205,6 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
-/**
- * @brief Find the nearest obstacle along the path using each object's footprint polygon at the
- * current time.
- * @details For every target object, polygon vertices are projected onto arc length along the
- * trajectory; the minimum over all vertices and objects defines the collision point.
- * @param trajectory_points Reference path.
- * @param target_objects Predicted objects to test (typically already filtered).
- * @param[out] colliding_object Object that yielded the minimum arc-length collision.
- * @return Collision point and arc length, or nullopt if inputs are invalid or no objects.
- */
-std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
-  PredictedObject & colliding_object);
-
 using ObjectDecelMap = std::unordered_map<ObjectType, double>;
 
 /**
@@ -251,7 +237,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
   const double ego_decel, const double reaction_time, const double safety_margin,
-  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object);
+  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object,
+  const bool use_rss_check = true);
 
 /// Filters predicted objects by semantic type, speed, and spatial relationship to the trajectory.
 struct ObjectFilter

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp
@@ -35,7 +35,7 @@ double calculate_distance_to_last_point(
 
 void replace_trajectory_with_stop_point(
   TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & ego_pose,
-  const double time_step);
+  const double time_step = 0.1);
 
 bool is_ego_vehicle_moving(
   const geometry_msgs::msg::Twist & twist, const double velocity_threshold);
@@ -51,7 +51,7 @@ bool stop_point_exists(
   const double duplicate_check_threshold = 0.0);
 
 bool insert_stop_point(
-  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double traj_length);
+  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double time_step = 0.1);
 
 }  // namespace autoware::trajectory_processor::utils
 

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -142,6 +142,13 @@ trajectory_processor_params:
       validation:
         bounds<>: [0.0, 100.0]
       read_only: false
+    minimum_stop_margin:
+      type: double
+      default_value: 3.0
+      description: Minimum distance to maintain from an obstacle when stopped [m]
+      validation:
+        bounds<>: [0.0, 100.0]
+      read_only: false
     lateral_margin:
       type: double
       default_value: 0.5

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -214,13 +214,6 @@ trajectory_processor_params:
         default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
         description: Types of objects to consider for obstacle stop
         read_only: false
-      max_velocity_th:
-        type: double
-        default_value: 5.0
-        description: Maximum velocity threshold for target object to be considered for obstacle stop [m/s]
-        validation:
-          bounds<>: [0.0, 100.0]
-        read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.25

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -209,11 +209,18 @@ trajectory_processor_params:
         read_only: false
 
     objects:
-      object_types:
-        type: string_array
-        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
-        description: Types of objects to consider for obstacle stop
-        read_only: false
+      target_objects:
+        bbox:
+          type: string_array
+          default_value:
+            [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, unknown]
+          description: Types of bounding box shaped objects to consider for obstacle stop
+          read_only: false
+        polygon:
+          type: string_array
+          default_value: [car, truck, bus, trailer, pedestrian, hazard, unknown]
+          description: Types of polygon shaped objects to consider for obstacle stop
+          read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.25
@@ -405,11 +412,18 @@ trajectory_processor_params:
       default_value: true
       description: Enable the use of pointcloud for surround obstacle stop
       read_only: false
-    object_types:
-      type: string_array
-      default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian]
-      description: Types of objects to consider for surround obstacle stop
-      read_only: false
+    target_objects:
+      bbox:
+        type: string_array
+        default_value:
+          [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
+        description: Types of bounding box shaped objects to consider for surround obstacle stop
+        read_only: false
+      polygon:
+        type: string_array
+        default_value: [car, truck, bus, trailer, pedestrian, hazard, animal, unknown]
+        description: Types of polygon shaped objects to consider for surround obstacle stop
+        read_only: false
     base_distance_th:
       &distance_th_template {
         type: double,

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -219,22 +219,46 @@
             "objects": {
               "type": "object",
               "properties": {
-                "object_types": {
-                  "type": "array",
-                  "description": "Object types to consider for obstacle stop",
-                  "default": [
-                    "car",
-                    "truck",
-                    "bus",
-                    "trailer",
-                    "motorcycle",
-                    "bicycle",
-                    "pedestrian",
-                    "hazard"
-                  ],
-                  "items": {
-                    "type": "string"
-                  }
+                "target_objects": {
+                  "type": "object",
+                  "properties": {
+                    "bbox": {
+                      "type": "array",
+                      "description": "Types of bounding box shaped objects to consider for obstacle stop",
+                      "default": [
+                        "car",
+                        "truck",
+                        "bus",
+                        "trailer",
+                        "motorcycle",
+                        "bicycle",
+                        "pedestrian",
+                        "hazard",
+                        "unknown"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "polygon": {
+                      "type": "array",
+                      "description": "Types of polygon shaped objects to consider for obstacle stop",
+                      "default": [
+                        "car",
+                        "truck",
+                        "bus",
+                        "trailer",
+                        "pedestrian",
+                        "hazard",
+                        "unknown"
+                      ],
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
                 },
                 "stopped_velocity_th": {
                   "type": "number",
@@ -447,13 +471,48 @@
               "description": "Enable the use of pointcloud for surround obstacle stop",
               "default": true
             },
-            "object_types": {
-              "type": "array",
-              "description": "Types of objects to consider for surround obstacle stop",
-              "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"],
-              "items": {
-                "type": "string"
-              }
+            "target_objects": {
+              "type": "object",
+              "properties": {
+                "bbox": {
+                  "type": "array",
+                  "description": "Types of bounding box shaped objects to consider for surround obstacle stop",
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "motorcycle",
+                    "bicycle",
+                    "pedestrian",
+                    "hazard",
+                    "animal",
+                    "unknown"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "polygon": {
+                  "type": "array",
+                  "description": "Types of polygon shaped objects to consider for surround obstacle stop",
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "pedestrian",
+                    "hazard",
+                    "animal",
+                    "unknown"
+                  ],
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [],
+              "additionalProperties": false
             },
             "front_distance_th": {
               "type": "object",

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -155,6 +155,12 @@
               "default": 6,
               "minimum": 0
             },
+            "minimum_stop_margin": {
+              "type": "number",
+              "description": "Minimum distance to maintain from an obstacle when stopped [m]",
+              "default": 3.0,
+              "minimum": 0.0
+            },
             "lateral_margin": {
               "type": "number",
               "description": "Lateral margin on top of ego width from trajectory to consider for obstacle stop [m]",

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -236,12 +236,6 @@
                     "type": "string"
                   }
                 },
-                "max_velocity_th": {
-                  "type": "number",
-                  "description": "Maximum velocity threshold for target object [m/s]",
-                  "default": 5,
-                  "minimum": 0
-                },
                 "stopped_velocity_th": {
                   "type": "number",
                   "description": "Velocity threshold for target object to be considered as stopped [m/s]",

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -78,7 +78,8 @@ void ObstacleStop::on_initialize(const TrajectoryProcessorParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+      p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
+      p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {
@@ -126,7 +127,8 @@ void ObstacleStop::update_params(const TrajectoryProcessorParams & params)
   {
     const auto & p = params_.objects;
     object_filter_->set_params(
-      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+      p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
+      p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -78,8 +78,7 @@ void ObstacleStop::on_initialize(const TrajectoryProcessorParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
-      p.safety_buffer);
+      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {
@@ -127,8 +126,7 @@ void ObstacleStop::update_params(const TrajectoryProcessorParams & params)
   {
     const auto & p = params_.objects;
     object_filter_->set_params(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
-      p.safety_buffer);
+      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -331,16 +331,11 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
-  auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
-    if (!params_.rss_params.enable) {
-      return get_nearest_object_collision(traj_points, active_objects, colliding_object);
-    }
-    return get_nearest_object_collision(
-      traj_points, context_->vehicle_info, active_objects, object_decel_map_,
-      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
-      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-      params_.rss_params.lookahead_horizon, colliding_object);
-  });
+  auto collision_point = get_nearest_object_collision(
+    traj_points, context_->vehicle_info, active_objects, object_decel_map_,
+    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
 
   if (collision_point) debug_data_.colliding_object = colliding_object;
 

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -215,26 +215,32 @@ bool ObstacleStop::set_stop_point(
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::set_stop_point", *get_time_keeper());
 
-  const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
+  const auto ego_longitudinal_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  const auto target_stop_margin = params_.stop_margin + ego_longitudinal_offset;
   const auto target_stop_point_arc_length = utils::clamp_stop_point_arc_length(
-    nearest_collision_point_->arc_length - stop_margin,
+    nearest_collision_point_->arc_length - target_stop_margin,
     debug_data_.trajectory_shape.trajectory_length, input.current_odometry->twist.twist.linear.x,
     input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
     stopping_params_.jerk_limit);
 
-  if (
-    utils::stop_point_exists(
-      traj_points, target_stop_point_arc_length, params_.duplicate_check_threshold)) {
+  // actual stop margin from ego front to collision point
+  const auto stop_margin =
+    nearest_collision_point_->arc_length - (target_stop_point_arc_length + ego_longitudinal_offset);
+  const auto overlap_th =
+    stop_margin > params_.minimum_stop_margin ? params_.duplicate_check_threshold : 0.0;
+  if (utils::stop_point_exists(traj_points, target_stop_point_arc_length, overlap_th)) {
     RCLCPP_WARN_THROTTLE(
       get_node_ptr()->get_logger(), *get_clock(), 1000,
       "[TM ObstacleStop] Preceding (or duplicate) stop point exists, skip inserting stop point");
     return false;
   }
 
+  const auto ego_arc_length = debug_data_.trajectory_shape.ego_arc_length();
+  const auto ego_to_stop_arc_length = target_stop_point_arc_length - ego_arc_length;
+
   if (
-    target_stop_point_arc_length < stopping_params_.arrived_distance_threshold ||
-    !utils::insert_stop_point(
-      traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
+    ego_to_stop_arc_length < stopping_params_.arrived_distance_threshold ||
+    !utils::insert_stop_point(traj_points, target_stop_point_arc_length, trajectory_time_step_)) {
     utils::replace_trajectory_with_stop_point(
       traj_points, input.current_odometry->pose.pose, trajectory_time_step_);
   }
@@ -243,10 +249,8 @@ bool ObstacleStop::set_stop_point(
   const auto & ego_pose = input.current_odometry->pose.pose;
   auto distance =
     motion_utils::calcSignedArcLength(traj_points, ego_pose.position, stop_pose.position);
-  if (std::isnan(distance)) distance = 0.0;
-  planning_factor_interface_->add(
-    distance, stop_pose, autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
-    safety_factors_);
+  if (std::isnan(distance) || distance < 1e-3) distance = 0.0;
+  planning_factor_interface_->add(distance, stop_pose, PlanningFactor::STOP, safety_factors_);
 
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 1000,

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -36,12 +36,15 @@ using autoware::obstacle_proximity_checker::ObstacleTypeParameters;
 using autoware::obstacle_proximity_checker::Parameters;
 
 ObstacleTypeParameters to_obstacle_type_parameters(
-  const double front_distance, const double side_distance, const double back_distance)
+  const double front_distance, const double side_distance, const double back_distance,
+  const bool enable_bbox_check = true, const bool enable_polygon_check = true)
 {
   ObstacleTypeParameters parameters;
   parameters.surround_check_front_distance = front_distance;
   parameters.surround_check_side_distance = side_distance;
   parameters.surround_check_back_distance = back_distance;
+  parameters.enable_bbox_check = enable_bbox_check;
+  parameters.enable_polygon_check = enable_polygon_check;
   return parameters;
 }
 
@@ -51,47 +54,57 @@ Parameters to_proximity_checker_parameters(
   Parameters parameters;
   parameters.pointcloud_enable_check = params.use_pointcloud;
 
-  const std::unordered_set<std::string> enabled_object_types(
-    params.object_types.begin(), params.object_types.end());
+  const std::unordered_set<std::string> bbox_enabled_object_types(
+    params.target_objects.bbox.begin(), params.target_objects.bbox.end());
+  const std::unordered_set<std::string> polygon_enabled_object_types(
+    params.target_objects.polygon.begin(), params.target_objects.polygon.end());
 
-  const auto set_object_enable = [&](const std::string & label) {
-    parameters.object_type_enable_check[label] = enabled_object_types.count(label) > 0;
+  auto is_bbox_enabled = [&](const std::string & label) {
+    return bbox_enabled_object_types.count(label) > 0;
   };
-  set_object_enable("unknown");
-  set_object_enable("car");
-  set_object_enable("truck");
-  set_object_enable("bus");
-  set_object_enable("trailer");
-  set_object_enable("motorcycle");
-  set_object_enable("bicycle");
-  set_object_enable("pedestrian");
-  set_object_enable("hazard");
-  set_object_enable("animal");
+  auto is_polygon_enabled = [&](const std::string & label) {
+    return polygon_enabled_object_types.count(label) > 0;
+  };
 
   const auto & front = params.front_distance_th;
   const auto & side = params.side_distance_th;
   const auto & back = params.back_distance_th;
+  auto get_object_distance_thresholds = [&](const std::string & label) {
+    if (label == "car") return std::make_tuple(front.car, side.car, back.car);
+    if (label == "truck") return std::make_tuple(front.truck, side.truck, back.truck);
+    if (label == "bus") return std::make_tuple(front.bus, side.bus, back.bus);
+    if (label == "trailer") return std::make_tuple(front.trailer, side.trailer, back.trailer);
+    if (label == "motorcycle")
+      return std::make_tuple(front.motorcycle, side.motorcycle, back.motorcycle);
+    if (label == "bicycle") return std::make_tuple(front.bicycle, side.bicycle, back.bicycle);
+    if (label == "pedestrian")
+      return std::make_tuple(front.pedestrian, side.pedestrian, back.pedestrian);
+    if (label == "hazard") return std::make_tuple(front.hazard, side.hazard, back.hazard);
+    if (label == "animal") return std::make_tuple(front.animal, side.animal, back.animal);
+    return std::make_tuple(front.unknown, side.unknown, back.unknown);
+  };
+
+  const auto set_object_params = [&](const std::string & label) {
+    const auto bbox_enabled = is_bbox_enabled(label);
+    const auto polygon_enabled = is_polygon_enabled(label);
+    const auto [front, side, back] = get_object_distance_thresholds(label);
+    parameters.object_type_enable_check[label] = bbox_enabled || polygon_enabled;
+    parameters.obstacle_types_map[label] =
+      to_obstacle_type_parameters(front, side, back, bbox_enabled, polygon_enabled);
+  };
+  set_object_params("unknown");
+  set_object_params("car");
+  set_object_params("truck");
+  set_object_params("bus");
+  set_object_params("trailer");
+  set_object_params("motorcycle");
+  set_object_params("bicycle");
+  set_object_params("pedestrian");
+  set_object_params("hazard");
+  set_object_params("animal");
 
   parameters.obstacle_types_map["pointcloud"] =
     to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
-  parameters.obstacle_types_map["unknown"] =
-    to_obstacle_type_parameters(front.unknown, side.unknown, back.unknown);
-  parameters.obstacle_types_map["car"] = to_obstacle_type_parameters(front.car, side.car, back.car);
-  parameters.obstacle_types_map["truck"] =
-    to_obstacle_type_parameters(front.truck, side.truck, back.truck);
-  parameters.obstacle_types_map["bus"] = to_obstacle_type_parameters(front.bus, side.bus, back.bus);
-  parameters.obstacle_types_map["trailer"] =
-    to_obstacle_type_parameters(front.trailer, side.trailer, back.trailer);
-  parameters.obstacle_types_map["motorcycle"] =
-    to_obstacle_type_parameters(front.motorcycle, side.motorcycle, back.motorcycle);
-  parameters.obstacle_types_map["bicycle"] =
-    to_obstacle_type_parameters(front.bicycle, side.bicycle, back.bicycle);
-  parameters.obstacle_types_map["pedestrian"] =
-    to_obstacle_type_parameters(front.pedestrian, side.pedestrian, back.pedestrian);
-  parameters.obstacle_types_map["hazard"] =
-    to_obstacle_type_parameters(front.hazard, side.hazard, back.hazard);
-  parameters.obstacle_types_map["animal"] =
-    to_obstacle_type_parameters(front.animal, side.animal, back.animal);
   return parameters;
 }
 }  // namespace

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -171,18 +171,9 @@ bool TrafficLightStop::set_stop_point(
 
   if (
     target_stop_point_arc_length < stopping_params_.arrived_distance_threshold ||
-    !utils::insert_stop_point(traj_points, target_stop_point_arc_length, trajectory_length)) {
-    traj_points = std::invoke([&]() {
-      TrajectoryPoints stop_points;
-      auto p = traj_points.front();
-      p.longitudinal_velocity_mps = 0.0;
-      p.acceleration_mps2 = 0.0;
-      p.time_from_start = rclcpp::Duration::from_seconds(0.0);
-      stop_points.push_back(p);
-      p.time_from_start = rclcpp::Duration::from_seconds(trajectory_time_step_);
-      stop_points.push_back(p);
-      return stop_points;
-    });
+    !utils::insert_stop_point(traj_points, target_stop_point_arc_length)) {
+    utils::replace_trajectory_with_stop_point(
+      traj_points, input.current_odometry->pose.pose, trajectory_time_step_);
   }
 
   const auto & stop_pose = traj_points.back().pose;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -67,50 +67,73 @@ double get_detection_length(
   return forward_traj_length + margin;
 }
 
-TrajectoryPoints extend_trajectory(
-  const TrajectoryPoints & trajectory_points, const double length, const double wheelbase_length)
+std::optional<std::pair<double, double>> get_curvature_at_end(
+  const TrajectoryPoints & trajectory_points, const double lookback_distance)
+{
+  // need at least 3 points to calculate curvature
+  if (trajectory_points.size() < 3) return std::nullopt;
+
+  const auto & last_p = trajectory_points.back();
+  const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(
+    trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
+  if (!lookback_pose) return std::nullopt;
+
+  const auto mid_pose = motion_utils::calcLongitudinalOffsetPose(
+    trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance / 2.0);
+  if (!mid_pose) return std::nullopt;
+
+  double curvature = 0.0;
+  try {
+    curvature = autoware_utils_geometry::calc_curvature(
+      lookback_pose.value().position, mid_pose.value().position, last_p.pose.position);
+  } catch (const std::exception &) {
+    return std::nullopt;
+  }
+
+  const auto yaw =
+    autoware_utils_geometry::calc_azimuth_angle(mid_pose.value().position, last_p.pose.position);
+  return std::make_pair(curvature, yaw);
+}
+
+TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, const double length)
 {
   if (length < 1e-3 || trajectory_points.empty()) return trajectory_points;
 
+  TrajectoryPoints extended_trajectory = trajectory_points;
+
   const auto & last_p = trajectory_points.back();
-  const auto yaw_last = tf2::getYaw(last_p.pose.orientation);
   constexpr double lookback_distance = 2.0;  // [m]
-  const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(
-    trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
+  const auto curvature_at_end = get_curvature_at_end(trajectory_points, lookback_distance);
+  const auto [curvature, yaw] = curvature_at_end
+                                  ? curvature_at_end.value()
+                                  : std::pair{0.0, tf2::getYaw(last_p.pose.orientation)};
 
-  auto steering_angle = 0.0;
-  if (lookback_pose) {
-    const auto lookback_yaw = tf2::getYaw(lookback_pose.value().orientation);
-    const auto delta_yaw = autoware_utils_geometry::normalize_radian(yaw_last - lookback_yaw);
-    const auto k = delta_yaw / lookback_distance;
-    steering_angle = std::atan(k * wheelbase_length);
-  }
-
-  if (std::abs(steering_angle) < 1e-3) {
-    auto extended_trajectory = trajectory_points;
+  const auto end_vel = last_p.longitudinal_velocity_mps;
+  constexpr double low_speed_threshold = 0.5;
+  constexpr double low_curvature_threshold = 1e-3;
+  if (std::abs(curvature) < low_curvature_threshold || end_vel < low_speed_threshold) {
     auto p = trajectory_points.back();
+    p.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
     p.pose = autoware_utils::calc_offset_pose(p.pose, length, 0, 0);
     extended_trajectory.push_back(p);
     return extended_trajectory;
   }
 
-  const auto turn_radius = wheelbase_length / std::tan(steering_angle);
-  const auto yaw = tf2::getYaw(last_p.pose.orientation);
-
+  const auto turn_radius = 1.0 / curvature;
   constexpr double step = 0.5;
-  TrajectoryPoints extended_trajectory;
+  TrajectoryPoints extension_points;
   for (auto d = length; d > 0; d -= step) {
     auto p = last_p;
     const auto beta = d / turn_radius;
     p.pose.position.x += turn_radius * (std::sin(yaw + beta) - std::sin(yaw));
     p.pose.position.y += turn_radius * (std::cos(yaw) - std::cos(yaw + beta));
     p.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw + beta);
-    extended_trajectory.push_back(p);
+    extension_points.push_back(p);
   }
-  std::reverse(extended_trajectory.begin(), extended_trajectory.end());
+  std::reverse(extension_points.begin(), extension_points.end());
 
   extended_trajectory.insert(
-    extended_trajectory.begin(), trajectory_points.begin(), trajectory_points.end());
+    extended_trajectory.end(), extension_points.begin(), extension_points.end());
   return extended_trajectory;
 }
 
@@ -137,7 +160,7 @@ TrajectoryShape get_trajectory_shape(
       return motion_utils::cropForwardPoints(
         trajectory_points, ego_pose.position, start_idx, detection_length);
     }
-    return extend_trajectory(trajectory_points, stop_margin, vehicle_info.wheel_base_m);
+    return extend_trajectory(trajectory_points, stop_margin);
   });
 
   autoware_utils_geometry::LineString2d ls_front_right;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -620,13 +620,14 @@ void ObstacleTracker::update_objects(
         existing_object.object.kinematics.initial_pose_with_covariance.pose.position);
       if (distance > min_distance) continue;
       // ignore orientation difference for cylinder objects
+      const bool is_symmetric =
+        std::abs(object.shape.dimensions.x - object.shape.dimensions.y) < 0.1;
       const auto yaw_diff =
-        object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER
-          ? 0.0
-          : std::abs(
-              autoware_utils_geometry::calc_yaw_deviation(
-                object.kinematics.initial_pose_with_covariance.pose,
-                existing_object.object.kinematics.initial_pose_with_covariance.pose));
+        is_symmetric ? 0.0
+                     : std::abs(
+                         autoware_utils_geometry::calc_yaw_deviation(
+                           object.kinematics.initial_pose_with_covariance.pose,
+                           existing_object.object.kinematics.initial_pose_with_covariance.pose));
       if (yaw_diff > object_yaw_th_) continue;
       min_distance = distance;
       closest_uuid = uuid;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -335,13 +335,13 @@ ObjectState get_object_state_at_time(
     motion_utils::findNearestSegmentIndex(trajectory_points, predicted_obj_pose.position);
   const auto p1 = trajectory_points.at(nearest_seg).pose.position;
   const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
-  auto lon_vel = std::invoke([&]() -> double {
+  auto lon_vel = [&]() {
     const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
     const Eigen::Rotation2Dd obj_rot(tf2::getYaw(predicted_obj_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
     const auto obj_vel_vector = obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y);
     return std::max(0.0, obj_vel_vector.dot(traj_dir));
-  });
+  }();
 
   const auto obj_polygon = autoware_utils::to_polygon2d(predicted_obj_pose, object.shape);
   auto min_arc_length = std::numeric_limits<double>::max();
@@ -413,14 +413,15 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
   bool is_dynamic_collision = false;
-  auto curr_arc_length = 0.0;
 
   for (const auto & object : target_objects.objects) {
     auto last_p = trajectory_points.front().pose.position;
+    auto curr_arc_length = 0.0;
     for (const auto & traj_p : trajectory_points) {
       const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
       if (t > lookahead_horizon) break;
       curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
+      last_p = traj_p.pose.position;
       const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
       const auto [safe, dynamic] =
@@ -433,7 +434,6 @@ std::optional<CollisionPoint> get_nearest_object_collision(
         nearest_collision_point = obj_state.nearest_point;
         is_dynamic_collision = dynamic;
       }
-      last_p = traj_p.pose.position;
       break;
     }
   }

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -379,9 +379,15 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
   const double ego_decel, const double reaction_time, const double safety_margin,
-  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object)
+  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object,
+  const bool use_rss_check)
 {
   if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+
+  // If RSS check is disabled, get the nearest object collision by pure geometric overlap.
+  if (!use_rss_check) {
+    return get_nearest_object_collision(trajectory_points, target_objects, colliding_object);
+  }
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
 
@@ -408,13 +414,14 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   bool found_collision = false;
   bool is_dynamic_collision = false;
   auto curr_arc_length = 0.0;
-  auto last_p = trajectory_points.front().pose.position;
-  for (const auto & traj_p : trajectory_points) {
-    const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
-    if (t > lookahead_horizon) break;
-    curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
-    const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
-    for (const auto & object : target_objects.objects) {
+
+  for (const auto & object : target_objects.objects) {
+    auto last_p = trajectory_points.front().pose.position;
+    for (const auto & traj_p : trajectory_points) {
+      const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
+      if (t > lookahead_horizon) break;
+      curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
+      const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
       const auto [safe, dynamic] =
         is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel);
@@ -426,8 +433,9 @@ std::optional<CollisionPoint> get_nearest_object_collision(
         nearest_collision_point = obj_state.nearest_point;
         is_dynamic_collision = dynamic;
       }
+      last_p = traj_p.pose.position;
+      break;
     }
-    last_p = traj_p.pose.position;
   }
 
   if (!found_collision) return std::nullopt;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/utils.cpp
@@ -143,7 +143,7 @@ bool insert_stop_point(
     return true;
   }
 
-  auto stop_idx = idx;
+  size_t stop_idx{};
   if (std::abs(distance - stop_point_arc_length) < overlap_threshold) {
     stop_idx = idx;
   } else if (std::abs(distance + seg_length - stop_point_arc_length) < overlap_threshold) {

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/utils.cpp
@@ -116,36 +116,47 @@ bool stop_point_exists(
 }
 
 bool insert_stop_point(
-  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double traj_length)
+  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double time_step)
 {
-  if (stop_point_arc_length < 1e-3) return false;
+  if (trajectory.empty()) return false;
 
-  const auto stop_index = [&]() -> size_t {
-    const auto index = motion_utils::insertStopPoint(stop_point_arc_length, trajectory);
-    if (index) return index.value();
+  if (stop_point_arc_length < 1e-3) {
+    replace_trajectory_with_stop_point(trajectory, trajectory.front().pose, time_step);
+    return true;
+  }
 
-    // TODO(Quda): this is a temporary fix, need to check why insertStopPoint fails when target
-    // distance is equal to trajectory length
-    if (stop_point_arc_length < traj_length) {
-      auto dist = 0.0;
-      auto it = std::adjacent_find(
-        trajectory.begin(), trajectory.end(), [&](const auto & p, const auto & next) {
-          dist += autoware_utils_geometry::calc_distance2d(p.pose.position, next.pose.position);
-          return dist >= stop_point_arc_length - 1e-3;
-        });
-      if (it != trajectory.end()) {
-        it->longitudinal_velocity_mps = 0.0;
-        it->acceleration_mps2 = 0.0;
-        return std::distance(trajectory.begin(), it);
-      }
-    }
+  constexpr double overlap_threshold = 0.1;
 
+  auto distance = 0.0;
+  auto seg_length = 0.0;
+  size_t idx = 0;
+  for (; idx < trajectory.size() - 1; ++idx) {
+    seg_length = autoware_utils_geometry::calc_distance2d(
+      trajectory[idx].pose.position, trajectory[idx + 1].pose.position);
+    if (distance + seg_length > stop_point_arc_length) break;
+    distance += seg_length;
+  }
+
+  if (idx == trajectory.size() - 1) {
     trajectory.back().longitudinal_velocity_mps = 0.0;
     trajectory.back().acceleration_mps2 = 0.0;
-    return trajectory.size() - 1;
-  }();
+    return true;
+  }
 
-  trajectory.erase(trajectory.begin() + stop_index + 1, trajectory.end());
+  auto stop_idx = idx;
+  if (std::abs(distance - stop_point_arc_length) < overlap_threshold) {
+    stop_idx = idx;
+  } else if (std::abs(distance + seg_length - stop_point_arc_length) < overlap_threshold) {
+    stop_idx = idx + 1;
+  } else {
+    auto target_idx =
+      motion_utils::insertStopPoint(idx, stop_point_arc_length - distance, trajectory);
+    stop_idx = target_idx ? target_idx.value() : idx;
+  }
+
+  if (stop_idx + 1 < trajectory.size()) {
+    trajectory.erase(trajectory.begin() + stop_idx + 1, trajectory.end());
+  }
   trajectory.back().longitudinal_velocity_mps = 0.0;
   trajectory.back().acceleration_mps2 = 0.0;
 

--- a/planning/autoware_trajectory_processor/src/trajectory_processor.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_processor.cpp
@@ -180,11 +180,10 @@ void TrajectoryProcessor::on_trajectories(const CandidateTrajectories::ConstShar
     auto & candidate = output.candidate_trajectories.at(candidate_index);
     auto data = input.value();
     for (auto & processor_plugin : plugins_) {
-      if (processor_plugin->process(candidate.points, data) != plugin::ProcessingResult::Modified) {
-        continue;
-      }
-      processor_plugin->publish_planning_factor();
+      const auto result = processor_plugin->process(candidate.points, data);
       processor_plugin->publish_debug_data("trajectory_" + std::to_string(candidate_index));
+      if (result != plugin::ProcessingResult::Modified) continue;
+      processor_plugin->publish_planning_factor();
       if (!modified_instances.empty()) {
         modified_instances += ", ";
       }

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -243,7 +243,8 @@ protected:
     p.obstacle_tracking.pcd_distance_th = 0.5;
     p.obstacle_tracking.grace_period = 0.5;
 
-    p.objects.object_types = {"car"};
+    p.objects.target_objects.bbox = {"car"};
+    p.objects.target_objects.polygon = {"car"};
 
     p.pointcloud.height_buffer = 0.5;
     p.pointcloud.min_height = 0.2;

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -244,7 +244,6 @@ protected:
     p.obstacle_tracking.grace_period = 0.5;
 
     p.objects.object_types = {"car"};
-    p.objects.max_velocity_th = 1.0;
 
     p.pointcloud.height_buffer = 0.5;
     p.pointcloud.min_height = 0.2;

--- a/planning/autoware_trajectory_processor/tests/test_surround_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_surround_obstacle_stop_integration.cpp
@@ -234,7 +234,8 @@ protected:
     auto & p = params_.surround_obstacle_stop;
     p.use_objects = true;
     p.use_pointcloud = true;
-    p.object_types = {"car"};
+    p.target_objects.bbox = {"car"};
+    p.target_objects.polygon = {"car"};
     p.hysteresis_distance = 0.5;
     p.hysteresis_time = 0.0;
     p.ego_stopped_vel_th = 0.1;


### PR DESCRIPTION
## Description

This PR applies the following improvements to `obstacle_stop` feature used in `trajectory_modifier` and `minimum_rule_based_planner`:
- refactor obstacle stop utility function `get_nearest_object_collision` to optimize collision check
- fix stop wall appears behind ego
- fix `extend_trajectory()` function
- use path curvature at end instead of relying on trajectory point orientations
- for low end speed trajectory, default to straight extension
- fix `insert_stop_point` logic to prevent wrong orientation stop pose
- introduce minimum stop margin below which `duplicate_check_threshold` is ignored
- remove max_velocity_th param and fix collision check logic

Additionally it updates the logic of `obstacle_stop` and `surround_obstacle_stop` to enable filtering by type and shape:
- update `obstacle_stop` params in modifier and backup planner to specify enabled types per shape
- update `surround_obstacle_stop` params in modifier and backup planner to specify enabled types per shape
- modify `ObjectFilter` code in `obstacle_stop_utils` to support filtering by type and shape
- modify `ObstacleProximityChecker` class to support filtering by type and shape
- fix `ObstacleTracker` logic for ignoring orientation change

## Related links

## How was this PR tested?
- PSIM

## Notes for reviewers

None.

## Interface changes

| Change | parameter name | description |
| :--- | :--- | :--- |
| Removed | `objects.object_types` | object types to consider for obstacle stop |
| Added | `objects.target_objects.bbox` | object classes with bbox shape type to consider for obstacle stop |
| Added | `objects.target_objects.polygon` | object classes with polygon shape type to consider for obstacle stop |
| Removed | `surround_obstacle_stop.object_types` | object types to consider for surround obstacle stop |
| Added | `surround_obstacle_stop.target_objects.bbox` | object classes with bbox shape type to consider for surround obstacle stop |
| Added | `surround_obstacle_stop.target_objects.polygon` | object classes with polygon shape type to consider for surround obstacle stop |

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

- improved stopping behavior
- reduced false positives
