### PR TITLE
fix(multi_object_tracker): keep batch window open to the target stream during latency convergence

### DIFF
--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -194,7 +194,7 @@ MeasurementProcessingResult process_measurement(
   state.processor->updateEgoPose(ego_pose);
 
   const auto association_result = state.processor->associate(*objects);
-  state.input_manager->push(channel_index, *objects, association_result);
+  state.input_manager->push(channel_index, *objects, association_result, current_time);
 
   result.has_objects = true;
   result.should_process = (channel_index == state.input_manager->getTargetChannelIdx());

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -343,6 +343,16 @@ void InputManager::getObjectTimeInterval(
     // The object_earliest_time is the latest exported object time
     object_earliest_time = latest_exported_object_time_;
   }
+
+  // The window start stays at or below the target stream's newest measurement, bounded by the
+  // 1-second interval: objects below the window start are dropped by getObjectsOlderThan(), so
+  // the target's backlog is exported while the latency estimate converges.
+  if (input_streams_.at(target_stream_idx_)->isTimeInitialized()) {
+    const rclcpp::Time target_horizon =
+      input_streams_.at(target_stream_idx_)->getLatestMeasurementTime();
+    object_earliest_time = std::min(object_earliest_time, target_horizon);
+  }
+  object_earliest_time = std::max(object_earliest_time, object_earliest_time_default);
 }
 
 bool InputManager::isStreamFresh(const InputStream & input_stream, const rclcpp::Time & now) const

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace autoware::multi_object_tracker
@@ -312,47 +313,40 @@ void InputManager::getObjectTimeInterval(
   const rclcpp::Time & now, rclcpp::Time & object_latest_time,
   rclcpp::Time & object_earliest_time) const
 {
-  // Set the object time interval
+  // The newest measurement of the target stream, once its time statistics are initialized
+  const auto & target_stream = input_streams_.at(target_stream_idx_);
+  const std::optional<rclcpp::Time> target_latest_measurement =
+    target_stream->isTimeInitialized()
+      ? std::make_optional(target_stream->getLatestMeasurementTime())
+      : std::nullopt;
 
   // 1. object_latest_time
-  // The object_latest_time is the current time minus the target stream latency
-  object_latest_time =
+  // The current time minus the target stream latency, kept at or above the target stream's
+  // newest measurement
+  const rclcpp::Time latency_based_latest_time =
     now - rclcpp::Duration::from_seconds(target_stream_latency_ - 0.1 * target_stream_latency_std_);
-
-  // check the target stream can be included in the object time interval
-  if (input_streams_.at(target_stream_idx_)->isTimeInitialized()) {
-    const rclcpp::Time latest_measurement_time =
-      input_streams_.at(target_stream_idx_)->getLatestMeasurementTime();
-    // if the object_latest_time is older than the latest measurement time, set it to the latest
-    // object time
-    object_latest_time =
-      object_latest_time < latest_measurement_time ? latest_measurement_time : object_latest_time;
-  }
+  object_latest_time = target_latest_measurement
+                         ? std::max(latency_based_latest_time, *target_latest_measurement)
+                         : latency_based_latest_time;
 
   // 2. object_earliest_time
-  // The default object_earliest_time is to have a 1-second time interval
-  const rclcpp::Time object_earliest_time_default =
+  // The window start resumes from the export watermark; a watermark ahead of the window end
+  // falls back to the default 1-second interval
+  const rclcpp::Time earliest_time_default =
     object_latest_time - rclcpp::Duration::from_seconds(1.0);
-  if (
-    latest_exported_object_time_ < object_earliest_time_default ||
-    latest_exported_object_time_ > object_latest_time) {
-    // if the latest exported object time is too old or newer than the object_latest_time,
-    // set to the default
-    object_earliest_time = object_earliest_time_default;
-  } else {
-    // The object_earliest_time is the latest exported object time
-    object_earliest_time = latest_exported_object_time_;
-  }
+  const rclcpp::Time export_resume_time = latest_exported_object_time_ > object_latest_time
+                                            ? earliest_time_default
+                                            : latest_exported_object_time_;
 
-  // The window start stays at or below the target stream's newest measurement, bounded by the
-  // 1-second interval: objects below the window start are dropped by getObjectsOlderThan(), so
-  // the target's backlog is exported while the latency estimate converges.
-  if (input_streams_.at(target_stream_idx_)->isTimeInitialized()) {
-    const rclcpp::Time target_horizon =
-      input_streams_.at(target_stream_idx_)->getLatestMeasurementTime();
-    object_earliest_time = std::min(object_earliest_time, target_horizon);
-  }
-  object_earliest_time = std::max(object_earliest_time, object_earliest_time_default);
+  // The window start stays at or below the target stream's newest measurement: objects below the
+  // window start are dropped by getObjectsOlderThan(), so the target's backlog is exported while
+  // the latency estimate converges
+  const rclcpp::Time target_covered_time =
+    target_latest_measurement ? std::min(export_resume_time, *target_latest_measurement)
+                              : export_resume_time;
+
+  // Bounded to the 1-second interval
+  object_earliest_time = std::max(target_covered_time, earliest_time_default);
 }
 
 bool InputManager::isStreamFresh(const InputStream & input_stream, const rclcpp::Time & now) const

--- a/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
@@ -495,8 +495,8 @@ public:
 namespace
 {
 
-constexpr size_t kHighLatencyChannel = 0;
-constexpr size_t kLowLatencyChannel = 1;
+constexpr size_t kHighLatencyChannel = 1;
+constexpr size_t kLowLatencyChannel = 0;
 constexpr int32_t kTestStartSec = 2000000000;
 constexpr double kMeasurementInterval = 0.1;
 constexpr double kStaleElapsedTime = 0.6;
@@ -625,6 +625,48 @@ TEST(InputManagerTargetSelection, BatchWindowAdvancesWithFreshStreamAfterTargetD
   EXPECT_TRUE(hasMeasurementAtOrAfter(objects, kLowLatencyChannel, latest_fresh_measurement));
 }
 
+TEST(InputManagerTargetSelection, ExportsRecoveredTargetMeasurementsDuringLatencyRamp)
+{
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto manager = makeInputManagerForTriggerTest(clock);
+  rclcpp::Time now = initializeLatencyStatistics(manager);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+
+  // converge the target latency and the export watermark to the steady state
+  for (size_t i = 0; i < 20; ++i) {
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.5);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+    autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+    manager.getObjects(now, objects);
+  }
+
+  // target dropout: fail over to the low-latency stream, the watermark follows it
+  now = advanceTime(now, kStaleElapsedTime);
+  for (size_t i = 0; i < 5; ++i) {
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+    autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+    manager.getObjects(now, objects);
+  }
+  ASSERT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
+
+  // recovery: every high-latency measurement is exported while the latency estimate converges
+  for (size_t i = 0; i < 20; ++i) {
+    const rclcpp::Time pushed = pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.5);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.05);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+    autoware::multi_object_tracker::types::ObjectsWithAssociationList objects;
+    manager.getObjects(now, objects);
+    EXPECT_TRUE(hasMeasurementAtOrAfter(objects, kHighLatencyChannel, pushed))
+      << "high-latency measurement lost at ramp cycle " << i;
+  }
+  EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+}
+
 TEST(InputManagerTargetSelection, KeepsTargetWithinLatencyHysteresis)
 {
   const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
@@ -633,30 +675,30 @@ TEST(InputManagerTargetSelection, KeepsTargetWithinLatencyHysteresis)
   // both channels have the same latency, so the first one is selected as the target
   rclcpp::Time now(kTestStartSec, 0, RCL_ROS_TIME);
   for (size_t i = 0; i < 20; ++i) {
-    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
     pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
     now = advanceTime(now, kMeasurementInterval);
     manager.optimizeChannelTimings(now);
   }
-  ASSERT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
+  ASSERT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
 
   // a latency difference smaller than the hysteresis must not flip the target stream
   for (size_t i = 0; i < 30; ++i) {
-    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
-    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.32);
-    now = advanceTime(now, kMeasurementInterval);
-    manager.optimizeChannelTimings(now);
-  }
-  EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
-
-  // a latency difference larger than the hysteresis switches the target stream
-  for (size_t i = 0; i < 100; ++i) {
-    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.30);
-    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.60);
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.32);
     now = advanceTime(now, kMeasurementInterval);
     manager.optimizeChannelTimings(now);
   }
   EXPECT_EQ(manager.getTargetChannelIdx(), kLowLatencyChannel);
+
+  // a latency difference larger than the hysteresis switches the target stream
+  for (size_t i = 0; i < 100; ++i) {
+    pushEmptyMeasurement(manager, kLowLatencyChannel, now, 0.30);
+    pushEmptyMeasurement(manager, kHighLatencyChannel, now, 0.60);
+    now = advanceTime(now, kMeasurementInterval);
+    manager.optimizeChannelTimings(now);
+  }
+  EXPECT_EQ(manager.getTargetChannelIdx(), kHighLatencyChannel);
 }
 
 TEST(InputManagerTargetSelection, ShiftsTargetLatencyGraduallyOnIncrease)


### PR DESCRIPTION
## Description

Follow-up to the review of #13181, targeting its branch.

The gradual `target_stream_latency_` shift added in ce83c0a moves the batch window **end** gradually, but the window **start** stays pinned to the export watermark (`latest_exported_object_time_`). Objects below the window start are dropped by `getObjectsOlderThan()` (skipped at the interval check, then popped). After a target-stream dropout → failover → recovery, the recovered stream's measurements sit below the window start for the whole latency convergence period (≈ Δ latency / 0.2 s/s, e.g. ~2.25 s for a 0.45 s latency step) and are silently discarded while batches stay non-empty from the fast channel.

### Changes

- **`getObjectTimeInterval()`**: the window start now stays at or below the target stream's newest measurement, bounded by the existing 1-second interval, so the target's backlog is exported while the latency estimate converges. The residual cost is bounded `dt < 0` updates (predict skipped, measurement update still applied) instead of lost measurements.
- **`getObjectTimeInterval()` refactor**: the target's newest measurement is fetched once, bounds are selected with `min`/`max` on single-assignment named values.
- **Production `push()`**: passes the in-scope `current_time`, so association-processing time is not folded into the stream latency statistics that now drive freshness and target selection.
- **Tests**:
  - `SelectsLargestLatencyStreamAfterTimingOptimization` was vacuous: `kHighLatencyChannel = 0` equals the default `target_stream_idx_{0}`, so it passed even with `optimizeChannelTimings()` as a no-op. Constants swapped so selection requires a real transition.
  - New regression test `ExportsRecoveredTargetMeasurementsDuringLatencyRamp`: warm-up → dropout/failover → recovery, asserting every recovered-target measurement is exported during the ramp. **Fails on the current branch head** ("high-latency measurement lost at ramp cycle 0…14"), passes with the fix.
  - `KeepsTargetWithinLatencyHysteresis` roles adapted to the swapped constants: the equal-latency phase selects the first channel (index 0), so the baseline stays on index 0 and the varying latency moved to index 1.

## Tests performed

- `colcon test --packages-select autoware_multi_object_tracker`: 285 tests, 0 failures.
- Regression test verified in both directions (fails on branch head without the window-start fix, passes with it).
- `pre-commit` clean on all touched files.

## Notes for reviewers

The latency ramp itself is kept as-is — it is load-bearing (keeps the window end monotonic so cycles stay non-empty). This PR only adds the matching low-side rule. Edge case: when the clamp pins the window end exactly on the target's newest stamp, the strict-`<` pop leaves that object queued and the open low edge re-exports it once — bounded to a single duplicate, which costs a `dt < 0` update, cheaper than a lost measurement.

## Interface changes

None.

## Effects on system behavior

After a target-stream dropout and recovery, the recovered stream's measurements are exported during the latency convergence period.
