### PR TITLE
fix(autoware_carla_interface): raise a descriptive error when the ego vehicle fails to spawn

### DIFF
--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
@@ -165,6 +165,13 @@ class InitializeInterface(object):
         self.ego_actor = CarlaDataProvider.request_new_actor(
             self.vehicle_type, spawn_point, self.agent_role_name, random_location=randomize
         )
+        if self.ego_actor is None:
+            raise RuntimeError(
+                f"Failed to spawn ego vehicle '{self.vehicle_type}' at "
+                f"({spawn_point.location.x:.1f}, {spawn_point.location.y:.1f}, "
+                f"{spawn_point.location.z:.1f}); the spawn point may be occupied "
+                "or invalid for this map"
+            )
         self.interface.ego_actor = self.ego_actor  # TODO improve design
         self.interface.physics_control = self.ego_actor.get_physics_control()
 


### PR DESCRIPTION
## Description

`CarlaDataProvider.request_new_actor` returns `None` when the ego vehicle cannot be spawned (occupied spawn point, blueprint invalid for the map, ...). The bridge then crashed later with an unrelated `AttributeError` on `None` (`get_physics_control`), hiding the actual cause.

Raise a `RuntimeError` right at the spawn site instead, naming the vehicle type and the requested spawn location, so the failure is diagnosable from the log.

This came out of debugging E2E simulator bring-up, where a failed ego spawn surfaced only as `AttributeError: 'NoneType' object has no attribute 'get_physics_control'`.

## How was this PR tested?

- `colcon build --packages-select autoware_carla_interface --symlink-install` passes.
- Forcing a spawn failure (occupied spawn point) now aborts with `RuntimeError: Failed to spawn ego vehicle 'vehicle.toyota.prius' at (x, y, z); the spawn point may be occupied or invalid for this map` instead of the AttributeError.

## Backward compatibility

- Successful spawns are unaffected. A failed spawn previously crashed anyway; only the exception type and message change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
