### PR TITLE
feat(trajectory_modifier, minimum_rule_based_planner): integrate semseg pointcloud into modifier and backup planner modules

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -84,6 +84,7 @@
       target_objects:
         bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
         polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"]
+        pointcloud: ["hazard", "structure", "vegetation"]
       front_distance_th:
         car: 0.5
         truck: 0.5

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -58,7 +58,7 @@
         safety_buffer: 0.1       # safety buffer to expand object shape [m]
 
       pointcloud:
-        target_types: ["hazard", "structure", "vegetation"]
+        target_types: ["structure", "vegetation"]
         height_buffer: 0.5  # height buffer to add above ego height [m]
         min_height: 0.2  # minimum height of pointcloud [m]
 

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -58,18 +58,9 @@
         safety_buffer: 0.1       # safety buffer to expand object shape [m]
 
       pointcloud:
+        target_types: ["hazard", "structure", "vegetation"]
         height_buffer: 0.5  # height buffer to add above ego height [m]
         min_height: 0.2  # minimum height of pointcloud [m]
-        voxel_grid_filter:
-          x: 0.2
-          y: 0.2
-          z: 0.2
-          min_size: 3
-        clustering:
-          tolerance: 0.5  #[m]
-          min_height: 0.5
-          min_size: 10
-          max_size: 10000
 
       rss_params:
         enable: true

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -84,7 +84,7 @@
       target_objects:
         bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
         polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"]
-        pointcloud: ["hazard", "structure", "vegetation"]
+        pointcloud: ["structure", "vegetation"]
       front_distance_th:
         car: 0.5
         truck: 0.5

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -189,6 +189,11 @@ minimum_rule_based_planner:
         validation:
           bounds<>: [0.0, 10.0]
     pointcloud:
+      target_types:
+        type: string_array
+        default_value: [hazard, structure, vegetation]
+        description: pointcloud types to consider for obstacle stop
+        read_only: false
       height_buffer:
         type: double
         default_value: 0.5
@@ -201,56 +206,6 @@ minimum_rule_based_planner:
         description: minimum height of pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
-      voxel_grid_filter:
-        x:
-          type: double
-          default_value: 0.2
-          description: x size of voxel grid filter [m]
-          validation:
-            bounds<>: [0.0, 1.0]
-        y:
-          type: double
-          default_value: 0.2
-          description: y size of voxel grid filter [m]
-          validation:
-            bounds<>: [0.0, 1.0]
-        z:
-          type: double
-          default_value: 0.2
-          description: z size of voxel grid filter [m]
-          validation:
-            bounds<>: [0.0, 1.0]
-        min_size:
-          type: int
-          default_value: 3
-          description: minimum size of voxel grid filter
-          validation:
-            bounds<>: [1, 100]
-      clustering:
-        tolerance:
-          type: double
-          default_value: 0.5
-          description: tolerance for clustering [m]
-          validation:
-            bounds<>: [0.0, 1.0]
-        min_height:
-          type: double
-          default_value: 0.5
-          description: minimum height for clustering [m]
-          validation:
-            bounds<>: [0.0, 1.0]
-        min_size:
-          type: int
-          default_value: 10
-          description: minimum size for clustering
-          validation:
-            bounds<>: [1, 100]
-        max_size:
-          type: int
-          default_value: 10000
-          description: maximum size for clustering
-          validation:
-            bounds<>: [1, 10000]
     rss_params:
       enable:
         type: bool

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -309,7 +309,7 @@ minimum_rule_based_planner:
         read_only: false
       pointcloud:
         type: string_array
-        default_value: [hazard, structure, vegetation]
+        default_value: [structure, vegetation]
         description: pointcloud types to consider for surround obstacle stop
         read_only: false
     base_distance_th:

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -191,7 +191,7 @@ minimum_rule_based_planner:
     pointcloud:
       target_types:
         type: string_array
-        default_value: [hazard, structure, vegetation]
+        default_value: [structure, vegetation]
         description: pointcloud types to consider for obstacle stop
         read_only: false
       height_buffer:

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -307,6 +307,11 @@ minimum_rule_based_planner:
         default_value: [car, truck, bus, trailer, pedestrian, hazard, animal, unknown]
         description: types of polygon shaped objects to consider for surround obstacle stop
         read_only: false
+      pointcloud:
+        type: string_array
+        default_value: [hazard, structure, vegetation]
+        description: pointcloud types to consider for surround obstacle stop
+        read_only: false
     base_distance_th:
       &distance_th_template {
         type: double,

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -49,10 +49,7 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
 
   pointcloud_filter_ =
     std::make_unique<trajectory_processor::utils::obstacle_stop::PointCloudFilter>(
-      params_.pointcloud.voxel_grid_filter.x, params_.pointcloud.voxel_grid_filter.y,
-      params_.pointcloud.voxel_grid_filter.z, params_.pointcloud.voxel_grid_filter.min_size,
-      params_.pointcloud.clustering.tolerance, params_.pointcloud.clustering.min_size,
-      params_.pointcloud.clustering.max_size);
+      params_.pointcloud.target_types);
 
   object_filter_ = std::make_unique<trajectory_processor::utils::obstacle_stop::ObjectFilter>(
     params_.objects.target_objects.bbox, params_.objects.target_objects.polygon,
@@ -230,10 +227,6 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       rel_max_point.y(), min_z, max_z);
   }
 
-  PointCloud::Ptr clustered_points(new PointCloud);
-  pointcloud_filter_->cluster_pointcloud(
-    filtered_pointcloud, clustered_points, params_.pointcloud.clustering.min_height);
-
   {
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
@@ -245,23 +238,21 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
     }
 
     Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.transform).cast<float>();
-    autoware_utils::transform_pointcloud(*filtered_pointcloud, *filtered_pointcloud, isometry);
-  }
-
-  {
-    const auto cluster_pointcloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
-    pcl::toROSMsg(*clustered_points, *cluster_pointcloud);
-    cluster_pointcloud->header.stamp = pointcloud->header.stamp;
-    cluster_pointcloud->header.frame_id = "map";
-    debug_data_.cluster_points = cluster_pointcloud;
+    for (auto & p : filtered_pointcloud->points) {
+      const Eigen::Vector3f q = isometry * Eigen::Vector3f(p.x, p.y, p.z);
+      p.x = q.x();
+      p.y = q.y();
+      p.z = q.z();
+    }
   }
 
   if (data.predicted_objects_ptr && !data.predicted_objects_ptr->objects.empty()) {
-    pointcloud_filter_->filter_pointcloud_by_object(clustered_points, *data.predicted_objects_ptr);
+    pointcloud_filter_->filter_pointcloud_by_object(
+      filtered_pointcloud, *data.predicted_objects_ptr);
   }
 
   return get_nearest_pcd_collision(
-    traj_points, debug_data_.trajectory_shape, clustered_points, debug_data_.target_pcd_points);
+    traj_points, debug_data_.trajectory_shape, filtered_pointcloud, debug_data_.target_pcd_points);
 }
 
 void ObstacleStop::update_collision_points_buffer(

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -56,8 +56,8 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
     params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th,
     params_.objects.safety_buffer);
 
-  pub_clustered_pointcloud_ =
-    get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);
+  pub_filtered_pointcloud_ =
+    get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/filtered_points", 1);
   debug_viz_pub_ = get_node_ptr()->create_publisher<MarkerArray>("~/obstacle_stop/debug/marker", 1);
   pub_debug_text_ =
     get_node_ptr()->create_publisher<StringStamped>("~/obstacle_stop/debug/text", 1);
@@ -216,15 +216,18 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
 
   {
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
-    const auto rel_min_point = autoware_utils_geometry::inverse_transform_point(
+    const auto rel_min_corner = autoware_utils_geometry::inverse_transform_point(
       bounding_box.min_corner().to_3d(), data.odometry_ptr->pose.pose);
-    const auto rel_max_point = autoware_utils_geometry::inverse_transform_point(
+    const auto rel_max_corner = autoware_utils_geometry::inverse_transform_point(
       bounding_box.max_corner().to_3d(), data.odometry_ptr->pose.pose);
+    constexpr double buffer = 1.0;
+    const auto [min_x, max_x] = std::minmax(rel_min_corner.x(), rel_max_corner.x());
+    const auto [min_y, max_y] = std::minmax(rel_min_corner.y(), rel_max_corner.y());
     const auto min_z = params_.pointcloud.min_height;
     const auto max_z = context_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
     pointcloud_filter_->filter_pointcloud(
-      filtered_pointcloud, rel_min_point.x(), rel_max_point.x(), rel_min_point.y(),
-      rel_max_point.y(), min_z, max_z);
+      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
+      max_z);
   }
 
   {
@@ -244,6 +247,14 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       p.y = q.y();
       p.z = q.z();
     }
+  }
+
+  {
+    const auto filtered_pointcloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    pcl::toROSMsg(*filtered_pointcloud, *filtered_pointcloud_msg);
+    filtered_pointcloud_msg->header.stamp = pointcloud->header.stamp;
+    filtered_pointcloud_msg->header.frame_id = "map";
+    debug_data_.filtered_points = filtered_pointcloud_msg;
   }
 
   if (data.predicted_objects_ptr && !data.predicted_objects_ptr->objects.empty()) {
@@ -337,15 +348,15 @@ std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point(
 
 void ObstacleStop::publish_debug_string(bool is_safe) const
 {
-  const auto cluster_pcd_size =
-    debug_data_.cluster_points ? debug_data_.cluster_points->data.size() : 0;
+  const auto filtered_pcd_size =
+    debug_data_.filtered_points ? debug_data_.filtered_points->data.size() : 0;
   std::ostringstream ss;
   ss << std::fixed << std::setprecision(2) << std::boolalpha;
   ss << "OBSTACLE STOP (Backup Planner):" << "\n";
   ss << "\t\t" << "SAFE: " << is_safe << "\n";
   ss << "\t\t" << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
      << debug_data_.target_polygons.size() << "\n";
-  ss << "\t\t" << "POINTCLOUD: " << cluster_pcd_size << " --> "
+  ss << "\t\t" << "POINTCLOUD: " << filtered_pcd_size << " --> "
      << debug_data_.target_pcd_points.size() << "\n";
   if (nearest_collision_point_) {
     ss << "\t\t" << "DISTANCE TO COLLISION: " << nearest_collision_point_->arc_length << " m"
@@ -360,7 +371,7 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
 
 void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData & data) const
 {
-  if (debug_data_.cluster_points) pub_clustered_pointcloud_->publish(*debug_data_.cluster_points);
+  if (debug_data_.filtered_points) pub_filtered_pointcloud_->publish(*debug_data_.filtered_points);
 
   MarkerArray marker_array;
   const auto ego_z = data.odometry_ptr->pose.pose.position.z;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -65,10 +65,7 @@ public:
 
     {
       const auto & p = params_.pointcloud;
-      pointcloud_filter_->set_params(
-        p.voxel_grid_filter.x, p.voxel_grid_filter.y, p.voxel_grid_filter.z,
-        p.voxel_grid_filter.min_size, p.clustering.tolerance, p.clustering.min_size,
-        p.clustering.max_size);
+      pointcloud_filter_->set_params(p.target_types);
     }
 
     update_object_decel_map();

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -99,7 +99,7 @@ private:
   ObjectDecelMap object_decel_map_;
 
   AUTOWARE_PUBLISHER_PTR(MarkerArray) debug_viz_pub_;
-  AUTOWARE_PUBLISHER_PTR(PointCloud2) pub_clustered_pointcloud_;
+  AUTOWARE_PUBLISHER_PTR(PointCloud2) pub_filtered_pointcloud_;
   AUTOWARE_PUBLISHER_PTR(StringStamped) pub_debug_text_;
 
   void update_object_decel_map()

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -17,17 +17,19 @@
 #include "autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp"
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware_utils/transform/transforms.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <cstdint>
 #include <iomanip>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <unordered_set>
+#include <utility>
 
 namespace
 {
@@ -124,6 +126,10 @@ void SurroundObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & p
   pub_debug_text_ =
     get_node_ptr()->create_publisher<StringStamped>("~/surround_obstacle_stop/debug/text", 1);
 
+  pointcloud_filter_ =
+    std::make_unique<trajectory_modifier::utils::obstacle_stop::PointCloudFilter>(
+      params_.target_objects.pointcloud);
+
   proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(
     to_proximity_checker_parameters(params_), context_->vehicle_info);
 }
@@ -132,6 +138,7 @@ void SurroundObstacleStop::update_params(const MinimumRuleBasedPlannerParams & p
 {
   params_ = params.surround_obstacle_stop;
   proximity_checker_->update_parameters(to_proximity_checker_parameters(params_));
+  pointcloud_filter_->set_params(params_.target_objects.pointcloud);
 }
 
 void SurroundObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data)
@@ -182,11 +189,40 @@ obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_in
 
   Eigen::Affine3f isometry =
     tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
-  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
-  pcl::fromROSMsg(*data.obstacle_pointcloud_ptr, transformed_pointcloud);
-  autoware_utils::transform_pointcloud(transformed_pointcloud, transformed_pointcloud, isometry);
+  PointCloud::Ptr transformed_pointcloud(new PointCloud);
+  pcl::fromROSMsg(*data.obstacle_pointcloud_ptr, *transformed_pointcloud);
+  for (auto & p : transformed_pointcloud->points) {
+    const Eigen::Vector3f q = isometry * Eigen::Vector3f(p.x, p.y, p.z);
+    p.x = q.x();
+    p.y = q.y();
+    p.z = q.z();
+  }
 
-  checker_inputs.pointcloud_in_base_link = transformed_pointcloud.makeShared();
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  const auto ego_rear_offset = context_->vehicle_info.rear_overhang_m;
+  const auto ego_side_offset = context_->vehicle_info.vehicle_width_m / 2.0;
+  const auto front_offset =
+    ego_front_offset + params_.front_distance_th.pointcloud + params_.hysteresis_distance;
+  const auto rear_offset =
+    ego_rear_offset + params_.back_distance_th.pointcloud + params_.hysteresis_distance;
+  const auto side_offset =
+    ego_side_offset + params_.side_distance_th.pointcloud + params_.hysteresis_distance;
+  const auto [min_x, max_x] = std::pair(-rear_offset, front_offset);
+  const auto [min_y, max_y] = std::pair(-side_offset, side_offset);
+  pointcloud_filter_->filter_pointcloud(
+    transformed_pointcloud, min_x, max_x, min_y, max_y, -10.0, 10.0);
+
+  // ProximityChecker expects PointXYZ; drop CPE fields after label/range filtering.
+  auto xyz_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+  xyz_pointcloud->points.reserve(transformed_pointcloud->points.size());
+  for (const auto & p : transformed_pointcloud->points) {
+    xyz_pointcloud->points.emplace_back(p.x, p.y, p.z);
+  }
+  xyz_pointcloud->width = static_cast<std::uint32_t>(xyz_pointcloud->points.size());
+  xyz_pointcloud->height = 1;
+  xyz_pointcloud->is_dense = transformed_pointcloud->is_dense;
+
+  checker_inputs.pointcloud_in_base_link = xyz_pointcloud;
 
   return checker_inputs;
 }

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -127,7 +127,7 @@ void SurroundObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & p
     get_node_ptr()->create_publisher<StringStamped>("~/surround_obstacle_stop/debug/text", 1);
 
   pointcloud_filter_ =
-    std::make_unique<trajectory_modifier::utils::obstacle_stop::PointCloudFilter>(
+    std::make_unique<trajectory_processor::utils::obstacle_stop::PointCloudFilter>(
       params_.target_objects.pointcloud);
 
   proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
@@ -18,6 +18,7 @@
 #include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
 #include "plugin_interface.hpp"
 
+#include <autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
@@ -33,6 +34,7 @@ namespace autoware::minimum_rule_based_planner::plugin
 using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
+using autoware::trajectory_processor::utils::obstacle_stop::PointCloud;
 
 class SurroundObstacleStop : public PluginInterface
 {
@@ -52,6 +54,7 @@ private:
   MinimumRuleBasedPlannerParams::SurroundObstacleStop params_;
 
   std::unique_ptr<obstacle_proximity_checker::ProximityChecker> proximity_checker_;
+  std::unique_ptr<trajectory_processor::utils::obstacle_stop::PointCloudFilter> pointcloud_filter_;
 
   std::optional<obstacle_proximity_checker::CheckResult> proximity_check_result_;
 

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -308,85 +308,25 @@
             "pointcloud": {
               "type": "object",
               "properties": {
+                "target_types": {
+                  "type": "array",
+                  "description": "Pointcloud types to consider for obstacle stop",
+                  "default": ["hazard", "structure", "vegetation"],
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "height_buffer": {
                   "type": "number",
-                  "description": "Height buffer [m]",
+                  "description": "Height buffer to add above ego height [m]",
                   "default": 0.5,
                   "minimum": 0.0
                 },
                 "min_height": {
                   "type": "number",
-                  "description": "Min height [m]",
+                  "description": "Minimum height of pointcloud [m]",
                   "default": 0.2,
                   "minimum": 0.0
-                },
-                "detection_range": {
-                  "type": "number",
-                  "description": "Detection range [m]",
-                  "default": 100.0,
-                  "minimum": 0.0
-                },
-                "voxel_grid_filter": {
-                  "type": "object",
-                  "properties": {
-                    "x": {
-                      "type": "number",
-                      "description": "X [m]",
-                      "default": 0.2,
-                      "minimum": 0.0
-                    },
-                    "y": {
-                      "type": "number",
-                      "description": "Y [m]",
-                      "default": 0.2,
-                      "minimum": 0.0
-                    },
-                    "z": {
-                      "type": "number",
-                      "description": "Z [m]",
-                      "default": 0.2,
-                      "minimum": 0.0
-                    },
-                    "min_size": {
-                      "type": "number",
-                      "description": "Min size",
-                      "default": 3,
-                      "minimum": 0.0
-                    }
-                  },
-                  "required": [],
-                  "additionalProperties": false
-                },
-                "clustering": {
-                  "type": "object",
-                  "properties": {
-                    "tolerance": {
-                      "type": "number",
-                      "description": "Tolerance [m]",
-                      "default": 0.5,
-                      "minimum": 0.0
-                    },
-                    "min_height": {
-                      "type": "number",
-                      "description": "Min height [m]",
-                      "default": 0.5,
-                      "minimum": 0.0
-                    },
-                    "min_size": {
-                      "type": "number",
-                      "description": "Min size",
-                      "default": 10,
-                      "minimum": 0.0
-                    },
-                    "max_size": {
-                      "type": "number",
-                      "description": "Max size",
-                      "default": 10000,
-                      "minimum": 0.0
-                    }
-                  },
-                  "required": [],
-                  "additionalProperties": false
                 }
               },
               "required": [],

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -481,7 +481,7 @@
                 "pointcloud": {
                   "type": "array",
                   "description": "Pointcloud types to consider for surround obstacle stop",
-                  "default": ["hazard", "structure", "vegetation"],
+                  "default": ["structure", "vegetation"],
                   "items": {
                     "type": "string"
                   }

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -311,7 +311,7 @@
                 "target_types": {
                   "type": "array",
                   "description": "Pointcloud types to consider for obstacle stop",
-                  "default": ["hazard", "structure", "vegetation"],
+                  "default": ["structure", "vegetation"],
                   "items": {
                     "type": "string"
                   }

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -477,6 +477,14 @@
                   "items": {
                     "type": "string"
                   }
+                },
+                "pointcloud": {
+                  "type": "array",
+                  "description": "Pointcloud types to consider for surround obstacle stop",
+                  "default": ["hazard", "structure", "vegetation"],
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_processor/CMakeLists.txt
+++ b/planning/autoware_trajectory_processor/CMakeLists.txt
@@ -50,7 +50,7 @@ ament_auto_add_library(autoware_trajectory_modifier_utils SHARED
 )
 autoware_agnocast_wrapper_setup(autoware_trajectory_modifier_utils)
 
-target_link_libraries(autoware_trajectory_modifier_utils PUBLIC
+ament_target_dependencies(autoware_trajectory_modifier_utils
   autoware_point_types
 )
 

--- a/planning/autoware_trajectory_processor/CMakeLists.txt
+++ b/planning/autoware_trajectory_processor/CMakeLists.txt
@@ -8,7 +8,10 @@ find_package(tf2_geometry_msgs REQUIRED)
 autoware_package()
 
 find_package(ament_cmake_export_dependencies REQUIRED)
-ament_export_dependencies(acados)
+ament_export_dependencies(
+  acados
+  autoware_point_types
+)
 
 # Temporal kinematic-bicycle acados solver: Python codegen at build time (add_custom_command).
 # See src/acados_mpt/CMakeLists.txt — target acados_interface_temporal.
@@ -49,10 +52,6 @@ ament_auto_add_library(autoware_trajectory_modifier_utils SHARED
   src/trajectory_modifier_utils/obstacle_stop_utils.cpp
 )
 autoware_agnocast_wrapper_setup(autoware_trajectory_modifier_utils)
-
-ament_target_dependencies(autoware_trajectory_modifier_utils
-  autoware_point_types
-)
 
 ament_auto_add_library(autoware_trajectory_optimizer_plugins SHARED
   src/trajectory_optimizer_plugins/trajectory_eb_smoother_optimizer.cpp

--- a/planning/autoware_trajectory_processor/CMakeLists.txt
+++ b/planning/autoware_trajectory_processor/CMakeLists.txt
@@ -50,6 +50,10 @@ ament_auto_add_library(autoware_trajectory_modifier_utils SHARED
 )
 autoware_agnocast_wrapper_setup(autoware_trajectory_modifier_utils)
 
+target_link_libraries(autoware_trajectory_modifier_utils PUBLIC
+  autoware_point_types
+)
+
 ament_auto_add_library(autoware_trajectory_optimizer_plugins SHARED
   src/trajectory_optimizer_plugins/trajectory_eb_smoother_optimizer.cpp
   src/trajectory_optimizer_plugins/trajectory_extender.cpp

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -76,18 +76,9 @@
         safety_buffer: 0.1 # [m] safety buffer to expand object shape
 
       pointcloud:
+        target_types: ["hazard", "structure", "vegetation"]
         height_buffer: 0.5  # height buffer to add above ego height [m]
         min_height: 0.2  # minimum height of pointcloud [m]
-        voxel_grid_filter:
-          x: 0.2
-          y: 0.2
-          z: 0.2
-          min_size: 3
-        clustering:
-          tolerance: 0.5  #[m]
-          min_height: 0.5
-          min_size: 10
-          max_size: 10000
 
       rss_params:
         enable: true

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -76,7 +76,7 @@
         safety_buffer: 0.1 # [m] safety buffer to expand object shape
 
       pointcloud:
-        target_types: ["hazard", "structure", "vegetation"]
+        target_types: ["structure", "vegetation"]
         height_buffer: 0.5  # height buffer to add above ego height [m]
         min_height: 0.2  # minimum height of pointcloud [m]
 

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -103,6 +103,7 @@
       target_objects:
         bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
         polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"]
+        pointcloud: ["hazard", "structure", "vegetation"]
       front_distance_th:
         car: 0.5
         truck: 0.5

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -91,7 +91,6 @@ private:
   MarkerArray marker_array_;
   PublisherHandle<visualization_msgs::msg::MarkerArray> debug_viz_pub_;
   PublisherHandle<PointCloud2> pub_filtered_pointcloud_;
-  PublisherHandle<PointCloud2> pub_clustered_pointcloud_;
   PublisherHandle<StringStamped> pub_debug_text_;
 
   void check_obstacles(const TrajectoryPoints & traj_points, const TrajectoryProcessorData & input);

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/surround_obstacle_stop.hpp
@@ -16,8 +16,8 @@
 #define AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_PLUGINS__SURROUND_OBSTACLE_STOP_HPP_
 
 #include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
-#include "autoware/trajectory_processor/trajectory_processor_plugin_base.hpp"
 #include "autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp"
+#include "autoware/trajectory_processor/trajectory_processor_plugin_base.hpp"
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/surround_obstacle_stop.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
 #include "autoware/trajectory_processor/trajectory_processor_plugin_base.hpp"
+#include "autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp"
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 
@@ -34,6 +35,7 @@ using autoware::trajectory_processor::plugin::TrajectoryPoints;
 using autoware::trajectory_processor::plugin::TrajectoryProcessorPluginBase;
 using ModifierParams = trajectory_processor_params::Params;
 using autoware_internal_debug_msgs::msg::StringStamped;
+using utils::obstacle_stop::PointCloud;
 
 class SurroundObstacleStop : public TrajectoryProcessorPluginBase
 {
@@ -57,7 +59,7 @@ private:
   ModifierParams::SurroundObstacleStop params_;
 
   std::unique_ptr<obstacle_proximity_checker::ProximityChecker> proximity_checker_;
-
+  std::unique_ptr<utils::obstacle_stop::PointCloudFilter> pointcloud_filter_;
   std::optional<obstacle_proximity_checker::CheckResult> proximity_check_result_;
 
   std::optional<rclcpp::Time> last_frame_time_;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -363,11 +363,11 @@ private:
   double safety_buffer_;
 };
 
-/// PCL-based downsampling, cropping, clustering, and object masking for obstacle point clouds.
+/// Range and semantic-label filtering plus object masking for obstacle point clouds.
 struct PointCloudFilter
 {
   /**
-   * @brief Configure voxel grid and euclidean clustering parameters used by subsequent filters.
+   * @brief Configure the set of point-cloud class labels kept by subsequent filters.
    */
   explicit PointCloudFilter(const std::vector<std::string> & target_types)
   {
@@ -378,7 +378,7 @@ struct PointCloudFilter
   };
 
   /**
-   * @brief Update voxel and clustering parameters at runtime.
+   * @brief Update the kept point-cloud class labels at runtime.
    */
   void set_params(const std::vector<std::string> & target_types)
   {

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_UTILS__OBSTACLE_STOP_UTILS_HPP_
 
 #include <autoware/object_recognition_utils/object_classification.hpp>
+#include <autoware/point_types/types.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <rclcpp/time.hpp>
@@ -30,16 +31,8 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_hash.hpp>
 
-#include <pcl/filters/crop_box.h>
-#include <pcl/filters/crop_hull.h>
-#include <pcl/filters/extract_indices.h>
-#include <pcl/filters/passthrough.h>
-#include <pcl/filters/voxel_grid.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <pcl/registration/gicp.h>
-#include <pcl/segmentation/extract_clusters.h>
-#include <pcl/surface/convex_hull.h>
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <memory>
@@ -51,8 +44,10 @@
 
 namespace autoware::trajectory_processor::utils::obstacle_stop
 {
+using autoware::point_types::PointCloudClassification;
+using autoware::point_types::PointXYZCPE;
 using sensor_msgs::msg::PointCloud2;
-using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
+using PointCloud = pcl::PointCloud<PointXYZCPE>;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
@@ -71,15 +66,28 @@ enum class ObjectType : uint8_t {
   BICYCLE,
   PEDESTRIAN,
   ANIMAL,
-  HAZARD
+  HAZARD,
+  FLAT_SURFACE,
+  STRUCTURE,
+  VEGETATION,
+  NOISE,
 };
 
 inline static const std::unordered_map<std::string, ObjectType> string_to_object_type = {
-  {"unknown", ObjectType::UNKNOWN}, {"car", ObjectType::CAR},
-  {"truck", ObjectType::TRUCK},     {"bus", ObjectType::BUS},
-  {"trailer", ObjectType::TRAILER}, {"motorcycle", ObjectType::MOTORCYCLE},
-  {"bicycle", ObjectType::BICYCLE}, {"pedestrian", ObjectType::PEDESTRIAN},
-  {"animal", ObjectType::ANIMAL},   {"hazard", ObjectType::HAZARD}};
+  {"unknown", ObjectType::UNKNOWN},
+  {"car", ObjectType::CAR},
+  {"truck", ObjectType::TRUCK},
+  {"bus", ObjectType::BUS},
+  {"trailer", ObjectType::TRAILER},
+  {"motorcycle", ObjectType::MOTORCYCLE},
+  {"bicycle", ObjectType::BICYCLE},
+  {"pedestrian", ObjectType::PEDESTRIAN},
+  {"animal", ObjectType::ANIMAL},
+  {"hazard", ObjectType::HAZARD},
+  {"flat_surface", ObjectType::FLAT_SURFACE},
+  {"structure", ObjectType::STRUCTURE},
+  {"vegetation", ObjectType::VEGETATION},
+  {"noise", ObjectType::NOISE}};
 
 inline static const std::unordered_map<uint8_t, ObjectType> classification_to_object_type = {
   {ObjectClassification::UNKNOWN, ObjectType::UNKNOWN},
@@ -92,6 +100,22 @@ inline static const std::unordered_map<uint8_t, ObjectType> classification_to_ob
   {ObjectClassification::PEDESTRIAN, ObjectType::PEDESTRIAN},
   {ObjectClassification::ANIMAL, ObjectType::ANIMAL},
   {ObjectClassification::HAZARD, ObjectType::HAZARD}};
+
+inline static const std::unordered_map<PointCloudClassification, ObjectType>
+  pcd_class_to_object_type = {
+    {PointCloudClassification::CAR, ObjectType::CAR},
+    {PointCloudClassification::TRUCK, ObjectType::TRUCK},
+    {PointCloudClassification::BUS, ObjectType::BUS},
+    {PointCloudClassification::MOTORCYCLE, ObjectType::MOTORCYCLE},
+    {PointCloudClassification::BICYCLE, ObjectType::BICYCLE},
+    {PointCloudClassification::PEDESTRIAN, ObjectType::PEDESTRIAN},
+    {PointCloudClassification::ANIMAL, ObjectType::ANIMAL},
+    {PointCloudClassification::HAZARD, ObjectType::HAZARD},
+    {PointCloudClassification::FLAT_SURFACE, ObjectType::FLAT_SURFACE},
+    {PointCloudClassification::STRUCTURE, ObjectType::STRUCTURE},
+    {PointCloudClassification::VEGETATION, ObjectType::VEGETATION},
+    {PointCloudClassification::NOISE, ObjectType::NOISE},
+    {PointCloudClassification::INVALID, ObjectType::UNKNOWN}};
 
 struct CollisionPoint
 {
@@ -346,49 +370,35 @@ struct PointCloudFilter
   /**
    * @brief Configure voxel grid and euclidean clustering parameters used by subsequent filters.
    */
-  PointCloudFilter(
-    double voxel_size_x, double voxel_size_y, double voxel_size_z, int voxel_min_size,
-    double cluster_tolerance, int cluster_min_size, int cluster_max_size)
+  explicit PointCloudFilter(const std::vector<std::string> & target_types)
   {
-    tree_ = std::make_shared<pcl::search::KdTree<pcl::PointXYZ>>();
-    ec_.setClusterTolerance(cluster_tolerance);
-    ec_.setMinClusterSize(cluster_min_size);
-    ec_.setMaxClusterSize(cluster_max_size);
-    voxel_grid_.setLeafSize(voxel_size_x, voxel_size_y, voxel_size_z);
-    voxel_grid_.setMinimumPointsNumberPerVoxel(voxel_min_size);
-    convex_hull_.setDimension(2);
+    for (const auto & target_type : target_types) {
+      if (string_to_object_type.count(target_type) == 0) continue;
+      pcd_types_.emplace(string_to_object_type.at(target_type));
+    }
   };
 
   /**
    * @brief Update voxel and clustering parameters at runtime.
    */
-  void set_params(
-    double voxel_size_x, double voxel_size_y, double voxel_size_z, int voxel_min_size,
-    double cluster_tolerance, int cluster_min_size, int cluster_max_size)
+  void set_params(const std::vector<std::string> & target_types)
   {
-    voxel_grid_.setLeafSize(voxel_size_x, voxel_size_y, voxel_size_z);
-    voxel_grid_.setMinimumPointsNumberPerVoxel(voxel_min_size);
-    ec_.setClusterTolerance(cluster_tolerance);
-    ec_.setMinClusterSize(cluster_min_size);
-    ec_.setMaxClusterSize(cluster_max_size);
+    pcd_types_.clear();
+    for (const auto & target_type : target_types) {
+      if (string_to_object_type.count(target_type) == 0) continue;
+      pcd_types_.emplace(string_to_object_type.at(target_type));
+    }
   }
 
   /**
-   * @brief Crop the cloud to an axis-aligned box, then apply voxel grid downsampling.
+   * @brief Crop the cloud to an axis-aligned box, then keep only configured class types.
    * @param[in,out] pointcloud Cloud updated in place; empty if nothing remains.
    * @param min_x,max_x,min_y,max_y,min_z,max_z Crop box bounds in the cloud frame.
    */
   void filter_pointcloud(
     PointCloud::Ptr & pointcloud, const double min_x, const double max_x, const double min_y,
     const double max_y, const double min_z, const double max_z);
-  /**
-   * @brief Cluster the cloud and output 2D convex hull vertices of clusters above a height cutoff.
-   * @param input Downsampled or cropped cloud.
-   * @param[out] output Hull vertices of qualifying clusters (typically for footprint tests).
-   * @param min_height A cluster is kept only if at least one point has z >= this value [m].
-   */
-  void cluster_pointcloud(
-    const PointCloud::Ptr & input, PointCloud::Ptr & output, const double min_height);
+
   /**
    * @brief Remove points that lie inside predicted object footprints (expanded by a small margin).
    * @param[in,out] pointcloud Cloud to strip in place.
@@ -397,11 +407,7 @@ struct PointCloudFilter
   void filter_pointcloud_by_object(PointCloud::Ptr & pointcloud, const PredictedObjects & objects);
 
 private:
-  pcl::search::KdTree<pcl::PointXYZ>::Ptr tree_;
-  pcl::EuclideanClusterExtraction<pcl::PointXYZ> ec_;
-  pcl::VoxelGrid<pcl::PointXYZ> voxel_grid_;
-  pcl::CropBox<pcl::PointXYZ> crop_box_;
-  pcl::ConvexHull<pcl::PointXYZ> convex_hull_;
+  std::unordered_set<ObjectType> pcd_types_;
 };
 
 /// Temporal association of obstacle detections (objects and points) with hysteresis.

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -505,9 +505,9 @@ private:
 
   struct PersistentPoint : public PersistentObstacle
   {
-    geometry_msgs::msg::Point position;
-    explicit PersistentPoint(const geometry_msgs::msg::Point & position, const rclcpp::Time & now)
-    : PersistentObstacle(now), position(position)
+    PointXYZCPE point;
+    explicit PersistentPoint(const PointXYZCPE & point, const rclcpp::Time & now)
+    : PersistentObstacle(now), point(point)
     {
     }
   };

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -173,7 +173,6 @@ struct TrajectoryShape
 
 struct DebugData
 {
-  PointCloud2::SharedPtr cluster_points;
   PointCloud2::SharedPtr filtered_points;
   PredictedObjects filtered_objects;
   MultiPolygon2d target_polygons;

--- a/planning/autoware_trajectory_processor/package.xml
+++ b/planning/autoware_trajectory_processor/package.xml
@@ -28,6 +28,7 @@
   <depend>autoware_path_smoother</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_point_types</depend>
   <depend>autoware_qp_interface</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_traffic_light_compliance_checker</depend>

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -243,6 +243,11 @@ trajectory_processor_params:
           bounds<>: [0.0, 10.0]
         read_only: false
     pointcloud:
+      target_types:
+        type: string_array
+        default_value: [hazard, structure, vegetation]
+        description: Pointcloud types to consider for obstacle stop
+        read_only: false
       height_buffer:
         type: double
         default_value: 0.5
@@ -257,57 +262,6 @@ trajectory_processor_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-      voxel_grid_filter:
-        x:
-          type: double
-          default_value: 0.2
-          validation:
-            bounds<>: [0.0, 1.0]
-          read_only: false
-        y:
-          type: double
-          default_value: 0.2
-          validation:
-            bounds<>: [0.0, 1.0]
-          read_only: false
-        z:
-          type: double
-          default_value: 0.2
-          validation:
-            bounds<>: [0.0, 1.0]
-          read_only: false
-        min_size:
-          type: int
-          default_value: 3
-          validation:
-            bounds<>: [1, 100]
-          read_only: false
-      clustering:
-        tolerance:
-          type: double
-          default_value: 0.2
-          description: Distance threshold for clustering points [m]
-          validation:
-            bounds<>: [0.0, 1.0]
-          read_only: false
-        min_height:
-          type: double
-          default_value: 0.5
-          validation:
-            bounds<>: [0.0, 1.0]
-          read_only: false
-        min_size:
-          type: int
-          default_value: 10
-          validation:
-            bounds<>: [1, 10000]
-          read_only: false
-        max_size:
-          type: int
-          default_value: 10000
-          validation:
-            bounds<>: [1, 10000]
-          read_only: false
 
     rss_params:
       enable:

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -378,6 +378,11 @@ trajectory_processor_params:
         default_value: [car, truck, bus, trailer, pedestrian, hazard, animal, unknown]
         description: Types of polygon shaped objects to consider for surround obstacle stop
         read_only: false
+      pointcloud:
+        type: string_array
+        default_value: [hazard, structure, vegetation]
+        description: Pointcloud types to consider for surround obstacle stop
+        read_only: false
     base_distance_th:
       &distance_th_template {
         type: double,

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -455,6 +455,14 @@
                   "items": {
                     "type": "string"
                   }
+                },
+                "pointcloud": {
+                  "type": "array",
+                  "description": "Pointcloud types to consider for surround obstacle stop",
+                  "default": ["hazard", "structure", "vegetation"],
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -285,6 +285,14 @@
             "pointcloud": {
               "type": "object",
               "properties": {
+                "target_types": {
+                  "type": "array",
+                  "description": "Pointcloud types to consider for obstacle stop",
+                  "default": ["hazard", "structure", "vegetation"],
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "height_buffer": {
                   "type": "number",
                   "description": "Height buffer to add above ego height [m]",
@@ -296,68 +304,6 @@
                   "description": "Minimum height of pointcloud [m]",
                   "default": 0.2,
                   "minimum": 0
-                },
-                "voxel_grid_filter": {
-                  "type": "object",
-                  "properties": {
-                    "x": {
-                      "type": "number",
-                      "description": "X dimension of voxel grid filter [m]",
-                      "default": 0.2,
-                      "minimum": 0
-                    },
-                    "y": {
-                      "type": "number",
-                      "description": "Y dimension of voxel grid filter [m]",
-                      "default": 0.2,
-                      "minimum": 0
-                    },
-                    "z": {
-                      "type": "number",
-                      "description": "Z dimension of voxel grid filter [m]",
-                      "default": 0.2,
-                      "minimum": 0
-                    },
-                    "min_size": {
-                      "type": "number",
-                      "description": "Minimum size of voxel grid filter [m]",
-                      "default": 3,
-                      "minimum": 0
-                    }
-                  },
-                  "required": [],
-                  "additionalProperties": false
-                },
-                "clustering": {
-                  "type": "object",
-                  "properties": {
-                    "tolerance": {
-                      "type": "number",
-                      "description": "Tolerance for clustering [m]",
-                      "default": 0.5,
-                      "minimum": 0
-                    },
-                    "min_height": {
-                      "type": "number",
-                      "description": "Minimum height for clustering [m]",
-                      "default": 0.5,
-                      "minimum": 0
-                    },
-                    "min_size": {
-                      "type": "number",
-                      "description": "Minimum size for clustering [m]",
-                      "default": 10,
-                      "minimum": 0
-                    },
-                    "max_size": {
-                      "type": "number",
-                      "description": "Maximum size for clustering [m]",
-                      "default": 10000,
-                      "minimum": 0
-                    }
-                  },
-                  "required": [],
-                  "additionalProperties": false
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -407,8 +407,6 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
 {
   const auto filtered_pcd_size =
     debug_data_.filtered_points ? debug_data_.filtered_points->data.size() : 0;
-  const auto cluster_pcd_size =
-    debug_data_.cluster_points ? debug_data_.cluster_points->data.size() : 0;
   std::ostringstream ss;
   ss << std::fixed << std::setprecision(2) << std::boolalpha;
   ss << "OBSTACLE STOP MODIFIER: "
@@ -418,8 +416,7 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
   ss << "\t\t"
      << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
      << debug_data_.target_polygons.size() << "\n";
-  ss << "\t\t"
-     << "POINTCLOUD: " << filtered_pcd_size << " --> " << cluster_pcd_size << " --> "
+  ss << "\t\t" << "POINTCLOUD: " << filtered_pcd_size << " --> "
      << debug_data_.target_pcd_points.size() << "\n";
   if (nearest_collision_point_) {
     ss << "\t\t"

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -45,7 +45,6 @@ void ObstacleStop::on_initialize(const TrajectoryProcessorParams & params)
 {
   init_planning_factor_interface("modifier_obstacle_stop");
 
-  pub_clustered_pointcloud_ = make_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points");
   pub_filtered_pointcloud_ = make_publisher<PointCloud2>("~/obstacle_stop/debug/filtered_points");
   debug_viz_pub_ =
     make_publisher<visualization_msgs::msg::MarkerArray>("~/obstacle_stop/debug/marker", 1);
@@ -64,10 +63,7 @@ void ObstacleStop::on_initialize(const TrajectoryProcessorParams & params)
 
   {
     const auto & p = params_.pointcloud;
-    pointcloud_filter_ = std::make_unique<utils::obstacle_stop::PointCloudFilter>(
-      p.voxel_grid_filter.x, p.voxel_grid_filter.y, p.voxel_grid_filter.z,
-      p.voxel_grid_filter.min_size, p.clustering.tolerance, p.clustering.min_size,
-      p.clustering.max_size);
+    pointcloud_filter_ = std::make_unique<utils::obstacle_stop::PointCloudFilter>(p.target_types);
   }
 
   {
@@ -113,10 +109,7 @@ void ObstacleStop::update_params(const TrajectoryProcessorParams & params)
 
   {
     const auto & p = params_.pointcloud;
-    pointcloud_filter_->set_params(
-      p.voxel_grid_filter.x, p.voxel_grid_filter.y, p.voxel_grid_filter.z,
-      p.voxel_grid_filter.min_size, p.clustering.tolerance, p.clustering.min_size,
-      p.clustering.max_size);
+    pointcloud_filter_->set_params(p.target_types);
   }
 
   {
@@ -363,15 +356,7 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       max_z);
   }
 
-  PointCloud::Ptr clustered_points(new PointCloud);
-  {
-    autoware_utils_debug::ScopedTimeTrack stt(
-      "ObstacleStop::cluster_pointcloud", *get_time_keeper());
-    pointcloud_filter_->cluster_pointcloud(
-      filtered_pointcloud, clustered_points, params_.pointcloud.clustering.min_height);
-  }
-
-  if (!clustered_points->empty()) {
+  if (!filtered_pointcloud->empty()) {
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
       transform_stamped = context_->tf_buffer.lookupTransform(
@@ -382,30 +367,30 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
     }
 
     Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.transform).cast<float>();
-    autoware_utils::transform_pointcloud(*clustered_points, *clustered_points, isometry);
+    for (auto & p : filtered_pointcloud->points) {
+      const Eigen::Vector3f q = isometry * Eigen::Vector3f(p.x, p.y, p.z);
+      p.x = q.x();
+      p.y = q.y();
+      p.z = q.z();
+    }
   }
 
   {
-    const auto cluster_pointcloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
     const auto filtered_pointcloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
-    pcl::toROSMsg(*clustered_points, *cluster_pointcloud_msg);
     pcl::toROSMsg(*filtered_pointcloud, *filtered_pointcloud_msg);
-    cluster_pointcloud_msg->header.stamp = input.obstacle_pointcloud->header.stamp;
-    cluster_pointcloud_msg->header.frame_id = "map";
     filtered_pointcloud_msg->header.stamp = input.obstacle_pointcloud->header.stamp;
     filtered_pointcloud_msg->header.frame_id = "map";
-    debug_data_.cluster_points = cluster_pointcloud_msg;
     debug_data_.filtered_points = filtered_pointcloud_msg;
   }
 
   if (input.predicted_objects && !input.predicted_objects->objects.empty()) {
     autoware_utils_debug::ScopedTimeTrack stt(
       "ObstacleStop::filter_pointcloud_by_object", *get_time_keeper());
-    pointcloud_filter_->filter_pointcloud_by_object(clustered_points, *input.predicted_objects);
+    pointcloud_filter_->filter_pointcloud_by_object(filtered_pointcloud, *input.predicted_objects);
   }
 
   PointCloud::Ptr active_points(new PointCloud);
-  obstacle_tracker_->update_points(clustered_points, active_points, get_clock()->now());
+  obstacle_tracker_->update_points(filtered_pointcloud, active_points, get_clock()->now());
 
   std::optional<CollisionPoint> collision_point;
   {
@@ -454,7 +439,6 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
 void ObstacleStop::publish_debug_data(const std::string & ns) const
 {
   if (debug_data_.filtered_points) pub_filtered_pointcloud_(*debug_data_.filtered_points);
-  if (debug_data_.cluster_points) pub_clustered_pointcloud_(*debug_data_.cluster_points);
 
   MarkerArray marker_array;
   const auto ego_z = debug_data_.ego_z;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -22,8 +22,11 @@
 
 #include <pcl/common/transforms.h>
 #include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <algorithm>
+#include <cstdint>
 #include <iomanip>
 #include <memory>
 #include <sstream>
@@ -122,6 +125,10 @@ void SurroundObstacleStop::on_initialize(const TrajectoryProcessorParams & param
   params_ = params.surround_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
 
+  pointcloud_filter_ =
+    std::make_unique<trajectory_processor::utils::obstacle_stop::PointCloudFilter>(
+      params_.target_objects.pointcloud);
+
   proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(
     to_proximity_checker_parameters(params_), context_->vehicle_info);
 }
@@ -132,6 +139,7 @@ void SurroundObstacleStop::update_params(const TrajectoryProcessorParams & param
   params_ = params.surround_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
   proximity_checker_->update_parameters(to_proximity_checker_parameters(params_));
+  pointcloud_filter_->set_params(params_.target_objects.pointcloud);
 }
 
 bool SurroundObstacleStop::check_inputs(const TrajectoryProcessorData & input) const
@@ -167,11 +175,40 @@ obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_in
 
   Eigen::Affine3f isometry =
     tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
-  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
-  pcl::fromROSMsg(*input.obstacle_pointcloud, transformed_pointcloud);
-  autoware_utils::transform_pointcloud(transformed_pointcloud, transformed_pointcloud, isometry);
+  PointCloud::Ptr transformed_pointcloud(new PointCloud);
+  pcl::fromROSMsg(*input.obstacle_pointcloud, *transformed_pointcloud);
+  for (auto & p : transformed_pointcloud->points) {
+    const Eigen::Vector3f q = isometry * Eigen::Vector3f(p.x, p.y, p.z);
+    p.x = q.x();
+    p.y = q.y();
+    p.z = q.z();
+  }
 
-  checker_inputs.pointcloud_in_base_link = transformed_pointcloud.makeShared();
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  const auto ego_rear_offset = context_->vehicle_info.rear_overhang_m;
+  const auto ego_side_offset = context_->vehicle_info.vehicle_width_m / 2.0;
+  const auto front_offset =
+    ego_front_offset + params_.front_distance_th.pointcloud + params_.hysteresis_distance;
+  const auto rear_offset =
+    ego_rear_offset + params_.back_distance_th.pointcloud + params_.hysteresis_distance;
+  const auto side_offset =
+    ego_side_offset + params_.side_distance_th.pointcloud + params_.hysteresis_distance;
+  const auto [min_x, max_x] = std::pair(-rear_offset, front_offset);
+  const auto [min_y, max_y] = std::pair(-side_offset, side_offset);
+  pointcloud_filter_->filter_pointcloud(
+    transformed_pointcloud, min_x, max_x, min_y, max_y, -10.0, 10.0);
+
+  // ProximityChecker expects PointXYZ; drop CPE fields after label/range filtering.
+  auto xyz_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+  xyz_pointcloud->points.reserve(transformed_pointcloud->points.size());
+  for (const auto & p : transformed_pointcloud->points) {
+    xyz_pointcloud->points.emplace_back(p.x, p.y, p.z);
+  }
+  xyz_pointcloud->width = static_cast<std::uint32_t>(xyz_pointcloud->points.size());
+  xyz_pointcloud->height = 1;
+  xyz_pointcloud->is_dense = transformed_pointcloud->is_dense;
+
+  checker_inputs.pointcloud_in_base_link = xyz_pointcloud;
 
   return checker_inputs;
 }

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -199,14 +199,8 @@ obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_in
     transformed_pointcloud, min_x, max_x, min_y, max_y, -10.0, 10.0);
 
   // ProximityChecker expects PointXYZ; drop CPE fields after label/range filtering.
-  auto xyz_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
-  xyz_pointcloud->points.reserve(transformed_pointcloud->points.size());
-  for (const auto & p : transformed_pointcloud->points) {
-    xyz_pointcloud->points.emplace_back(p.x, p.y, p.z);
-  }
-  xyz_pointcloud->width = static_cast<std::uint32_t>(xyz_pointcloud->points.size());
-  xyz_pointcloud->height = 1;
-  xyz_pointcloud->is_dense = transformed_pointcloud->is_dense;
+  pcl::PointCloud<pcl::PointXYZ>::Ptr xyz_pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::copyPointCloud(*transformed_pointcloud, *xyz_pointcloud);
 
   checker_inputs.pointcloud_in_base_link = xyz_pointcloud;
 

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -17,6 +17,7 @@
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/object_recognition_utils/predicted_path_utils.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
@@ -309,21 +310,32 @@ geometry_msgs::msg::Pose get_predicted_obj_pose_at_time(
     return extrapolate_object_pose_from_kinematics(object, t);
   }
 
-  const auto & pred_path = object.kinematics.predicted_paths.front();
-  if (pred_path.path.size() < 2) {
+  const auto predicted_path = [&]() {
+    std::optional<autoware_perception_msgs::msg::PredictedPath> p;
+    for (const auto & path : object.kinematics.predicted_paths) {
+      if (path.path.empty()) continue;
+      if (!p || path.confidence > p->confidence) p = path;
+    }
+    return p;
+  }();
+
+  if (!predicted_path) {
     return extrapolate_object_pose_from_kinematics(object, t);
   }
 
-  const auto dt = std::max(rclcpp::Duration(pred_path.time_step).seconds(), 1e-3);
-  const double max_time = dt * static_cast<double>(pred_path.path.size() - 1);
-  const double clamped_t = std::clamp(t, 0.0, max_time);
+  const double dt = std::max(rclcpp::Duration(predicted_path->time_step).seconds(), 1e-3);
+  const double path_horizon = dt * static_cast<double>(predicted_path->path.size() - 1);
+  if (t >= path_horizon) {
+    return predicted_path->path.back();
+  }
 
-  const auto index = static_cast<size_t>(std::floor(clamped_t / dt));
-  const size_t next_index = std::min(index + 1, pred_path.path.size() - 1);
-  const double ratio = (clamped_t - static_cast<double>(index) * dt) / dt;
+  auto interpolated_pose =
+    autoware::object_recognition_utils::calcInterpolatedPose(*predicted_path, t);
+  if (!interpolated_pose) {
+    return extrapolate_object_pose_from_kinematics(object, t);
+  }
 
-  return autoware_utils_geometry::calc_interpolated_pose(
-    pred_path.path.at(index), pred_path.path.at(next_index), ratio, false);
+  return interpolated_pose.value();
 }
 
 ObjectState get_object_state_at_time(

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -678,8 +678,7 @@ void ObstacleTracker::update_points(
     if (persistent_point_map_.empty()) return std::nullopt;
     double min_distance = pcd_distance_th_ + std::numeric_limits<double>::epsilon();
     for (const auto & [uuid, existing_point] : persistent_point_map_) {
-      const auto distance =
-        std::hypot(point.x - existing_point.point.x, point.y - existing_point.point.y);
+      const auto distance = autoware_utils::calc_distance2d(point, existing_point.point);
       if (distance > min_distance) continue;
       min_distance = distance;
       closest_uuid = uuid;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -673,12 +673,13 @@ void ObstacleTracker::update_points(
   }
 
   auto get_closest_point_uuid =
-    [&](const geometry_msgs::msg::Point & point) -> std::optional<boost::uuids::uuid> {
+    [&](const PointXYZCPE & point) -> std::optional<boost::uuids::uuid> {
     std::optional<boost::uuids::uuid> closest_uuid = std::nullopt;
     if (persistent_point_map_.empty()) return std::nullopt;
     double min_distance = pcd_distance_th_ + std::numeric_limits<double>::epsilon();
     for (const auto & [uuid, existing_point] : persistent_point_map_) {
-      const auto distance = autoware_utils::calc_distance2d(point, existing_point.position);
+      const auto distance = std::hypot(
+        point.x - existing_point.point.x, point.y - existing_point.point.y);
       if (distance > min_distance) continue;
       min_distance = distance;
       closest_uuid = uuid;
@@ -687,26 +688,21 @@ void ObstacleTracker::update_points(
   };
 
   for (const auto & point : points->points) {
-    auto point_msg = autoware_utils::create_point(point.x, point.y, point.z);
-    const auto closest_uuid = get_closest_point_uuid(point_msg);
+    const auto closest_uuid = get_closest_point_uuid(point);
     if (!closest_uuid) {
-      persistent_point_map_.emplace(id_generator_(), PersistentPoint(point_msg, now));
+      persistent_point_map_.emplace(id_generator_(), PersistentPoint(point, now));
       continue;
     }
     auto & closest_point = persistent_point_map_.at(closest_uuid.value());
     closest_point.last_seen_time = now;
-    closest_point.position = point_msg;
+    closest_point.point = point;
     const auto duration = (now - closest_point.first_seen_time).seconds();
     closest_point.is_active = duration >= on_time_buffer_;
   }
 
   for (const auto & [uuid, entry] : persistent_point_map_) {
     if (entry.is_active) {
-      autoware::point_types::PointXYZCPE point;
-      point.x = entry.position.x;
-      point.y = entry.position.y;
-      point.z = entry.position.z;
-      persistent_points->points.push_back(point);
+      persistent_points->points.push_back(entry.point);
     }
   }
 }

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -471,49 +471,24 @@ void PointCloudFilter::filter_pointcloud(
 {
   if (pointcloud->empty()) return;
 
-  crop_box_.setMin(Eigen::Vector4f(min_x, min_y, min_z, 1.0));
-  crop_box_.setMax(Eigen::Vector4f(max_x, max_y, max_z, 1.0));
-  crop_box_.setInputCloud(pointcloud);
-  crop_box_.filter(*pointcloud);
+  auto is_within_range = [&](const auto & point) {
+    return point.x >= min_x && point.x <= max_x && point.y >= min_y && point.y <= max_y &&
+           point.z >= min_z && point.z <= max_z;
+  };
 
-  if (pointcloud->empty()) return;
+  auto is_target_type = [&](const auto & point) {
+    const auto classification = static_cast<PointCloudClassification>(point.class_id);
+    if (pcd_class_to_object_type.count(classification) == 0) return false;
+    return pcd_types_.count(pcd_class_to_object_type.at(classification)) != 0;
+  };
 
-  voxel_grid_.setInputCloud(pointcloud);
-  voxel_grid_.filter(*pointcloud);
-}
-
-void PointCloudFilter::cluster_pointcloud(
-  const PointCloud::Ptr & input, PointCloud::Ptr & output, const double min_height)
-{
-  if (input->empty()) return;
-
-  std::vector<pcl::PointIndices> cluster_indices;
-  tree_->setInputCloud(input);
-  ec_.setSearchMethod(tree_);
-  ec_.setInputCloud(input);
-  ec_.extract(cluster_indices);
-
-  PointCloud::Ptr cluster_buffer(new PointCloud);
-  PointCloud::Ptr hull_buffer(new PointCloud);
-
-  for (const auto & indices : cluster_indices) {
-    cluster_buffer->clear();
-    hull_buffer->clear();
-    bool cluster_above_height_threshold{false};
-    for (const auto & index : indices.indices) {
-      const auto & point = (*input)[index];
-
-      cluster_above_height_threshold |= point.z >= min_height;
-      cluster_buffer->push_back(point);
-    }
-    if (!cluster_above_height_threshold || cluster_buffer->empty()) continue;
-
-    convex_hull_.setInputCloud(cluster_buffer);
-    convex_hull_.reconstruct(*hull_buffer);
-    for (const auto & point : *hull_buffer) {
-      output->push_back(point);
-    }
-  }
+  // Axis-aligned crop via x/y/z only. pcl::CropBox cannot be used with PointXYZCPE because
+  // PCL transform helpers require a .data member that this point type does not provide.
+  pointcloud->erase(
+    std::remove_if(
+      pointcloud->begin(), pointcloud->end(),
+      [&](const auto & point) { return !is_within_range(point) || !is_target_type(point); }),
+    pointcloud->end());
 }
 
 void PointCloudFilter::filter_pointcloud_by_object(
@@ -727,7 +702,11 @@ void ObstacleTracker::update_points(
 
   for (const auto & [uuid, entry] : persistent_point_map_) {
     if (entry.is_active) {
-      persistent_points->points.emplace_back(entry.position.x, entry.position.y, entry.position.z);
+      autoware::point_types::PointXYZCPE point;
+      point.x = entry.position.x;
+      point.y = entry.position.y;
+      point.z = entry.position.z;
+      persistent_points->points.push_back(point);
     }
   }
 }

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -678,8 +678,8 @@ void ObstacleTracker::update_points(
     if (persistent_point_map_.empty()) return std::nullopt;
     double min_distance = pcd_distance_th_ + std::numeric_limits<double>::epsilon();
     for (const auto & [uuid, existing_point] : persistent_point_map_) {
-      const auto distance = std::hypot(
-        point.x - existing_point.point.x, point.y - existing_point.point.y);
+      const auto distance =
+        std::hypot(point.x - existing_point.point.x, point.y - existing_point.point.y);
       if (distance > min_distance) continue;
       min_distance = distance;
       closest_uuid = uuid;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -557,6 +557,12 @@ void ObjectFilter::filter_by_target_area(
   };
 
   auto get_object_polygon = [&](const auto & pose, const auto & shape) {
+    if (shape.type != Shape::POLYGON) {
+      auto s = shape;
+      s.dimensions.x += safety_buffer_;
+      s.dimensions.y += safety_buffer_;
+      return autoware_utils::to_polygon2d(pose, s);
+    }
     const auto polygon = autoware_utils::to_polygon2d(pose, shape);
     return autoware_utils::expand_polygon(polygon, safety_buffer_);
   };

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -439,8 +439,10 @@ std::optional<CollisionPoint> get_nearest_object_collision(
       if (collision_arc_length < min_collision_arc_length) {
         min_collision_arc_length = collision_arc_length;
         colliding_object = object;
-        const auto collision_point = motion_utils::calcLongitudinalOffsetPose(trajectory_points, obj_state.nearest_point, obj_stopping_distance);
-        nearest_collision_point = collision_point.has_value() ? collision_point.value().position : obj_state.nearest_point;
+        const auto collision_point = motion_utils::calcLongitudinalOffsetPose(
+          trajectory_points, obj_state.nearest_point, obj_stopping_distance);
+        nearest_collision_point =
+          collision_point.has_value() ? collision_point.value().position : obj_state.nearest_point;
         is_dynamic_collision = dynamic;
       }
       break;

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -360,15 +360,13 @@ ObjectState get_object_state_at_time(
 }
 
 double get_safe_distance(
-  const double ego_vel, const double object_vel, const double ego_decel, const double object_decel,
+  const double ego_vel, const double ego_decel, const double object_stopping_distance,
   const double reaction_time, const double safety_margin)
 {
   constexpr double eps = 1e-3;
   const auto ego_decel_mag = std::max(std::abs(ego_decel), eps);
-  const auto object_decel_mag = std::max(std::abs(object_decel), eps);
   const auto reaction_distance = ego_vel * reaction_time;
   const auto ego_stopping_distance = ego_vel * ego_vel / (2 * ego_decel_mag);
-  const auto object_stopping_distance = object_vel * object_vel / (2 * object_decel_mag);
   const auto safe_distance =
     reaction_distance + ego_stopping_distance - object_stopping_distance + safety_margin;
   return std::max(safe_distance, safety_margin);
@@ -390,26 +388,34 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   }
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
+  constexpr double eps = 1e-3;
 
-  auto is_safe = [&](
-                   const auto & object, const double obj_arc_length, const double obj_lon_vel,
-                   const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
+  auto get_object_stopping_distance = [&](const auto & object, const double obj_lon_vel) {
+    if (obj_lon_vel < stopped_vel_th) return 0.0;
     const auto label =
       object.classification.empty()
         ? ObjectClassification::UNKNOWN
         : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
     const auto obj_type = classification_to_object_type.at(label);
-    if (!object_decel_map.count(obj_type)) return {false, false};
+    if (!object_decel_map.count(obj_type)) return 0.0;
     const auto obj_decel = object_decel_map.at(obj_type);
-    if (obj_lon_vel < stopped_vel_th) return {false, false};
+    const auto object_decel_mag = std::max(std::abs(obj_decel), eps);
+    const auto object_stopping_distance = obj_lon_vel * obj_lon_vel / (2 * object_decel_mag);
+    return object_stopping_distance;
+  };
+
+  auto is_safe = [&](
+                   const double obj_arc_length, const double obj_stopping_distance,
+                   const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
+    if (obj_stopping_distance <= eps) return {false, false};
     const auto safe_dist =
-      get_safe_distance(ego_vel, obj_lon_vel, ego_decel, obj_decel, reaction_time, safety_margin);
+      get_safe_distance(ego_vel, ego_decel, obj_stopping_distance, reaction_time, safety_margin);
     const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
     return {relative_arc_length - safe_dist > 1e-3, true};
   };
 
-  auto min_obj_arc_length = std::numeric_limits<double>::max();
+  auto min_collision_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
   bool is_dynamic_collision = false;
@@ -424,14 +430,17 @@ std::optional<CollisionPoint> get_nearest_object_collision(
       last_p = traj_p.pose.position;
       const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
+      const auto obj_stopping_distance = get_object_stopping_distance(object, obj_state.lon_vel);
       const auto [safe, dynamic] =
-        is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel);
+        is_safe(obj_state.arc_length, obj_stopping_distance, curr_arc_length, target_ego_vel);
       if (safe) continue;
       found_collision = true;
-      if (obj_state.arc_length < min_obj_arc_length) {
-        min_obj_arc_length = obj_state.arc_length;
+      auto collision_arc_length = obj_state.arc_length + obj_stopping_distance;
+      if (collision_arc_length < min_collision_arc_length) {
+        min_collision_arc_length = collision_arc_length;
         colliding_object = object;
-        nearest_collision_point = obj_state.nearest_point;
+        const auto collision_point = motion_utils::calcLongitudinalOffsetPose(trajectory_points, obj_state.nearest_point, obj_stopping_distance);
+        nearest_collision_point = collision_point.has_value() ? collision_point.value().position : obj_state.nearest_point;
         is_dynamic_collision = dynamic;
       }
       break;
@@ -439,7 +448,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   }
 
   if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_obj_arc_length, is_dynamic_collision);
+  return CollisionPoint(nearest_collision_point, min_collision_arc_length, is_dynamic_collision);
 }
 
 void PointCloudFilter::filter_pointcloud(

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -133,7 +133,7 @@ PredictedObjects::ConstSharedPtr make_blocking_car(double x, double y)
   return std::make_shared<const PredictedObjects>(predicted_objects);
 }
 
-// Build a dense pointcloud cluster the obstacle_stop pipeline will detect.
+// Build a dense blocking pointcloud the obstacle_stop pipeline will detect.
 sensor_msgs::msg::PointCloud2::ConstSharedPtr make_blocking_pointcloud_cluster(
   double center_x, double center_y, double height)
 {

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -246,16 +246,9 @@ protected:
     p.objects.target_objects.bbox = {"car"};
     p.objects.target_objects.polygon = {"car"};
 
+    p.pointcloud.target_types = {"unknown"};
     p.pointcloud.height_buffer = 0.5;
     p.pointcloud.min_height = 0.2;
-    p.pointcloud.voxel_grid_filter.x = 0.2;
-    p.pointcloud.voxel_grid_filter.y = 0.2;
-    p.pointcloud.voxel_grid_filter.z = 0.2;
-    p.pointcloud.voxel_grid_filter.min_size = 3;
-    p.pointcloud.clustering.tolerance = 0.3;
-    p.pointcloud.clustering.min_height = 0.5;
-    p.pointcloud.clustering.min_size = 10;
-    p.pointcloud.clustering.max_size = 10000;
 
     p.rss_params.enable = true;
     p.rss_params.object_decel.car = 1.5;

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -16,6 +16,8 @@
 #include "trajectory_processor_test_utils.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware/point_types/memory.hpp>
+#include <autoware/point_types/types.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 #include <autoware_trajectory_processor/trajectory_processor_param.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -26,12 +28,11 @@
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <gtest/gtest.h>
 
 #include <chrono>
-#include <limits>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <thread>
@@ -133,35 +134,33 @@ PredictedObjects::ConstSharedPtr make_blocking_car(double x, double y)
   return std::make_shared<const PredictedObjects>(predicted_objects);
 }
 
-// Build a dense blocking pointcloud the obstacle_stop pipeline will detect.
-sensor_msgs::msg::PointCloud2::ConstSharedPtr make_blocking_pointcloud_cluster(
-  double center_x, double center_y, double height)
+// Build a single blocking PointXYZCPE point. obstacle_stop evaluates points independently
+// (no voxel/clustering), so a dense cluster is unnecessary and can confuse the tracker when
+// neighboring points fall within pcd_distance_th.
+sensor_msgs::msg::PointCloud2::ConstSharedPtr make_blocking_pointcloud(double x, double y, double z)
 {
-  constexpr int voxel_count_x = 4;
-  constexpr int voxel_count_y = 3;
-  constexpr int points_per_voxel = 3;
+  using autoware::point_types::PointCloudClassification;
+  using autoware::point_types::PointXYZCPE;
 
   sensor_msgs::msg::PointCloud2 cloud;
   cloud.header.frame_id = "map";
-  sensor_msgs::PointCloud2Modifier modifier(cloud);
-  modifier.setPointCloud2FieldsByString(1, "xyz");
-  modifier.resize(voxel_count_x * voxel_count_y * points_per_voxel);
+  cloud.height = 1;
+  cloud.width = 1;
+  cloud.is_dense = true;
+  cloud.is_bigendian = false;
+  cloud.fields = autoware::point_types::create_fields_point_xyzcpe();
+  cloud.point_step = sizeof(PointXYZCPE);
+  cloud.row_step = cloud.point_step * cloud.width;
+  cloud.data.resize(cloud.row_step);
 
-  sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
-  for (int xi = 0; xi < voxel_count_x; ++xi) {
-    for (int yi = 0; yi < voxel_count_y; ++yi) {
-      for (int p = 0; p < points_per_voxel; ++p) {
-        *iter_x = static_cast<float>(center_x + 0.2 * xi + 0.05 + 0.01 * p);
-        *iter_y = static_cast<float>(center_y + 0.2 * yi + 0.05);
-        *iter_z = static_cast<float>(height);
-        ++iter_x;
-        ++iter_y;
-        ++iter_z;
-      }
-    }
-  }
+  PointXYZCPE point;
+  point.x = static_cast<float>(x);
+  point.y = static_cast<float>(y);
+  point.z = static_cast<float>(z);
+  // INVALID maps to target type "unknown" used by the integration test params.
+  point.class_id = static_cast<std::uint8_t>(PointCloudClassification::INVALID);
+  point.probability = 1.0F;
+  std::memcpy(cloud.data.data(), &point, sizeof(PointXYZCPE));
 
   return std::make_shared<const sensor_msgs::msg::PointCloud2>(cloud);
 }
@@ -390,13 +389,12 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedBeforeObject_ReachMaxDecel)
   EXPECT_NEAR(object_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }
 
-TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluster)
+TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloud)
 {
   // Arrange
-  constexpr double cluster_center_x = 25.0;
+  constexpr double obstacle_x = 25.0;
   auto trajectory = create_straight_trajectory(30.0, 8.0);
-  const auto pointcloud_blocking_path =
-    make_blocking_pointcloud_cluster(cluster_center_x, 0.0, 0.7);
+  const auto pointcloud_blocking_path = make_blocking_pointcloud(obstacle_x, 0.0, 0.7);
   const auto input = create_input_data(
     make_odometry(0.0, 0.0, 8.0), make_acceleration(0.0), nullptr, pointcloud_blocking_path);
 
@@ -409,31 +407,19 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluste
   // Assert
   ASSERT_TRUE(modified);
   EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
-  EXPECT_LT(trajectory.back().pose.position.x, cluster_center_x);
-
-  const auto min_pcd_x = [&pointcloud_blocking_path]() {
-    sensor_msgs::PointCloud2ConstIterator<float> iter_x(*pointcloud_blocking_path, "x");
-    auto min_x = std::numeric_limits<float>::max();
-    for (; iter_x != iter_x.end(); ++iter_x) {
-      if (*iter_x < min_x) {
-        min_x = *iter_x;
-      }
-    }
-    return min_x;
-  }();
+  EXPECT_LT(trajectory.back().pose.position.x, obstacle_x);
 
   const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
   const auto expected_stop_margin = params_.obstacle_stop.stop_margin + ego_front_offset;
-  EXPECT_NEAR(min_pcd_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
+  EXPECT_NEAR(obstacle_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }
 
-TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluster_ReachMaxDecel)
+TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloud_ReachMaxDecel)
 {
   // Arrange
-  constexpr double cluster_center_x = 15.0;
+  constexpr double obstacle_x = 15.0;
   auto trajectory = create_straight_trajectory(30.0, 8.0);
-  const auto pointcloud_blocking_path =
-    make_blocking_pointcloud_cluster(cluster_center_x, 0.0, 0.7);
+  const auto pointcloud_blocking_path = make_blocking_pointcloud(obstacle_x, 0.0, 0.7);
   const auto input = create_input_data(
     make_odometry(0.0, 0.0, 8.0), make_acceleration(0.0), nullptr, pointcloud_blocking_path);
 
@@ -446,19 +432,8 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluste
   // Assert
   ASSERT_TRUE(modified);
   EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
-  EXPECT_LT(trajectory.back().pose.position.x, cluster_center_x);
+  EXPECT_LT(trajectory.back().pose.position.x, obstacle_x);
 
-  const auto min_pcd_x = [&pointcloud_blocking_path]() {
-    sensor_msgs::PointCloud2ConstIterator<float> iter_x(*pointcloud_blocking_path, "x");
-    auto min_x = std::numeric_limits<float>::max();
-    for (; iter_x != iter_x.end(); ++iter_x) {
-      if (*iter_x < min_x) {
-        min_x = *iter_x;
-      }
-    }
-    return min_x;
-  }();
-
-  const auto expected_stop_margin = 2.01;  // Computed based on max_decel limit and jerk limit
-  EXPECT_NEAR(min_pcd_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
+  const auto expected_stop_margin = 1.96;  // Computed based on max_decel limit and jerk limit
+  EXPECT_NEAR(obstacle_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }

--- a/planning/autoware_trajectory_processor/tests/test_surround_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_surround_obstacle_stop_integration.cpp
@@ -236,6 +236,7 @@ protected:
     p.use_pointcloud = true;
     p.target_objects.bbox = {"car"};
     p.target_objects.polygon = {"car"};
+    p.target_objects.pointcloud = {"unknown"};
     p.hysteresis_distance = 0.5;
     p.hysteresis_time = 0.0;
     p.ego_stopped_vel_th = 0.1;


### PR DESCRIPTION
## Description
This PR integrates the new semantic pointcloud interface (`PointXYZCPE`) into `trajectory_modifier` and `minimum_rule_based_planner` **obstacle_stop** / **surround_obstacle_stop** plugins.
It replaces the heavy local PCD processing (voxel grid, Euclidean clustering, convex hull) with light label + range filtering.

Additionally it fixes the obstacle_stop collision distance logic to return the distance to projected collision point instead of distance to initial object state.

### Background:
Perception now publishes a prefiltered, labeled pointcloud (`PointXYZCPE` with `class_id` / `probability` / `entropy`). Planning no longer needs to reconstruct obstacle candidates from dense unlabeled clouds; it should only keep target semantic classes and apply range/footprint bounds applying safety checks.

### Changes:

**Obstacle stop:**
- Switch PCD type from `pcl::PointXYZ` to `PointXYZCPE`
- Filter by configurable `pointcloud.target_types` (`class_id`) and range/height bounds
- Remove voxel-grid / clustering / convex-hull pipeline and related params from config, parameter structs, and schemas
- Add `PointCloudClassification` → `ObjectType` mapping
- Preserve full CPE fields (`class_id`, `probability`, `entropy`) in `ObstacleTracker` persistent points.
- Add `autoware_point_types` dependency to `trajectory_modifier`.
- Fix function get_nearest_object_collision() to return distance to projected collision point instead of distance to initial object state.
- Simplify polygon expansion logic for objects with shape types other than POLYGON

**Surround obstacle stop:**
- Parse CPE clouds, filter by `target_objects.pointcloud` labels, and crop to the ego footprint expanded by front/side/back thresholds + hysteresis.
- Convert filtered points to `pcl::PointXYZ` for `ProximityChecker`.
- Add `target_objects.pointcloud` params to config, parameter structs, and schemas in both packages.


## Related Links
