### PR TITLE
fix(image_projection_based_fusion): dangling reference bug fix

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -30,12 +30,14 @@
 
 #include <boost/optional.hpp>
 
+#include <atomic>
 #include <cmath>
 #include <limits>
 #include <list>
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -273,24 +275,30 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::camera_info_callback(
   // This assume the camera info does not change while the node is running
   auto & det2d_status = det2d_status_list_.at(rois_id);
   if (det2d_status.camera_projector_ptr == nullptr && check_camera_info(*input_camera_info_msg)) {
-    std::atomic<bool> initializing{true};
-    std::thread([this, &initializing, rois_id]() {
+    // The flag is shared with the logging thread so that it outlives this scope even if the
+    // thread is still running, and the thread is joined below to guarantee that `this` stays
+    // valid for the whole lifetime of the thread.
+    auto initializing = std::make_shared<std::atomic<bool>>(true);
+    std::thread logging_thread([this, initializing, rois_id]() {
       rclcpp::Rate rate(1.0);  // 1 Hz
-      while (rclcpp::ok() && initializing.load()) {
+      while (rclcpp::ok() && initializing->load()) {
         RCLCPP_WARN(
           this->get_logger(), "Still initializing camera projector for ROI %zu... please wait...",
           rois_id);
         rate.sleep();
       }
-    }).detach();
+    });
 
     det2d_status.camera_projector_ptr = std::make_unique<CameraProjection>(
       *input_camera_info_msg, approx_grid_cell_w_size_, approx_grid_cell_h_size_,
       det2d_status.project_to_unrectified_image, det2d_status.approximate_camera_projection);
     det2d_status.camera_projector_ptr->initialize();
 
-    // Mark as finished
-    initializing = false;
+    // Mark as finished and wait for the logging thread to exit, so that no stray warning is
+    // printed after the message below and no thread outlives this node.
+    initializing->store(false);
+    logging_thread.join();
+
     RCLCPP_INFO(
       this->get_logger(), "Camera projector initialization for ROI %zu finished.", rois_id);
 


### PR DESCRIPTION
## Description

Fixes the bug raised in https://github.com/autowarefoundation/autoware_universe/issues/13172

- Implements option 4 from the issue discussion — share the flag's ownership and join the
thread:

- The flag becomes std::shared_ptr<std::atomic<bool>> captured by value, so it outlives the
  callback frame even while the thread is still running. Fixes (1).
- The thread is joined instead of detached, so the callback cannot return until the thread has
  exited. This guarantees this remains valid for the thread's whole lifetime and that no thread
  outlives the node. Fixes (2) and (3).

The 1 Hz heartbeat logging behaviour is unchanged.

## Related links

Parent Issue:

- https://github.com/autowarefoundation/autoware_universe/issues/13172

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->
## How was this PR tested?

- Built autoware_image_projection_based_fusion and launched roi_pointcloud_fusion with point_project_to_unrectified_image: true (the initialization path only runs when this is
enabled), then confirmed in the log that no Still initializing camera projector for ROI N line
appears after Camera projector initialization for ROI N finished., and that the node terminates
without crashing.
- Below is log of testing logging_simulator with `roi_pointcloud_fusion` node for 3 camera in irregular_object_detection pipeline 
``` 
[roi_pointcloud_fusion_node-49] [WARN] [1787576523.342578442] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Still initializing camera projector for ROI 0... please wait...
[roi_pointcloud_fusion_node-49] [INFO] [1787576523.416298378] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Camera projector initialization for ROI 0 finished.
[roi_pointcloud_fusion_node-49] [WARN] [1787576523.416617046] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Still initializing camera projector for ROI 1... please wait...
[roi_pointcloud_fusion_node-49] [WARN] [1787576524.342579383] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Still initializing camera projector for ROI 0... please wait...
[roi_pointcloud_fusion_node-49] [WARN] [1787576524.416670201] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Still initializing camera projector for ROI 1... please wait...
[roi_pointcloud_fusion_node-49] [INFO] [1787576524.496183713] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Camera projector initialization for ROI 1 finished.
[roi_pointcloud_fusion_node-49] [WARN] [1787576524.496609207] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Still initializing camera projector for ROI 2... please wait...
[roi_pointcloud_fusion_node-49] [WARN] [1787576525.416672915] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Still initializing camera projector for ROI 1... please wait...
[roi_pointcloud_fusion_node-49] [WARN] [1787576525.496666695] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Still initializing camera projector for ROI 2... please wait...
[roi_pointcloud_fusion_node-49] [INFO] [1787576525.517560995] [perception.object_recognition.detection.irregular_object.roi_pointcloud_fusion]: Camera projector initialization for ROI 2 finished.
```





## Effects on system behavior
- join() waits for the heartbeat thread's current rate.sleep() to expire, so each camera adds up
to 1 s (~0.5 s on average) after its projector finishes initializing — up to 6 s with 6 cameras in
the worst case. This trade-off was discussed and accepted in the issue.

- Note that the heartbeat's 1 s sleeps themselves cost nothing: they run concurrently with
initialize(). Only the leftover tail of the final sleep is idle time.

- No change to fusion behaviour, message flow, or published output.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->
