### PR TITLE
refactor(autoware_traffic_light_arbiter): accept source_priority as string at the boundary

### DIFF
--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -35,6 +36,8 @@ enum class SourcePriority {
   EXTERNAL,    // Prioritize external signals
   PERCEPTION   // Prioritize perception signals
 };
+
+SourcePriority to_source_priority(const std::string & source_priority);
 
 /**
  * @class SignalMatchValidator
@@ -56,11 +59,14 @@ public:
    * @brief Construct a validator with the source-priority mode fixed at
    *        construction. The mode is immutable for the validator's lifetime.
    *
-   * @param source_priority CONFIDENCE (confidence-based selection),
-   *                        EXTERNAL (prioritize external), or
-   *                        PERCEPTION (prioritize perception).
+   * @param source_priority "confidence" (confidence-based selection),
+   *                        "external" (prioritize external), or
+   *                        "perception" (prioritize perception). Any other
+   *                        value is treated as "confidence", mirroring
+   *                        TrafficLightArbiterNode's parameter fallback.
    */
-  explicit SignalMatchValidator(SourcePriority source_priority) : source_priority_(source_priority)
+  explicit SignalMatchValidator(const std::string & source_priority)
+  : source_priority_(to_source_priority(source_priority))
   {
   }
 

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -40,8 +41,10 @@ public:
   using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
   using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
 
+  // source_priority is "confidence", "external", or "perception"; any other value is treated as
+  // "confidence"
   TrafficLightArbiter(
-    SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
+    std::string source_priority, bool enable_signal_matching, double external_delay_tolerance,
     double external_time_tolerance, double perception_time_tolerance);
 
   // Extracts and stores the regulatory-element IDs the Core needs from the map

--- a/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -219,6 +220,17 @@ Time get_newer_stamp(const Time & stamp1, const Time & stamp2)
 
 namespace autoware::traffic_light
 {
+
+SourcePriority to_source_priority(const std::string & source_priority)
+{
+  if (source_priority == "external") {
+    return SourcePriority::EXTERNAL;
+  }
+  if (source_priority == "perception") {
+    return SourcePriority::PERCEPTION;
+  }
+  return SourcePriority::CONFIDENCE;
+}
 
 autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::validate_signals(
   const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals) const

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -202,15 +203,15 @@ std::unordered_set<lanelet::Id> extract_pedestrian_traffic_light_ids(
 }  // namespace
 
 TrafficLightArbiter::TrafficLightArbiter(
-  SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
+  std::string source_priority, bool enable_signal_matching, double external_delay_tolerance,
   double external_time_tolerance, double perception_time_tolerance)
-: source_priority_(source_priority),
+: source_priority_(to_source_priority(source_priority)),
   external_delay_tolerance_(external_delay_tolerance),
   external_time_tolerance_(external_time_tolerance),
   perception_time_tolerance_(perception_time_tolerance)
 {
   if (enable_signal_matching) {
-    signal_match_validator_ = std::make_unique<SignalMatchValidator>(source_priority_);
+    signal_match_validator_ = std::make_unique<SignalMatchValidator>(source_priority);
   }
 }
 

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_node.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_node.cpp
@@ -30,20 +30,16 @@ TrafficLightArbiterNode::TrafficLightArbiterNode(const rclcpp::NodeOptions & opt
   const auto perception_time_tolerance =
     this->declare_parameter<double>("perception_time_tolerance");
 
-  // Parse source priority parameter
-  SourcePriority source_priority;
-  const std::string priority_str = this->declare_parameter<std::string>("source_priority");
-  if (priority_str == "external") {
-    source_priority = SourcePriority::EXTERNAL;
-  } else if (priority_str == "perception") {
-    source_priority = SourcePriority::PERCEPTION;
-  } else if (priority_str == "confidence") {
-    source_priority = SourcePriority::CONFIDENCE;
-  } else {
+  // Parse source priority parameter. Any value other than "external"/"perception"/"confidence" is
+  // normalized to "confidence" here so TrafficLightArbiter never has to guard against a typo.
+  std::string source_priority = this->declare_parameter<std::string>("source_priority");
+  if (
+    source_priority != "external" && source_priority != "perception" &&
+    source_priority != "confidence") {
     RCLCPP_WARN(
       get_logger(), "Unknown source_priority '%s', defaulting to 'confidence'",
-      priority_str.c_str());
-    source_priority = SourcePriority::CONFIDENCE;
+      source_priority.c_str());
+    source_priority = "confidence";
   }
 
   const bool enable_signal_matching = this->declare_parameter<bool>("enable_signal_matching");

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter.cpp
@@ -39,7 +39,6 @@
 namespace
 {
 
-using autoware::traffic_light::SourcePriority;
 using autoware::traffic_light::TrafficLightArbiter;
 using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTrafficLightState;
 using TrafficLightElement = autoware_perception_msgs::msg::TrafficLightElement;
@@ -47,14 +46,14 @@ using TrafficLightGroup = autoware_perception_msgs::msg::TrafficLightGroup;
 using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
 using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
 
-// --- Short aliases for enum values used throughout the tests ----------
+// --- Short aliases for the source_priority values used throughout the tests ---
 //
 // Anonymous-namespace scoped so they don't leak; keeps each test's reading
-// flow on color/shape/priority rather than on the enum-qualifying prefix.
+// flow on color/shape/priority rather than on the string literal.
 
-constexpr auto CONFIDENCE = SourcePriority::CONFIDENCE;
-constexpr auto EXTERNAL = SourcePriority::EXTERNAL;
-constexpr auto PERCEPTION = SourcePriority::PERCEPTION;
+constexpr const char * CONFIDENCE = "confidence";
+constexpr const char * EXTERNAL = "external";
+constexpr const char * PERCEPTION = "perception";
 
 constexpr uint8_t RED = TrafficLightElement::RED;
 constexpr uint8_t GREEN = TrafficLightElement::GREEN;
@@ -301,7 +300,7 @@ const lanelet::LaneletMapConstPtr shared_map = []() {
 
 // Builds an arbiter with the suite-wide map already loaded. priority and
 // enable_signal_matching select the reconciliation mode under test.
-TrafficLightArbiter make_arbiter(SourcePriority priority, bool enable_signal_matching)
+TrafficLightArbiter make_arbiter(std::string priority, bool enable_signal_matching)
 {
   TrafficLightArbiter arbiter(
     priority, enable_signal_matching, default_external_delay_tolerance,


### PR DESCRIPTION
## Description

`TrafficLightArbiterNode`'s `source_priority` parameter is read from ROS as a `std::string`, but `TrafficLightArbiter` and `SignalMatchValidator` required callers to pre-convert it into the `SourcePriority` enum themselves, duplicating the string-to-enum parsing logic at the call site.

This PR moves that conversion into the core library: both constructors now accept `source_priority` as a plain `std::string` and convert it internally via a new free function, `to_source_priority()`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_arbiter` — build succeeds.
- `colcon test --packages-select autoware_traffic_light_arbiter --event-handlers console_cohesion+` — all 6 test suites pass, including 39 gtest cases covering signal matching, confidence/external/perception priority modes, staleness handling, and boundary conditions.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
