### PR TITLE
fix(autoware_planning_evaluator): fix out-of-bounds read in calc_lookahead_trajectory_distance

### DIFF
--- a/evaluator/autoware_planning_evaluator/src/metrics/metrics_utils.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metrics/metrics_utils.cpp
@@ -86,12 +86,16 @@ Trajectory get_lookahead_trajectory(
 
 double calc_lookahead_trajectory_distance(const Trajectory & traj, const Pose & ego_pose)
 {
+  if (traj.points.empty()) {
+    return 0.0;
+  }
+
   const auto ego_index =
     autoware::motion_utils::findNearestSegmentIndex(traj.points, ego_pose.position);
   double dist = 0.0;
   auto curr_point_it = std::next(traj.points.begin(), ego_index);
   auto prev_point_it = curr_point_it;
-  for (size_t i = 0; i < traj.points.size(); ++i) {
+  while (curr_point_it != traj.points.end()) {
     const auto d =
       autoware_utils::calc_distance2d(prev_point_it->pose.position, curr_point_it->pose.position);
     dist += d;


### PR DESCRIPTION
## Description

`calc_lookahead_trajectory_distance` starts iterating at `ego_index` but loops `traj.points.size()` times, so it dereferences up to `ego_index` elements past the end of `traj.points`.

Guard the loop with `end()`, matching `get_lookahead_trajectory` directly above it, and return early for an empty trajectory.

## Related links

None.

## How was this PR tested?

Ran the logging simulator with the sample rosbag 14 times, with a goal set so this metric is exercised. The runs used `ENABLE_AGNOCAST=1`, which puts this node on a multi-threaded executor where the out-of-bounds read hits the guard region of a per-thread glibc arena instead of silently reading mapped memory. Before the fix, `planning_evaluator` died with SIGSEGV inside this function in 5 of 14 runs; after the fix, 0 of 14.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

The returned distance is now the trajectory length ahead of the ego, instead of a sum that included reads past the end of the buffer.
