### PR TITLE
fix(autoware_carla_interface): normalize the steer command by the wheel max steer angle

### DIFF
--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -300,6 +300,7 @@ class carla_ros2_interface(object):
         self.prev_timestamp = None
         self.prev_steer_output = 0.0
         self.tau = 0.2
+        self._max_steer_angle_rad = None
         self.timestamp = None
         self.ego_actor = None
         self.physics_control = None
@@ -747,19 +748,33 @@ class carla_ros2_interface(object):
             if not self.physics_control or not self.ego_actor:
                 return  # Skip if vehicle not initialized yet
 
-            steer_curve = self.physics_control.steering_curve
-            # numpy.interp requires the sample x-coordinates to be increasing.
-            # CARLA 0.10 can return the steering-curve points out of order,
-            # so sort by x before interpolating. On 0.9.x the curve is already
-            # sorted, making this a no-op.
-            steer_curve = sorted(steer_curve, key=lambda v: v.x)
-            current_vel = self.ego_actor.get_velocity()
-            max_steer_ratio = numpy.interp(
-                abs(current_vel.x), [v.x for v in steer_curve], [v.y for v in steer_curve]
-            )
-            out_cmd.steer = self.first_order_steering(-in_cmd.actuation.steer_cmd) * max_steer_ratio
+            # steer_cmd is a tire angle in radians (raw_vehicle_cmd_converter
+            # passes control_cmd.steering_tire_angle through), while
+            # VehicleControl.steer expects a fraction of the wheel's max steer
+            # angle in [-1, 1]. Normalize by the max wheel angle; the sign flips
+            # because Autoware is CCW-positive and CARLA CW-positive.
+            # NOTE: no steering_curve multiplication here — the simulator applies
+            # its speed-based steering limit internally, and CARLA 0.10 returns
+            # corrupt curve data (duplicated/unsorted points) anyway.
+            steer_norm = -in_cmd.actuation.steer_cmd / self._max_wheel_steer_angle_rad()
+            steer_norm = max(-1.0, min(1.0, steer_norm))
+            out_cmd.steer = self.first_order_steering(steer_norm)
             out_cmd.brake = in_cmd.actuation.brake_cmd
             self.current_control = out_cmd
+
+    def _max_wheel_steer_angle_rad(self):
+        """Max steerable wheel angle [rad], cached from the vehicle physics.
+
+        Must be called with ``physics_control`` already available.
+        """
+        if self._max_steer_angle_rad is None:
+            max_deg = max(
+                (w.max_steer_angle for w in self.physics_control.wheels), default=0.0
+            )
+            if max_deg <= 0.0:
+                max_deg = 70.0  # CARLA's usual front-wheel default
+            self._max_steer_angle_rad = math.radians(max_deg)
+        return self._max_steer_angle_rad
 
     def turn_indicators_callback(self, in_cmd):
         """Store turn indicator command (thread-safe)."""

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -768,9 +768,7 @@ class carla_ros2_interface(object):
         Must be called with ``physics_control`` already available.
         """
         if self._max_steer_angle_rad is None:
-            max_deg = max(
-                (w.max_steer_angle for w in self.physics_control.wheels), default=0.0
-            )
+            max_deg = max((w.max_steer_angle for w in self.physics_control.wheels), default=0.0)
             if max_deg <= 0.0:
                 max_deg = 70.0  # CARLA's usual front-wheel default
             self._max_steer_angle_rad = math.radians(max_deg)


### PR DESCRIPTION
## Description

The steer command from `raw_vehicle_cmd_converter` (`convert_steer_cmd: false`) is a **tire angle in radians**, but it was written to `VehicleControl.steer` as-is, which CARLA interprets as a **fraction of the wheel's max steer angle** (~70 deg for most vehicles). On top of that it was multiplied by the physics `steering_curve`, which the simulator already applies internally — and which CARLA 0.10 returns as corrupt data (duplicated, unsorted points such as `(10 m/s, 0.5)`, halving the steering around 36 km/h).

This PR normalizes the commanded tire angle by the max wheel steer angle from the vehicle physics, clamps to [-1, 1], and drops the steering-curve multiplication so the speed-based limit is only applied once, inside the simulator.

## How was this PR tested?

- Closed-loop CARLA 0.10 run (taxi.ford, ~2 m/s, OnePlanner E2E stack), measuring the achieved tire angle from the ground-truth yaw rate (`atan(yaw_rate * wheel_base / v)`): before this series the command→achieved DC gain was speed-dependent and far from unity; with the series applied the vehicle completed a 75-degree turn it previously could not make. Detailed numbers in the follow-up calibration PR.
- `colcon build --packages-select autoware_carla_interface --symlink-install` passes.

## Backward compatibility

The conversion gain changes for every consumer of `autoware_carla_interface` (this is the point of the fix: the previous gain was wrong in both units and speed dependence).

Part of the CARLA 0.10 steering fix series. Follow-ups #13276 (steering report fallback) and #13278 (max-steer-angle calibration) build on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
