### PR TITLE
feat(autoware_carla_interface): allow overriding the wheel max steer angle for steer calibration

### DIFF
--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -59,6 +59,7 @@
     <let name="sensor_mapping_file_default" value="$(find-pkg-share autoware_carla_interface)/config/sensor_mapping_light_weight.yaml" if="$(var use_light_weight_sensor_mapping)"/>
     <let name="sensor_mapping_file_default" value="$(find-pkg-share autoware_carla_interface)/config/sensor_mapping.yaml" unless="$(var use_light_weight_sensor_mapping)"/>
     <arg name="sensor_mapping_file" default="$(var sensor_mapping_file_default)" description="Path to sensor mapping YAML"/>
+    <arg name="max_wheel_steer_angle_deg" default="0.0" description="Override the wheel max steer angle [deg] used for steer normalization; 0 uses the physics value"/>
     <arg name="flatten_steering_curve" default="false" description="Replace the ego vehicle's speed-based steering curve with an identity curve (CARLA 0.10 corrupt-curve workaround)"/>
     <arg name="wake_sleeping_physics" default="false" description="Nudge the ego physics body awake when launching from standstill (CARLA 0.10 sleeping-body workaround; not needed on 0.9.15)"/>
 
@@ -87,6 +88,7 @@
       <param name="sensor_kit_name" value="$(var sensor_kit_name)"/>
       <param name="sensor_mapping_file" value="$(var sensor_mapping_file)"/>
       <param name="publish_ground_truth_localization" value="$(var use_e2e_planning)"/>
+      <param name="max_wheel_steer_angle_deg" value="$(var max_wheel_steer_angle_deg)"/>
       <param name="flatten_steering_curve" value="$(var flatten_steering_curve)"/>
       <param name="wake_sleeping_physics" value="$(var wake_sleeping_physics)"/>
     </node>

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -123,6 +123,12 @@ class carla_ros2_interface(object):
             # Sensor configuration parameters
             "sensor_kit_name": (rclpy.Parameter.Type.STRING, ""),  # Empty = use YAML default
             "sensor_mapping_file": (rclpy.Parameter.Type.STRING, ""),
+            # Override the wheel max steer angle [deg] used to convert between
+            # tire angles and the normalized VehicleControl.steer. 0 uses the
+            # value reported by the vehicle physics. CARLA 0.10 (Chaos) reports
+            # 70 deg but only achieves roughly a third of it, so calibrating
+            # this to the measured full-steer angle restores a unity gain.
+            "max_wheel_steer_angle_deg": (rclpy.Parameter.Type.DOUBLE, 0.0),
             # Replace the ego vehicle's speed-based steering curve with an
             # identity curve (workaround for the corrupt curve data CARLA 0.10
             # returns, which attenuates steering at driving speeds).
@@ -970,7 +976,9 @@ class carla_ros2_interface(object):
         Must be called with ``physics_control`` already available.
         """
         if self._max_steer_angle_rad is None:
-            max_deg = max((w.max_steer_angle for w in self.physics_control.wheels), default=0.0)
+            max_deg = float(self.param_values.get("max_wheel_steer_angle_deg", 0.0))
+            if max_deg <= 0.0:
+                max_deg = max((w.max_steer_angle for w in self.physics_control.wheels), default=0.0)
             if max_deg <= 0.0:
                 max_deg = 70.0  # CARLA's usual front-wheel default
             self._max_steer_angle_rad = math.radians(max_deg)

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -363,6 +363,7 @@ class carla_ros2_interface(object):
         self.prev_steer_output = 0.0
         self.tau = 0.2
         self._max_steer_angle_rad = None
+        self._physics_max_steer_angle_rad = None
         self.timestamp = None
         self.ego_actor = None
         self.physics_control = None
@@ -970,19 +971,48 @@ class carla_ros2_interface(object):
             out_cmd.brake = in_cmd.actuation.brake_cmd
             self.current_control = out_cmd
 
-    def _max_wheel_steer_angle_rad(self):
-        """Max steerable wheel angle [rad], cached from the vehicle physics.
+    def _physics_max_wheel_steer_angle_rad(self):
+        """Max steerable wheel angle [rad] reported by the vehicle physics.
 
-        Must be called with ``physics_control`` already available.
+        This is CARLA's own full-steer angle: normalized VehicleControl.steer
+        in [-1, 1] maps to +/- this angle, and ``get_wheel_steer_angle()``
+        returns a value on the same scale. Must be called with
+        ``physics_control`` already available.
+        """
+        if self._physics_max_steer_angle_rad is None:
+            max_deg = max((w.max_steer_angle for w in self.physics_control.wheels), default=0.0)
+            if max_deg <= 0.0:
+                max_deg = 70.0  # CARLA's usual front-wheel default
+            self._physics_max_steer_angle_rad = math.radians(max_deg)
+        return self._physics_max_steer_angle_rad
+
+    def _max_wheel_steer_angle_rad(self):
+        """Calibrated full-steer wheel angle [rad] used for steer conversion.
+
+        Uses ``max_wheel_steer_angle_deg`` when set (> 0), otherwise the
+        physics value. Must be called with ``physics_control`` available.
         """
         if self._max_steer_angle_rad is None:
             max_deg = float(self.param_values.get("max_wheel_steer_angle_deg", 0.0))
             if max_deg <= 0.0:
-                max_deg = max((w.max_steer_angle for w in self.physics_control.wheels), default=0.0)
-            if max_deg <= 0.0:
-                max_deg = 70.0  # CARLA's usual front-wheel default
-            self._max_steer_angle_rad = math.radians(max_deg)
+                self._max_steer_angle_rad = self._physics_max_wheel_steer_angle_rad()
+            else:
+                self._max_steer_angle_rad = math.radians(max_deg)
         return self._max_steer_angle_rad
+
+    def _steer_report_scale(self):
+        """Factor mapping CARLA's reported wheel angle to the calibrated angle.
+
+        ``get_wheel_steer_angle()`` returns an angle on the physics full-steer
+        scale, but the command path normalizes by the (possibly overridden)
+        calibrated angle. Scaling the report by calibrated / physics keeps the
+        steering feedback consistent with the command, so the ~3x report
+        mismatch the override removes on the command side is removed here too.
+        """
+        physics_rad = self._physics_max_wheel_steer_angle_rad()
+        if physics_rad <= 0.0:
+            return 1.0
+        return self._max_wheel_steer_angle_rad() / physics_rad
 
     def turn_indicators_callback(self, in_cmd):
         """Store turn indicator command (thread-safe)."""
@@ -1070,7 +1100,13 @@ class carla_ros2_interface(object):
         out_vel_state.heading_rate = -math.radians(ego_angular_velocity.z)
 
         out_steering_state.stamp = out_vel_state.header.stamp
-        out_steering_state.steering_tire_angle = -math.radians(steer_angle)
+        # Scale CARLA's reported wheel angle onto the calibrated full-steer
+        # range so the feedback matches the command normalization (identity
+        # when max_wheel_steer_angle_deg is unset). The sign flips because
+        # Autoware is CCW-positive and CARLA CW-positive.
+        out_steering_state.steering_tire_angle = (
+            -math.radians(steer_angle) * self._steer_report_scale()
+        )
 
         out_gear_state.stamp = out_vel_state.header.stamp
         out_gear_state.report = GearReport.DRIVE


### PR DESCRIPTION
## Description

CARLA 0.10 (Chaos) reports `max_steer_angle = 70 deg` for the front wheels but only achieves roughly a third of it: with a sustained steer input of 0.33-0.41 the yaw-rate-derived tire angle saturates around 0.11-0.16 rad, i.e. an effective full-steer angle of about **22 deg**. The normalized steer command and the synthesized steering report both use the reported 70 deg, so the command is ~3x weaker than intended and the reported steering is ~3x larger than what the vehicle actually does — the mismatch makes MPC-based lateral control overshoot.

Add a `max_wheel_steer_angle_deg` parameter (default `0` = use the physics value) that overrides the angle used for both conversions, so it can be calibrated to the measured full-steer angle of the simulated vehicle.

## Depends on

- #13275 (modifies the `_max_wheel_steer_angle_rad()` helper introduced there; this PR's diff includes that commit until it merges)

## How was this PR tested?

Closed-loop CARLA 0.10 runs (taxi.ford, OnePlanner E2E, achieved tire angle derived from the GT yaw rate):

| configuration | command→achieved DC gain |
|---|---|
| before the steering fix series | -2.4 (sign-inconsistent feedback, crashed in the first curve) |
| #13275 + #13276, no calibration | 0.20-0.33 (understeer, overshoot from the 3x report mismatch) |
| **+ `max_wheel_steer_angle_deg:=22.0`** | **0.86 median (1.02-1.13 at large steer); completed a 75-degree turn** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)