### PR TITLE
fix(autoware_carla_interface): unify kinematic_state to the ground-truth publisher

### DIFF
--- a/simulator/autoware_carla_interface/.gitignore
+++ b/simulator/autoware_carla_interface/.gitignore
@@ -1,0 +1,6 @@
+# SplatSim gRPC modules generated at build time by protoc from the vendored
+# rendering_service.proto (see CMakeLists.txt / generate_splatsim_proto.py).
+# Not committed so they stay in sync with the installed protobuf/grpc runtime.
+/src/autoware_carla_interface/splatsim/proto/rendering_service_pb2.py
+/src/autoware_carla_interface/splatsim/proto/rendering_service_pb2.pyi
+/src/autoware_carla_interface/splatsim/proto/rendering_service_pb2_grpc.py

--- a/simulator/autoware_carla_interface/CMakeLists.txt
+++ b/simulator/autoware_carla_interface/CMakeLists.txt
@@ -40,6 +40,35 @@ rclcpp_components_register_node(${PROJECT_NAME}_operation_mode_component
 )
 
 # ============================================================================
+# SplatSim gRPC proto (vendored from the tier4/splatsim release, generated here)
+# ============================================================================
+# rendering_service.proto is vendored from the pinned SplatSim release
+# (SPLATSIM_VERSION). The generated *_pb2*.py modules are NOT committed; they are
+# regenerated on every build so they stay in sync with the installed
+# protobuf/grpc runtime and no generated code is linted. The autoware build
+# sandbox has no outbound internet, so the proto is vendored rather than fetched;
+# refresh it with tools/update_splatsim_proto.sh when bumping SPLATSIM_VERSION.
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+set(SPLATSIM_VERSION "v1.2.0")
+set(_splatsim_proto_dir "${CMAKE_CURRENT_SOURCE_DIR}/src/${PROJECT_NAME}/splatsim/proto")
+set(_splatsim_proto_file "${_splatsim_proto_dir}/rendering_service.proto")
+
+if(NOT EXISTS "${_splatsim_proto_file}")
+  message(FATAL_ERROR "SplatSim proto not found: ${_splatsim_proto_file}")
+endif()
+
+message(STATUS "Generating SplatSim gRPC stubs (${SPLATSIM_VERSION}) from ${_splatsim_proto_file}")
+execute_process(
+  COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/generate_splatsim_proto.py"
+    --proto "${_splatsim_proto_file}"
+    --out-dir "${_splatsim_proto_dir}"
+  RESULT_VARIABLE _splatsim_gen_result)
+if(NOT _splatsim_gen_result EQUAL 0)
+  message(FATAL_ERROR "Failed to generate SplatSim proto Python modules")
+endif()
+
+# ============================================================================
 # Python Package Installation
 # ============================================================================
 

--- a/simulator/autoware_carla_interface/config/sensor_mapping.yaml
+++ b/simulator/autoware_carla_interface/config/sensor_mapping.yaml
@@ -23,6 +23,17 @@ sensor_mappings:
       lower_fov: -30.0
       rotation_frequency: 20
       noise_stddev: 0.0
+      # SplatSim rendering settings (used only when render_with_splatsim:=true).
+      # Values mirror the real Velodyne HDL-64E sensor spec (CARLA's default
+      # LiDAR) instead of relying on the server-side defaults selected by 0.
+      sensor_type: HDL64E # built-in HDL-64E elevation table (actual per-channel vertical angles, +2.0 deg to -24.33 deg)
+      fps: 10.0 # 10 Hz frame rate
+      n_rows: 64 # 64 channels
+      n_columns: 2083 # 360 deg / 0.1728 deg horizontal resolution at 10 Hz
+      min_range_m: 0.9 # minimum range
+      max_range_m: 120.0 # maximum range
+      drop_threshold: 0.5 # return gating (explicit server default)
+      alpha_threshold: 0.1 # return gating (explicit server default)
 
   # CARLA multi-camera setup (6 cameras for 360-degree coverage)
   CAM_FRONT/camera_link:
@@ -38,6 +49,10 @@ sensor_mappings:
       image_size_x: 1600
       image_size_y: 900
       fov: 70.0
+      # SplatSim rendering settings (used only when render_with_splatsim:=true;
+      # other cameras inherit the SplatSimCameraConfig defaults / frequency_hz).
+      near_plane: 0.01
+      far_plane: 1000.0
 
   CAM_FRONT_LEFT/camera_link:
     carla_type: sensor.camera.rgb

--- a/simulator/autoware_carla_interface/config/sensor_mapping_light_weight.yaml
+++ b/simulator/autoware_carla_interface/config/sensor_mapping_light_weight.yaml
@@ -26,6 +26,17 @@ sensor_mappings:
       lower_fov: -30.0
       rotation_frequency: 20
       noise_stddev: 0.0
+      # SplatSim rendering settings (used only when render_with_splatsim:=true).
+      # Values mirror the real Velodyne HDL-64E sensor spec (CARLA's default
+      # LiDAR) instead of relying on the server-side defaults selected by 0.
+      sensor_type: HDL64E # built-in HDL-64E elevation table (actual per-channel vertical angles, +2.0 deg to -24.33 deg)
+      fps: 10.0 # 10 Hz frame rate
+      n_rows: 64 # 64 channels
+      n_columns: 2083 # 360 deg / 0.1728 deg horizontal resolution at 10 Hz
+      min_range_m: 0.9 # minimum range
+      max_range_m: 120.0 # maximum range
+      drop_threshold: 0.5 # return gating (explicit server default)
+      alpha_threshold: 0.1 # return gating (explicit server default)
 
   CAM_FRONT/camera_link:
     carla_type: sensor.camera.rgb
@@ -40,6 +51,9 @@ sensor_mappings:
       image_size_x: 1080
       image_size_y: 720
       fov: 120.0
+      # SplatSim rendering settings (used only when render_with_splatsim:=true).
+      near_plane: 0.01
+      far_plane: 1000.0
 
   # IMU sensor
   tamagawa/imu_link:

--- a/simulator/autoware_carla_interface/cspell.json
+++ b/simulator/autoware_carla_interface/cspell.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "clat",
+    "clon",
+    "fstop",
+    "gaussians",
+    "grpcio",
+    "gsplat",
+    "HDL64E",
+    "misaligns",
+    "noheader",
+    "pcov",
+    "pyproj",
+    "recentred",
+    "rlog",
+    "slon",
+    "splatsim",
+    "tileset",
+    "usdz",
+    "Velodyne",
+    "viewmat",
+    "wxyz"
+  ]
+}

--- a/simulator/autoware_carla_interface/generate_splatsim_proto.py
+++ b/simulator/autoware_carla_interface/generate_splatsim_proto.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate the SplatSim gRPC Python stubs from a proto file.
+
+Invoked by CMakeLists.txt at build time. The proto file is fetched from the
+pinned tier4/splatsim release, and the generated ``*_pb2*.py`` modules are
+written into the package so ``ament_python_install_package`` can install them.
+The generated modules are intentionally not committed (see .gitignore); they
+are produced on every build to stay in sync with the installed protobuf/grpc
+runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+
+LICENSE_HEADER = """# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse the command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--proto", required=True, help="Path to the .proto file.")
+    parser.add_argument("--out-dir", required=True, help="Directory for generated modules.")
+    parser.add_argument(
+        "--package",
+        default="autoware_carla_interface.splatsim.proto",
+        help="Python package the generated modules are installed under.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run protoc and rewrite the stub import to the installed package path."""
+    args = parse_args()
+
+    proto_file = Path(args.proto).resolve()
+    proto_dir = proto_file.parent
+    out_dir = Path(args.out_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Note: --pyi_out is intentionally omitted. It needs the protoc-gen-pyi plugin,
+    # which the distro python3-grpc-tools package does not ship, and the .pyi stub
+    # is only a type hint that is not needed at runtime.
+    command = [
+        sys.executable,
+        "-m",
+        "grpc_tools.protoc",
+        f"-I{proto_dir}",
+        f"--python_out={out_dir}",
+        f"--grpc_python_out={out_dir}",
+        str(proto_file),
+    ]
+    print("Running:", " ".join(command))
+    subprocess.run(command, check=True)
+
+    stem = proto_file.stem
+    pb2_module = out_dir / f"{stem}_pb2.py"
+    grpc_module = out_dir / f"{stem}_pb2_grpc.py"
+
+    # protoc emits a flat ``import <stem>_pb2`` in the gRPC stub. Rewrite it to
+    # the fully-qualified package path so the module resolves once installed.
+    grpc_text = grpc_module.read_text()
+    grpc_text = grpc_text.replace(
+        f"import {stem}_pb2 as",
+        f"from {args.package} import {stem}_pb2 as",
+    )
+    grpc_text = grpc_text.replace(
+        f"from . import {stem}_pb2 as",
+        f"from {args.package} import {stem}_pb2 as",
+    )
+    grpc_module.write_text(grpc_text)
+
+    # Prepend the license header the ament_copyright linter requires (the
+    # generated files are scanned along with the hand-written sources).
+    for module in (pb2_module, grpc_module):
+        module.write_text(LICENSE_HEADER + module.read_text())
+
+    # Keep the output directory importable as a Python package.
+    (out_dir / "__init__.py").touch()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -43,8 +43,8 @@
     <arg name="splatsim_tileset_path" default="" description="Host path to the 3DGS scene (.usdz containing scene.json with world.ecef_anchor); required only when render_with_splatsim:=true"/>
     <arg
       name="splatsim_image"
-      default="ghcr.io/tier4/splatsim:latest-sm{arch}"
-      description="Docker image for splatsim (pulled from GHCR; '{arch}' is auto-resolved to the host GPU compute capability, e.g. sm86/sm89/sm120)"
+      default="splatsim:latest"
+      description="Docker image for splatsim. Defaults to a local image (never pulled). A registry-qualified image (e.g. ghcr.io/tier4/splatsim:latest-sm{arch}) is pulled only when missing locally; '{arch}' is auto-resolved to the host GPU compute capability, e.g. sm86/sm89/sm120"
     />
     <arg name="splatsim_grpc_port" default="50051"/>
     <arg name="splatsim_use_sh" default="true"/>

--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -74,6 +74,7 @@
       <param name="sensor_kit_name" value="$(var sensor_kit_name)"/>
       <param name="sensor_mapping_file" value="$(var sensor_mapping_file)"/>
       <param name="render_with_splatsim" value="$(var render_with_splatsim)"/>
+      <param name="publish_ground_truth_localization" value="$(var use_e2e_planning)"/>
       <param name="splatsim_tileset_path" value="$(var splatsim_tileset_path)"/>
       <param name="splatsim_image" value="$(var splatsim_image)"/>
       <param name="splatsim_grpc_port" value="$(var splatsim_grpc_port)"/>
@@ -171,33 +172,11 @@
 
     <!-- E2E Planning Infrastructure -->
     <group if="$(var use_e2e_planning)">
-      <!-- Convert vehicle velocity report to twist -->
-      <include file="$(find-pkg-share autoware_vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">
-        <arg name="input_vehicle_velocity_topic" value="/vehicle/status/velocity_status"/>
-        <arg name="output_twist_with_covariance" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
-      </include>
-
-      <!-- Publish Odometry (localization/kinematic_state) from CARLA pose + twist -->
-      <node pkg="autoware_carla_interface" exec="carla_state_publisher" name="carla_state_publisher" output="screen">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
-        <param name="frame_id" value="map"/>
-        <param name="child_frame_id" value="base_link"/>
-        <param name="publish_tf" value="true"/>
-        <param name="max_time_diff_sec" value="0.3"/>
-        <remap from="~/input/pose_with_covariance" to="/sensing/gnss/pose_with_covariance"/>
-        <remap from="~/input/twist_with_covariance" to="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
-        <remap from="~/output/odometry" to="/localization/kinematic_state"/>
-      </node>
-
-      <!-- Derive acceleration from twist -->
-      <node pkg="autoware_twist2accel" exec="autoware_twist2accel_node" name="twist2accel" output="screen">
-        <param name="use_sim_time" value="$(var use_sim_time)"/>
-        <param from="$(find-pkg-share autoware_twist2accel)/config/twist2accel.param.yaml"/>
-        <param name="use_odom" value="false"/>
-        <param name="accel_lowpass_gain" value="0.5"/>
-        <remap from="input/twist" to="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
-        <remap from="output/accel" to="/localization/acceleration"/>
-      </node>
+      <!-- Localization (kinematic_state / TF / pose / acceleration) is published
+           directly from the CARLA ground truth by the interface node
+           (publish_ground_truth_localization); the former GNSS round-trip via
+           vehicle_velocity_converter + carla_state_publisher + twist2accel
+           duplicated those topics with a broken heading rate. -->
 
       <!-- Minimal control: trajectory follower only -->
       <node_container pkg="rclcpp_components" exec="component_container_mt" name="e2e_control_container" namespace="" output="screen">

--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -21,6 +21,10 @@
 
     <log message="[CARLA Interface] Map Path: '$(var map_path)' -> Loading CARLA Map: '$(var carla_map)'"/>
 
+    <let name="carla_map" value="$(eval &quot;'$(var carla_map)' if '$(var carla_map)' else (__import__('os').path.basename('$(var map_path)'.strip().rstrip('/')) or 'Town01')&quot;)"/>
+
+    <log message="[CARLA Interface] Map Path: '$(var map_path)' -> Loading CARLA Map: '$(var carla_map)'"/>
+
     <!-- Sensor Configuration -->
     <arg
       name="use_light_weight_sensor_mapping"
@@ -31,6 +35,28 @@
     <let name="sensor_mapping_file_default" value="$(find-pkg-share autoware_carla_interface)/config/sensor_mapping_light_weight.yaml" if="$(var use_light_weight_sensor_mapping)"/>
     <let name="sensor_mapping_file_default" value="$(find-pkg-share autoware_carla_interface)/config/sensor_mapping.yaml" unless="$(var use_light_weight_sensor_mapping)"/>
     <arg name="sensor_mapping_file" default="$(var sensor_mapping_file_default)" description="Path to sensor mapping YAML"/>
+    <!-- SplatSim integration (optional) -->
+    <arg name="render_with_splatsim" default="false" description="Enable splatsim rendering via Docker + gRPC"/>
+    <arg name="splatsim_render_camera" default="false" description="Render cameras via splatsim (false = cameras fully off in splatsim mode)"/>
+    <!-- The splatsim geographic origin is derived from the scene's own
+         world.ecef_anchor (stored in the .usdz), so no lanelet2 map is needed. -->
+    <arg name="splatsim_tileset_path" default="" description="Host path to the 3DGS scene (.usdz containing scene.json with world.ecef_anchor); required only when render_with_splatsim:=true"/>
+    <arg
+      name="splatsim_image"
+      default="ghcr.io/tier4/splatsim:latest-sm{arch}"
+      description="Docker image for splatsim (pulled from GHCR; '{arch}' is auto-resolved to the host GPU compute capability, e.g. sm86/sm89/sm120)"
+    />
+    <arg name="splatsim_grpc_port" default="50051"/>
+    <arg name="splatsim_use_sh" default="true"/>
+    <arg name="splatsim_enable_lod" default="true"/>
+    <arg name="splatsim_device" default="cuda:0"/>
+    <arg name="splatsim_restart_container" default="false" description="Force restart splatsim container even if already running"/>
+    <arg name="splatsim_compress_format" default="jpeg" description="Image compression format: 'jpeg', 'png', or '' for raw"/>
+    <arg name="splatsim_render_lidar" default="true" description="Render LiDAR via splatsim (publishes PointCloud2 to the sensing topic)"/>
+    <arg name="splatsim_lidar_grpc_port" default="50061" description="Base gRPC port for splatsim LiDAR containers"/>
+    <!-- Per-sensor SplatSim rendering settings (camera near/far/frame_rate, LiDAR
+         sensor_type/fps/rows/ranges/thresholds) come from the sensor mapping's
+         per-sensor `parameters:` block, not from launch args. -->
 
     <!-- CARLA Interface -->
     <node pkg="autoware_carla_interface" exec="autoware_carla_interface" name="autoware_carla_interface" output="screen">
@@ -47,6 +73,18 @@
       <param name="max_real_delta_seconds" value="$(var max_real_delta_seconds)"/>
       <param name="sensor_kit_name" value="$(var sensor_kit_name)"/>
       <param name="sensor_mapping_file" value="$(var sensor_mapping_file)"/>
+      <param name="render_with_splatsim" value="$(var render_with_splatsim)"/>
+      <param name="splatsim_tileset_path" value="$(var splatsim_tileset_path)"/>
+      <param name="splatsim_image" value="$(var splatsim_image)"/>
+      <param name="splatsim_grpc_port" value="$(var splatsim_grpc_port)"/>
+      <param name="splatsim_use_sh" value="$(var splatsim_use_sh)"/>
+      <param name="splatsim_enable_lod" value="$(var splatsim_enable_lod)"/>
+      <param name="splatsim_device" value="$(var splatsim_device)"/>
+      <param name="splatsim_restart_container" value="$(var splatsim_restart_container)"/>
+      <param name="splatsim_compress_format" value="$(var splatsim_compress_format)"/>
+      <param name="splatsim_render_camera" value="$(var splatsim_render_camera)"/>
+      <param name="splatsim_render_lidar" value="$(var splatsim_render_lidar)"/>
+      <param name="splatsim_lidar_grpc_port" value="$(var splatsim_lidar_grpc_port)"/>
     </node>
 
     <arg name="input_control_cmd" default="/control/command/control_cmd"/>
@@ -68,65 +106,68 @@
     <!-- <node pkg="tf2_ros" exec="static_transform_publisher" name="carla_velodyne_top" args="0 0 1 -1.5386 -0.015 0.001 velodyne_top velodyne_top_changed"/> -->
     <!-- <node pkg="tf2_ros" exec="static_transform_publisher" name="carla_imu" args="0 0 1 -3.10519265 -0.015 -3.14059265359 tamagawa/imu_link tamagawa/imu_link_changed"/> -->
 
-    <!-- Relay CAM_FRONT to traffic_light namespace for traffic light recognition.
-         These relays subscribe the raw image, which forces the interface to
-         convert and publish every CAM_FRONT frame; skip them in light-weight
-         mode like the republish nodes below. -->
-    <node pkg="topic_tools" exec="relay" name="traffic_light_image_relay" args="/sensing/camera/CAM_FRONT/image_raw /sensing/camera/traffic_light/image_raw"/>
-    <node pkg="topic_tools" exec="relay" name="traffic_light_camera_info_relay" args="/sensing/camera/CAM_FRONT/camera_info /sensing/camera/traffic_light/camera_info"/>
+    <!-- CARLA-only nodes: republish raw→compressed, relay, combiner (skipped in splatsim mode) -->
+    <group unless="$(var render_with_splatsim)">
+      <!-- Relay CAM_FRONT to traffic_light namespace for traffic light recognition.
+           These relays subscribe the raw image, which forces the interface to
+           convert and publish every CAM_FRONT frame; skip them in light-weight
+           mode like the republish nodes below. -->
+      <node pkg="topic_tools" exec="relay" name="traffic_light_image_relay" args="/sensing/camera/CAM_FRONT/image_raw /sensing/camera/traffic_light/image_raw"/>
+      <node pkg="topic_tools" exec="relay" name="traffic_light_camera_info_relay" args="/sensing/camera/CAM_FRONT/camera_info /sensing/camera/traffic_light/camera_info"/>
 
-    <!-- Image transport nodes to create compressed versions for all cameras -->
-    <node
-      pkg="image_transport"
-      exec="republish"
-      name="cam_front_republish"
-      args="raw compressed --ros-args -r in:=/sensing/camera/CAM_FRONT/image_raw -r out/compressed:=/sensing/camera/CAM_FRONT/image_raw/compressed"
-    />
+      <!-- Image transport nodes to create compressed versions for all cameras -->
+      <node
+        pkg="image_transport"
+        exec="republish"
+        name="cam_front_republish"
+        args="raw compressed --ros-args -r in:=/sensing/camera/CAM_FRONT/image_raw -r out/compressed:=/sensing/camera/CAM_FRONT/image_raw/compressed"
+      />
 
-    <node
-      pkg="image_transport"
-      exec="republish"
-      name="cam_front_left_republish"
-      args="raw compressed --ros-args -r in:=/sensing/camera/CAM_FRONT_LEFT/image_raw -r out/compressed:=/sensing/camera/CAM_FRONT_LEFT/image_raw/compressed"
-      unless="$(var use_light_weight_sensor_mapping)"
-    />
-    <node
-      pkg="image_transport"
-      exec="republish"
-      name="cam_front_right_republish"
-      args="raw compressed --ros-args -r in:=/sensing/camera/CAM_FRONT_RIGHT/image_raw -r out/compressed:=/sensing/camera/CAM_FRONT_RIGHT/image_raw/compressed"
-      unless="$(var use_light_weight_sensor_mapping)"
-    />
-    <node
-      pkg="image_transport"
-      exec="republish"
-      name="cam_back_republish"
-      args="raw compressed --ros-args -r in:=/sensing/camera/CAM_BACK/image_raw -r out/compressed:=/sensing/camera/CAM_BACK/image_raw/compressed"
-      unless="$(var use_light_weight_sensor_mapping)"
-    />
-    <node
-      pkg="image_transport"
-      exec="republish"
-      name="cam_back_left_republish"
-      args="raw compressed --ros-args -r in:=/sensing/camera/CAM_BACK_LEFT/image_raw -r out/compressed:=/sensing/camera/CAM_BACK_LEFT/image_raw/compressed"
-      unless="$(var use_light_weight_sensor_mapping)"
-    />
-    <node
-      pkg="image_transport"
-      exec="republish"
-      name="cam_back_right_republish"
-      args="raw compressed --ros-args -r in:=/sensing/camera/CAM_BACK_RIGHT/image_raw -r out/compressed:=/sensing/camera/CAM_BACK_RIGHT/image_raw/compressed"
-      unless="$(var use_light_weight_sensor_mapping)"
-    />
-    <node
-      pkg="image_transport"
-      exec="republish"
-      name="traffic_light_republish"
-      args="raw compressed --ros-args -r in:=/sensing/camera/traffic_light/image_raw -r out/compressed:=/sensing/camera/traffic_light/image_raw/compressed"
-    />
+      <node
+        pkg="image_transport"
+        exec="republish"
+        name="cam_front_left_republish"
+        args="raw compressed --ros-args -r in:=/sensing/camera/CAM_FRONT_LEFT/image_raw -r out/compressed:=/sensing/camera/CAM_FRONT_LEFT/image_raw/compressed"
+        unless="$(var use_light_weight_sensor_mapping)"
+      />
+      <node
+        pkg="image_transport"
+        exec="republish"
+        name="cam_front_right_republish"
+        args="raw compressed --ros-args -r in:=/sensing/camera/CAM_FRONT_RIGHT/image_raw -r out/compressed:=/sensing/camera/CAM_FRONT_RIGHT/image_raw/compressed"
+        unless="$(var use_light_weight_sensor_mapping)"
+      />
+      <node
+        pkg="image_transport"
+        exec="republish"
+        name="cam_back_republish"
+        args="raw compressed --ros-args -r in:=/sensing/camera/CAM_BACK/image_raw -r out/compressed:=/sensing/camera/CAM_BACK/image_raw/compressed"
+        unless="$(var use_light_weight_sensor_mapping)"
+      />
+      <node
+        pkg="image_transport"
+        exec="republish"
+        name="cam_back_left_republish"
+        args="raw compressed --ros-args -r in:=/sensing/camera/CAM_BACK_LEFT/image_raw -r out/compressed:=/sensing/camera/CAM_BACK_LEFT/image_raw/compressed"
+        unless="$(var use_light_weight_sensor_mapping)"
+      />
+      <node
+        pkg="image_transport"
+        exec="republish"
+        name="cam_back_right_republish"
+        args="raw compressed --ros-args -r in:=/sensing/camera/CAM_BACK_RIGHT/image_raw -r out/compressed:=/sensing/camera/CAM_BACK_RIGHT/image_raw/compressed"
+        unless="$(var use_light_weight_sensor_mapping)"
+      />
+      <node
+        pkg="image_transport"
+        exec="republish"
+        name="traffic_light_republish"
+        args="raw compressed --ros-args -r in:=/sensing/camera/traffic_light/image_raw -r out/compressed:=/sensing/camera/traffic_light/image_raw/compressed"
+      />
 
-    <!-- Multi-camera combiner for RViz visualization -->
-    <node pkg="autoware_carla_interface" exec="multi_camera_combiner" output="screen" unless="$(var use_light_weight_sensor_mapping)"/>
+      <!-- Multi-camera combiner for RViz visualization -->
+      <node pkg="autoware_carla_interface" exec="multi_camera_combiner" output="screen" unless="$(var use_light_weight_sensor_mapping)"/>
+    </group>
 
     <!-- E2E Planning Infrastructure -->
     <group if="$(var use_e2e_planning)">

--- a/simulator/autoware_carla_interface/package.xml
+++ b/simulator/autoware_carla_interface/package.xml
@@ -11,14 +11,20 @@
 
   <exec_depend>autoware_agnocast_wrapper</exec_depend>
   <exec_depend>autoware_external_cmd_selector</exec_depend>
+  <exec_depend>autoware_lanelet2_extension_python</exec_depend>
   <exec_depend>autoware_twist2accel</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
+  <exec_depend>python3-docker</exec_depend>
+  <exec_depend>python3-grpcio</exec_depend>
+  <exec_depend>python3-protobuf</exec_depend>
+  <exec_depend>python3-pyproj</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>
+  <depend>lanelet2</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
@@ -28,12 +34,18 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_vehicle_msgs</depend>
+  <!-- Python-only dependency (used from carla_ros.py / splatsim). Keep it as an
+       exec_depend so ament_auto does not find_package() it at build time, which
+       would trip its ament_cmake export in downstream configuration. -->
 
   <!-- C++ dependencies for utility nodes -->
+
+  <!-- Python dependencies for SplatSim integration -->
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
+  <buildtool_depend>python3-grpc-tools</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
@@ -169,6 +169,10 @@ class InitializeInterface(object):
         self.sensor_wrapper = SensorWrapper(self.interface)
         self.sensor_wrapper.setup_sensors(self.ego_actor, False)
 
+        # Initialize splatsim cameras and lidars after CARLA world and ego actor are ready
+        self.interface.init_splatsim_cameras()
+        self.interface.init_splatsim_lidars()
+
         if self.use_traffic_manager:
             self._setup_traffic_manager(client)
 

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -1075,9 +1075,12 @@ class carla_ros2_interface(object):
         elif sensor_type == "sensor.lidar.ray_cast":
             self._submit_worker_sensor(key, self.lidar, data)
         elif sensor_type == "sensor.other.gnss":
-            # Skip GNSS pose when splatsim provides localization directly
-            if not self.render_with_splatsim:
-                self.pose()
+            # Publish the GT GNSS pose in splatsim mode too: the E2E planning
+            # infrastructure (carla_state_publisher) synthesizes
+            # /localization/kinematic_state and the map->base_link TF from it,
+            # and without this pose there is no ego localization at all when
+            # the Autoware localization stack is disabled.
+            self.pose()
         elif sensor_type == "sensor.other.imu":
             self.imu(data[1])
         else:

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -15,6 +15,9 @@
 import math
 import threading
 
+from autoware_adapi_v1_msgs.msg import LocalizationInitializationState
+from autoware_perception_msgs.msg import PredictedObjects
+from autoware_perception_msgs.msg import TrafficLightGroupArray
 from autoware_vehicle_msgs.msg import ControlModeReport
 from autoware_vehicle_msgs.msg import GearReport
 from autoware_vehicle_msgs.msg import HazardLightsCommand
@@ -27,15 +30,26 @@ from builtin_interfaces.msg import Time
 import carla
 import cv2
 from cv_bridge import CvBridge
+from geometry_msgs.msg import AccelWithCovarianceStamped
 from geometry_msgs.msg import Pose
+from geometry_msgs.msg import PoseStamped
 from geometry_msgs.msg import PoseWithCovarianceStamped
+from geometry_msgs.msg import Quaternion
+from geometry_msgs.msg import TransformStamped
+from nav_msgs.msg import OccupancyGrid
+from nav_msgs.msg import Odometry
 import numpy
 import rclpy
+from rclpy.qos import DurabilityPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import ReliabilityPolicy
 from rosgraph_msgs.msg import Clock
 from sensor_msgs.msg import CameraInfo
 from sensor_msgs.msg import Imu
+from sensor_msgs.msg import PointCloud2
 from sensor_msgs.msg import PointField
 from std_msgs.msg import Header
+from tf2_msgs.msg import TFMessage
 from tier4_vehicle_msgs.msg import ActuationCommandStamped
 from tier4_vehicle_msgs.msg import ActuationStatusStamped
 from transforms3d.euler import euler2quat
@@ -51,6 +65,70 @@ from .modules.carla_utils import carla_rotation_to_ros_quaternion
 from .modules.carla_utils import create_cloud
 from .modules.carla_utils import ros_pose_to_carla_transform
 from .modules.carla_wrapper import SensorInterface
+
+
+def _origin_from_usdz(usdz_path: str):
+    """Derive ``(lat_0, lon_0)`` from a splatsim ``.usdz`` scene bundle.
+
+    ``scene.json`` stores ``world.ecef_anchor``: the 4x4 ENU->ECEF transform
+    whose translation column is the ECEF position of the ENU/world origin the
+    3DGS scene is aligned to.  Converting that point to WGS84 yields exactly the
+    geographic origin splatsim needs, so no external lanelet2 map or OpenDRIVE
+    GeoReference is required.
+    """
+    import json
+    import zipfile
+
+    from pyproj import Transformer
+
+    try:
+        with zipfile.ZipFile(usdz_path) as zf:
+            with zf.open("scene.json") as f:
+                scene = json.load(f)
+        anchor = scene["world"]["ecef_anchor"]
+    except (KeyError, OSError, zipfile.BadZipFile, ValueError) as exc:
+        raise RuntimeError(
+            f"Could not read 'scene.json' -> world.ecef_anchor from splatsim scene "
+            f"'{usdz_path}'.  A splatsim .usdz bundle is required to derive the "
+            f"geographic origin."
+        ) from exc
+    x, y, z = anchor[0][3], anchor[1][3], anchor[2][3]
+    ecef_to_lla = Transformer.from_crs("EPSG:4978", "EPSG:4326", always_xy=True)
+    lon, lat, _ = ecef_to_lla.transform(x, y, z)
+    return float(lat), float(lon)
+
+
+def _parse_geo_reference(xodr_xml: str):
+    """Extract ``(lat_0, lon_0)`` from the OpenDRIVE ``<geoReference>`` PROJ string.
+
+    This is the geographic origin of the CARLA world / ROS-map ENU frame that the
+    streamed splatsim poses are expressed in.  It is distinct from the usdz scene
+    ecef_anchor (which places the 3DGS gaussians and is handled by the tileset
+    transform); conflating the two is what misaligns the LiDAR to zero points.
+    """
+    import re
+    import xml.etree.ElementTree as ET
+
+    match = re.search(
+        r"<geoReference>\s*<!\[CDATA\[(.*?)\]\]>\s*</geoReference>",
+        xodr_xml,
+        re.DOTALL,
+    )
+    if match:
+        proj_string = match.group(1).strip()
+    else:
+        root = ET.fromstring(xodr_xml)
+        geo_ref = root.find(".//geoReference")
+        if geo_ref is not None and geo_ref.text:
+            proj_string = geo_ref.text.strip()
+        else:
+            raise ValueError("No <geoReference> found in OpenDRIVE XML")
+
+    lat_match = re.search(r"\+lat_0=([0-9eE.+-]+)", proj_string)
+    lon_match = re.search(r"\+lon_0=([0-9eE.+-]+)", proj_string)
+    if lat_match is None or lon_match is None:
+        raise ValueError(f"Cannot extract +lat_0/+lon_0 from GeoReference: {proj_string}")
+    return float(lat_match.group(1)), float(lon_match.group(1))
 
 
 class carla_ros2_interface(object):
@@ -71,9 +149,24 @@ class carla_ros2_interface(object):
             "vehicle_type": (rclpy.Parameter.Type.STRING, None),
             "use_traffic_manager": (rclpy.Parameter.Type.BOOL, None),
             "max_real_delta_seconds": (rclpy.Parameter.Type.DOUBLE, None),
+            "initial_pose_ground_offset_z": (rclpy.Parameter.Type.DOUBLE, 1.0),
             # Sensor configuration parameters
             "sensor_kit_name": (rclpy.Parameter.Type.STRING, ""),  # Empty = use YAML default
             "sensor_mapping_file": (rclpy.Parameter.Type.STRING, ""),
+            # SplatSim parameters (global only; per-sensor rendering settings are
+            # read from the sensor mapping's per-sensor `parameters:` block).
+            "render_with_splatsim": (rclpy.Parameter.Type.BOOL, False),
+            "splatsim_render_camera": (rclpy.Parameter.Type.BOOL, True),
+            "splatsim_render_lidar": (rclpy.Parameter.Type.BOOL, False),
+            "splatsim_tileset_path": (rclpy.Parameter.Type.STRING, ""),
+            "splatsim_image": (rclpy.Parameter.Type.STRING, "splatsim:latest"),
+            "splatsim_grpc_port": (rclpy.Parameter.Type.INTEGER, 50051),
+            "splatsim_lidar_grpc_port": (rclpy.Parameter.Type.INTEGER, 50061),
+            "splatsim_use_sh": (rclpy.Parameter.Type.BOOL, True),
+            "splatsim_enable_lod": (rclpy.Parameter.Type.BOOL, True),
+            "splatsim_device": (rclpy.Parameter.Type.STRING, "cuda:0"),
+            "splatsim_restart_container": (rclpy.Parameter.Type.BOOL, False),
+            "splatsim_compress_format": (rclpy.Parameter.Type.STRING, "jpeg"),
         }
 
         self.param_values = {}
@@ -177,11 +270,50 @@ class carla_ros2_interface(object):
                 "Check enabled_sensors list and calibration files."
             )
 
+        # SplatSim: separate camera/LiDAR configs and filter them out of CARLA
+        # sensors.  Camera and LiDAR rendering are independently gated so the
+        # scene can be driven by LiDAR alone (splatsim_render_camera=false)
+        # without spinning up a Docker container per camera.
+        if self.render_with_splatsim:
+            self.sensor_configs = self._partition_splatsim_configs()
+
         self._register_sensor_configs(self.sensor_configs)
         self._create_sensor_publishers_from_registry()
         self.sensors = {"sensors": self._build_sensor_specs(self.sensor_configs)}
 
         self.logger.info(f"Configured {len(self.sensor_configs)} sensors from mapping")
+
+    def _partition_splatsim_configs(self) -> list:
+        """Route camera/LiDAR configs to the splatsim lists; return the CARLA-only rest."""
+        render_camera = bool(self.param_values.get("splatsim_render_camera", True))
+        render_lidar = bool(self.param_values.get("splatsim_render_lidar"))
+        carla_configs = []
+        for cfg in self.sensor_configs:
+            if cfg.carla_type.startswith("sensor.camera"):
+                self._assign_splatsim_camera(cfg, render_camera)
+            elif cfg.carla_type.startswith("sensor.lidar"):
+                self._assign_splatsim_lidar(cfg, render_lidar)
+            else:
+                carla_configs.append(cfg)
+        return carla_configs
+
+    def _assign_splatsim_camera(self, cfg, render_camera) -> None:
+        """Register a camera config for splatsim rendering, or log that it is disabled."""
+        if render_camera:
+            self._splatsim_camera_configs.append(cfg)
+            self.logger.info(f"Rendering camera '{cfg.sensor_id}' via splatsim")
+        else:
+            self.logger.info(
+                f"Skipping camera '{cfg.sensor_id}' (splatsim mode, camera rendering disabled)"
+            )
+
+    def _assign_splatsim_lidar(self, cfg, render_lidar) -> None:
+        """Register a LiDAR config for splatsim rendering, or log that it is disabled."""
+        if render_lidar:
+            self._splatsim_lidar_configs.append(cfg)
+            self.logger.info(f"Rendering LiDAR '{cfg.sensor_id}' via splatsim")
+        else:
+            self.logger.info(f"Skipping LiDAR '{cfg.sensor_id}' (splatsim mode)")
 
     def _resolve_sensor_kit_name(self) -> str:
         """Resolve the effective sensor kit name based on parameters and mapping."""
@@ -257,6 +389,7 @@ class carla_ros2_interface(object):
 
         # Setup all components
         self._initialize_parameters()
+        self.render_with_splatsim = bool(self.param_values.get("render_with_splatsim", False))
         self._setup_tf_listener()
         self._initialize_clock_publisher()
 
@@ -265,6 +398,10 @@ class carla_ros2_interface(object):
         # Initialize publishers and subscriptions
         self._initialize_subscriptions()
         self._initialize_status_publishers()
+
+        # SplatSim: create dummy perception and localization publishers
+        if self.render_with_splatsim:
+            self._initialize_splatsim_publishers()
 
         # Start ROS 2 spin thread (Thread Safety: Shared state protected by self._state_lock)
         self.spin_thread = threading.Thread(target=rclpy.spin, args=(self.ros2_node,))
@@ -314,6 +451,32 @@ class carla_ros2_interface(object):
         self.clock_publisher = None
         self.spin_thread = None
         self.cv_bridge = CvBridge()
+
+        # SplatSim state
+        self.render_with_splatsim = False
+        self._splatsim_cameras = []
+        self._splatsim_camera_configs = []
+        self._splatsim_lidars = []
+        self._splatsim_lidar_configs = []
+        self._geo_transform_ready = False
+        self._mgrs_offset_x = 0.0
+        self._mgrs_offset_y = 0.0
+        self._proj_origin = (0.0, 0.0)
+        self._latest_imu_accel = None
+
+    def _ros_context_ok(self):
+        return not self._shutting_down and rclpy.ok()
+
+    def _safe_publish(self, publisher, msg):
+        if not self._ros_context_ok() or publisher is None:
+            return False
+        try:
+            publisher.publish(msg)
+            return True
+        except Exception as exc:
+            if self._shutting_down or not rclpy.ok():
+                return False
+            raise exc
 
     def __call__(self):
         input_data = self.sensor_interface.get_data()
@@ -648,6 +811,14 @@ class carla_ros2_interface(object):
         else:
             self.logger.warning("IMU publisher not initialized")
 
+        # Cache acceleration for splatsim localization publishing
+        if self.render_with_splatsim:
+            self._latest_imu_accel = (
+                imu_msg.linear_acceleration.x,
+                imu_msg.linear_acceleration.y,
+                imu_msg.linear_acceleration.z,
+            )
+
     def first_order_steering(self, steer_input):
         """
         First order steering model.
@@ -866,35 +1037,11 @@ class carla_ros2_interface(object):
 
         # publish data of all sensors
         for key, data in input_data.items():
-            # Safely get sensor type with fallback
-            sensor_type = self.id_to_sensor_type_map.get(key)
-            if not sensor_type:
-                self.logger.warning(
-                    f"Unknown sensor ID '{key}' received from CARLA - skipping. "
-                    f"This may indicate a sensor configuration mismatch."
-                )
-                continue
+            self._dispatch_sensor(key, data)
 
-            # Camera and lidar conversion/publishing run on per-sensor worker
-            # threads: publishing multi-megabyte messages inline (reliable-QoS
-            # camera images in particular block on DDS flow control) would
-            # stall this loop and slow simulation time itself. Frequency
-            # gating and registry bookkeeping stay on this thread so the
-            # registry is never accessed concurrently.
-            if sensor_type == "sensor.camera.rgb":
-                if not self.checkFrequency(key):
-                    self.sensor_registry.update_sensor_timestamp(key, self.timestamp)
-                    self._submit_to_publish_worker(key, self.camera, data[1], key, self.timestamp)
-            elif sensor_type == "sensor.other.gnss":
-                self.pose()
-            elif sensor_type == "sensor.lidar.ray_cast":
-                if not self.checkFrequency(key):
-                    self.sensor_registry.update_sensor_timestamp(key, self.timestamp)
-                    self._submit_to_publish_worker(key, self.lidar, data[1], key, self.timestamp)
-            elif sensor_type == "sensor.other.imu":
-                self.imu(data[1])
-            else:
-                self.logger.debug(f"No publisher for sensor '{key}' (type={sensor_type})")
+        # SplatSim: send ego pose to splatsim cameras and publish dummy data
+        if self.render_with_splatsim:
+            self._splatsim_tick(seconds, nanoseconds)
 
         # Push turn indicator / hazard lights to CARLA before reading status back.
         self.apply_light_state()
@@ -906,6 +1053,454 @@ class carla_ros2_interface(object):
         with self._state_lock:
             return self.current_control
 
+    def _dispatch_sensor(self, key, data) -> None:
+        """Publish one CARLA sensor sample according to its registered type.
+
+        Camera and lidar conversion/publishing run on per-sensor worker threads:
+        publishing multi-megabyte messages inline (reliable-QoS camera images in
+        particular block on DDS flow control) would stall run_step and slow
+        simulation time itself. Frequency gating and registry bookkeeping stay on
+        the caller's thread so the registry is never accessed concurrently.
+        """
+        sensor_type = self.id_to_sensor_type_map.get(key)
+        if not sensor_type:
+            self.logger.warning(
+                f"Unknown sensor ID '{key}' received from CARLA - skipping. "
+                f"This may indicate a sensor configuration mismatch."
+            )
+            return
+
+        if sensor_type == "sensor.camera.rgb":
+            self._submit_worker_sensor(key, self.camera, data)
+        elif sensor_type == "sensor.lidar.ray_cast":
+            self._submit_worker_sensor(key, self.lidar, data)
+        elif sensor_type == "sensor.other.gnss":
+            # Skip GNSS pose when splatsim provides localization directly
+            if not self.render_with_splatsim:
+                self.pose()
+        elif sensor_type == "sensor.other.imu":
+            self.imu(data[1])
+        else:
+            self.logger.debug(f"No publisher for sensor '{key}' (type={sensor_type})")
+
+    def _submit_worker_sensor(self, key, converter, data) -> None:
+        """Frequency-gate a camera/lidar sample and hand it to its publish worker.
+
+        Shared by the camera and lidar branches of :meth:`_dispatch_sensor`:
+        both update the registry timestamp and submit the raw CARLA data to the
+        per-sensor worker via the same converter interface.
+        """
+        if not self.checkFrequency(key):
+            self.sensor_registry.update_sensor_timestamp(key, self.timestamp)
+            self._submit_to_publish_worker(key, converter, data[1], key, self.timestamp)
+
+    # ── SplatSim integration methods ──────────────────────────────────────
+
+    def _initialize_splatsim_publishers(self):
+        """Create publishers for dummy perception and localization (splatsim mode)."""
+        self.pub_empty_objects = self.ros2_node.create_publisher(
+            PredictedObjects, "/perception/object_recognition/objects", 1
+        )
+        self.pub_empty_pointcloud = self.ros2_node.create_publisher(
+            PointCloud2, "/perception/obstacle_segmentation/pointcloud", 1
+        )
+        self.pub_empty_traffic_signals = self.ros2_node.create_publisher(
+            TrafficLightGroupArray,
+            "/perception/traffic_light_recognition/traffic_signals",
+            1,
+        )
+        self.pub_empty_occupancy_grid = self.ros2_node.create_publisher(
+            OccupancyGrid, "/perception/occupancy_grid_map/map", 1
+        )
+        self.pub_tf = self.ros2_node.create_publisher(TFMessage, "/tf", 10)
+        self.pub_localization_odom = self.ros2_node.create_publisher(
+            Odometry, "/localization/kinematic_state", 10
+        )
+        self.pub_localization_pose = self.ros2_node.create_publisher(
+            PoseWithCovarianceStamped,
+            "/localization/pose_estimator/pose_with_covariance",
+            10,
+        )
+        self.pub_localization_accel = self.ros2_node.create_publisher(
+            AccelWithCovarianceStamped, "/localization/acceleration", 10
+        )
+        loc_init_qos = QoSProfile(
+            depth=1,
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+        )
+        self.pub_localization_init_state = self.ros2_node.create_publisher(
+            LocalizationInitializationState,
+            "/localization/initialization_state",
+            loc_init_qos,
+        )
+        self.pub_fusion_pose = self.ros2_node.create_publisher(
+            PoseStamped, "/localization/pose_twist_fusion_filter/pose", 10
+        )
+        self.pub_initialpose3d = self.ros2_node.create_publisher(
+            PoseWithCovarianceStamped, "/initialpose3d", 10
+        )
+
+    def _init_geo_transform(self):
+        """Resolve the splatsim geographic origin and its MGRS offset.
+
+        The origin (lat/lon of the CARLA world origin) is parsed from the CARLA
+        map's OpenDRIVE ``<geoReference>`` (+lat_0/+lon_0): this is the true
+        geographic origin of the CARLA / ROS-map ENU frame the streamed poses are
+        expressed in, which is what ``CoordinateTransformer.proj_origin`` expects.
+        The splatsim scene's own placement is handled separately via the tileset
+        ECEF transform, so the usdz ``ecef_anchor`` must NOT be used as the origin
+        here (doing so misaligns the sensor to zero points whenever the scene
+        anchor differs from the CARLA world origin).  Falls back to the usdz
+        anchor only when the OpenDRIVE has no parsable geoReference.
+        """
+        if self._geo_transform_ready:
+            return
+        from autoware_lanelet2_extension_python.projection import MGRSProjector
+        import lanelet2.core
+        import lanelet2.io
+
+        from .modules.carla_data_provider import CarlaDataProvider
+
+        # Narrow the catch to the "no parsable geoReference" cases (e.g. CARLA
+        # 0.10 Odaiba) so an unexpected error surfaces instead of silently
+        # reverting to the usdz anchor -- the wrong origin this fix exists to
+        # avoid. On that expected failure, fall back to the usdz ecef_anchor.
+        try:
+            xodr_xml = CarlaDataProvider.get_world().get_map().to_opendrive()
+            self._proj_origin = _parse_geo_reference(xodr_xml)
+            source = "CARLA OpenDRIVE geoReference"
+        except (RuntimeError, ValueError) as exc:
+            self.logger.warning(
+                f"Could not parse CARLA OpenDRIVE geoReference ({exc}); "
+                "falling back to splatsim usdz ecef_anchor."
+            )
+            tileset_path = str(self.param_values.get("splatsim_tileset_path", "") or "").strip()
+            if not tileset_path:
+                raise RuntimeError(
+                    "No CARLA OpenDRIVE geoReference and no splatsim_tileset_path; "
+                    "cannot derive the geographic origin."
+                )
+            self._proj_origin = _origin_from_usdz(tileset_path)
+            source = f"splatsim scene '{tileset_path}'"
+        self.logger.info(
+            f"GeoTransform origin from {source}: "
+            f"origin=({self._proj_origin[0]:.8f}, {self._proj_origin[1]:.8f})"
+        )
+        lat_0, lon_0 = self._proj_origin
+
+        projector = MGRSProjector(lanelet2.io.Origin(lat_0, lon_0))
+        origin_gps = lanelet2.core.GPSPoint(lat_0, lon_0, 0.0)
+        origin_local = projector.forward(origin_gps)
+        self._mgrs_offset_x = origin_local.x
+        self._mgrs_offset_y = origin_local.y
+
+        self._geo_transform_ready = True
+        self.logger.info(
+            f"GeoTransform initialized: lat_0={lat_0:.8f}, lon_0={lon_0:.8f}, "
+            f"mgrs_offset=({self._mgrs_offset_x:.1f}, {self._mgrs_offset_y:.1f})"
+        )
+
+    def init_splatsim_cameras(self):
+        """Create SplatSimRGBCamera instances for each camera sensor.
+
+        Must be called after the CARLA world is loaded (ego_actor is set).
+        """
+        if not self.render_with_splatsim or not self._splatsim_camera_configs:
+            return
+        if not self.param_values.get("splatsim_tileset_path"):
+            self.logger.warning(
+                "render_with_splatsim is true but splatsim_tileset_path is empty; "
+                "skipping splatsim camera initialization"
+            )
+            return
+
+        self._init_geo_transform()
+
+        from .splatsim.splatsim_camera import SplatSimRGBCamera
+
+        base_grpc_port = self.param_values["splatsim_grpc_port"]
+        for cam_idx, cfg in enumerate(self._splatsim_camera_configs):
+            cam = SplatSimRGBCamera(
+                self._make_camera_spec(cfg),
+                proj_origin=self._proj_origin,
+                config=self._make_camera_config(cfg, base_grpc_port + cam_idx),
+            )
+            self._splatsim_cameras.append(cam)
+            self.logger.info(f"SplatSimRGBCamera created for sensor '{cfg.sensor_id}'")
+
+    @staticmethod
+    def _make_camera_spec(cfg) -> dict:
+        """Build the sensor-spec dict that SplatSimRGBCamera expects."""
+        return {
+            "id": cfg.sensor_id,
+            "image_size_x": cfg.parameters.get("image_size_x", 1600),
+            "image_size_y": cfg.parameters.get("image_size_y", 900),
+            "fov": cfg.parameters.get("fov", 70.0),
+            "spawn_point": cfg.transform
+            or {"x": 0.0, "y": 0.0, "z": 0.0, "roll": 0.0, "pitch": 0.0, "yaw": 0.0},
+        }
+
+    def _make_camera_config(self, cfg, grpc_port):
+        """Build the SplatSimCameraConfig for one camera sensor.
+
+        Global settings come from node params; per-sensor topics/optics/rate come
+        from the sensor mapping (``cfg`` / ``cfg.parameters``), falling back to the
+        SplatSimCameraConfig dataclass defaults when unset.
+        """
+        from .splatsim.splatsim_camera import SplatSimCameraConfig
+
+        p = self.param_values
+        params = cfg.parameters or {}
+        kwargs = {
+            "tileset_path": p["splatsim_tileset_path"],
+            "splatsim_image": p["splatsim_image"],
+            "grpc_port": grpc_port,
+            "use_sh": p["splatsim_use_sh"],
+            "enable_lod": p["splatsim_enable_lod"],
+            "device": p["splatsim_device"],
+            "restart_container": p["splatsim_restart_container"],
+            "compress_format": p.get("splatsim_compress_format", ""),
+            "frame_rate": params.get("frame_rate", cfg.frequency_hz),
+        }
+        if cfg.topic_image:
+            kwargs["image_topic"] = cfg.topic_image
+        if cfg.topic_info:
+            kwargs["camera_info_topic"] = cfg.topic_info
+        if cfg.frame_id:
+            kwargs["frame_id"] = cfg.frame_id
+        for key in ("near_plane", "far_plane"):
+            if key in params:
+                kwargs[key] = params[key]
+        return SplatSimCameraConfig(**kwargs)
+
+    def init_splatsim_lidars(self):
+        """Create SplatSimLidar instances for each LiDAR sensor.
+
+        Must be called after the CARLA world is loaded (ego_actor is set).
+        The rendered PointCloud2 is published on the sensor's sensing topic so
+        the existing preprocessing pipeline (and OnePlanner) runs unchanged.
+        """
+        if not self.render_with_splatsim or not self._splatsim_lidar_configs:
+            return
+        if not self.param_values.get("splatsim_tileset_path"):
+            self.logger.warning(
+                "render_with_splatsim is true but splatsim_tileset_path is empty; "
+                "skipping splatsim lidar initialization"
+            )
+            return
+
+        self._init_geo_transform()
+
+        from .splatsim.splatsim_lidar import SplatSimLidar
+
+        base_grpc_port = self.param_values["splatsim_lidar_grpc_port"]
+        for lidar_idx, cfg in enumerate(self._splatsim_lidar_configs):
+            lidar = SplatSimLidar(
+                self._make_lidar_spec(cfg),
+                proj_origin=self._proj_origin,
+                config=self._make_lidar_config(cfg, base_grpc_port + lidar_idx),
+            )
+            self._splatsim_lidars.append(lidar)
+            self.logger.info(f"SplatSimLidar created for sensor '{cfg.sensor_id}'")
+
+    @staticmethod
+    def _make_lidar_spec(cfg) -> dict:
+        """Build the sensor-spec dict that SplatSimLidar expects."""
+        return {
+            "id": cfg.sensor_id,
+            "spawn_point": cfg.transform
+            or {"x": 0.0, "y": 0.0, "z": 0.0, "roll": 0.0, "pitch": 0.0, "yaw": 0.0},
+        }
+
+    def _make_lidar_config(self, cfg, grpc_port):
+        """Build the SplatSimLidarConfig for one LiDAR sensor.
+
+        Global settings come from node params; per-sensor rendering settings come
+        from the sensor mapping (``cfg`` / ``cfg.parameters``), falling back to the
+        SplatSimLidarConfig dataclass defaults when unset.
+        """
+        from .splatsim.splatsim_lidar import SplatSimLidarConfig
+
+        p = self.param_values
+        params = cfg.parameters or {}
+        kwargs = {
+            "tileset_path": p["splatsim_tileset_path"],
+            "splatsim_image": p["splatsim_image"],
+            "grpc_port": grpc_port,
+            "use_sh": p["splatsim_use_sh"],
+            "enable_lod": p["splatsim_enable_lod"],
+            "device": p["splatsim_device"],
+            "restart_container": p["splatsim_restart_container"],
+            "fps": params.get("fps", cfg.frequency_hz),
+        }
+        if cfg.topic:
+            kwargs["pointcloud_topic"] = cfg.topic
+        if cfg.frame_id:
+            kwargs["frame_id"] = cfg.frame_id
+        for key in (
+            "sensor_type",
+            "n_rows",
+            "n_columns",
+            "min_range_m",
+            "drop_threshold",
+            "alpha_threshold",
+        ):
+            if key in params:
+                kwargs[key] = params[key]
+        # max range: explicit splatsim key wins, else the CARLA sensor mapping range.
+        if "max_range_m" in params:
+            kwargs["max_range_m"] = params["max_range_m"]
+        elif "range" in params:
+            kwargs["max_range_m"] = float(params["range"])
+        if "elevation_deg" in params:
+            kwargs["elevation_deg"] = tuple(params["elevation_deg"])
+        return SplatSimLidarConfig(**kwargs)
+
+    def _splatsim_tick(self, seconds, nanoseconds):
+        """Per-tick splatsim work: send poses, publish dummy perception/localization."""
+        with self._state_lock:
+            actor_matrix = (
+                self.ego_actor.get_transform().get_matrix() if self.ego_actor is not None else None
+            )
+        if actor_matrix is not None:
+            self._send_splatsim_poses(actor_matrix, seconds, nanoseconds)
+
+        self._publish_dummy_perception()
+
+        with self._state_lock:
+            has_ego = self.ego_actor is not None
+        if has_ego:
+            self._publish_localization()
+
+    def _send_splatsim_poses(self, actor_matrix, seconds, nanoseconds) -> None:
+        """Forward the ego pose to every splatsim camera and LiDAR container."""
+        for sensor in (*self._splatsim_cameras, *self._splatsim_lidars):
+            sensor.update(
+                actor_matrix_4x4=actor_matrix,
+                stamp_sec=seconds,
+                stamp_nanosec=nanoseconds,
+            )
+
+    def _publish_dummy_perception(self) -> None:
+        """Publish empty perception outputs so downstream nodes keep ticking."""
+        header = self.get_msg_header(frame_id="map")
+
+        empty_objects = PredictedObjects()
+        empty_objects.header = header
+        self.pub_empty_objects.publish(empty_objects)
+
+        empty_pc = PointCloud2()
+        empty_pc.header = self.get_msg_header(frame_id="base_link")
+        empty_pc.fields = [
+            PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1),
+            PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1),
+            PointField(name="z", offset=8, datatype=PointField.FLOAT32, count=1),
+            PointField(name="intensity", offset=12, datatype=PointField.UINT8, count=1),
+            PointField(name="return_type", offset=13, datatype=PointField.UINT8, count=1),
+            PointField(name="channel", offset=14, datatype=PointField.UINT16, count=1),
+        ]
+        empty_pc.point_step = 16
+        empty_pc.height = 1
+        empty_pc.width = 0
+        empty_pc.row_step = 0
+        empty_pc.is_dense = True
+        self.pub_empty_pointcloud.publish(empty_pc)
+
+        empty_tl = TrafficLightGroupArray()
+        empty_tl.stamp = header.stamp
+        self.pub_empty_traffic_signals.publish(empty_tl)
+
+        empty_og = OccupancyGrid()
+        empty_og.header = self.get_msg_header(frame_id="map")
+        empty_og.info.resolution = 0.5
+        empty_og.info.width = 0
+        empty_og.info.height = 0
+        self.pub_empty_occupancy_grid.publish(empty_og)
+
+    def _publish_localization(self):
+        """Publish localization data from CARLA ground truth (splatsim mode).
+
+        Position: CARLA → xodr (flip y) → MGRS absolute (add offset)
+        Orientation: 2D yaw only (CARLA CW+ → ROS CCW+)
+        """
+        header = self.get_msg_header(frame_id="map")
+
+        with self._state_lock:
+            carla_tf = self.ego_actor.get_transform()
+            ego_vel = self.ego_actor.get_velocity()
+            ego_ang_vel = self.ego_actor.get_angular_velocity()
+            trans_mat = numpy.array(carla_tf.get_matrix()).reshape(4, 4)
+
+        # Position
+        pose = Pose()
+        pose.position.x = carla_tf.location.x + self._mgrs_offset_x
+        pose.position.y = -carla_tf.location.y + self._mgrs_offset_y
+        pose.position.z = carla_tf.location.z
+
+        # Orientation (2D yaw only)
+        yaw = -math.radians(carla_tf.rotation.yaw)
+        qw = math.cos(yaw / 2.0)
+        qz = math.sin(yaw / 2.0)
+        pose.orientation = Quaternion(x=0.0, y=0.0, z=qz, w=qw)
+
+        # /tf (map → base_link)
+        tf_stamped = TransformStamped()
+        tf_stamped.header = header
+        tf_stamped.child_frame_id = "base_link"
+        tf_stamped.transform.translation.x = pose.position.x
+        tf_stamped.transform.translation.y = pose.position.y
+        tf_stamped.transform.translation.z = pose.position.z
+        tf_stamped.transform.rotation = pose.orientation
+        self.pub_tf.publish(TFMessage(transforms=[tf_stamped]))
+
+        # /localization/kinematic_state (Odometry)
+        odom = Odometry()
+        odom.header = header
+        odom.child_frame_id = "base_link"
+        odom.pose.pose = pose
+        rot_mat = trans_mat[0:3, 0:3]
+        inv_rot_mat = rot_mat.T
+        vel_vec = numpy.array([ego_vel.x, ego_vel.y, ego_vel.z]).reshape(3, 1)
+        ego_velocity = (inv_rot_mat @ vel_vec).T[0]
+        odom.twist.twist.linear.x = float(ego_velocity[0])
+        odom.twist.twist.linear.y = float(-ego_velocity[1])
+        odom.twist.twist.linear.z = float(ego_velocity[2])
+        odom.twist.twist.angular.z = -math.radians(ego_ang_vel.z)
+        self.pub_localization_odom.publish(odom)
+
+        # Pose with covariance
+        pose_cov = PoseWithCovarianceStamped()
+        pose_cov.header = header
+        pose_cov.pose.pose = pose
+        pcov = pose_cov.pose.covariance
+        pcov[0] = pcov[7] = pcov[14] = pcov[21] = pcov[28] = pcov[35] = 0.0001
+        self.pub_localization_pose.publish(pose_cov)
+
+        # Acceleration
+        accel_msg = AccelWithCovarianceStamped()
+        accel_msg.header = self.get_msg_header(frame_id="base_link")
+        if self._latest_imu_accel is not None:
+            accel_msg.accel.accel.linear.x = self._latest_imu_accel[0]
+            accel_msg.accel.accel.linear.y = self._latest_imu_accel[1]
+            accel_msg.accel.accel.linear.z = self._latest_imu_accel[2]
+        self.pub_localization_accel.publish(accel_msg)
+
+        # Localization initialization state
+        init_state = LocalizationInitializationState()
+        init_state.stamp = header.stamp
+        init_state.state = LocalizationInitializationState.INITIALIZED
+        self.pub_localization_init_state.publish(init_state)
+
+        # Satisfy topic_state_monitors
+        pose_stamped = PoseStamped()
+        pose_stamped.header = header
+        pose_stamped.pose = pose
+        self.pub_fusion_pose.publish(pose_stamped)
+        self.pub_initialpose3d.publish(pose_cov)
+
+    # ── Shutdown ──────────────────────────────────────────────────────────
+
     def shutdown(self):
         """
         Clean shutdown of ROS node and spin thread.
@@ -914,12 +1509,30 @@ class carla_ros2_interface(object):
         process hanging and publisher leaks.
 
         """
-        # Stop publish workers before destroying the publishers they use
+        self._stop_publish_workers()
+        self._shutdown_splatsim_sensors()
+        self._shutdown_ros()
+
+    def _stop_publish_workers(self) -> None:
+        """Signal and stop per-sensor publish worker threads before destroying publishers."""
+        # Worker loops poll self._shutting_down; stop them before destroying the
+        # publishers they use, avoiding hangs and leaks.
+        self._shutting_down = True
         for worker in self._publish_workers.values():
             worker.stop()
         self._publish_workers.clear()
 
-        # Destroy publishers first
+    def _shutdown_splatsim_sensors(self) -> None:
+        """Shut down and clear all splatsim camera and LiDAR containers."""
+        for cam in self._splatsim_cameras:
+            cam.shutdown()
+        self._splatsim_cameras.clear()
+        for lidar in self._splatsim_lidars:
+            lidar.shutdown()
+        self._splatsim_lidars.clear()
+
+    def _shutdown_ros(self) -> None:
+        """Destroy publishers/node, join the spin thread, and shut down rclpy."""
         if self.ros_publisher_manager:
             self.ros_publisher_manager.destroy_all_publishers()
 

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -156,6 +156,11 @@ class carla_ros2_interface(object):
             # SplatSim parameters (global only; per-sensor rendering settings are
             # read from the sensor mapping's per-sensor `parameters:` block).
             "render_with_splatsim": (rclpy.Parameter.Type.BOOL, False),
+            # Publish CARLA ground-truth localization (kinematic_state, TF,
+            # pose, acceleration) even without splatsim rendering. Used by the
+            # E2E planning setup instead of the former carla_state_publisher
+            # GNSS round-trip, which duplicated these topics.
+            "publish_ground_truth_localization": (rclpy.Parameter.Type.BOOL, False),
             "splatsim_render_camera": (rclpy.Parameter.Type.BOOL, True),
             "splatsim_render_lidar": (rclpy.Parameter.Type.BOOL, False),
             "splatsim_tileset_path": (rclpy.Parameter.Type.STRING, ""),
@@ -390,6 +395,12 @@ class carla_ros2_interface(object):
         # Setup all components
         self._initialize_parameters()
         self.render_with_splatsim = bool(self.param_values.get("render_with_splatsim", False))
+        # Ground-truth localization is implied by splatsim rendering (no other
+        # localization source exists in that mode) and can be requested
+        # standalone for the E2E planning setup.
+        self.publish_gt_localization = self.render_with_splatsim or bool(
+            self.param_values.get("publish_ground_truth_localization", False)
+        )
         self._setup_tf_listener()
         self._initialize_clock_publisher()
 
@@ -399,9 +410,11 @@ class carla_ros2_interface(object):
         self._initialize_subscriptions()
         self._initialize_status_publishers()
 
-        # SplatSim: create dummy perception and localization publishers
+        # SplatSim: create dummy perception publishers
         if self.render_with_splatsim:
             self._initialize_splatsim_publishers()
+        if self.publish_gt_localization:
+            self._initialize_localization_publishers()
 
         # Start ROS 2 spin thread (Thread Safety: Shared state protected by self._state_lock)
         self.spin_thread = threading.Thread(target=rclpy.spin, args=(self.ros2_node,))
@@ -1043,6 +1056,13 @@ class carla_ros2_interface(object):
         if self.render_with_splatsim:
             self._splatsim_tick(seconds, nanoseconds)
 
+        # Ground-truth localization (kinematic_state / TF / pose / accel)
+        if self.publish_gt_localization:
+            with self._state_lock:
+                has_ego = self.ego_actor is not None
+            if has_ego:
+                self._publish_localization()
+
         # Push turn indicator / hazard lights to CARLA before reading status back.
         self.apply_light_state()
 
@@ -1100,7 +1120,7 @@ class carla_ros2_interface(object):
     # ── SplatSim integration methods ──────────────────────────────────────
 
     def _initialize_splatsim_publishers(self):
-        """Create publishers for dummy perception and localization (splatsim mode)."""
+        """Create publishers for dummy perception (splatsim mode)."""
         self.pub_empty_objects = self.ros2_node.create_publisher(
             PredictedObjects, "/perception/object_recognition/objects", 1
         )
@@ -1115,6 +1135,9 @@ class carla_ros2_interface(object):
         self.pub_empty_occupancy_grid = self.ros2_node.create_publisher(
             OccupancyGrid, "/perception/occupancy_grid_map/map", 1
         )
+
+    def _initialize_localization_publishers(self):
+        """Create publishers for CARLA ground-truth localization."""
         self.pub_tf = self.ros2_node.create_publisher(TFMessage, "/tf", 10)
         self.pub_localization_odom = self.ros2_node.create_publisher(
             Odometry, "/localization/kinematic_state", 10
@@ -1361,7 +1384,7 @@ class carla_ros2_interface(object):
         return SplatSimLidarConfig(**kwargs)
 
     def _splatsim_tick(self, seconds, nanoseconds):
-        """Per-tick splatsim work: send poses, publish dummy perception/localization."""
+        """Per-tick splatsim work: send poses, publish dummy perception."""
         with self._state_lock:
             actor_matrix = (
                 self.ego_actor.get_transform().get_matrix() if self.ego_actor is not None else None
@@ -1370,11 +1393,6 @@ class carla_ros2_interface(object):
             self._send_splatsim_poses(actor_matrix, seconds, nanoseconds)
 
         self._publish_dummy_perception()
-
-        with self._state_lock:
-            has_ego = self.ego_actor is not None
-        if has_ego:
-            self._publish_localization()
 
     def _send_splatsim_poses(self, actor_matrix, seconds, nanoseconds) -> None:
         """Forward the ego pose to every splatsim camera and LiDAR container."""

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/sensor_manager.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/sensor_manager.py
@@ -42,7 +42,7 @@ class SensorConfig:
     frequency_hz: float = 20.0
     qos_profile: str = "reliable"
     # What a camera's pixels are published as. A consumer that only wants
-    # luminance otherwise pays four times the bytes through serialisation and
+    # luminance otherwise pays four times the bytes through serialization and
     # the transport for three channels it discards on arrival.
     image_encoding: str = "bgra8"
     parameters: Dict[str, Any] = field(default_factory=dict)

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/coordinate_transformer.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/coordinate_transformer.py
@@ -1,0 +1,285 @@
+# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coordinate transformation from ROS map (ENU) to re-centered tile-local.
+
+The conversion pipeline mirrors ``splatsim.carla_integration.geo_transform``
+but operates on **ENU** positions directly (no CARLA Y-flip needed because
+the ROS map frame published by ``carla_ros.py`` is already ENU).
+
+Pipeline (position)::
+
+    ROS map  (x=East, y=North, z=Up)
+      → MGRS absolute  (+ offset from proj_origin)
+      → LLA             (lanelet2 MGRSProjector.reverse)
+      → ECEF            (pyproj WGS84)
+      → tile-local      (R_tile^T @ (ecef − t_tile))
+      → re-centered     (− scene_origin)
+
+Pipeline (rotation)::
+
+    R_enu  →  R_enu_to_tile @ R_enu  →  R_tile
+"""
+
+from __future__ import annotations
+
+import json
+
+from autoware_lanelet2_extension_python.projection import MGRSProjector
+import lanelet2.core
+import lanelet2.io
+import numpy as np
+from numpy.typing import NDArray
+from pyproj import Transformer
+import rclpy
+
+_rlog = rclpy.logging.get_logger("splatsim_coord")
+
+
+def _enu_to_ecef_rotation(lat_deg: float, lon_deg: float) -> NDArray[np.float64]:
+    """Rotation matrix from ENU to ECEF at the given lat/lon (degrees)."""
+    lat = np.radians(lat_deg)
+    lon = np.radians(lon_deg)
+    slat, clat = np.sin(lat), np.cos(lat)
+    slon, clon = np.sin(lon), np.cos(lon)
+    return np.array(
+        [
+            [-slon, -slat * clon, clat * clon],
+            [clon, -slat * slon, clat * slon],
+            [0.0, clat, slat],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _rotation_matrix_to_quaternion_wxyz(
+    R: NDArray[np.float64],
+) -> tuple[float, float, float, float]:
+    """Convert a 3x3 rotation matrix to ``(w, x, y, z)`` quaternion."""
+    trace = R[0, 0] + R[1, 1] + R[2, 2]
+    if trace > 0:
+        s = 0.5 / np.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (R[2, 1] - R[1, 2]) * s
+        y = (R[0, 2] - R[2, 0]) * s
+        z = (R[1, 0] - R[0, 1]) * s
+    elif R[0, 0] > R[1, 1] and R[0, 0] > R[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + R[0, 0] - R[1, 1] - R[2, 2])
+        w = (R[2, 1] - R[1, 2]) / s
+        x = 0.25 * s
+        y = (R[0, 1] + R[1, 0]) / s
+        z = (R[0, 2] + R[2, 0]) / s
+    elif R[1, 1] > R[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + R[1, 1] - R[0, 0] - R[2, 2])
+        w = (R[0, 2] - R[2, 0]) / s
+        x = (R[0, 1] + R[1, 0]) / s
+        y = 0.25 * s
+        z = (R[1, 2] + R[2, 1]) / s
+    else:
+        s = 2.0 * np.sqrt(1.0 + R[2, 2] - R[0, 0] - R[1, 1])
+        w = (R[1, 0] - R[0, 1]) / s
+        x = (R[0, 2] + R[2, 0]) / s
+        y = (R[1, 2] + R[2, 1]) / s
+        z = 0.25 * s
+    return (float(w), float(x), float(y), float(z))
+
+
+def _quaternion_xyzw_to_rotation_matrix(
+    x: float,
+    y: float,
+    z: float,
+    w: float,
+) -> NDArray[np.float64]:
+    """Convert ROS quaternion ``(x, y, z, w)`` to a 3x3 rotation matrix."""
+    R = np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
+    return R
+
+
+def parse_tileset_transform(
+    tileset_path: str,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Read the root tile's ECEF rotation & translation from ``tileset.json``.
+
+    Returns ``(ecef_rotation_3x3, ecef_translation_3)`` both as float64.
+    """
+    with open(tileset_path) as f:
+        data = json.load(f)
+
+    # Navigate to root tile transform — 3D Tiles stores a flat 16-element
+    # column-major array.
+    root = data.get("root", data)
+    transform_flat = root["transform"]
+    T = np.array(transform_flat, dtype=np.float64).reshape(4, 4).T  # col→row major
+    return T[:3, :3].copy(), T[:3, 3].copy()
+
+
+def resolve_ecef_transform(
+    resp, tileset_path: str
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return the scene's ``(ecef_rotation_3x3, ecef_translation_3)``.
+
+    Prefer the transform reported by the gRPC server; fall back to parsing the
+    local ``tileset.json`` when the server omits it.
+    """
+    if resp.ecef_rotation:
+        ecef_rot = np.array(resp.ecef_rotation, dtype=np.float64).reshape(3, 3)
+        ecef_trans = np.array(
+            [resp.ecef_translation.x, resp.ecef_translation.y, resp.ecef_translation.z],
+            dtype=np.float64,
+        )
+        _rlog.warn("Using ECEF transform from gRPC server")
+        return ecef_rot, ecef_trans
+    _rlog.warn("gRPC server did not return ECEF transform; falling back to parse_tileset_transform")
+    return parse_tileset_transform(tileset_path)
+
+
+class CoordinateTransformer:
+    """Transform poses from ROS map (ENU) to re-centered tile-local.
+
+    Parameters
+    ----------
+    proj_origin:
+        ``(latitude, longitude)`` of the xodr GeoReference origin in
+        decimal degrees (parsed from ``+lat_0`` / ``+lon_0``).
+    ecef_rotation:
+        3x3 rotation from tile-local to ECEF (from ``tileset.json``).
+    ecef_translation:
+        3-vector ECEF translation (from ``tileset.json``).
+    scene_origin:
+        3-vector subtracted for re-centering (from
+        ``InitializeResponse.scene_origin``).
+    """
+
+    def __init__(
+        self,
+        proj_origin: tuple[float, float],
+        ecef_rotation: NDArray[np.float64],
+        ecef_translation: NDArray[np.float64],
+        scene_origin: NDArray[np.float64],
+    ) -> None:
+        lat_0, lon_0 = proj_origin
+
+        # Lanelet2 MGRS projector
+        self._projector = MGRSProjector(lanelet2.io.Origin(lat_0, lon_0))
+
+        # MGRS offset at the geographic origin
+        origin_gps = lanelet2.core.GPSPoint(lat_0, lon_0, 0.0)
+        origin_local = self._projector.forward(origin_gps)
+        self._mgrs_offset_x = origin_local.x
+        self._mgrs_offset_y = origin_local.y
+
+        # pyproj: LLA → ECEF
+        self._lla_to_ecef = Transformer.from_crs("EPSG:4326", "EPSG:4978", always_xy=True)
+
+        # Tileset: tile_local → ECEF:  p_ecef = R @ p_tile + t
+        self._tile_R_inv = ecef_rotation.T  # ECEF → tile-local
+        self._tile_t = ecef_translation
+
+        self._scene_origin = scene_origin
+
+        # Precompute ENU → tile-local rotation
+        R_enu_to_ecef = _enu_to_ecef_rotation(lat_0, lon_0)
+        self._R_enu_to_tile = self._tile_R_inv @ R_enu_to_ecef
+
+        self._debug_logged = False
+
+        _rlog.warn(
+            f"CoordinateTransformer: origin=({lat_0:.6f}, {lon_0:.6f}), "
+            f"mgrs_offset=({self._mgrs_offset_x:.1f}, {self._mgrs_offset_y:.1f}), "
+            f"scene_origin=({scene_origin[0]:.1f}, {scene_origin[1]:.1f}, {scene_origin[2]:.1f})"
+        )
+
+    def enu_position_to_tile_local(
+        self,
+        x: float,
+        y: float,
+        z: float,
+    ) -> NDArray[np.float64]:
+        """Convert an ENU (ROS map) position to re-centered tile-local."""
+        # 1. ENU → MGRS absolute
+        mgrs_x = x + self._mgrs_offset_x
+        mgrs_y = y + self._mgrs_offset_y
+
+        # 2. MGRS → LLA
+        mgrs_pt = lanelet2.core.BasicPoint3d(mgrs_x, mgrs_y, z)
+        gps = self._projector.reverse(mgrs_pt)
+
+        # 3. LLA → ECEF
+        ex, ey, ez = self._lla_to_ecef.transform(gps.lon, gps.lat, z)
+        ecef = np.array([ex, ey, ez], dtype=np.float64)
+
+        # 4. ECEF → tile-local
+        tile_local = self._tile_R_inv @ (ecef - self._tile_t)
+
+        # 5. Re-center
+        result = tile_local - self._scene_origin
+
+        if not self._debug_logged:
+            self._debug_logged = True
+            _rlog.warn(
+                f"enu_position_to_tile_local:\n"
+                f"  ENU input:  ({x:.4f}, {y:.4f}, {z:.4f})\n"
+                f"  MGRS abs:   ({mgrs_x:.4f}, {mgrs_y:.4f})\n"
+                f"  LLA:        (lat={gps.lat:.8f}, lon={gps.lon:.8f}, alt={z:.4f})\n"
+                f"  ECEF:       ({ex:.4f}, {ey:.4f}, {ez:.4f})\n"
+                f"  tile_local: ({tile_local[0]:.4f}, {tile_local[1]:.4f}, {tile_local[2]:.4f})\n"
+                f"  scene_orig: ({self._scene_origin[0]:.4f}, {self._scene_origin[1]:.4f}, {self._scene_origin[2]:.4f})\n"
+                f"  result:     ({result[0]:.4f}, {result[1]:.4f}, {result[2]:.4f})"
+            )
+
+        return result
+
+    def enu_rotation_to_tile_local(
+        self,
+        R_enu: NDArray[np.float64],
+    ) -> NDArray[np.float64]:
+        """Convert an ENU rotation matrix to tile-local."""
+        return self._R_enu_to_tile @ R_enu
+
+    def transform_pose(
+        self,
+        position_enu: tuple[float, float, float],
+        quaternion_xyzw: tuple[float, float, float, float],
+    ) -> tuple[tuple[float, float, float], tuple[float, float, float, float]]:
+        """Convert a full ROS pose to tile-local ``(position, quat_wxyz)``.
+
+        Parameters
+        ----------
+        position_enu:
+            ``(x, y, z)`` in ROS map / ENU frame.
+        quaternion_xyzw:
+            ``(x, y, z, w)`` quaternion (ROS convention).
+
+        Returns
+        -------
+        tuple
+            ``((x, y, z), (w, x, y, z))`` in re-centered tile-local.
+        """
+        tile_pos = self.enu_position_to_tile_local(*position_enu)
+
+        R_enu = _quaternion_xyzw_to_rotation_matrix(*quaternion_xyzw)
+        R_tile = self.enu_rotation_to_tile_local(R_enu)
+        quat_wxyz = _rotation_matrix_to_quaternion_wxyz(R_tile)
+
+        return (
+            (float(tile_pos[0]), float(tile_pos[1]), float(tile_pos[2])),
+            quat_wxyz,
+        )

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/docker_manager.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/docker_manager.py
@@ -216,15 +216,24 @@ class SplatSimDockerManager:
         return volumes
 
     def _pull_registry_image(self) -> None:
-        """Best-effort pull of a registry-qualified image to refresh the tag.
+        """Pull a registry-qualified image only when it is not available locally.
 
-        For an image such as ``ghcr.io/tier4/splatsim:latest-sm89`` the newest
-        GHCR build is pulled instead of a stale local tag. Bare local tags (e.g.
-        ``splatsim:latest``) are left untouched; a failed pull falls back to the
+        Bare local tags (e.g. ``splatsim:latest``) are never pulled, so a
+        locally built image can be referenced without any registry access.
+        A registry-qualified image (e.g. ``ghcr.io/tier4/splatsim:latest-sm89``)
+        that already exists locally is used as-is; set ``SPLATSIM_ALWAYS_PULL=1``
+        to force a refresh from the registry. A failed pull falls back to the
         local image.
         """
         if "/" not in self._image:
             return
+        if not os.environ.get("SPLATSIM_ALWAYS_PULL"):
+            try:
+                self._client.images.get(self._image)
+                _log(f"Using local image {self._image} (set SPLATSIM_ALWAYS_PULL=1 to refresh)")
+                return
+            except docker.errors.ImageNotFound:
+                pass
         repo, _, tag = self._image.rpartition(":")
         if not repo:
             repo, tag = self._image, "latest"

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/docker_manager.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/docker_manager.py
@@ -1,0 +1,308 @@
+# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Manage the splatsim Docker container lifecycle."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+
+import docker
+from docker.types import DeviceRequest
+import grpc
+
+
+def _log(msg: str) -> None:
+    """Print to stderr so it always appears in the ROS 2 launch terminal."""
+    print(f"[splatsim-docker] {msg}", file=sys.stderr, flush=True)
+
+
+def _detect_cuda_arch(default: str = "89") -> str:
+    """Host GPU compute capability as an sm string (e.g. '8.9' -> '89', '12.0' -> '120').
+
+    Used to auto-select the matching GHCR splatsim image tag (``latest-sm<arch>``),
+    so the pulled image follows the host GPU. Falls back to *default* (sm_89, Ada)
+    when ``nvidia-smi`` is unavailable.
+    """
+    try:
+        out = (
+            subprocess.run(
+                ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            )
+            .stdout.strip()
+            .splitlines()[0]
+            .strip()
+        )
+        major, _, minor = out.partition(".")
+        return f"{int(major)}{int(minor)}"
+    except Exception as exc:  # noqa: BLE001
+        _log(f"WARNING: GPU compute-cap detection failed ({exc}); defaulting to sm_{default}")
+        return default
+
+
+class SplatSimDockerManager:
+    """Start / stop the ``splatsim:latest`` Docker container.
+
+    The container is launched with ``--network=host`` so that DDS
+    multicast discovery works between the container and the host, and
+    with full GPU access via the NVIDIA Container Toolkit.
+    """
+
+    def __init__(
+        self,
+        image: str = "splatsim:latest",
+        grpc_port: int = 50051,
+        container_name: str | None = None,
+        force_restart: bool = False,
+    ) -> None:
+        self._image = image
+        self._grpc_port = grpc_port
+        self._container_name = container_name
+        self._force_restart = force_restart
+        self._client = docker.from_env()
+        self._container = None
+        self._container_dead = False
+        self._reused = False
+
+    @property
+    def grpc_address(self) -> str:
+        return f"localhost:{self._grpc_port}"
+
+    def start(self, tileset_host_path: str) -> str:
+        """Start the container and return the gRPC address.
+
+        If a container with the configured name already exists and is
+        running, it will be reused instead of launching a new one.
+
+        Parameters
+        ----------
+        tileset_host_path:
+            Absolute path to the tileset directory on the host.
+            Mounted as ``/data`` inside the container.
+        """
+        if self._reuse_running_container():
+            return self.grpc_address
+
+        tileset_dir = str(Path(tileset_host_path).resolve().parent)
+        self._resolve_image_arch()
+        _log(
+            f"Starting container (image={self._image}, name={self._container_name}, "
+            f"mount={tileset_dir} -> /data)"
+        )
+        run_kwargs = {
+            "image": self._image,
+            "command": f"splatsim-grpc-server --port {self._grpc_port}",
+            "detach": True,
+            "network_mode": "host",
+            "device_requests": [DeviceRequest(count=-1, capabilities=[["gpu"]])],
+            "volumes": self._build_volumes(tileset_dir),
+            "environment": self._build_environment(),
+        }
+        if self._container_name:
+            run_kwargs["name"] = self._container_name
+
+        self._pull_registry_image()
+        self._container = self._client.containers.run(**run_kwargs)
+        _log(f"Container started: {self._container.short_id}")
+        self._start_log_thread()
+        return self.grpc_address
+
+    def _reuse_running_container(self) -> bool:
+        """Reuse an existing running container, or remove a stale one.
+
+        Returns True when a running container with the configured name was
+        reused (the caller should return immediately); False when a fresh
+        container must be launched. ``force_restart`` always removes and
+        relaunches.
+        """
+        if not self._container_name:
+            return False
+        try:
+            existing = self._client.containers.get(self._container_name)
+        except docker.errors.NotFound:
+            return False
+        existing.reload()
+        if existing.status == "running" and not self._force_restart:
+            _log(
+                f"Container '{self._container_name}' is already running "
+                f"({existing.short_id}), reusing it"
+            )
+            self._container = existing
+            self._reused = True
+            self._start_log_thread()
+            return True
+        reason = "force_restart requested" if self._force_restart else f"status={existing.status}"
+        _log(f"Container '{self._container_name}' exists ({reason}), removing it")
+        existing.stop(timeout=10)
+        existing.remove(force=True)
+        return False
+
+    def _resolve_image_arch(self) -> None:
+        """Resolve an ``{arch}`` placeholder in the image tag from the host GPU.
+
+        e.g. ``ghcr.io/tier4/splatsim:latest-sm{arch}`` -> ``...-sm86`` /
+        ``...-sm89`` / ``...-sm120`` so the matching GHCR build is pulled.
+        """
+        if "{arch}" in self._image:
+            self._image = self._image.replace("{arch}", _detect_cuda_arch())
+            _log(f"Resolved GPU-specific splatsim image: {self._image}")
+
+    def _build_environment(self) -> dict:
+        """Container environment variables.
+
+        Propagates ROS 2 DDS settings so the container's CycloneDDS PointCloud2
+        publisher joins the same graph as the Autoware side. Both run with
+        ``--network=host``, so pinning CycloneDDS to the loopback interface
+        matches the Autoware devcontainer's lo-only config and lets discovery
+        succeed over the shared host lo (default all-interface discovery does
+        not reach the lo-restricted subscriber). ROS_DOMAIN_ID / RMW must match.
+        """
+        env = {"GRPC_PORT": str(self._grpc_port)}
+        splatsim_log_level = os.environ.get("SPLATSIM_LOG_LEVEL")
+        if splatsim_log_level:
+            env["SPLATSIM_LOG_LEVEL"] = splatsim_log_level
+        env["ROS_DOMAIN_ID"] = os.environ.get("ROS_DOMAIN_ID", "0")
+        env["RMW_IMPLEMENTATION"] = os.environ.get("RMW_IMPLEMENTATION", "rmw_cyclonedds_cpp")
+        env["CYCLONEDDS_URI"] = os.environ.get(
+            "SPLATSIM_CYCLONEDDS_URI",
+            '<CycloneDDS><Domain Id="any"><General><Interfaces><NetworkInterface name="lo" priority="default" multicast="default"/></Interfaces><AllowMulticast>default</AllowMulticast></General></Domain></CycloneDDS>',
+        )
+        return env
+
+    def _build_volumes(self, tileset_dir: str) -> dict:
+        """Build the container volume binds.
+
+        The tileset dir is mounted read-only as ``/data``, plus an optional
+        dev-only PointCloud2-publisher override.
+
+        TEMPORARY dev-only escape hatch (``SPLATSIM_PC_PUBLISHER_PATCH``):
+        shadow-mount a host copy of the container's PointCloud2 publisher, e.g.
+        to switch its DDS QoS to BEST_EFFORT so it matches Autoware's
+        SensorDataQoS (a RELIABLE writer stalls per-frame on ~2 MB LiDAR
+        messages and caps FPS). The real fix is a one-line QoS change in
+        tier4/splatsim's publisher shipped in the GHCR image; drop this hatch
+        once that lands. Off unless the env var is set. The bind source is a
+        HOST path (resolved by the host daemon) and the target is splatsim's
+        private layout, so it is inherently coupled to the image internals --
+        keep it opt-in, never a default.
+        """
+        volumes = {tileset_dir: {"bind": "/data", "mode": "ro"}}
+        pc_patch = os.environ.get("SPLATSIM_PC_PUBLISHER_PATCH")
+        if pc_patch:
+            volumes[pc_patch] = {
+                "bind": "/workspace/splatsim/src/splatsim/cyclonedds/pointcloud2_publisher.py",
+                "mode": "ro",
+            }
+        return volumes
+
+    def _pull_registry_image(self) -> None:
+        """Best-effort pull of a registry-qualified image to refresh the tag.
+
+        For an image such as ``ghcr.io/tier4/splatsim:latest-sm89`` the newest
+        GHCR build is pulled instead of a stale local tag. Bare local tags (e.g.
+        ``splatsim:latest``) are left untouched; a failed pull falls back to the
+        local image.
+        """
+        if "/" not in self._image:
+            return
+        repo, _, tag = self._image.rpartition(":")
+        if not repo:
+            repo, tag = self._image, "latest"
+        try:
+            _log(f"Pulling {self._image} from registry ...")
+            self._client.images.pull(repo, tag=tag or "latest")
+            _log(f"Pull complete: {self._image}")
+        except docker.errors.APIError as exc:
+            _log(f"WARNING: pull failed ({exc}); using local image if present")
+
+    def _start_log_thread(self) -> None:
+        """Start the daemon thread that streams container logs to stderr."""
+        self._log_thread = threading.Thread(target=self._stream_logs, daemon=True)
+        self._log_thread.start()
+
+    def wait_for_ready(self, timeout: float = 60.0) -> None:
+        """Block until the gRPC server is reachable or *timeout* expires."""
+        deadline = time.monotonic() + timeout
+        address = self.grpc_address
+        while time.monotonic() < deadline:
+            if self._container_dead:
+                raise RuntimeError(
+                    "splatsim container exited before gRPC became ready. "
+                    "Check the [splatsim] log lines above for details."
+                )
+            try:
+                channel = grpc.insecure_channel(address)
+                grpc.channel_ready_future(channel).result(timeout=2.0)
+                channel.close()
+                _log(f"gRPC server is ready at {address}")
+                return
+            except grpc.FutureTimeoutError:
+                pass
+            except Exception:
+                pass
+            time.sleep(1.0)
+        raise TimeoutError(f"splatsim gRPC server at {address} not ready within {timeout}s")
+
+    def _stream_logs(self) -> None:
+        """Stream container logs to stderr in a background thread."""
+        try:
+            for chunk in self._container.logs(stream=True, follow=True):
+                for line in chunk.decode("utf-8", errors="replace").splitlines():
+                    _log(line)
+        except Exception as exc:
+            _log(f"Log stream ended: {exc}")
+        # If we reach here, the container has stopped producing logs.
+        try:
+            self._container.reload()
+            status = self._container.status
+        except Exception:
+            status = "removed"
+        if status != "running":
+            _log(f"Container is no longer running (status={status})")
+            self._container_dead = True
+
+    def stop(self) -> None:
+        """Stop and remove the container (idempotent).
+
+        A container that was reused (i.e. started externally before the
+        bridge) is left running: this manager did not create it, so it must
+        not tear it down on shutdown.
+        """
+        if self._container is None:
+            return
+        if self._reused:
+            _log(
+                f"Container '{self._container_name}' was reused, " f"leaving it running on shutdown"
+            )
+            self._container = None
+            return
+        try:
+            self._container.stop(timeout=10)
+            _log(f"Container stopped: {self._container.short_id}")
+        except Exception as exc:
+            _log(f"Error stopping container: {exc}")
+        try:
+            self._container.remove(force=True)
+        except Exception:
+            pass
+        self._container = None

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/grpc_client.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/grpc_client.py
@@ -1,0 +1,270 @@
+# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""gRPC client wrapper for the splatsim RenderingService."""
+
+from __future__ import annotations
+
+import threading
+from typing import Iterator
+
+from autoware_carla_interface.splatsim.proto import rendering_service_pb2 as pb2
+from autoware_carla_interface.splatsim.proto import rendering_service_pb2_grpc as pb2_grpc
+import grpc
+import rclpy
+
+_rlog = rclpy.logging.get_logger("splatsim_grpc_client")
+
+
+class SplatSimGrpcClient:
+    """Thread-safe gRPC client for the splatsim ``RenderingService``.
+
+    No client-side buffering — only the latest pose is kept.  The
+    generator yields only when a new pose arrives, so the gRPC
+    transport never accumulates a stale backlog.
+    """
+
+    def __init__(self, address: str = "localhost:50051") -> None:
+        self._address = address
+        self._channel = grpc.insecure_channel(address)
+        self._stub = pb2_grpc.RenderingServiceStub(self._channel)
+
+        # Single-slot latest pose (no queue)
+        self._latest_pose: pb2.CameraData | None = None
+        self._pose_lock = threading.Lock()
+        self._new_pose = threading.Event()
+        self._closed = False
+
+        self._stream_thread: threading.Thread | None = None
+        self._stream_result: pb2.StreamSummary | None = None
+        self._stream_error: Exception | None = None
+        self._send_count: int = 0
+
+        # ── LiDAR streaming (independent single-slot latest pose) ──
+        self._latest_lidar_pose: pb2.LidarData | None = None
+        self._lidar_pose_lock = threading.Lock()
+        self._lidar_new_pose = threading.Event()
+        self._lidar_closed = False
+        self._lidar_stream_thread: threading.Thread | None = None
+        self._lidar_stream_result: pb2.StreamSummary | None = None
+        self._lidar_stream_error: Exception | None = None
+        self._lidar_send_count: int = 0
+
+    def initialize(self, request: pb2.InitializeRequest) -> pb2.InitializeResponse:
+        """Send ``Initialize`` RPC.  Blocks until the server finishes loading."""
+        _rlog.warn(f"Sending Initialize to {self._address} ...")
+        response = self._stub.Initialize(request)
+        if response.success:
+            _rlog.warn("Initialize succeeded")
+        else:
+            _rlog.error(f"Initialize failed: {response.message}")
+        return response
+
+    # ── streaming ─────────────────────────────────────────────────────
+
+    def start_stream(self) -> None:
+        """Open the ``StreamCameraData`` client-streaming RPC in a background thread."""
+        self._stream_thread = threading.Thread(target=self._stream_worker, daemon=True)
+        self._stream_thread.start()
+
+    @staticmethod
+    def _make_pose(position, rotation_wxyz) -> pb2.Pose:
+        """Build a gRPC ``Pose`` from a position and a wxyz quaternion."""
+        return pb2.Pose(
+            position=pb2.Vector3(x=position[0], y=position[1], z=position[2]),
+            rotation=pb2.Quaternion(
+                w=rotation_wxyz[0],
+                x=rotation_wxyz[1],
+                y=rotation_wxyz[2],
+                z=rotation_wxyz[3],
+            ),
+        )
+
+    def send_camera_data(
+        self,
+        sec: int,
+        nanosec: int,
+        position: tuple[float, float, float],
+        rotation_wxyz: tuple[float, float, float, float],
+    ) -> None:
+        """Store the latest camera pose for the background stream."""
+        if self._stream_thread is not None and not self._stream_thread.is_alive():
+            if self._stream_error is not None:
+                _rlog.error(f"gRPC stream died: {self._stream_error}")
+            else:
+                _rlog.error("gRPC stream thread ended unexpectedly")
+            return
+
+        msg = pb2.CameraData(
+            stamp=pb2.Timestamp(sec=sec, nanosec=nanosec),
+            pose=self._make_pose(position, rotation_wxyz),
+        )
+        with self._pose_lock:
+            self._latest_pose = msg
+        self._new_pose.set()
+
+        self._send_count += 1
+        if self._send_count <= 10 or self._send_count % 50 == 0:
+            _rlog.warn(
+                f"gRPC send #{self._send_count}: "
+                f"pos=({position[0]:.4f}, {position[1]:.4f}, {position[2]:.4f})"
+            )
+
+    def close_stream(self) -> pb2.StreamSummary | None:
+        """Signal end-of-stream and wait for the background thread."""
+        self._closed = True
+        self._new_pose.set()  # wake generator
+        if self._stream_thread is not None:
+            self._stream_thread.join(timeout=10.0)
+        if self._stream_error is not None:
+            _rlog.error(f"Stream ended with error: {self._stream_error}")
+        return self._stream_result
+
+    def close(self) -> None:
+        """Close the gRPC channel."""
+        self._channel.close()
+
+    # ── LiDAR ─────────────────────────────────────────────────────────
+
+    def initialize_lidar(self, request: pb2.InitializeLidarRequest) -> pb2.InitializeResponse:
+        """Send ``InitializeLidar`` RPC.  ``Initialize`` must have run first."""
+        _rlog.warn(f"Sending InitializeLidar to {self._address} ...")
+        response = self._stub.InitializeLidar(request)
+        if response.success:
+            _rlog.warn("InitializeLidar succeeded")
+        else:
+            _rlog.error(f"InitializeLidar failed: {response.message}")
+        return response
+
+    def start_lidar_stream(self) -> None:
+        """Open the ``StreamLidarData`` client-streaming RPC in a background thread."""
+        self._lidar_stream_thread = threading.Thread(target=self._lidar_stream_worker, daemon=True)
+        self._lidar_stream_thread.start()
+
+    def send_lidar_data(
+        self,
+        sec: int,
+        nanosec: int,
+        position: tuple[float, float, float],
+        rotation_wxyz: tuple[float, float, float, float],
+    ) -> None:
+        """Store the latest base_link pose for the background LiDAR stream."""
+        if self._lidar_stream_thread is not None and not self._lidar_stream_thread.is_alive():
+            if self._lidar_stream_error is not None:
+                _rlog.error(f"LiDAR gRPC stream died: {self._lidar_stream_error}")
+            else:
+                _rlog.error("LiDAR gRPC stream thread ended unexpectedly")
+            return
+
+        msg = pb2.LidarData(
+            stamp=pb2.Timestamp(sec=sec, nanosec=nanosec),
+            pose=self._make_pose(position, rotation_wxyz),
+        )
+        with self._lidar_pose_lock:
+            self._latest_lidar_pose = msg
+        self._lidar_new_pose.set()
+
+        self._lidar_send_count += 1
+        if self._lidar_send_count <= 10 or self._lidar_send_count % 50 == 0:
+            _rlog.warn(
+                f"LiDAR gRPC send #{self._lidar_send_count}: "
+                f"pos=({position[0]:.4f}, {position[1]:.4f}, {position[2]:.4f})"
+            )
+
+    def close_lidar_stream(self) -> pb2.StreamSummary | None:
+        """Signal end-of-stream and wait for the background LiDAR thread."""
+        self._lidar_closed = True
+        self._lidar_new_pose.set()  # wake generator
+        if self._lidar_stream_thread is not None:
+            self._lidar_stream_thread.join(timeout=10.0)
+        if self._lidar_stream_error is not None:
+            _rlog.error(f"LiDAR stream ended with error: {self._lidar_stream_error}")
+        return self._lidar_stream_result
+
+    def _lidar_pose_generator(self) -> Iterator[pb2.LidarData]:
+        """Yield only the latest base_link pose, blocking until a new one arrives."""
+        yield_count = 0
+        while True:
+            self._lidar_new_pose.wait()
+            if self._lidar_closed:
+                _rlog.warn(f"LiDAR generator done after {yield_count} yields")
+                return
+            self._lidar_new_pose.clear()
+
+            with self._lidar_pose_lock:
+                msg = self._latest_lidar_pose
+            if msg is None:
+                continue
+
+            yield_count += 1
+            if yield_count <= 10 or yield_count % 50 == 0:
+                p = msg.pose.position
+                _rlog.warn(
+                    f"LiDAR generator yield #{yield_count}: "
+                    f"pos=({p.x:.4f}, {p.y:.4f}, {p.z:.4f}) "
+                    f"t={msg.stamp.sec}.{msg.stamp.nanosec:09d}"
+                )
+            yield msg
+
+    def _lidar_stream_worker(self) -> None:
+        """Background thread that drives the StreamLidarData RPC."""
+        try:
+            self._lidar_stream_result = self._stub.StreamLidarData(self._lidar_pose_generator())
+            _rlog.warn(
+                "LiDAR stream finished: "
+                f"rendered={self._lidar_stream_result.frames_rendered}, "
+                f"received={self._lidar_stream_result.poses_received}"
+            )
+        except Exception as exc:
+            self._lidar_stream_error = exc
+            _rlog.error(f"StreamLidarData failed: {exc}")
+
+    # ── internals ─────────────────────────────────────────────────────
+
+    def _pose_generator(self) -> Iterator[pb2.CameraData]:
+        """Yield only the latest pose, blocking until a new one arrives."""
+        yield_count = 0
+        while True:
+            self._new_pose.wait()
+            if self._closed:
+                _rlog.warn(f"Generator done after {yield_count} yields")
+                return
+            self._new_pose.clear()
+
+            with self._pose_lock:
+                msg = self._latest_pose
+            if msg is None:
+                continue
+
+            yield_count += 1
+            if yield_count <= 10 or yield_count % 50 == 0:
+                p = msg.pose.position
+                _rlog.warn(
+                    f"Generator yield #{yield_count}: "
+                    f"pos=({p.x:.4f}, {p.y:.4f}, {p.z:.4f}) "
+                    f"t={msg.stamp.sec}.{msg.stamp.nanosec:09d}"
+                )
+            yield msg
+
+    def _stream_worker(self) -> None:
+        """Background thread that drives the StreamCameraData RPC."""
+        try:
+            self._stream_result = self._stub.StreamCameraData(self._pose_generator())
+            _rlog.warn(
+                f"Stream finished: rendered={self._stream_result.frames_rendered}, "
+                f"received={self._stream_result.poses_received}"
+            )
+        except Exception as exc:
+            self._stream_error = exc
+            _rlog.error(f"StreamCameraData failed: {exc}")

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/grpc_client.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/grpc_client.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import threading
+from typing import Callable
 from typing import Iterator
 
 from autoware_carla_interface.splatsim.proto import rendering_service_pb2 as pb2
@@ -27,56 +28,128 @@ import rclpy
 _rlog = rclpy.logging.get_logger("splatsim_grpc_client")
 
 
-class SplatSimGrpcClient:
-    """Thread-safe gRPC client for the splatsim ``RenderingService``.
+class _PoseStream:
+    """Single-slot latest-pose client stream shared by the camera and LiDAR paths.
 
     No client-side buffering — only the latest pose is kept.  The
     generator yields only when a new pose arrives, so the gRPC
     transport never accumulates a stale backlog.
     """
 
+    def __init__(self, name: str, rpc: Callable) -> None:
+        self._name = name
+        self._rpc = rpc
+        self._latest_pose = None
+        self._pose_lock = threading.Lock()
+        self._new_pose = threading.Event()
+        self._closed = False
+        self._thread: threading.Thread | None = None
+        self._result: pb2.StreamSummary | None = None
+        self._error: Exception | None = None
+        self._send_count: int = 0
+
+    def start(self) -> None:
+        """Open the client-streaming RPC in a background thread."""
+        self._thread = threading.Thread(target=self._worker, daemon=True)
+        self._thread.start()
+
+    def send(self, msg) -> None:
+        """Store the latest pose message for the background stream."""
+        if self._thread is not None and not self._thread.is_alive():
+            if self._error is not None:
+                _rlog.error(f"{self._name} gRPC stream died: {self._error}")
+            else:
+                _rlog.error(f"{self._name} gRPC stream thread ended unexpectedly")
+            return
+
+        with self._pose_lock:
+            self._latest_pose = msg
+        self._new_pose.set()
+
+        self._send_count += 1
+        if self._send_count <= 10 or self._send_count % 50 == 0:
+            p = msg.pose.position
+            _rlog.warn(
+                f"{self._name} gRPC send #{self._send_count}: "
+                f"pos=({p.x:.4f}, {p.y:.4f}, {p.z:.4f})"
+            )
+
+    def close(self) -> pb2.StreamSummary | None:
+        """Signal end-of-stream and wait for the background thread."""
+        self._closed = True
+        self._new_pose.set()  # wake generator
+        if self._thread is not None:
+            self._thread.join(timeout=10.0)
+        if self._error is not None:
+            _rlog.error(f"{self._name} stream ended with error: {self._error}")
+        return self._result
+
+    def _pose_generator(self) -> Iterator:
+        """Yield only the latest pose, blocking until a new one arrives."""
+        yield_count = 0
+        while True:
+            self._new_pose.wait()
+            if self._closed:
+                _rlog.warn(f"{self._name} generator done after {yield_count} yields")
+                return
+            self._new_pose.clear()
+
+            with self._pose_lock:
+                msg = self._latest_pose
+            if msg is None:
+                continue
+
+            yield_count += 1
+            if yield_count <= 10 or yield_count % 50 == 0:
+                p = msg.pose.position
+                _rlog.warn(
+                    f"{self._name} generator yield #{yield_count}: "
+                    f"pos=({p.x:.4f}, {p.y:.4f}, {p.z:.4f}) "
+                    f"t={msg.stamp.sec}.{msg.stamp.nanosec:09d}"
+                )
+            yield msg
+
+    def _worker(self) -> None:
+        """Background thread that drives the client-streaming RPC."""
+        try:
+            self._result = self._rpc(self._pose_generator())
+            _rlog.warn(
+                f"{self._name} stream finished: "
+                f"rendered={self._result.frames_rendered}, "
+                f"received={self._result.poses_received}"
+            )
+        except Exception as exc:
+            self._error = exc
+            _rlog.error(f"{self._name} stream RPC failed: {exc}")
+
+
+class SplatSimGrpcClient:
+    """Thread-safe gRPC client for the splatsim ``RenderingService``.
+
+    The camera and LiDAR paths each own an independent single-slot
+    latest-pose stream (:class:`_PoseStream`).
+    """
+
     def __init__(self, address: str = "localhost:50051") -> None:
         self._address = address
         self._channel = grpc.insecure_channel(address)
         self._stub = pb2_grpc.RenderingServiceStub(self._channel)
+        self._camera_stream = _PoseStream("camera", self._stub.StreamCameraData)
+        self._lidar_stream = _PoseStream("LiDAR", self._stub.StreamLidarData)
 
-        # Single-slot latest pose (no queue)
-        self._latest_pose: pb2.CameraData | None = None
-        self._pose_lock = threading.Lock()
-        self._new_pose = threading.Event()
-        self._closed = False
-
-        self._stream_thread: threading.Thread | None = None
-        self._stream_result: pb2.StreamSummary | None = None
-        self._stream_error: Exception | None = None
-        self._send_count: int = 0
-
-        # ── LiDAR streaming (independent single-slot latest pose) ──
-        self._latest_lidar_pose: pb2.LidarData | None = None
-        self._lidar_pose_lock = threading.Lock()
-        self._lidar_new_pose = threading.Event()
-        self._lidar_closed = False
-        self._lidar_stream_thread: threading.Thread | None = None
-        self._lidar_stream_result: pb2.StreamSummary | None = None
-        self._lidar_stream_error: Exception | None = None
-        self._lidar_send_count: int = 0
+    def _call_initialize(self, name: str, rpc: Callable, request) -> pb2.InitializeResponse:
+        """Send an initialize-style RPC.  Blocks until the server finishes loading."""
+        _rlog.warn(f"Sending {name} to {self._address} ...")
+        response = rpc(request)
+        if response.success:
+            _rlog.warn(f"{name} succeeded")
+        else:
+            _rlog.error(f"{name} failed: {response.message}")
+        return response
 
     def initialize(self, request: pb2.InitializeRequest) -> pb2.InitializeResponse:
         """Send ``Initialize`` RPC.  Blocks until the server finishes loading."""
-        _rlog.warn(f"Sending Initialize to {self._address} ...")
-        response = self._stub.Initialize(request)
-        if response.success:
-            _rlog.warn("Initialize succeeded")
-        else:
-            _rlog.error(f"Initialize failed: {response.message}")
-        return response
-
-    # ── streaming ─────────────────────────────────────────────────────
-
-    def start_stream(self) -> None:
-        """Open the ``StreamCameraData`` client-streaming RPC in a background thread."""
-        self._stream_thread = threading.Thread(target=self._stream_worker, daemon=True)
-        self._stream_thread.start()
+        return self._call_initialize("Initialize", self._stub.Initialize, request)
 
     @staticmethod
     def _make_pose(position, rotation_wxyz) -> pb2.Pose:
@@ -91,6 +164,12 @@ class SplatSimGrpcClient:
             ),
         )
 
+    # ── camera streaming ──────────────────────────────────────────────
+
+    def start_stream(self) -> None:
+        """Open the ``StreamCameraData`` client-streaming RPC in a background thread."""
+        self._camera_stream.start()
+
     def send_camera_data(
         self,
         sec: int,
@@ -99,58 +178,30 @@ class SplatSimGrpcClient:
         rotation_wxyz: tuple[float, float, float, float],
     ) -> None:
         """Store the latest camera pose for the background stream."""
-        if self._stream_thread is not None and not self._stream_thread.is_alive():
-            if self._stream_error is not None:
-                _rlog.error(f"gRPC stream died: {self._stream_error}")
-            else:
-                _rlog.error("gRPC stream thread ended unexpectedly")
-            return
-
-        msg = pb2.CameraData(
-            stamp=pb2.Timestamp(sec=sec, nanosec=nanosec),
-            pose=self._make_pose(position, rotation_wxyz),
-        )
-        with self._pose_lock:
-            self._latest_pose = msg
-        self._new_pose.set()
-
-        self._send_count += 1
-        if self._send_count <= 10 or self._send_count % 50 == 0:
-            _rlog.warn(
-                f"gRPC send #{self._send_count}: "
-                f"pos=({position[0]:.4f}, {position[1]:.4f}, {position[2]:.4f})"
+        self._camera_stream.send(
+            pb2.CameraData(
+                stamp=pb2.Timestamp(sec=sec, nanosec=nanosec),
+                pose=self._make_pose(position, rotation_wxyz),
             )
+        )
 
     def close_stream(self) -> pb2.StreamSummary | None:
         """Signal end-of-stream and wait for the background thread."""
-        self._closed = True
-        self._new_pose.set()  # wake generator
-        if self._stream_thread is not None:
-            self._stream_thread.join(timeout=10.0)
-        if self._stream_error is not None:
-            _rlog.error(f"Stream ended with error: {self._stream_error}")
-        return self._stream_result
+        return self._camera_stream.close()
 
     def close(self) -> None:
         """Close the gRPC channel."""
         self._channel.close()
 
-    # ── LiDAR ─────────────────────────────────────────────────────────
+    # ── LiDAR streaming ───────────────────────────────────────────────
 
     def initialize_lidar(self, request: pb2.InitializeLidarRequest) -> pb2.InitializeResponse:
         """Send ``InitializeLidar`` RPC.  ``Initialize`` must have run first."""
-        _rlog.warn(f"Sending InitializeLidar to {self._address} ...")
-        response = self._stub.InitializeLidar(request)
-        if response.success:
-            _rlog.warn("InitializeLidar succeeded")
-        else:
-            _rlog.error(f"InitializeLidar failed: {response.message}")
-        return response
+        return self._call_initialize("InitializeLidar", self._stub.InitializeLidar, request)
 
     def start_lidar_stream(self) -> None:
         """Open the ``StreamLidarData`` client-streaming RPC in a background thread."""
-        self._lidar_stream_thread = threading.Thread(target=self._lidar_stream_worker, daemon=True)
-        self._lidar_stream_thread.start()
+        self._lidar_stream.start()
 
     def send_lidar_data(
         self,
@@ -160,111 +211,13 @@ class SplatSimGrpcClient:
         rotation_wxyz: tuple[float, float, float, float],
     ) -> None:
         """Store the latest base_link pose for the background LiDAR stream."""
-        if self._lidar_stream_thread is not None and not self._lidar_stream_thread.is_alive():
-            if self._lidar_stream_error is not None:
-                _rlog.error(f"LiDAR gRPC stream died: {self._lidar_stream_error}")
-            else:
-                _rlog.error("LiDAR gRPC stream thread ended unexpectedly")
-            return
-
-        msg = pb2.LidarData(
-            stamp=pb2.Timestamp(sec=sec, nanosec=nanosec),
-            pose=self._make_pose(position, rotation_wxyz),
-        )
-        with self._lidar_pose_lock:
-            self._latest_lidar_pose = msg
-        self._lidar_new_pose.set()
-
-        self._lidar_send_count += 1
-        if self._lidar_send_count <= 10 or self._lidar_send_count % 50 == 0:
-            _rlog.warn(
-                f"LiDAR gRPC send #{self._lidar_send_count}: "
-                f"pos=({position[0]:.4f}, {position[1]:.4f}, {position[2]:.4f})"
+        self._lidar_stream.send(
+            pb2.LidarData(
+                stamp=pb2.Timestamp(sec=sec, nanosec=nanosec),
+                pose=self._make_pose(position, rotation_wxyz),
             )
+        )
 
     def close_lidar_stream(self) -> pb2.StreamSummary | None:
         """Signal end-of-stream and wait for the background LiDAR thread."""
-        self._lidar_closed = True
-        self._lidar_new_pose.set()  # wake generator
-        if self._lidar_stream_thread is not None:
-            self._lidar_stream_thread.join(timeout=10.0)
-        if self._lidar_stream_error is not None:
-            _rlog.error(f"LiDAR stream ended with error: {self._lidar_stream_error}")
-        return self._lidar_stream_result
-
-    def _lidar_pose_generator(self) -> Iterator[pb2.LidarData]:
-        """Yield only the latest base_link pose, blocking until a new one arrives."""
-        yield_count = 0
-        while True:
-            self._lidar_new_pose.wait()
-            if self._lidar_closed:
-                _rlog.warn(f"LiDAR generator done after {yield_count} yields")
-                return
-            self._lidar_new_pose.clear()
-
-            with self._lidar_pose_lock:
-                msg = self._latest_lidar_pose
-            if msg is None:
-                continue
-
-            yield_count += 1
-            if yield_count <= 10 or yield_count % 50 == 0:
-                p = msg.pose.position
-                _rlog.warn(
-                    f"LiDAR generator yield #{yield_count}: "
-                    f"pos=({p.x:.4f}, {p.y:.4f}, {p.z:.4f}) "
-                    f"t={msg.stamp.sec}.{msg.stamp.nanosec:09d}"
-                )
-            yield msg
-
-    def _lidar_stream_worker(self) -> None:
-        """Background thread that drives the StreamLidarData RPC."""
-        try:
-            self._lidar_stream_result = self._stub.StreamLidarData(self._lidar_pose_generator())
-            _rlog.warn(
-                "LiDAR stream finished: "
-                f"rendered={self._lidar_stream_result.frames_rendered}, "
-                f"received={self._lidar_stream_result.poses_received}"
-            )
-        except Exception as exc:
-            self._lidar_stream_error = exc
-            _rlog.error(f"StreamLidarData failed: {exc}")
-
-    # ── internals ─────────────────────────────────────────────────────
-
-    def _pose_generator(self) -> Iterator[pb2.CameraData]:
-        """Yield only the latest pose, blocking until a new one arrives."""
-        yield_count = 0
-        while True:
-            self._new_pose.wait()
-            if self._closed:
-                _rlog.warn(f"Generator done after {yield_count} yields")
-                return
-            self._new_pose.clear()
-
-            with self._pose_lock:
-                msg = self._latest_pose
-            if msg is None:
-                continue
-
-            yield_count += 1
-            if yield_count <= 10 or yield_count % 50 == 0:
-                p = msg.pose.position
-                _rlog.warn(
-                    f"Generator yield #{yield_count}: "
-                    f"pos=({p.x:.4f}, {p.y:.4f}, {p.z:.4f}) "
-                    f"t={msg.stamp.sec}.{msg.stamp.nanosec:09d}"
-                )
-            yield msg
-
-    def _stream_worker(self) -> None:
-        """Background thread that drives the StreamCameraData RPC."""
-        try:
-            self._stream_result = self._stub.StreamCameraData(self._pose_generator())
-            _rlog.warn(
-                f"Stream finished: rendered={self._stream_result.frames_rendered}, "
-                f"received={self._stream_result.poses_received}"
-            )
-        except Exception as exc:
-            self._stream_error = exc
-            _rlog.error(f"StreamCameraData failed: {exc}")
+        return self._lidar_stream.close()

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/proto/rendering_service.proto
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/proto/rendering_service.proto
@@ -1,0 +1,171 @@
+syntax = "proto3";
+
+package splatsim.v1;
+
+// ── Shared sub-messages ──────────────────────────────────────────────
+
+message Timestamp {
+  int32 sec = 1;
+  uint32 nanosec = 2;
+}
+
+message CameraIntrinsics {
+  double fx = 1;
+  double fy = 2;
+  double cx = 3;
+  double cy = 4;
+  uint32 width = 5;
+  uint32 height = 6;
+}
+
+message Vector3 {
+  double x = 1;
+  double y = 2;
+  double z = 3;
+}
+
+message Quaternion {
+  // wxyz convention (matching gsplat / splatsim convention).
+  double w = 1;
+  double x = 2;
+  double y = 3;
+  double z = 4;
+}
+
+message Pose {
+  Vector3 position = 1;
+  Quaternion rotation = 2;
+}
+
+// ── Initialization ───────────────────────────────────────────────────
+
+message InitializeRequest {
+  // Scene
+  string scene_path = 1;  // path to a v2 scene USDZ (.usdz)
+  bool use_sh = 2;
+
+  // Camera
+  CameraIntrinsics intrinsics = 3;
+  Pose initial_pose = 4;
+
+  // Rendering schedule
+  double frame_rate = 5;          // Hz (e.g. 30.0)
+  Timestamp clock_initial = 6;    // starting time for frame scheduling
+
+  // DDS publishing
+  string image_topic = 7;
+  string camera_info_topic = 8;
+  string frame_id = 9;
+
+  // Renderer settings
+  float near_plane = 10;
+  float far_plane = 11;
+  string device = 12;             // "cuda" or "cuda:0" etc.
+  Vector3 background_color = 13;  // RGB [0, 1]
+  string compress_format = 14;    // "jpeg", "png", or "" for raw Image
+
+  // Level-of-Detail. Set true to start with distance-adaptive Gaussian
+  // filtering enabled. Plain (non-optional) bool so the stubs generate with
+  // the protoc bundled in the distro grpc_tools (which rejects proto3
+  // "optional"); as a result an unset/false value is indistinguishable on the
+  // wire and the server keeps its default (LoD on). Toggle at runtime via
+  // SetLod, which carries explicit on/off.
+  bool enable_lod = 15;
+}
+
+message InitializeResponse {
+  bool success = 1;
+  string message = 2;
+  Vector3 scene_origin = 3;      // re-centering origin (mean of Gaussian positions)
+  Vector3 ecef_translation = 4;  // scene anchor ECEF translation
+  repeated double ecef_rotation = 5;  // scene anchor ECEF rotation (9 doubles, row-major 3x3)
+}
+
+// ── Camera data streaming ────────────────────────────────────────────
+
+message CameraData {
+  Timestamp stamp = 1;
+  Pose pose = 2;
+}
+
+message StreamSummary {
+  uint64 frames_rendered = 1;
+  uint64 poses_received = 2;
+}
+
+// ── LiDAR data streaming ─────────────────────────────────────────────
+
+message LidarSensorConfig {
+  string name = 1;
+  // Built-in elevation table selector: "OT128" | "XT32" | "HDL64E" | ""
+  // (empty). A known model supplies a faithful default beam count / azimuth
+  // resolution / spin rate / range for any numeric field left at 0. When
+  // ``elevation_deg`` below is set it takes precedence over this.
+  string sensor_type = 2;
+  uint32 n_rows = 3;              // uniform-elevation beam count (fallback)
+  uint32 n_columns = 4;           // azimuth samples per revolution
+  double fps = 5;                 // spin rate (Hz); also the render cadence
+  double min_range_m = 6;
+  double max_range_m = 7;
+  // Sensor mount pose in the base_link frame (sensor-in-base). The rotation
+  // is a wxyz quaternion. No inversion is applied — this is the genuine
+  // sensor→base extrinsic.
+  Pose extrinsic = 8;
+  // Explicit per-beam elevation table in degrees, any order. When non-empty
+  // it overrides ``sensor_type`` and the uniform ``n_rows`` fallback.
+  repeated double elevation_deg = 9;
+  // DDS publishing.
+  string pointcloud_topic = 10;
+  string frame_id = 11;
+  // Return gating. 0 selects the server defaults (drop=0.5, alpha=0.1).
+  double drop_threshold = 12;
+  double alpha_threshold = 13;
+}
+
+message InitializeLidarRequest {
+  // The scene must already be loaded via Initialize.
+  LidarSensorConfig sensor = 1;
+}
+
+message LidarData {
+  Timestamp stamp = 1;
+  // base_link → world pose (position + wxyz quaternion). The server applies
+  // the sensor→base extrinsic from InitializeLidar internally.
+  Pose pose = 2;
+}
+
+message SetLodRequest {
+  // Turn distance-adaptive LoD Gaussian filtering on (true) or off (false).
+  bool enabled = 1;
+}
+
+message SetLodResponse {
+  bool success = 1;
+  // Effective LoD state after the call. Note this stays false when no LoD
+  // index was pre-computed for the scene (nothing to filter).
+  bool enabled = 2;
+  string message = 3;
+}
+
+// ── Service definition ───────────────────────────────────────────────
+
+service RenderingService {
+  // Load scene, create renderer and publishers. Blocks until ready.
+  rpc Initialize(InitializeRequest) returns (InitializeResponse);
+
+  // Client streams timestamped camera poses. Server renders at frame_rate
+  // cadence and publishes via DDS. Returns summary when stream closes.
+  rpc StreamCameraData(stream CameraData) returns (StreamSummary);
+
+  // Add a LiDAR sensor to the already-loaded scene. Call Initialize first.
+  rpc InitializeLidar(InitializeLidarRequest) returns (InitializeResponse);
+
+  // Client streams timestamped base_link poses. Server renders the LiDAR
+  // panorama at the sensor's spin rate and publishes sensor_msgs/PointCloud2
+  // via DDS. Returns summary when the stream closes.
+  rpc StreamLidarData(stream LidarData) returns (StreamSummary);
+
+  // Toggle distance-adaptive LoD Gaussian filtering at runtime. The render
+  // loop reads the scene's LoD state per frame. Requires Initialize first.
+  rpc SetLod(SetLodRequest) returns (SetLodResponse);
+}

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_camera.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_camera.py
@@ -1,0 +1,242 @@
+# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SplatSimRGBCamera -- one Docker container + gRPC stream per RGB camera."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from pathlib import Path
+
+from autoware_carla_interface.splatsim.coordinate_transformer import (
+    _rotation_matrix_to_quaternion_wxyz,
+)
+from autoware_carla_interface.splatsim.coordinate_transformer import CoordinateTransformer
+from autoware_carla_interface.splatsim.coordinate_transformer import resolve_ecef_transform
+from autoware_carla_interface.splatsim.docker_manager import SplatSimDockerManager
+from autoware_carla_interface.splatsim.grpc_client import SplatSimGrpcClient
+from autoware_carla_interface.splatsim.proto import rendering_service_pb2 as pb2
+import carla
+import numpy as np
+import rclpy
+
+_rlog = rclpy.logging.get_logger("splatsim_camera")
+
+# CARLA → ENU: flip y-axis (CARLA South → ENU North)
+_S_CARLA_TO_ENU = np.diag([1.0, -1.0, 1.0])
+
+
+def _fov_to_intrinsics(
+    width: int,
+    height: int,
+    fov_deg: float,
+) -> tuple[float, float, float, float]:
+    """Convert horizontal FOV + resolution to ``(fx, fy, cx, cy)``."""
+    fov_rad = math.radians(fov_deg)
+    fx = width / (2.0 * math.tan(fov_rad / 2.0))
+    fy = fx
+    cx = width / 2.0
+    cy = height / 2.0
+    return fx, fy, cx, cy
+
+
+@dataclass(frozen=True)
+class SplatSimCameraConfig:
+    """Tunable parameters for a :class:`SplatSimRGBCamera`."""
+
+    tileset_path: str
+    splatsim_image: str = "ghcr.io/tier4/splatsim:latest-sm{arch}"
+    grpc_port: int = 50051
+    use_sh: bool = True
+    # Distance-adaptive LoD Gaussian filtering (server-side); see
+    # SplatSimLidarConfig.enable_lod. Ignored by pre-LoD splatsim servers.
+    enable_lod: bool = True
+    frame_rate: float = 20.0
+    image_topic: str = "/splatsim/image_raw"
+    camera_info_topic: str = "/splatsim/camera_info"
+    frame_id: str = "splatsim_camera"
+    near_plane: float = 0.01
+    far_plane: float = 1000.0
+    device: str = "cuda:0"
+    restart_container: bool = False
+    compress_format: str = ""
+
+
+class SplatSimRGBCamera:
+    """Manages one splatsim Docker container for a single RGB camera.
+
+    Replaces a CARLA ``sensor.camera.rgb`` sensor with Gaussian Splatting
+    rendering.  The Docker container publishes ``Image`` and ``CameraInfo``
+    messages directly via CycloneDDS.
+    """
+
+    def __init__(
+        self,
+        sensor_spec: dict,
+        *,
+        proj_origin: tuple[float, float],
+        config: SplatSimCameraConfig,
+    ) -> None:
+        self._sensor_id = sensor_spec["id"]
+
+        # Camera extrinsic (actor -> camera) as CARLA Transform
+        sp = sensor_spec["spawn_point"]
+        self._sensor_transform = carla.Transform(
+            carla.Location(x=sp["x"], y=sp["y"], z=sp["z"]),
+            carla.Rotation(roll=sp["roll"], pitch=sp["pitch"], yaw=sp["yaw"]),
+        )
+
+        self._docker = self._start_container(config)
+        self._grpc = SplatSimGrpcClient(address=self._docker.grpc_address)
+        resp = self._initialize_render(sensor_spec, config)
+        self._transformer = self._build_transformer(resp, config, proj_origin)
+
+        # ── Start streaming ──
+        self._grpc.start_stream()
+        self._update_count = 0
+        _rlog.warn(f"SplatSimRGBCamera '{self._sensor_id}' initialized")
+
+    def _start_container(self, config: SplatSimCameraConfig) -> SplatSimDockerManager:
+        docker = SplatSimDockerManager(
+            image=config.splatsim_image,
+            grpc_port=config.grpc_port,
+            container_name=f"splatsim_{self._sensor_id}",
+            force_restart=config.restart_container,
+        )
+        docker.start(config.tileset_path)
+        docker.wait_for_ready(timeout=120.0)
+        return docker
+
+    def _initialize_render(self, sensor_spec: dict, config: SplatSimCameraConfig):
+        fx, fy, cx, cy = _fov_to_intrinsics(
+            sensor_spec["image_size_x"], sensor_spec["image_size_y"], sensor_spec["fov"]
+        )
+        init_request = pb2.InitializeRequest(
+            scene_path=f"/data/{Path(config.tileset_path).name}",
+            use_sh=config.use_sh,
+            intrinsics=pb2.CameraIntrinsics(
+                fx=fx,
+                fy=fy,
+                cx=cx,
+                cy=cy,
+                width=sensor_spec["image_size_x"],
+                height=sensor_spec["image_size_y"],
+            ),
+            frame_rate=config.frame_rate,
+            image_topic=config.image_topic,
+            camera_info_topic=config.camera_info_topic,
+            frame_id=config.frame_id,
+            near_plane=config.near_plane,
+            far_plane=config.far_plane,
+            device=config.device,
+            background_color=pb2.Vector3(x=0.0, y=0.0, z=0.0),
+            compress_format=config.compress_format,
+            enable_lod=config.enable_lod,
+        )
+        resp = self._grpc.initialize(init_request)
+        if not resp.success:
+            raise RuntimeError(f"splatsim Initialize failed: {resp.message}")
+        return resp
+
+    def _build_transformer(
+        self, resp, config: SplatSimCameraConfig, proj_origin: tuple[float, float]
+    ) -> CoordinateTransformer:
+        scene_origin = np.array(
+            [resp.scene_origin.x, resp.scene_origin.y, resp.scene_origin.z],
+            dtype=np.float64,
+        )
+        ecef_rot, ecef_trans = resolve_ecef_transform(resp, config.tileset_path)
+        _rlog.warn(
+            f"ECEF rot:\n{ecef_rot}\n" f"ECEF trans: {ecef_trans}\n" f"scene_origin: {scene_origin}"
+        )
+        return CoordinateTransformer(
+            proj_origin=proj_origin,
+            ecef_rotation=ecef_rot,
+            ecef_translation=ecef_trans,
+            scene_origin=scene_origin,
+        )
+
+    def update(
+        self,
+        actor_matrix_4x4: list[list[float]],
+        stamp_sec: int,
+        stamp_nanosec: int,
+    ) -> None:
+        """Compute camera pose in tile-local coordinates and send to splatsim.
+
+        Parameters
+        ----------
+        actor_matrix_4x4 : list[list[float]]
+            Raw 4x4 world-to-actor matrix from ``carla.Transform.get_matrix()``.
+        """
+        T_world_actor = np.array(actor_matrix_4x4, dtype=np.float64)
+        T_actor_camera = np.asarray(
+            self._sensor_transform.get_matrix(),
+            dtype=np.float64,
+        )
+        T_carla_cam = T_world_actor @ T_actor_camera
+
+        carla_pos = T_carla_cam[:3, 3]
+        R_carla = T_carla_cam[:3, :3]
+
+        # Position: CARLA → ENU (flip y) → tile-local
+        enu_pos = _S_CARLA_TO_ENU @ carla_pos
+        tile_pos = self._transformer.enu_position_to_tile_local(
+            enu_pos[0],
+            enu_pos[1],
+            enu_pos[2],
+        )
+
+        self._update_count += 1
+        if self._update_count <= 10 or self._update_count % 50 == 0:
+            _rlog.warn(
+                f"Pose update #{self._update_count}:\n"
+                f"  CARLA pos: ({carla_pos[0]:.4f}, {carla_pos[1]:.4f}, {carla_pos[2]:.4f})\n"
+                f"  ENU pos:   ({enu_pos[0]:.4f}, {enu_pos[1]:.4f}, {enu_pos[2]:.4f})\n"
+                f"  tile_pos:  ({tile_pos[0]:.4f}, {tile_pos[1]:.4f}, {tile_pos[2]:.4f})"
+            )
+
+        # Rotation: CARLA → ENU (flip y) → tile-local → RDF
+        R_enu = _S_CARLA_TO_ENU @ R_carla
+        R_tile = self._transformer.enu_rotation_to_tile_local(R_enu)
+        # R_tile has det=-1 (from the Y-flip).  Apply RDF remapping here
+        # (same as standalone _compute_viewmat) so the result is a proper
+        # rotation (det=+1) that survives the quaternion roundtrip.
+        #   gsplat X=right  ← camera Y = R_tile[:, 1]
+        #   gsplat Y=down   ← camera -Z = -R_tile[:, 2]
+        #   gsplat Z=forward ← camera X = R_tile[:, 0]
+        R_rdf = np.column_stack([R_tile[:, 1], -R_tile[:, 2], R_tile[:, 0]])
+        quat_wxyz = _rotation_matrix_to_quaternion_wxyz(R_rdf)
+
+        self._grpc.send_camera_data(
+            sec=stamp_sec,
+            nanosec=stamp_nanosec,
+            position=(float(tile_pos[0]), float(tile_pos[1]), float(tile_pos[2])),
+            rotation_wxyz=quat_wxyz,
+        )
+
+    def shutdown(self) -> None:
+        """Close gRPC stream and stop Docker container."""
+        if self._grpc is None:
+            return
+        _rlog.warn(f"Shutting down SplatSimRGBCamera '{self._sensor_id}'")
+        self._grpc.close_stream()
+        self._grpc.close()
+        self._grpc = None
+        self._docker.stop()
+        self._docker = None
+
+    def __del__(self) -> None:
+        self.shutdown()

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_camera.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_camera.py
@@ -57,7 +57,7 @@ class SplatSimCameraConfig:
     """Tunable parameters for a :class:`SplatSimRGBCamera`."""
 
     tileset_path: str
-    splatsim_image: str = "ghcr.io/tier4/splatsim:latest-sm{arch}"
+    splatsim_image: str = "splatsim:latest"
     grpc_port: int = 50051
     use_sh: bool = True
     # Distance-adaptive LoD Gaussian filtering (server-side); see

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_lidar.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_lidar.py
@@ -1,0 +1,271 @@
+# Copyright 2024 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SplatSimLidar -- one Docker container + gRPC stream per LiDAR sensor.
+
+Replaces a CARLA ``sensor.lidar.ray_cast`` sensor with Gaussian Splatting
+rendering.  The Docker container publishes ``sensor_msgs/PointCloud2`` messages
+directly via CycloneDDS on the sensor's sensing topic.
+
+Coordinate contract (splatsim v2 / v25 ENU usdz, verified against the server):
+
+* World frame is Z-up ENU, recentred to the scene centroid.  The client sends
+  the **base_link -> world** pose in ROS convention (X-forward, Y-left, Z-up),
+  tile-local.  Unlike the camera path there is **no RDF remap**.
+* The **sensor -> base_link** extrinsic is sent once at ``InitializeLidar``.
+  The server composes ``sensor_to_world = base_to_world @ extrinsic`` internally,
+  so the stream only carries the moving base_link pose.
+
+To reproduce the exact viewpoint of the real CARLA LiDAR the extrinsic is taken
+from the same actor-relative spawn pose CARLA used (``cfg.transform``), converted
+from CARLA (Y-right) to ROS base_link (Y-left).  Because this integration
+publishes the CARLA actor pose *as* base_link (see ``_publish_localization``),
+the streamed pose is the actor pose and the extrinsic stays actor-relative --
+identical placement to the CARLA sensor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from autoware_carla_interface.splatsim.coordinate_transformer import (
+    _rotation_matrix_to_quaternion_wxyz,
+)
+from autoware_carla_interface.splatsim.coordinate_transformer import CoordinateTransformer
+from autoware_carla_interface.splatsim.coordinate_transformer import resolve_ecef_transform
+from autoware_carla_interface.splatsim.docker_manager import SplatSimDockerManager
+from autoware_carla_interface.splatsim.grpc_client import SplatSimGrpcClient
+from autoware_carla_interface.splatsim.proto import rendering_service_pb2 as pb2
+import carla
+import numpy as np
+import rclpy
+
+_rlog = rclpy.logging.get_logger("splatsim_lidar")
+
+# CARLA -> ENU: flip y-axis (CARLA South -> ENU North)
+_S_CARLA_TO_ENU = np.diag([1.0, -1.0, 1.0])
+# CARLA (Y-right) <-> ROS (Y-left) similarity for a 4x4 rigid transform.
+_S4_CARLA_TO_ROS = np.diag([1.0, -1.0, 1.0, 1.0])
+
+
+@dataclass(frozen=True)
+class SplatSimLidarConfig:
+    """Tunable parameters for a :class:`SplatSimLidar`."""
+
+    tileset_path: str
+    splatsim_image: str = "ghcr.io/tier4/splatsim:latest-sm{arch}"
+    grpc_port: int = 50061
+    use_sh: bool = True
+    # Distance-adaptive LoD Gaussian filtering (server-side). Passed to the
+    # scene at Initialize; True keeps LoD on (its server default), False forces
+    # it off. Requires a splatsim build with the gRPC LoD path (tier4/splatsim
+    # PR #78); older servers ignore the unknown field and always run without LoD.
+    enable_lod: bool = True
+    # Defaults mirror the real Velodyne HDL-64E sensor spec (CARLA's default
+    # LiDAR: min range 0.9 m, max range 120 m, 64 channels, 0.1728 deg
+    # horizontal resolution at 10 Hz). The built-in "HDL64E" table supplies the
+    # actual per-channel vertical angles, so elevation_deg is left empty.
+    sensor_type: str = "HDL64E"
+    fps: float = 10.0
+    n_rows: int = 64
+    n_columns: int = 2083
+    min_range_m: float = 0.9
+    max_range_m: float = 120.0
+    elevation_deg: tuple[float, ...] = ()
+    drop_threshold: float = 0.5
+    alpha_threshold: float = 0.1
+    pointcloud_topic: str = "/sensing/lidar/top/pointcloud_before_sync"
+    frame_id: str = "velodyne_top"
+    device: str = "cuda:0"
+    restart_container: bool = False
+
+
+class SplatSimLidar:
+    """Manages one splatsim Docker container for a single LiDAR sensor."""
+
+    def __init__(
+        self,
+        sensor_spec: dict,
+        *,
+        proj_origin: tuple[float, float],
+        config: SplatSimLidarConfig,
+    ) -> None:
+        self._sensor_id = sensor_spec["id"]
+
+        ext_pos, ext_quat_wxyz = self._sensor_extrinsic(sensor_spec["spawn_point"])
+        self._docker = self._start_container(config)
+        self._grpc = SplatSimGrpcClient(address=self._docker.grpc_address)
+        resp = self._initialize_scene(config)
+        self._transformer = self._build_transformer(resp, config, proj_origin)
+        self._initialize_lidar(config, ext_pos, ext_quat_wxyz)
+
+        # ── Start streaming ──
+        self._grpc.start_lidar_stream()
+        self._update_count = 0
+
+    @staticmethod
+    def _sensor_extrinsic(sp: dict):
+        """Convert an actor-relative CARLA spawn pose to a ROS base_link extrinsic."""
+        carla_tf = carla.Transform(
+            carla.Location(x=sp["x"], y=sp["y"], z=sp["z"]),
+            carla.Rotation(roll=sp["roll"], pitch=sp["pitch"], yaw=sp["yaw"]),
+        )
+        t_carla = np.asarray(carla_tf.get_matrix(), dtype=np.float64)
+        t_ros = _S4_CARLA_TO_ROS @ t_carla @ _S4_CARLA_TO_ROS
+        return t_ros[:3, 3], _rotation_matrix_to_quaternion_wxyz(t_ros[:3, :3])
+
+    def _start_container(self, config: SplatSimLidarConfig) -> SplatSimDockerManager:
+        docker = SplatSimDockerManager(
+            image=config.splatsim_image,
+            grpc_port=config.grpc_port,
+            container_name=f"splatsim_{self._sensor_id}",
+            force_restart=config.restart_container,
+        )
+        docker.start(config.tileset_path)
+        docker.wait_for_ready(timeout=120.0)
+        return docker
+
+    def _initialize_scene(self, config: SplatSimLidarConfig):
+        init_request = pb2.InitializeRequest(
+            scene_path=f"/data/{Path(config.tileset_path).name}",
+            use_sh=config.use_sh,
+            frame_rate=config.fps,
+            device=config.device,
+            enable_lod=config.enable_lod,
+        )
+        resp = self._grpc.initialize(init_request)
+        if not resp.success:
+            raise RuntimeError(f"splatsim Initialize failed: {resp.message}")
+        return resp
+
+    def _build_transformer(
+        self, resp, config: SplatSimLidarConfig, proj_origin: tuple[float, float]
+    ) -> CoordinateTransformer:
+        scene_origin = np.array(
+            [resp.scene_origin.x, resp.scene_origin.y, resp.scene_origin.z],
+            dtype=np.float64,
+        )
+        ecef_rot, ecef_trans = resolve_ecef_transform(resp, config.tileset_path)
+        return CoordinateTransformer(
+            proj_origin=proj_origin,
+            ecef_rotation=ecef_rot,
+            ecef_translation=ecef_trans,
+            scene_origin=scene_origin,
+        )
+
+    def _initialize_lidar(self, config: SplatSimLidarConfig, ext_pos, ext_quat_wxyz) -> None:
+        lidar_request = pb2.InitializeLidarRequest(
+            sensor=pb2.LidarSensorConfig(
+                name=str(self._sensor_id),
+                sensor_type=config.sensor_type,
+                n_rows=int(config.n_rows),
+                n_columns=int(config.n_columns),
+                fps=config.fps,
+                min_range_m=config.min_range_m,
+                max_range_m=config.max_range_m,
+                extrinsic=pb2.Pose(
+                    position=pb2.Vector3(
+                        x=float(ext_pos[0]),
+                        y=float(ext_pos[1]),
+                        z=float(ext_pos[2]),
+                    ),
+                    rotation=pb2.Quaternion(
+                        w=ext_quat_wxyz[0],
+                        x=ext_quat_wxyz[1],
+                        y=ext_quat_wxyz[2],
+                        z=ext_quat_wxyz[3],
+                    ),
+                ),
+                elevation_deg=list(config.elevation_deg),
+                pointcloud_topic=config.pointcloud_topic,
+                frame_id=config.frame_id,
+                drop_threshold=config.drop_threshold,
+                alpha_threshold=config.alpha_threshold,
+            )
+        )
+        lidar_resp = self._grpc.initialize_lidar(lidar_request)
+        if not lidar_resp.success:
+            raise RuntimeError(f"splatsim InitializeLidar failed: {lidar_resp.message}")
+
+        _rlog.warn(
+            f"SplatSimLidar '{self._sensor_id}' initialized "
+            f"(type={config.sensor_type}, topic={config.pointcloud_topic}, "
+            f"frame={config.frame_id})\n"
+            f"  extrinsic pos=({ext_pos[0]:.4f}, {ext_pos[1]:.4f}, {ext_pos[2]:.4f})"
+        )
+
+    def update(
+        self,
+        actor_matrix_4x4: list[list[float]],
+        stamp_sec: int,
+        stamp_nanosec: int,
+    ) -> None:
+        """Send the base_link (ego actor) pose in tile-local ROS coords to splatsim.
+
+        Parameters
+        ----------
+        actor_matrix_4x4 : list[list[float]]
+            Raw 4x4 world-to-actor matrix from ``carla.Transform.get_matrix()``.
+            The ego actor pose is published as base_link by this integration.
+        """
+        t_world_actor = np.array(actor_matrix_4x4, dtype=np.float64)
+        carla_pos = t_world_actor[:3, 3]
+        r_carla = t_world_actor[:3, :3]
+
+        # Position: CARLA -> ENU (flip y) -> tile-local
+        enu_pos = _S_CARLA_TO_ENU @ carla_pos
+        tile_pos = self._transformer.enu_position_to_tile_local(
+            enu_pos[0],
+            enu_pos[1],
+            enu_pos[2],
+        )
+
+        # Rotation: CARLA -> ENU -> tile-local -> ROS base_link (X-fwd, Y-left, Z-up).
+        # R_tile columns are the physical [fwd, right, up] axes in the world frame
+        # (det=-1 from the Y-flip).  Negating the "right" column yields "left" and
+        # restores det=+1, giving a proper base_link->world rotation (no RDF remap).
+        r_enu = _S_CARLA_TO_ENU @ r_carla
+        r_tile = self._transformer.enu_rotation_to_tile_local(r_enu)
+        r_b2w = np.column_stack([r_tile[:, 0], -r_tile[:, 1], r_tile[:, 2]])
+        quat_wxyz = _rotation_matrix_to_quaternion_wxyz(r_b2w)
+
+        self._update_count += 1
+        if self._update_count <= 10 or self._update_count % 50 == 0:
+            _rlog.warn(
+                f"LiDAR pose update #{self._update_count}:\n"
+                f"  CARLA pos: ({carla_pos[0]:.4f}, {carla_pos[1]:.4f}, {carla_pos[2]:.4f})\n"
+                f"  tile_pos:  ({tile_pos[0]:.4f}, {tile_pos[1]:.4f}, {tile_pos[2]:.4f})"
+            )
+
+        self._grpc.send_lidar_data(
+            sec=stamp_sec,
+            nanosec=stamp_nanosec,
+            position=(float(tile_pos[0]), float(tile_pos[1]), float(tile_pos[2])),
+            rotation_wxyz=quat_wxyz,
+        )
+
+    def shutdown(self) -> None:
+        """Close gRPC stream and stop Docker container."""
+        if self._grpc is None:
+            return
+        _rlog.warn(f"Shutting down SplatSimLidar '{self._sensor_id}'")
+        self._grpc.close_lidar_stream()
+        self._grpc.close()
+        self._grpc = None
+        self._docker.stop()
+        self._docker = None
+
+    def __del__(self) -> None:
+        self.shutdown()

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_lidar.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_lidar.py
@@ -65,7 +65,7 @@ class SplatSimLidarConfig:
     """Tunable parameters for a :class:`SplatSimLidar`."""
 
     tileset_path: str
-    splatsim_image: str = "ghcr.io/tier4/splatsim:latest-sm{arch}"
+    splatsim_image: str = "splatsim:latest"
     grpc_port: int = 50061
     use_sh: bool = True
     # Distance-adaptive LoD Gaussian filtering (server-side). Passed to the

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_lidar.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/splatsim/splatsim_lidar.py
@@ -144,6 +144,14 @@ class SplatSimLidar:
             frame_rate=config.fps,
             device=config.device,
             enable_lod=config.enable_lod,
+            # The LiDAR path never uses the camera pipeline, but newer splatsim
+            # servers run a camera warmup render inside Initialize. Leaving the
+            # intrinsics unset builds a 0x0 camera whose CUDA tile grid divides
+            # by zero (SIGFPE, uncatchable server-side), so send a small valid
+            # placeholder camera instead.
+            intrinsics=pb2.CameraIntrinsics(
+                fx=32.0, fy=32.0, cx=32.0, cy=32.0, width=64, height=64
+            ),
         )
         resp = self._grpc.initialize(init_request)
         if not resp.success:

--- a/simulator/autoware_carla_interface/tools/update_splatsim_proto.sh
+++ b/simulator/autoware_carla_interface/tools/update_splatsim_proto.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Refresh the vendored SplatSim proto from a tier4/splatsim release tag.
+#
+# The autoware build sandbox has no outbound internet, so rendering_service.proto
+# is vendored into the package and the *_pb2*.py stubs are generated from it at
+# build time. Run this from a networked machine when bumping the pinned version,
+# then update SPLATSIM_VERSION in CMakeLists.txt to match.
+#
+# Usage: tools/update_splatsim_proto.sh [version]   # default: v1.2.0
+set -euo pipefail
+
+version="${1:-v1.2.0}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dest="${script_dir}/../src/autoware_carla_interface/splatsim/proto/rendering_service.proto"
+url="https://raw.githubusercontent.com/tier4/splatsim/${version}/proto/splatsim/v1/rendering_service.proto"
+
+echo "Fetching SplatSim proto ${version} from ${url}"
+curl -fsSL "${url}" -o "${dest}"
+echo "Updated ${dest}"


### PR DESCRIPTION
## Description

When splatsim rendering (#13089) and the E2E planning group are both enabled, `/localization/kinematic_state` (and `/localization/acceleration`, the `map->base_link` TF) is published by **two nodes at once**: the interface's ground-truth localization path and `carla_state_publisher` (GNSS pose merged with the `vehicle_velocity_converter` twist). Controllers receive the two interleaved streams (verified with `ros2 topic info -v`: publisher count 2 on both topics), one of which carries the raw CARLA heading rate (see #13274).

This PR unifies localization on the ground-truth path:

- add a `publish_ground_truth_localization` parameter and publish the GT localization set from the interface whenever it is enabled (implied by `render_with_splatsim` as before, now also set by `use_e2e_planning`)
- drop `carla_state_publisher`, `vehicle_velocity_converter` and `twist2accel` from the E2E launch group (all their outputs are covered by the GT path; their only twist subscribers were each other)

`carla_state_publisher.cpp` itself is left in place for now; it can be removed in a follow-up once nothing references it.

## Depends on

- **#13089** (the GT localization publisher this unifies onto) — this PR is stacked on that branch and stays a **draft** until it merges; the diff shows only the last commit's worth of changes once #13089 lands.

## How was this PR tested?

- Closed-loop CARLA 0.10 run: publisher count on `/localization/kinematic_state` and `/localization/acceleration` went from 2 to 1 (20 Hz, GT path), and the OnePlanner E2E stack completed a run that previously failed.
- `colcon build --packages-select autoware_carla_interface --symlink-install` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)