### PR TITLE
fix(control): declare the fixed-name compatibility interfaces in the control node designs

### DIFF
--- a/control/autoware_external_cmd_selector/design/ExternalCmdSelector.node.yaml
+++ b/control/autoware_external_cmd_selector/design/ExternalCmdSelector.node.yaml
@@ -57,6 +57,7 @@ publishers:
 servers:
   - name: select_external_command
     message_type: tier4_control_msgs/srv/ExternalCommandSelect
+    remap_target: ~/service/select_external_command
 
 # parameters
 param_files:

--- a/control/autoware_operation_mode_transition_manager/design/OperationModeTransitionManager.node.yaml
+++ b/control/autoware_operation_mode_transition_manager/design/OperationModeTransitionManager.node.yaml
@@ -31,7 +31,7 @@ subscribers:
   - name: gate_operation_mode
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
     remap_target: gate_operation_mode
-  # compatibility interface: fixed topic names shared with vehicle_cmd_gate and external_cmd_selector
+  # legacy interfaces: node-side names are fixed
   - name: engage
     message_type: autoware_vehicle_msgs/msg/Engage
     remap_target: /api/autoware/get/engage
@@ -45,11 +45,14 @@ subscribers:
 publishers:
   - name: operation_mode
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
+  # shared with external operators; multiple publishers
   - name: engage
     message_type: autoware_vehicle_msgs/msg/Engage
+    global: /autoware/engage
     remap_target: /autoware/engage
   - name: gate_mode_cmd
     message_type: tier4_control_msgs/msg/GateMode
+    global: /control/gate_mode_cmd
     remap_target: /control/gate_mode_cmd
 
 clients:

--- a/control/autoware_operation_mode_transition_manager/design/OperationModeTransitionManager.node.yaml
+++ b/control/autoware_operation_mode_transition_manager/design/OperationModeTransitionManager.node.yaml
@@ -31,21 +31,34 @@ subscribers:
   - name: gate_operation_mode
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
     remap_target: gate_operation_mode
+  # compatibility interface: fixed topic names shared with vehicle_cmd_gate and external_cmd_selector
   - name: engage
     message_type: autoware_vehicle_msgs/msg/Engage
+    remap_target: /api/autoware/get/engage
+  - name: current_gate_mode
+    message_type: tier4_control_msgs/msg/GateMode
+    remap_target: /control/current_gate_mode
+  - name: current_selector_mode
+    message_type: tier4_control_msgs/msg/ExternalCommandSelectorMode
+    remap_target: /control/external_cmd_selector/current_selector_mode
 
 publishers:
   - name: operation_mode
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
   - name: engage
     message_type: autoware_vehicle_msgs/msg/Engage
+    remap_target: /autoware/engage
   - name: gate_mode_cmd
     message_type: tier4_control_msgs/msg/GateMode
+    remap_target: /control/gate_mode_cmd
 
 clients:
   - name: control_mode_request
     message_type: autoware_vehicle_msgs/srv/ControlModeCommand
     remap_target: control_mode_request
+  - name: select_external_command
+    message_type: tier4_control_msgs/srv/ExternalCommandSelect
+    remap_target: /control/external_cmd_selector/select_external_command
 
 # parameters
 param_files:

--- a/control/autoware_vehicle_cmd_gate/design/VehicleCmdGate.node.yaml
+++ b/control/autoware_vehicle_cmd_gate/design/VehicleCmdGate.node.yaml
@@ -105,10 +105,13 @@ publishers:
     remap_target: output/operation_mode
   - name: is_paused
     message_type: tier4_control_msgs/msg/IsPaused
+    remap_target: /control/vehicle_cmd_gate/is_paused
   - name: is_start_requested
     message_type: tier4_control_msgs/msg/IsStartRequested
+    remap_target: /control/vehicle_cmd_gate/is_start_requested
   - name: is_stopped
     message_type: tier4_control_msgs/msg/IsStopped
+    remap_target: /control/vehicle_cmd_gate/is_stopped
   - name: is_filter_activated
     message_type: autoware_vehicle_cmd_gate/msg/IsFilterActivated
 
@@ -127,8 +130,10 @@ servers:
     remap_target: ~/service/clear_external_emergency_stop
   - name: set_pause
     message_type: tier4_control_msgs/srv/SetPause
+    remap_target: /control/vehicle_cmd_gate/set_pause
   - name: set_stop
     message_type: tier4_control_msgs/srv/SetStop
+    remap_target: /control/vehicle_cmd_gate/set_stop
 
 # parameters
 param_files:

--- a/control/autoware_vehicle_cmd_gate/design/VehicleCmdGate.node.yaml
+++ b/control/autoware_vehicle_cmd_gate/design/VehicleCmdGate.node.yaml
@@ -48,6 +48,7 @@ subscribers:
     remap_target: input/external_emergency_stop_heartbeat
   - name: gate_mode
     message_type: tier4_control_msgs/msg/GateMode
+    global: /control/gate_mode_cmd
     remap_target: input/gate_mode
   - name: emergency_control_cmd
     message_type: autoware_control_msgs/msg/Control


### PR DESCRIPTION
## Description

Declares the fixed-name compatibility interfaces of the control nodes in their Autoware System Designer node designs so that a system design can connect them and keep the names stable.

- `OperationModeTransitionManager.node.yaml`: adds the legacy ports the node uses by fixed name (`compatibility.cpp`) — subscribers `engage` (`/api/autoware/get/engage`), `current_gate_mode` (`/control/current_gate_mode`), `current_selector_mode` (`/control/external_cmd_selector/current_selector_mode`); publishers `engage` (`/autoware/engage`), `gate_mode_cmd` (`/control/gate_mode_cmd`); client `select_external_command` (`/control/external_cmd_selector/select_external_command`).
  - The single-publisher interfaces (`current_gate_mode`, `current_selector_mode`, `/api/autoware/get/engage`, `select_external_command`) carry `remap_target` only, so a module design connects them like any other port and the designer remaps the node-side names.
  - `/autoware/engage` and `/control/gate_mode_cmd` also have publishers outside the design (`autoware_iv_internal_api_adaptor`, `joy_controller`, RViz state panel). The designer's one-publisher-per-topic rule does not fit them, so they are declared `global:` on both ends (OMTM publishers, `VehicleCmdGate` `gate_mode` subscriber), like `/tf`. `VehicleCmdGate`'s `engage` subscriber was already `global: /autoware/engage`.
- `ExternalCmdSelector.node.yaml`: `select_external_command` server gets `remap_target: ~/service/select_external_command`, matching the node implementation.
- `VehicleCmdGate.node.yaml`: the ADAPI pause/stop interfaces (`is_paused`, `is_start_requested`, `is_stopped`, `set_pause`, `set_stop`) get their `component_interface_specs` names as `remap_target`.

Background: when the control module design is nested into sub-modules (autowarefoundation/autoware_launch, control launcher restructuring), the exported node namespaces change (e.g. `/control/external_command/external_cmd_selector`). Without these ports the exporter could not wire `current_selector_mode` to the operation mode transition manager, whose compatibility layer then never resolved a mode and every autonomous transition timed out (`Planning ⇄ WaitingForEngage`). With the ports declared, the module design exposes them under the official names and the transition completes.

## Related links

**Parent Issue:**

- autowarefoundation/autoware_launch#1939

**Counterpart:**

- autowarefoundation/autoware_launch#1965 — exposes these interfaces as `Control.module` ports (stacked on autowarefoundation/autoware_launch#1962)

## How was this PR tested?

- `autoware_sample_designs` builds with the nested control module design; the export remaps `~/output/current_selector_mode` → `/control/external_cmd_selector/current_selector_mode`, `~/service/select_external_command` → `/control/external_cmd_selector/select_external_command`, and the gate pause/stop interfaces to `/control/vehicle_cmd_gate/*`. Designer warnings 17 → 13: the connections into the now-global `gate_mode` / `engage` inputs, which the designer skipped with a warning, are dropped on the launcher side; exported topic names are unchanged.
- E2E simulation (AWSIM, `AutowareSample` system export): `/control/external_cmd_selector/current_selector_mode` now has 1 publisher / 1 subscriber, `/api/operation_mode/state` reaches `mode: 2` (AUTONOMOUS) with `is_autonomous_mode_available: true`.
- `pre-commit` on the changed files.

## Notes for reviewers

Design-only change (`design/*.node.yaml`); no launch file or source code is touched. The launcher-side counterpart exposes these ports on `Control.module` (autowarefoundation/autoware_launch#1965).

## Interface changes

None.

## Effects on system behavior

None.


