### PR TITLE
feat(autoware_carla_interface): add a tick follower mode for co-simul…

### DIFF
--- a/simulator/autoware_carla_interface/README.md
+++ b/simulator/autoware_carla_interface/README.md
@@ -157,6 +157,7 @@ All the key parameters can be configured in `autoware_carla_interface.launch.xml
 | `fixed_delta_seconds`             | double | 0.05                                                                              | Time step for the simulation (related to client FPS)                                                                                                                                                                                                                                                                                                                                |
 | `use_traffic_manager`             | bool   | False                                                                             | Boolean flag to set traffic manager in CARLA                                                                                                                                                                                                                                                                                                                                        |
 | `max_real_delta_seconds`          | double | 0.05                                                                              | Parameter to limit the simulation speed below `fixed_delta_seconds`                                                                                                                                                                                                                                                                                                                 |
+| `tick_follower`                   | bool   | False                                                                             | If True, the bridge does not tick the CARLA world and instead follows the frames ticked by another client. See [Multi-client co-simulation](#multi-client-co-simulation).                                                                                                                                                                                                           |
 | `carla_map`                       | string | ""                                                                                | Explicit CARLA level name. When non-empty it overrides the name derived from `map_path`; useful for CARLA 0.10 levels whose name differs from the Autoware map directory. Empty reproduces the current behavior.                                                                                                                                                                    |
 | `no_rendering_mode`               | bool   | False                                                                             | Disable CARLA scene rendering via world settings for headless/faster simulation. Applied unconditionally on world load, so the default `False` (re-)enables rendering even if the server was started headless; set `True` to keep rendering off.                                                                                                                                    |
 | `force_load_world`                | bool   | False                                                                             | Always reload the world with `client.load_world()` instead of `load_world_if_different()`. Default False reproduces the current call (with a version-tolerant fallback).                                                                                                                                                                                                            |
@@ -210,6 +211,27 @@ On a CARLA API without `ground_projection`, snapping is skipped and the previous
 fixed z-offset is used, so enabling the flag never raises. The spawn-point path
 logs a warning when it falls back; the RViz initial-pose fallback is silent (and
 with the default random spawn the spawn-point path is not exercised at all).
+
+### Multi-client co-simulation
+
+By default this bridge owns the CARLA simulation clock: its main loop calls `world.tick()` on every
+cycle. A server in synchronous mode advances one frame per `tick()` call, so a second client that
+also ticks, for example an external traffic simulator feeding background vehicles into the same
+server, makes the simulation advance more than once per intended step.
+
+Setting `tick_follower` to `True` puts the bridge in a passive mode. It no longer ticks the world in
+its main loop, and instead publishes sensor data, the clock and the ego control for the frames that
+the external client ticks. Exactly one client in the whole setup may own the clock.
+
+Two things to keep in mind when using this mode:
+
+- **Start the bridge before the tick owner.** Loading the world still ticks it a few times to bring
+  up the ego vehicle and its sensors, and those ticks must not race the external owner.
+- **The cadence belongs to the tick owner**, so `max_real_delta_seconds` no longer paces the loop.
+  Set `fixed_delta_seconds` to the step length that the owner uses.
+
+If the bridge cannot keep up with the incoming cadence it drops the frames it has fallen behind on
+and reports how many it skipped through a throttled warning.
 
 ### Sensor Configuration
 

--- a/simulator/autoware_carla_interface/README.md
+++ b/simulator/autoware_carla_interface/README.md
@@ -229,6 +229,8 @@ Two things to keep in mind when using this mode:
   up the ego vehicle and its sensors, and those ticks must not race the external owner.
 - **The cadence belongs to the tick owner**, so `max_real_delta_seconds` no longer paces the loop.
   Set `fixed_delta_seconds` to the step length that the owner uses.
+- **`/clock` starts at zero on the first frame that the bridge processes.** In this mode it stays a
+  constant offset behind the CARLA elapsed time: the idle time before the owner started.
 
 If the bridge cannot keep up with the incoming cadence it drops the frames it has fallen behind on
 and reports how many it skipped through a throttled warning.

--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -16,6 +16,11 @@
     <arg name="fixed_delta_seconds" default="0.05" description="Time step for CARLA, FPS=1/value"/>
     <arg name="use_traffic_manager" default="False"/>
     <arg name="max_real_delta_seconds" default="0.05"/>
+    <arg
+      name="tick_follower"
+      default="False"
+      description="Follow the frames ticked by an external co-simulation client instead of calling world.tick(). Exactly one client may own the simulation clock"
+    />
     <arg name="spawn_point_ground_snap" default="False" description="Snap the ego spawn point and RViz initial pose onto CARLA map geometry via ground_projection"/>
     <arg name="spawn_point_ground_offset_z" default="0.5" description="Z offset added above the projected ground when ground-snapping the spawn point"/>
     <arg name="initial_pose_ground_offset_z" default="1.0" description="Z offset added above the projected ground when ground-snapping the RViz initial pose"/>
@@ -90,6 +95,7 @@
       <param name="vehicle_type" value="$(var vehicle_type)"/>
       <param name="use_traffic_manager" value="$(var use_traffic_manager)"/>
       <param name="max_real_delta_seconds" value="$(var max_real_delta_seconds)"/>
+      <param name="tick_follower" value="$(var tick_follower)"/>
       <param name="spawn_point_ground_snap" value="$(var spawn_point_ground_snap)"/>
       <param name="spawn_point_ground_offset_z" value="$(var spawn_point_ground_offset_z)"/>
       <param name="initial_pose_ground_offset_z" value="$(var initial_pose_ground_offset_z)"/>

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
@@ -471,14 +471,30 @@ class InitializeInterface(object):
                 self.prev_tick_wall_time = time.time()
                 self.bridge_loop._tick_sensor(timestamp)
 
+    @staticmethod
+    def _next_frame(frame_queue):
+        """Block for the next frame; drain to the newest one if several queued.
+
+        Returns (timestamp, skipped) where timestamp is None when no frame
+        arrived within the timeout (the tick owner is not running yet, or has
+        stopped). Skipped frames are dropped because sensor data is perishable.
+        """
+        try:
+            timestamp = frame_queue.get(timeout=1.0)
+        except queue.Empty:
+            return None, 0
+        skipped = 0
+        while not frame_queue.empty():  # single consumer: get_nowait cannot fail
+            timestamp = frame_queue.get_nowait()
+            skipped += 1
+        return timestamp, skipped
+
     def _run_bridge_follower(self):
         """Consume the frames another client ticks, without ticking the world.
 
         Frames arrive through world.on_tick() rather than wait_for_tick(),
         which only reports the frames that arrive while it is being awaited
-        and so loses one whenever an iteration runs long. When this loop does
-        fall behind it drains the queue to the newest frame, because sensor
-        data is perishable.
+        and so loses one whenever an iteration runs long.
         """
         world = CarlaDataProvider.get_world()
         frame_queue = queue.Queue()
@@ -488,18 +504,9 @@ class InitializeInterface(object):
         skipped_total = 0
         try:
             while self.bridge_loop.running:
-                try:
-                    timestamp = frame_queue.get(timeout=1.0)
-                except queue.Empty:
-                    # The tick owner is not running yet, or has stopped.
+                timestamp, skipped = self._next_frame(frame_queue)
+                if timestamp is None:
                     continue
-                skipped = 0
-                while True:
-                    try:
-                        timestamp = frame_queue.get_nowait()
-                        skipped += 1
-                    except queue.Empty:
-                        break
                 if skipped:
                     skipped_total += skipped
                     logger.warning(

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import queue
 import random
 import signal
 import time
@@ -42,6 +43,7 @@ class SensorLoop(object):
         self.running = False
         self.timestamp_last_run = 0.0
         self.timeout = 20.0
+        self.tick_follower = False
 
     def _stop_loop(self):
         self.running = False
@@ -56,7 +58,7 @@ class SensorLoop(object):
             except SensorReceivedNoData as e:
                 raise RuntimeError(e)
             self.ego_actor.apply_control(ego_action)
-        if self.running:
+        if self.running and not self.tick_follower:
             CarlaDataProvider.get_world().tick()
 
 
@@ -83,6 +85,7 @@ class InitializeInterface(object):
         self.spawn_point = self.param_["spawn_point"]
         self.use_traffic_manager = self.param_["use_traffic_manager"]
         self.max_real_delta_seconds = self.param_["max_real_delta_seconds"]
+        self.tick_follower = self.param_["tick_follower"]
         self.spawn_point_ground_snap = self.param_["spawn_point_ground_snap"]
         self.spawn_point_ground_offset_z = self.param_["spawn_point_ground_offset_z"]
         self.force_load_world = self.param_["force_load_world"]
@@ -448,7 +451,11 @@ class InitializeInterface(object):
         self.bridge_loop.ego_actor = self.ego_actor
         self.bridge_loop.start_system_time = time.time()
         self.bridge_loop.start_game_time = GameTime.get_time()
+        self.bridge_loop.tick_follower = self.tick_follower
         self.bridge_loop.running = True
+        if self.tick_follower:
+            self._run_bridge_follower()
+            return
         while self.bridge_loop.running:
             timestamp = None
             world = CarlaDataProvider.get_world()
@@ -463,6 +470,47 @@ class InitializeInterface(object):
                     time.sleep(self.max_real_delta_seconds - delta_step)
                 self.prev_tick_wall_time = time.time()
                 self.bridge_loop._tick_sensor(timestamp)
+
+    def _run_bridge_follower(self):
+        """Consume the frames another client ticks, without ticking the world.
+
+        Frames arrive through world.on_tick() rather than wait_for_tick(),
+        which only reports the frames that arrive while it is being awaited
+        and so loses one whenever an iteration runs long. When this loop does
+        fall behind it drains the queue to the newest frame, because sensor
+        data is perishable.
+        """
+        world = CarlaDataProvider.get_world()
+        frame_queue = queue.Queue()
+        callback_id = world.on_tick(lambda snapshot: frame_queue.put(snapshot.timestamp))
+        logger = self.interface.logger
+        logger.info("tick_follower mode: waiting for frames ticked by an external client")
+        skipped_total = 0
+        try:
+            while self.bridge_loop.running:
+                try:
+                    timestamp = frame_queue.get(timeout=1.0)
+                except queue.Empty:
+                    # The tick owner is not running yet, or has stopped.
+                    continue
+                skipped = 0
+                while True:
+                    try:
+                        timestamp = frame_queue.get_nowait()
+                        skipped += 1
+                    except queue.Empty:
+                        break
+                if skipped:
+                    skipped_total += skipped
+                    logger.warning(
+                        f"tick_follower is behind the tick cadence: skipped {skipped} "
+                        f"frame(s) ({skipped_total} in total), resuming at frame "
+                        f"{timestamp.frame}",
+                        throttle_duration_sec=10.0,
+                    )
+                self.bridge_loop._tick_sensor(timestamp)
+        finally:
+            world.remove_on_tick(callback_id)
 
     def _stop_loop(self, sign, frame):
         self.bridge_loop._stop_loop()

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -123,6 +123,7 @@ class carla_ros2_interface(object):
             "vehicle_type": (rclpy.Parameter.Type.STRING, None),
             "use_traffic_manager": (rclpy.Parameter.Type.BOOL, None),
             "max_real_delta_seconds": (rclpy.Parameter.Type.DOUBLE, None),
+            "tick_follower": (rclpy.Parameter.Type.BOOL, False),
             "spawn_point_ground_snap": (rclpy.Parameter.Type.BOOL, False),
             "spawn_point_ground_offset_z": (rclpy.Parameter.Type.DOUBLE, 0.5),
             "initial_pose_ground_offset_z": (rclpy.Parameter.Type.DOUBLE, 1.0),


### PR DESCRIPTION
## Description

The bridge's main loop always calls `world.tick()`. A CARLA server in synchronous mode advances one
frame per `tick()` call, so the bridge cannot run next to another client that also ticks, such as a
traffic simulator feeding background vehicles into the same server: both tick, and the simulation
advances more than once per intended step.

This adds `tick_follower` (default `False`). When it is on, the main loop never ticks the world and
instead publishes sensor data, the clock and the ego control for the frames that the external clock
owner produces.

**On receiving frames with `on_tick()` rather than `wait_for_tick()`.** `wait_for_tick()` only
reports the frames that arrive while it is being awaited, so a frame completing while the loop is
still converting the previous one is lost.

When the loop does fall behind it drains the queue to the newest frame.

## Related links

**Parent Issue:**

- None.

**Related pull requests** 
independent of this one; together they make that co-simulation work end
to end:

- #13285 — ground truth object publishing, so the externally injected vehicles reach perception.
- autowarefoundation/autoware_launch#1966 — makes the planning simulator's dummy vehicle toggle an
  argument, so an external source can own the ego state.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

`colcon build --packages-select autoware_carla_interface --symlink-install` passes, and pre-commit
passes on every changed file.

Run against a live CARLA 0.9.16 server on Town01 and kashiwanoha, with the planning simulator and this bridge
launched separately, `tick_follower:=true`, and an external traffic simulator owning `world.tick()`
at a fixed 50 ms cadence while mirroring its vehicles into the same server.

We used TeraSim as the planning simulator. (https://github.com/autowarefoundation/TeraSim)
We confirmed successful operation on two maps.
We plan to further enhance the integration between TeraSim and Autoware_CARLA_Interface.

(Not tested against CARLA 0.9.15. However, there shouldn't be any impact.)

## Notes for reviewers

**On start-up order.** The bridge has to be launched before the external tick owner, because
`load_world()` still ticks the world a few times to bring up the ego vehicle and its sensors. This
is in the README section the new parameter links to.

**On `max_real_delta_seconds`.** It no longer paces the loop in this mode, because the cadence
belongs to the tick owner.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
The added setting is off by default.

## AI assistance

I used Claude Opus 5 / Fable 5 to check, modify, and review the code.
I conducted thorough functional testing across two maps, and I have personally reviewed the entire content of this PR.