### PR TITLE
fix(autoware_cuda_pointcloud_preprocessor): stop over-allocating the concatenated cloud by the lidar count

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -82,8 +82,8 @@ void CombineCloudHandler<CudaPointCloud2Traits>::allocate_pointclouds()
   }
 
   concatenated_cloud_ptr_ = std::make_unique<cuda_blackboard::CudaPointCloud2>();
-  concatenated_cloud_ptr_->data = cuda_blackboard::make_unique<std::uint8_t[]>(
-    max_concat_pointcloud_size_ * input_topics_.size());
+  concatenated_cloud_ptr_->data =
+    cuda_blackboard::make_unique<std::uint8_t[]>(max_concat_pointcloud_size_);
 }
 
 ConcatenatedCloudResult<CudaPointCloud2Traits>
@@ -132,8 +132,8 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
   if (total_data_size > max_concat_pointcloud_size_ || !concatenated_cloud_ptr_) {
     max_concat_pointcloud_size_ = CHUNK_SIZE * (1 + total_data_size / CHUNK_SIZE);
     concatenated_cloud_ptr_ = std::make_unique<cuda_blackboard::CudaPointCloud2>();
-    concatenated_cloud_ptr_->data = cuda_blackboard::make_unique<std::uint8_t[]>(
-      max_concat_pointcloud_size_ * input_topics_.size());
+    concatenated_cloud_ptr_->data =
+      cuda_blackboard::make_unique<std::uint8_t[]>(max_concat_pointcloud_size_);
   }
 
   concatenate_cloud_result.concatenate_cloud_ptr = std::move(concatenated_cloud_ptr_);


### PR DESCRIPTION
## What

`max_concat_pointcloud_size_` is derived from `total_data_size`, which is already the sum over every entry of `topic_to_cloud_map` — the size of the whole concatenated cloud. Both allocation sites then multiply it by `input_topics_.size()` again, so the concatenated buffer is allocated N times larger than the data it holds. On a vehicle with eight lidars that is **8×**.

The guard above the allocation already grows `max_concat_pointcloud_size_` whenever `total_data_size` exceeds it, so the buffer remains large enough for the frame being written. Only the surplus goes away.

## Memory impact

Measured on an 8 LiDAR rosbag, ~858,000 points per concatenated cloud:

| | as shipped | with this change |
|---|---|---|
| allocated per frame | 110.2 MB | **13.8 MB** |
| data actually held | 13.7 MB | 13.7 MB |

## Context

Found while investigating reported GPU memory growth in a perception container. The growth is not a leak — pool *live* usage is flat and every configuration plateaus — but this over-allocation sets how high the plateau sits.
