### PR TITLE
fix(autoware_tensorrt_common): stop warning on the documented network fallback

### DIFF
--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -90,12 +90,16 @@ public:
   /**
    * @brief Get TensorRT engine precision.
    *
+   * Valid immediately after construction. Valid to call before `setup()`.
+   *
    * @return string representation of TensorRT engine precision.
    */
   [[nodiscard]] std::string getPrecision() const;
 
   /**
    * @brief Get tensor name by index from TensorRT engine with fallback from TensorRT network.
+   *
+   * Valid immediately after construction. Valid to call before `setup()`.
    *
    * @param[in] index Tensor index.
    * @return Tensor name.
@@ -105,12 +109,16 @@ public:
   /**
    * @brief Get number of IO tensors from TensorRT engine with fallback from TensorRT network.
    *
+   * Valid immediately after construction. Valid to call before `setup()`.
+   *
    * @return Number of IO tensors.
    */
   [[nodiscard]] int32_t getNbIOTensors() const;
 
   /**
    * @brief Get tensor shape by index from TensorRT engine with fallback from TensorRT network.
+   *
+   * Valid immediately after construction. Valid to call before `setup()`.
    *
    * @param[in] index Tensor index.
    * @return Tensor shape.
@@ -144,6 +152,8 @@ public:
   /**
    * @brief Get input tensor shape by index from TensorRT network.
    *
+   * Valid immediately after construction. Valid to call before `setup()`.
+   *
    * @param[in] index Tensor index.
    * @return Tensor shape.
    */
@@ -151,6 +161,8 @@ public:
 
   /**
    * @brief Get output tensor shape by index from TensorRT network.
+   *
+   * Valid immediately after construction. Valid to call before `setup()`.
    *
    * @param[in] index Tensor index.
    * @return Tensor shape.
@@ -264,12 +276,16 @@ public:
   /**
    * @brief Get per-layer profiler for model.
    *
+   * Valid immediately after construction. Valid to call before `setup()`.
+   *
    * @return Per-layer profiler.
    */
   [[nodiscard]] std::shared_ptr<Profiler> getModelProfiler();
 
   /**
    * @brief Get per-layer profiler for host.
+   *
+   * Valid immediately after construction. Valid to call before `setup()`.
    *
    * @return Per-layer profiler.
    */
@@ -278,12 +294,16 @@ public:
   /**
    * @brief Get TensorRT common configuration.
    *
+   * Valid immediately after construction. Valid to call before `setup()`.
+   *
    * @return TensorRT common configuration.
    */
   [[nodiscard]] std::shared_ptr<TrtCommonConfig> getTrtCommonConfig();
 
   /**
    * @brief Get TensorRT builder configuration.
+   *
+   * Valid immediately after construction. Valid to call before `setup()`.
    *
    * @return TensorRT builder configuration.
    */
@@ -292,12 +312,16 @@ public:
   /**
    * @brief Get TensorRT network definition.
    *
+   * Valid immediately after construction. Valid to call before `setup()`.
+   *
    * @return TensorRT network definition.
    */
   [[nodiscard]] std::shared_ptr<nvinfer1::INetworkDefinition> getNetwork();
 
   /**
    * @brief Get TensorRT logger.
+   *
+   * Valid immediately after construction. Valid to call before `setup()`.
    *
    * @return TensorRT logger.
    */

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -200,71 +200,62 @@ std::string TrtCommon::getPrecision() const
 
 const char * TrtCommon::getIOTensorName(const int32_t index) const
 {
-  if (!engine_) {
-    logger_->log(
-      nvinfer1::ILogger::Severity::kWARNING,
-      "Engine is not initialized. Retrieving data from network");
-    if (!network_) {
-      logger_->log(nvinfer1::ILogger::Severity::kERROR, "Network is not initialized");
-      return nullptr;
-    }
-    auto num_inputs = network_->getNbInputs();
-    auto num_outputs = network_->getNbOutputs();
-    if (index < 0 || index >= num_inputs + num_outputs) {
-      logger_->log(
-        nvinfer1::ILogger::Severity::kERROR,
-        "Invalid index for I/O tensor: %d. Total I/O tensors: %d", index, num_inputs + num_outputs);
-      return nullptr;
-    }
-    if (index < num_inputs) {
-      return network_->getInput(index)->getName();
-    }
-    return network_->getOutput(index - num_inputs)->getName();
+  if (!network_) {
+    logger_->log(nvinfer1::ILogger::Severity::kERROR, "Network is not initialized");
+    return nullptr;
   }
-
-  return engine_->getIOTensorName(index);
+  if (engine_) {
+    return engine_->getIOTensorName(index);
+  }
+  // Before setup() the parsed network is the only source of IO, and reading it is supported:
+  // it is how a caller inspects what the model declares before the engine exists.
+  const auto num_inputs = network_->getNbInputs();
+  const auto num_outputs = network_->getNbOutputs();
+  if (index < 0 || index >= num_inputs + num_outputs) {
+    logger_->log(
+      nvinfer1::ILogger::Severity::kERROR,
+      "Invalid index for I/O tensor: %d. Total I/O tensors: %d", index, num_inputs + num_outputs);
+    return nullptr;
+  }
+  if (index < num_inputs) {
+    return network_->getInput(index)->getName();
+  }
+  return network_->getOutput(index - num_inputs)->getName();
 }
 
 int32_t TrtCommon::getNbIOTensors() const
 {
-  if (!engine_) {
-    logger_->log(
-      nvinfer1::ILogger::Severity::kWARNING,
-      "Engine is not initialized. Retrieving data from network");
-    if (!network_) {
-      logger_->log(nvinfer1::ILogger::Severity::kERROR, "Network is not initialized");
-      return 0;
-    }
-    return network_->getNbInputs() + network_->getNbOutputs();
+  if (!network_) {
+    logger_->log(nvinfer1::ILogger::Severity::kERROR, "Network is not initialized");
+    return 0;
   }
-  return engine_->getNbIOTensors();
+  if (engine_) {
+    return engine_->getNbIOTensors();
+  }
+  return network_->getNbInputs() + network_->getNbOutputs();
 }
 
 nvinfer1::Dims TrtCommon::getTensorShape(const int32_t index) const
 {
-  if (!engine_) {
-    logger_->log(
-      nvinfer1::ILogger::Severity::kWARNING,
-      "Engine is not initialized. Retrieving data from network");
-    if (!network_) {
-      logger_->log(nvinfer1::ILogger::Severity::kERROR, "Network is not initialized");
-      return nvinfer1::Dims{};
-    }
-    auto num_inputs = network_->getNbInputs();
-    auto num_outputs = network_->getNbOutputs();
-    if (index < 0 || index >= num_inputs + num_outputs) {
-      logger_->log(
-        nvinfer1::ILogger::Severity::kERROR,
-        "Invalid index for I/O tensor: %d. Total I/O tensors: %d", index, num_inputs + num_outputs);
-      return nvinfer1::Dims{};
-    }
-    if (index < num_inputs) {
-      return network_->getInput(index)->getDimensions();
-    }
-    return network_->getOutput(index - num_inputs)->getDimensions();
+  if (!network_) {
+    logger_->log(nvinfer1::ILogger::Severity::kERROR, "Network is not initialized");
+    return nvinfer1::Dims{};
   }
-  auto const & name = getIOTensorName(index);
-  return getTensorShape(name);
+  if (engine_) {
+    return getTensorShape(getIOTensorName(index));
+  }
+  const auto num_inputs = network_->getNbInputs();
+  const auto num_outputs = network_->getNbOutputs();
+  if (index < 0 || index >= num_inputs + num_outputs) {
+    logger_->log(
+      nvinfer1::ILogger::Severity::kERROR,
+      "Invalid index for I/O tensor: %d. Total I/O tensors: %d", index, num_inputs + num_outputs);
+    return nvinfer1::Dims{};
+  }
+  if (index < num_inputs) {
+    return network_->getInput(index)->getDimensions();
+  }
+  return network_->getOutput(index - num_inputs)->getDimensions();
 }
 
 nvinfer1::Dims TrtCommon::getTensorShape(const char * tensor_name) const


### PR DESCRIPTION
## Description

`getIOTensorName`, `getNbIOTensors` and `getTensorShape(index)` fall back to the parsed network
when no engine exists yet. That is the documented contract — the header already says *"with
fallback from TensorRT network"* — and it is how a caller inspects the IO a model declares before
`setup()` builds or loads the engine.

Logging `kWARNING` on every such call turns intended use into noise: enumerating a 27-input
encoder emits 27 warnings before the engine exists, which buries the warnings that matter. The log
is dropped; a missing network stays an error.

The three fallbacks are also flattened to early returns — network missing is an error, an engine
short-circuits, otherwise read the network — instead of nesting the network path inside
`if (!engine_)`. `network_` is created by `initialize()` from the constructor and never reset, so
testing it first is safe.

Every member that reads only state established by the constructor now says so: *"Valid immediately
after construction. Valid to call before `setup()`."*

## Related links

**Parent Issue:**

- None

## How was this PR tested?

By reading the rewritten bodies against the originals rather than by execution: the only removed
statements are log calls, and each function returns the same value for every input it previously
handled. The `engine_` branch is unchanged, and the network branch is now reached in exactly the
cases where `!engine_` held before.

## Notes for reviewers

`getTensorShape(int32_t)` now delegates to the name overload inside the `engine_` branch rather
than falling through to it at the end. Same result, one less path to follow.

I did not adopt the suggestion to treat `network_` as ground truth and throw when a loaded engine
disagrees — see the review thread. In short, `setup()` treats that disagreement as recoverable and
rebuilds, and it detects it *through* these accessors, so throwing here would make the rebuild
unreachable. Happy to add the check as a helper `setup()` calls instead.

## Interface changes

None.

## Effects on system behavior

Three `kWARNING` lines no longer appear when an accessor is called before `setup()`. Nothing else
changes at runtime.
