### PR TITLE
fix(yabloc): declare the actual service names and shared topics in the node designs

### DIFF
--- a/localization/yabloc/yabloc_particle_filter/design/CameraParticleCorrector.node.yaml
+++ b/localization/yabloc/yabloc_particle_filter/design/CameraParticleCorrector.node.yaml
@@ -22,6 +22,7 @@ subscribers:
 publishers:
   - name: weighted_particles
     message_type: yabloc_particle_filter/msg/ParticleArray
+    global: /localization/pose_estimator/yabloc/pf/weighted_particles
   - name: match_image
     message_type: sensor_msgs/msg/Image
     remap_target: ~/debug/match_image
@@ -43,7 +44,7 @@ publishers:
 servers:
   - name: switch_srv
     message_type: std_srvs/srv/SetBool
-    remap_target: ~/service/switch_srv
+    remap_target: ~/switch_srv
 # parameters
 param_files:
   - name: camera_particle_corrector_param

--- a/localization/yabloc/yabloc_particle_filter/design/GnssParticleCorrector.node.yaml
+++ b/localization/yabloc/yabloc_particle_filter/design/GnssParticleCorrector.node.yaml
@@ -18,6 +18,7 @@ subscribers:
 publishers:
   - name: weighted_particles
     message_type: yabloc_particle_filter/msg/ParticleArray
+    global: /localization/pose_estimator/yabloc/pf/weighted_particles
   - name: gnss_range_marker
     message_type: visualization_msgs/msg/MarkerArray
     remap_target: ~/debug/gnss_range_marker

--- a/localization/yabloc/yabloc_particle_filter/design/YablocPredictor.node.yaml
+++ b/localization/yabloc/yabloc_particle_filter/design/YablocPredictor.node.yaml
@@ -13,6 +13,7 @@ subscribers:
     message_type: geometry_msgs/msg/PoseWithCovarianceStamped
   - name: weighted_particles
     message_type: yabloc_particle_filter/msg/ParticleArray
+    global: /localization/pose_estimator/yabloc/pf/weighted_particles
   - name: height
     message_type: std_msgs/msg/Float32
   - name: twist_with_covariance
@@ -38,7 +39,7 @@ publishers:
 servers:
   - name: yabloc_trigger_srv
     message_type: std_srvs/srv/SetBool
-    remap_target: ~/service/yabloc_trigger_srv
+    remap_target: ~/yabloc_trigger_srv
 # parameters
 param_files:
   - name: predictor_param

--- a/localization/yabloc/yabloc_pose_initializer/design/CameraPoseInitializer.node.yaml
+++ b/localization/yabloc/yabloc_pose_initializer/design/CameraPoseInitializer.node.yaml
@@ -13,6 +13,8 @@ subscribers:
     message_type: autoware_map_msgs/msg/LaneletMapBin
   - name: image_raw
     message_type: sensor_msgs/msg/Image
+  - name: camera_info
+    message_type: sensor_msgs/msg/CameraInfo
 publishers:
   - name: init_candidates
     message_type: visualization_msgs/msg/MarkerArray
@@ -20,7 +22,7 @@ publishers:
 servers:
   - name: yabloc_align_srv
     message_type: autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped
-    remap_target: ~/service/yabloc_align_srv
+    remap_target: ~/yabloc_align_srv
 # parameters
 param_files:
   - name: camera_pose_initializer_param


### PR DESCRIPTION
## Description

Corrects the YabLoc node designs so a system-designer module can compose the YabLoc pose estimator (autowarefoundation/autoware_launch#1939):

- Service `remap_target`s were `~/service/<name>`, but the nodes create them as `~/<name>` (`~/yabloc_align_srv`, `~/yabloc_trigger_srv`, `~/switch_srv`), so the exported remaps never matched.
- `CameraPoseInitializer` also subscribes `~/input/camera_info`; the port was missing.
- `weighted_particles` is published by both `camera_particle_corrector` and `gnss_particle_corrector` and consumed by `predictor`. The designer allows one publisher per connected topic, so the three ports pin the topic with `global: /localization/pose_estimator/yabloc/pf/weighted_particles`, the name `yabloc_particle_filter.launch.xml` uses.

## Related links

- autowarefoundation/autoware_launch#1939
- Consumer: autowarefoundation/autoware_launch#1968 (Localization_yabloc variant)

## How was this PR tested?

- `pre-commit run` on the changed files (`lint-system-design-format` passes).
- Resolved a scratch system with the `Localization_yabloc.module` variant: all 21 YabLoc/localization nodes export with the same topic and service names as `tier4_localization_launch/launch/pose_twist_estimator/yabloc.launch.xml`.

## Interface changes

None (design files only).

## Effects on system behavior

None.
