### PR TITLE
refactor(euclidean_cluster): separate processor into preprocess and clustering process

### DIFF
--- a/perception/autoware_euclidean_cluster/README.md
+++ b/perception/autoware_euclidean_cluster/README.md
@@ -21,7 +21,10 @@ and `label_based_euclidean_cluster`.
 
 ### label_based_euclidean_cluster
 
-`LabelBasedEuclideanCluster` converts a semantically segmented pointcloud into `DetectedObjects`.
+The label-based pipeline first validates the `PointXYZCPE` layout and filters points by semantic
+probability in `PointCloudPreprocessor`. `LabelBasedEuclideanCluster` then groups the preprocessed
+points by label, clusters object-compatible labels, and returns `DetectedObjects` together with the
+remaining non-object semantic segments.
 
 See [docs/label-based-euclidean-cluster.md](./docs/label-based-euclidean-cluster.md) for the node-specific behavior and configuration details.
 

--- a/perception/autoware_euclidean_cluster/docs/label-based-euclidean-cluster.md
+++ b/perception/autoware_euclidean_cluster/docs/label-based-euclidean-cluster.md
@@ -37,11 +37,16 @@ a throttled warning.
 
 ## Processing Flow
 
+Processing is divided into two stages. `PointCloudPreprocessor` owns ROS message validation,
+conversion, and probability filtering. `LabelBasedEuclideanCluster` operates on the resulting typed
+PCL cloud and owns label-based clustering, merging, and shape estimation.
+
 1. Validate that the incoming pointcloud is a densely packed `autoware::point_types::PointXYZCPE` cloud.
-2. Interpret `class_id` values as `PointCloudClassification`.
-3. Send object-compatible classifications through clustering and copy non-object or unknown classifications to `output_segments`.
-4. Drop points with `probability < min_probability`.
-5. Split object-compatible points into buckets keyed by the Autoware object label.
+2. Convert the ROS pointcloud to `pcl::PointCloud<PointXYZCPE>` and preserve its density metadata.
+3. Drop points with `probability < min_probability`.
+4. Interpret the remaining `class_id` values as `PointCloudClassification`.
+5. Split object-compatible points into buckets keyed by the Autoware object label, and copy
+   non-object or unknown classifications to `~/output/pointcloud`.
 6. Run `VoxelGridBasedEuclideanCluster` independently for each label bucket, using the per-label parameter overrides from `label_cluster_params.*` where configured and the global defaults otherwise.
 7. Merge over-segmented clusters across labels that belong to the same confusable label group (`confusable_label_groups.*`).
 8. Compute the average semantic probability for each output cluster from the points that ended up in that cluster. This uses the source-point indices returned by the clustering backend for the per-label filtered cloud, rather than rematching points by coordinate.

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
@@ -17,6 +17,7 @@
 #include "autoware/euclidean_cluster/confusable_cluster_merger.hpp"
 #include "autoware/euclidean_cluster/euclidean_cluster_interface.hpp"
 
+#include <autoware/point_types/types.hpp>
 #include <autoware/shape_estimation/shape_estimator.hpp>
 #include <tl/expected.hpp>
 
@@ -36,6 +37,25 @@ enum ShapePolicy : uint8_t {
   LABEL_DEPEND = 1,
 };
 
+class PointCloudPreprocessor
+{
+public:
+  using result_t = tl::expected<pcl::PointCloud<point_types::PointXYZCPE>, std::string>;
+
+  /// @brief Construct a semantic point cloud preprocessor.
+  /// @param min_probability Minimum confidence required to retain a point.
+  explicit PointCloudPreprocessor(float min_probability);
+
+  /// @brief Validate, convert, and filter an input semantic point cloud.
+  /// @param input_msg Input point cloud, which must be a densely packed
+  ///        `autoware::point_types::PointXYZCPE` cloud.
+  /// @return Filtered PCL cloud, or an error string when the input layout is invalid.
+  result_t process(const sensor_msgs::msg::PointCloud2 & input_msg);
+
+private:
+  float min_probability_;
+};
+
 /// @brief Core clustering logic without ROS dependencies.
 ///
 /// This class encapsulates the semantic point cloud clustering algorithm, independent of
@@ -44,13 +64,15 @@ enum ShapePolicy : uint8_t {
 ///
 /// The input is assumed to be an `autoware::point_types::PointXYZCPE` cloud, whose `class_id`
 /// values are `autoware::object_recognition_utils::PointCloudClassification` values.
+/// Probability filtering and ROS-to-PCL conversion are performed by `PointCloudPreprocessor`
+/// before this class is called.
 ///
 /// The clustering process:
-/// 1. Filters and splits points by semantic label
+/// 1. Splits preprocessed points by semantic label
 /// 2. Runs independent euclidean clustering per label
 /// 3. Merges over-segmented clusters across confusable labels
 /// 4. Estimates shapes and poses for each cluster
-/// 5. Returns structured detected objects
+/// 5. Returns detected objects and non-object semantic segments
 class LabelBasedEuclideanCluster
 {
 public:
@@ -63,15 +85,13 @@ public:
   using result_t = tl::expected<Output, std::string>;
 
   /// @brief Construct with full configuration for clustering and shape estimation.
-  /// @param min_probability Minimum confidence threshold for points.
   /// @param shape_policy Strategy for shape estimation (ALL_POLYGON or LABEL_DEPEND).
   /// @param default_cluster Default cluster executer used when no per-label override exists.
   /// @param label_cluster_executers Optional per-label cluster executer overrides.
   /// @param shape_estimator Shape estimator for converting clusters to DetectedObjects.
   /// @param confusable_groups Optional label groups for post-clustering merge.
   LabelBasedEuclideanCluster(
-    float min_probability, ShapePolicy shape_policy,
-    std::shared_ptr<EuclideanClusterInterface> default_cluster,
+    ShapePolicy shape_policy, std::shared_ptr<EuclideanClusterInterface> default_cluster,
     const std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>> &
       label_cluster_executers,
     std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator,
@@ -82,14 +102,11 @@ public:
   /// Note: Returned messages will have empty frame_id and timestamp.
   /// The caller (ROS node) must populate these fields from the input message.
   ///
-  /// @param input_msg Input point cloud, which must be a densely packed
-  ///        `autoware::point_types::PointXYZCPE` cloud (x, y, z, class_id, probability, entropy).
-  /// @return Output messages without frame_id or timestamp populated, or an error string when the
-  ///         input layout is not `autoware::point_types::PointXYZCPE`.
-  [[nodiscard]] result_t process(const sensor_msgs::msg::PointCloud2 & input_msg);
+  /// @param input Preprocessed `autoware::point_types::PointXYZCPE` cloud.
+  /// @return Output messages without frame_id or timestamp populated.
+  [[nodiscard]] result_t process(const pcl::PointCloud<point_types::PointXYZCPE> & input);
 
 private:
-  float min_probability_;
   ShapePolicy shape_policy_;
   std::shared_ptr<EuclideanClusterInterface> default_cluster_;
   std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>>

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -213,7 +213,6 @@ LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
   if (!shape_estimator_) {
     throw std::invalid_argument("LabelBasedEuclideanCluster: shape_estimator is null");
   }
-
   // Build label-to-group index for confusable merging
   for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
     for (const auto label : confusable_groups_[g].labels) {

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -213,6 +213,7 @@ LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
   if (!shape_estimator_) {
     throw std::invalid_argument("LabelBasedEuclideanCluster: shape_estimator is null");
   }
+
   // Build label-to-group index for confusable merging
   for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
     for (const auto label : confusable_groups_[g].labels) {

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -19,6 +19,7 @@
 #include <autoware/object_recognition_utils/pointcloud_classification.hpp>
 #include <autoware/point_types/memory.hpp>
 #include <autoware/point_types/types.hpp>
+#include <pcl/impl/point_types.hpp>
 
 #include <autoware_perception_msgs/msg/detected_object.hpp>
 #include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
@@ -86,42 +87,29 @@ tl::expected<pcl::PointCloud<PointXYZCPE>, std::string> from_ros_msg(
   return points;
 }
 
-/// @brief Add a PointCloudClassification point to object buckets or segment output.
-void append_classified_point(SplitResult & result, const PointXYZCPE & point)
+/// @brief Split `PointXYZCPE` points into buckets keyed by object label.
+SplitResult split_pointcloud(const pcl::PointCloud<PointXYZCPE> & points)
 {
   namespace utils = autoware::object_recognition_utils;
 
-  const auto classification = static_cast<point_types::PointCloudClassification>(point.class_id);
-  const auto object_label = utils::try_into_object(classification);
-  if (object_label) {
-    result.object_points[*object_label].push_back(point);
-    return;
-  }
-
-  // The whole point is kept, so every field of the input point is preserved in the segment output.
-  result.segment_points.push_back(point);
-}
-
-/// @brief Split `PointXYZCPE` points into buckets keyed by object label.
-SplitResult split_pointcloud(
-  const pcl::PointCloud<PointXYZCPE> & points, const float min_probability)
-{
   SplitResult result;
   result.segment_points.header = points.header;
   result.segment_points.is_dense = points.is_dense;
 
   for (const auto & point : points) {
-    if (point.probability < min_probability) {
-      continue;
+    const auto classification = static_cast<point_types::PointCloudClassification>(point.class_id);
+    if (const auto object_label = utils::try_into_object(classification); object_label) {
+      result.object_points[*object_label].push_back(point);
+    } else {
+      result.segment_points.push_back(point);
     }
-    append_classified_point(result, point);
   }
 
   return result;
 }
 
 /// @brief Compute the average semantic probability for one clustered object instance.
-/// @details `indices` are relative to the per-label filtered cloud built from `points`.
+/// @details `indices` are relative to the per-label cloud built from `points`.
 float cluster_probability_from_indices(
   const pcl::PointCloud<PointXYZCPE> & points, const pcl::Indices & indices)
 {
@@ -193,15 +181,39 @@ std::pair<Shape, geometry_msgs::msg::Pose> create_fallback_shape_and_pose(
 
 }  // namespace
 
+PointCloudPreprocessor::PointCloudPreprocessor(float min_probability)
+: min_probability_(min_probability)
+{
+}
+
+PointCloudPreprocessor::result_t PointCloudPreprocessor::process(
+  const sensor_msgs::msg::PointCloud2 & input_msg)
+{
+  // Validate and convert the PointXYZCPE input message.
+  const auto result = from_ros_msg(input_msg);
+  if (!result) {
+    return tl::unexpected(result.error());
+  }
+
+  pcl::PointCloud<PointXYZCPE> filtered;
+  filtered.is_dense = input_msg.is_dense;
+  for (const auto & point : result->points) {
+    if (point.probability < min_probability_) {
+      continue;
+    }
+    filtered.push_back(point);
+  }
+
+  return filtered;
+}
+
 LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
-  float min_probability, ShapePolicy shape_policy,
-  std::shared_ptr<EuclideanClusterInterface> default_cluster,
+  ShapePolicy shape_policy, std::shared_ptr<EuclideanClusterInterface> default_cluster,
   const std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>> &
     label_cluster_executers,
   std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator,
   const std::vector<ConfusableLabelGroup> & confusable_groups)
-: min_probability_(min_probability),
-  shape_policy_(shape_policy),
+: shape_policy_(shape_policy),
   default_cluster_(std::move(default_cluster)),
   label_cluster_executers_(label_cluster_executers),
   shape_estimator_(std::move(shape_estimator)),
@@ -234,22 +246,16 @@ EuclideanClusterInterface & LabelBasedEuclideanCluster::get_cluster_executer(
 }
 
 LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
-  const sensor_msgs::msg::PointCloud2 & input_msg)
+  const pcl::PointCloud<PointXYZCPE> & input)
 {
   Output output;
   // Note: frame_id and timestamp are NOT set here; they must be set by the caller (ROS node)
 
-  // 1. Convert the input message into PointXYZCPE points, which the input is required to carry
-  const auto points = from_ros_msg(input_msg);
-  if (!points) {
-    return tl::unexpected(points.error());
-  }
-
-  // 2. Split points by label and filter by probability
-  auto split_points = split_pointcloud(*points, min_probability_);
+  // 1. Split preprocessed points by label.
+  auto split_points = split_pointcloud(input);
   pcl::toROSMsg(split_points.segment_points, output.segments);
 
-  // 3. Run per-label clustering and collect all cluster entries
+  // 2. Run per-label clustering and collect all cluster entries
   std::vector<ClusterEntry> all_entries;
   for (const auto & [label, semantic_points] : split_points.object_points) {
     // Convert PointXYZCPE points to PointXYZ for clustering
@@ -268,7 +274,7 @@ LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
     }
   }
 
-  // 4. Post-merge clusters that belong to the same confusable label group
+  // 3. Post-merge clusters that belong to the same confusable label group
   std::vector<std::vector<ClusterEntry>> per_group(confusable_groups_.size());
   std::vector<ClusterEntry> output_entries;
   output_entries.reserve(all_entries.size());
@@ -288,7 +294,7 @@ LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
     }
   }
 
-  // 5. Build detected objects from final entries
+  // 4. Build detected objects from final entries
   for (const auto & e : output_entries) {
     DetectedObject object;
     Shape shape;

--- a/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cmath>
 #include <random>
-#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -14,6 +14,7 @@
 
 #include "label_based_euclidean_cluster_node.hpp"
 
+#include "autoware/euclidean_cluster/label_based_euclidean_cluster.hpp"
 #include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 
 #include <autoware/object_recognition_utils/object_classification.hpp>
@@ -30,6 +31,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -166,12 +168,11 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
   // Load parameters
   const auto min_probability = static_cast<float>(
     autoware_utils_rclcpp::get_or_declare_parameter<double>(*this, "min_probability"));
-  const auto min_cluster_size_m = static_cast<float>(
-    autoware_utils_rclcpp::get_or_declare_parameter<double>(*this, "min_cluster_size_m"));
-  const auto shape_policy = to_shape_policy(
-    autoware_utils_rclcpp::get_or_declare_parameter<uint8_t>(*this, "shape_policy"));
+  preprocessor_ = std::make_unique<PointCloudPreprocessor>(min_probability);
 
   // Initialize the default voxel grid based euclidean cluster
+  const auto shape_policy = to_shape_policy(
+    autoware_utils_rclcpp::get_or_declare_parameter<uint8_t>(*this, "shape_policy"));
   const auto use_height =
     autoware_utils_rclcpp::get_or_declare_parameter<bool>(*this, "use_height");
   const auto min_points_per_cluster = static_cast<int>(
@@ -190,6 +191,8 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
       *this, "large_cluster_max_points_per_voxel"));
   const auto max_voxels_per_cluster = static_cast<int>(
     autoware_utils_rclcpp::get_or_declare_parameter<int64_t>(*this, "max_voxels_per_cluster"));
+  const auto min_cluster_size_m = static_cast<float>(
+    autoware_utils_rclcpp::get_or_declare_parameter<double>(*this, "min_cluster_size_m"));
 
   auto default_cluster = std::make_shared<VoxelGridBasedEuclideanCluster>(
     use_height, min_points_per_cluster, tolerance, voxel_leaf_size, min_points_per_voxel,
@@ -260,9 +263,8 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
   const auto confusable_groups = load_confusable_groups(*this);
 
   // Create the core clustering processor
-  processor_ = std::make_unique<LabelBasedEuclideanCluster>(
-    min_probability, shape_policy, default_cluster, label_cluster_executers, shape_estimator,
-    confusable_groups);
+  cluster_ = std::make_unique<LabelBasedEuclideanCluster>(
+    shape_policy, default_cluster, label_cluster_executers, shape_estimator, confusable_groups);
 
   // Set up ROS pub/sub
   using std::placeholders::_1;
@@ -288,8 +290,15 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
 {
   stop_watch_ptr_->toc("processing_time", true);
 
+  auto preprocessed = preprocessor_->process(*input_msg);
+  if (!preprocessed) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000, "Skipping pointcloud: %s", preprocessed.error().c_str());
+    return;
+  }
+
   // Process the point cloud using the core cluster
-  auto result = processor_->process(*input_msg);
+  auto result = cluster_->process(*preprocessed);
   if (!result) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Skipping pointcloud: %s", result.error().c_str());

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
@@ -57,7 +57,8 @@ private:
   AUTOWARE_PUBLISHER_PTR(sensor_msgs::msg::PointCloud2) segments_pub_;
 
   // Core clustering processor
-  std::unique_ptr<LabelBasedEuclideanCluster> processor_;
+  std::unique_ptr<PointCloudPreprocessor> preprocessor_;
+  std::unique_ptr<LabelBasedEuclideanCluster> cluster_;
 
   // Timing and debug instrumentation
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
@@ -30,7 +30,9 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::euclidean_cluster
@@ -95,6 +97,18 @@ protected:
     return msg;
   }
 
+  pcl::PointCloud<PointXYZCPE> preprocess(
+    const sensor_msgs::msg::PointCloud2 & input, const float min_probability = 0.0F)
+  {
+    PointCloudPreprocessor preprocessor(min_probability);
+    auto result = preprocessor.process(input);
+    if (!result) {
+      ADD_FAILURE() << "Preprocessing failed: " << result.error();
+      return {};
+    }
+    return std::move(*result);
+  }
+
   static constexpr std::uint8_t kCarClassId =
     static_cast<std::uint8_t>(PointCloudClassification::CAR);
 };
@@ -106,13 +120,13 @@ protected:
 TEST_F(LabelBasedEuclideanClusterTest, EmptyPointCloudReturnsEmptyObjects)
 {
   LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
 
   auto pc = create_pointcloud({}, {}, {});
 
   // Act
-  auto result = cluster.process(pc);
+  auto result = cluster.process(preprocess(pc));
 
   // Assert
   ASSERT_TRUE(result.has_value());
@@ -123,7 +137,7 @@ TEST_F(LabelBasedEuclideanClusterTest, EmptyPointCloudReturnsEmptyObjects)
 TEST_F(LabelBasedEuclideanClusterTest, PointCloudWithDefaultClassIdUsesCarLabel)
 {
   LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
 
   // Create enough points to potentially form a cluster
@@ -137,7 +151,7 @@ TEST_F(LabelBasedEuclideanClusterTest, PointCloudWithDefaultClassIdUsesCarLabel)
   auto pc = create_pointcloud(x_coords, y_coords, z_coords);
 
   // Act
-  auto result = cluster.process(pc);
+  auto result = cluster.process(preprocess(pc));
 
   // Assert
   ASSERT_TRUE(result.has_value());
@@ -151,7 +165,7 @@ TEST_F(LabelBasedEuclideanClusterTest, PointCloudWithDefaultClassIdUsesCarLabel)
 TEST_F(LabelBasedEuclideanClusterTest, PointsAreGroupedByLabel)
 {
   LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
 
   // Create two well-separated clusters: car at origin and pedestrian at (5,0)
@@ -176,7 +190,7 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsAreGroupedByLabel)
     x_vals, y_vals, z_vals, std::vector<uint8_t>(class_vals.begin(), class_vals.end()), prob_vals);
 
   // Act
-  auto result = cluster.process(pc);
+  auto result = cluster.process(preprocess(pc));
 
   // Assert - should have clusters for both classes
   ASSERT_TRUE(result.has_value());
@@ -207,7 +221,7 @@ TEST_F(LabelBasedEuclideanClusterTest, PerLabelMinimumSizeFiltersTinyTruckButKee
   auto hazard_cluster =
     std::make_shared<VoxelGridBasedEuclideanCluster>(false, 2, 1.0, 0.1, 1, 10, 100, 10000, 0.0F);
   LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{
       {truck_object_label, truck_cluster},
       {hazard_object_label, hazard_cluster},
@@ -226,7 +240,7 @@ TEST_F(LabelBasedEuclideanClusterTest, PerLabelMinimumSizeFiltersTinyTruckButKee
       hazard_point_label,
     });
 
-  const auto result = cluster.process(pc);
+  const auto result = cluster.process(preprocess(pc));
 
   ASSERT_TRUE(result.has_value());
   ASSERT_EQ(result->objects.objects.size(), 1U);
@@ -240,10 +254,6 @@ TEST_F(LabelBasedEuclideanClusterTest, PerLabelMinimumSizeFiltersTinyTruckButKee
 
 TEST_F(LabelBasedEuclideanClusterTest, PointsBelowMinProbabilityAreFiltered)
 {
-  LabelBasedEuclideanCluster cluster(
-    0.8f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
-
   // Create points with varying probabilities
   auto pc = create_pointcloud(
     {0.0f, 0.1f, 0.2f, 0.3f},  // x
@@ -254,18 +264,22 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsBelowMinProbabilityAreFiltered)
   );
 
   // Act
-  auto result = cluster.process(pc);
+  PointCloudPreprocessor preprocessor(0.8F);
+  const auto result = preprocessor.process(pc);
 
   // Assert - only points with prob >= 0.8 should be kept (indices 1, 3)
-  // These should form a cluster or be filtered out if too small
   ASSERT_TRUE(result.has_value());
-  EXPECT_LE(result->objects.objects.size(), 2U);
+  ASSERT_EQ(result->size(), 2U);
+  EXPECT_FLOAT_EQ(result->points[0].x, 0.1F);
+  EXPECT_FLOAT_EQ(result->points[0].probability, 0.9F);
+  EXPECT_FLOAT_EQ(result->points[1].x, 0.3F);
+  EXPECT_FLOAT_EQ(result->points[1].probability, 0.95F);
 }
 
 TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)
 {
   LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
 
   // Create cluster with known probabilities
@@ -284,7 +298,7 @@ TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)
   auto pc = create_pointcloud(x_vals, y_vals, z_vals, class_ids, prob_vals);
 
   // Act
-  auto result = cluster.process(pc);
+  auto result = cluster.process(preprocess(pc));
 
   // Assert
   ASSERT_TRUE(result.has_value());
@@ -299,7 +313,7 @@ TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)
 TEST_F(LabelBasedEuclideanClusterTest, ShapeIsPopulated)
 {
   LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
 
   // Create a reasonable cluster
@@ -315,7 +329,7 @@ TEST_F(LabelBasedEuclideanClusterTest, ShapeIsPopulated)
   auto pc = create_pointcloud(x_vals, y_vals, z_vals, class_ids);
 
   // Act
-  auto result = cluster.process(pc);
+  auto result = cluster.process(preprocess(pc));
 
   // Assert
   ASSERT_TRUE(result.has_value());
@@ -331,7 +345,7 @@ TEST_F(LabelBasedEuclideanClusterTest, ShapeIsPopulated)
 TEST_F(LabelBasedEuclideanClusterTest, InvalidClassificationsAreOutputAsSegments)
 {
   LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
 
   auto pc = create_pointcloud(
@@ -343,7 +357,7 @@ TEST_F(LabelBasedEuclideanClusterTest, InvalidClassificationsAreOutputAsSegments
   );
 
   // Act
-  auto result = cluster.process(pc);
+  auto result = cluster.process(preprocess(pc));
 
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->segments.width, 2U);
@@ -355,7 +369,7 @@ TEST_F(LabelBasedEuclideanClusterTest, InvalidClassificationsAreOutputAsSegments
 TEST_F(LabelBasedEuclideanClusterTest, SemanticNonObjectLabelsAreOutputAsSegments)
 {
   LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    ShapePolicy::ALL_POLYGON, default_cluster_,
     std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
 
   const auto flat_surface = static_cast<std::uint8_t>(PointCloudClassification::FLAT_SURFACE);
@@ -363,7 +377,7 @@ TEST_F(LabelBasedEuclideanClusterTest, SemanticNonObjectLabelsAreOutputAsSegment
     {0.0f, 0.1f, 0.2f}, {0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 0.0f},
     {flat_surface, flat_surface, flat_surface}, {0.9f, 0.8f, 0.7f});
 
-  const auto result = cluster.process(pc);
+  const auto result = cluster.process(preprocess(pc));
 
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result->objects.objects.empty());
@@ -376,27 +390,20 @@ TEST_F(LabelBasedEuclideanClusterTest, SemanticNonObjectLabelsAreOutputAsSegment
 
 TEST_F(LabelBasedEuclideanClusterTest, ReturnsErrorWhenRequiredFieldsAreMissing)
 {
-  LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
-
   sensor_msgs::msg::PointCloud2 pc;
   pc.height = 1;
   pc.width = 1;
   pc.is_dense = true;
   // Intentionally missing x/y/z field definitions
 
-  const auto result = cluster.process(pc);
+  PointCloudPreprocessor preprocessor(0.0F);
+  const auto result = preprocessor.process(pc);
   ASSERT_FALSE(result.has_value());
   EXPECT_FALSE(result.error().empty());
 }
 
 TEST_F(LabelBasedEuclideanClusterTest, ReturnsErrorWhenLayoutIsNotPointXYZCPE)
 {
-  LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
-
   // A PointXYZI cloud carries x/y/z but is not a PointXYZCPE cloud.
   sensor_msgs::msg::PointCloud2 pc;
   pc.height = 1;
@@ -407,39 +414,34 @@ TEST_F(LabelBasedEuclideanClusterTest, ReturnsErrorWhenLayoutIsNotPointXYZCPE)
   pc.row_step = pc.point_step * pc.width;
   pc.data.resize(pc.row_step);
 
-  const auto result = cluster.process(pc);
+  PointCloudPreprocessor preprocessor(0.0F);
+  const auto result = preprocessor.process(pc);
   ASSERT_FALSE(result.has_value());
   EXPECT_FALSE(result.error().empty());
 }
 
 TEST_F(LabelBasedEuclideanClusterTest, ReturnsErrorWhenPointStepDoesNotMatchPointXYZCPE)
 {
-  LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
-
   // The PointXYZCPE fields with extra per-point padding are not a densely packed cloud.
   auto pc = create_pointcloud({0.0f}, {0.0f}, {0.0f});
   pc.point_step = sizeof(PointXYZCPE) + 4U;
   pc.row_step = pc.point_step * pc.width;
   pc.data.resize(pc.row_step);
 
-  const auto result = cluster.process(pc);
+  PointCloudPreprocessor preprocessor(0.0F);
+  const auto result = preprocessor.process(pc);
   ASSERT_FALSE(result.has_value());
   EXPECT_FALSE(result.error().empty());
 }
 
 TEST_F(LabelBasedEuclideanClusterTest, ReturnsErrorWhenDataSizeDoesNotAgreeWithPointCount)
 {
-  LabelBasedEuclideanCluster cluster(
-    0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
-    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
-
   // More bytes than width * height * point_step would overrun the converted cloud.
   auto pc = create_pointcloud({0.0f}, {0.0f}, {0.0f});
   pc.data.resize(pc.data.size() * 4U);
 
-  const auto result = cluster.process(pc);
+  PointCloudPreprocessor preprocessor(0.0F);
+  const auto result = preprocessor.process(pc);
   ASSERT_FALSE(result.has_value());
   EXPECT_FALSE(result.error().empty());
 }


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
