### PR TITLE
fix(design): declare the fixed-name interfaces as remap targets in the ADAPI node designs

### DIFF
--- a/control/autoware_operation_mode_transition_manager/design/AutonomousModeTransitionFlag.node.yaml
+++ b/control/autoware_operation_mode_transition_manager/design/AutonomousModeTransitionFlag.node.yaml
@@ -25,10 +25,10 @@ subscribers:
 publishers:
   - name: transition_available
     message_type: tier4_system_msgs/msg/ModeChangeAvailable
-    global: /system/command_mode/transition/available
+    remap_target: /system/command_mode/transition/available
   - name: transition_completed
     message_type: tier4_system_msgs/msg/ModeChangeAvailable
-    global: /system/command_mode/transition/completed
+    remap_target: /system/command_mode/transition/completed
   - name: debug_info
     message_type: autoware_operation_mode_transition_manager/msg/OperationModeTransitionManagerDebug
     remap_target: ~/debug_info

--- a/evaluator/autoware_evaluation_adapter/design/AutowareEngage.node.yaml
+++ b/evaluator/autoware_evaluation_adapter/design/AutowareEngage.node.yaml
@@ -12,19 +12,19 @@ launch:
 subscribers:
   - name: operation_mode_state
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
-    global: /api/operation_mode/state
+    remap_target: /api/operation_mode/state
 publishers: []
 servers:
   - name: set_engage
     message_type: tier4_external_api_msgs/srv/Engage
-    global: /api/external/set/engage
+    remap_target: /api/external/set/engage
 clients:
   - name: change_to_stop
     message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
-    global: /api/operation_mode/change_to_stop
+    remap_target: /api/operation_mode/change_to_stop
   - name: change_to_autonomous
     message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
-    global: /api/operation_mode/change_to_autonomous
+    remap_target: /api/operation_mode/change_to_autonomous
 # parameters
 param_files: []
 param_values: []

--- a/evaluator/autoware_evaluation_adapter/design/AutowareEngage.node.yaml
+++ b/evaluator/autoware_evaluation_adapter/design/AutowareEngage.node.yaml
@@ -6,7 +6,6 @@ package:
   provider: autoware
 launch:
   plugin: autoware::evaluation_adapter::AutowareEngage
-  executable: autoware_evaluation_adapter_node
   node_output: screen
 # interfaces
 subscribers:

--- a/evaluator/autoware_evaluation_adapter/design/VelocityLimit.node.yaml
+++ b/evaluator/autoware_evaluation_adapter/design/VelocityLimit.node.yaml
@@ -6,7 +6,6 @@ package:
   provider: autoware
 launch:
   plugin: autoware::evaluation_adapter::VelocityLimit
-  executable: autoware_evaluation_adapter_node
   node_output: screen
 # interfaces
 subscribers:

--- a/evaluator/autoware_evaluation_adapter/design/VelocityLimit.node.yaml
+++ b/evaluator/autoware_evaluation_adapter/design/VelocityLimit.node.yaml
@@ -12,15 +12,15 @@ launch:
 subscribers:
   - name: current_max_velocity
     message_type: autoware_internal_planning_msgs/msg/VelocityLimit
-    global: /planning/scenario_planning/current_max_velocity
+    remap_target: /planning/scenario_planning/current_max_velocity
 publishers:
   - name: max_velocity_default
     message_type: autoware_internal_planning_msgs/msg/VelocityLimit
-    global: /planning/scenario_planning/max_velocity_default
+    remap_target: /planning/scenario_planning/max_velocity_default
 servers:
   - name: set_velocity_limit
     message_type: tier4_external_api_msgs/srv/SetVelocityLimit
-    global: /api/autoware/set/velocity_limit
+    remap_target: /api/autoware/set/velocity_limit
 # parameters
 param_files: []
 param_values: []

--- a/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer/design/AutomaticPoseInitializer.node.yaml
+++ b/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer/design/AutomaticPoseInitializer.node.yaml
@@ -18,14 +18,14 @@ launch:
 subscribers:
   - name: initialization_state
     message_type: autoware_adapi_v1_msgs/msg/LocalizationInitializationState
-    global: /localization/initialization_state
+    remap_target: /localization/initialization_state
 
 publishers: []
 
 clients:
   - name: initialize
     message_type: autoware_localization_msgs/srv/InitializeLocalization
-    global: /localization/initialize
+    remap_target: /localization/initialize
 
 # parameters
 param_files: []

--- a/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphConverter.node.yaml
+++ b/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphConverter.node.yaml
@@ -17,15 +17,15 @@ launch:
 subscribers:
   - name: diag_graph_struct
     message_type: tier4_system_msgs/msg/DiagGraphStruct
-    global: /diagnostics_graph/struct
+    remap_target: /diagnostics_graph/struct
   - name: diag_graph_status
     message_type: tier4_system_msgs/msg/DiagGraphStatus
-    global: /diagnostics_graph/status
+    remap_target: /diagnostics_graph/status
 
 publishers:
   - name: diagnostics_array
     message_type: diagnostic_msgs/msg/DiagnosticArray
-    global: /diagnostics_array
+    remap_target: /diagnostics_array
 
 # parameters
 param_files: []

--- a/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphDump.node.yaml
+++ b/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphDump.node.yaml
@@ -17,10 +17,10 @@ launch:
 subscribers:
   - name: diag_graph_struct
     message_type: tier4_system_msgs/msg/DiagGraphStruct
-    global: /diagnostics_graph/struct
+    remap_target: /diagnostics_graph/struct
   - name: diag_graph_status
     message_type: tier4_system_msgs/msg/DiagGraphStatus
-    global: /diagnostics_graph/status
+    remap_target: /diagnostics_graph/status
 
 publishers: []
 

--- a/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphLogging.node.yaml
+++ b/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphLogging.node.yaml
@@ -18,10 +18,10 @@ launch:
 subscribers:
   - name: diag_graph_struct
     message_type: tier4_system_msgs/msg/DiagGraphStruct
-    global: /diagnostics_graph/struct
+    remap_target: /diagnostics_graph/struct
   - name: diag_graph_status
     message_type: tier4_system_msgs/msg/DiagGraphStatus
-    global: /diagnostics_graph/status
+    remap_target: /diagnostics_graph/status
 
 publishers: []
 

--- a/system/autoware_hazard_status_converter/design/HazardStatusConverter.node.yaml
+++ b/system/autoware_hazard_status_converter/design/HazardStatusConverter.node.yaml
@@ -18,10 +18,10 @@ launch:
 subscribers:
   - name: diag_graph_struct
     message_type: tier4_system_msgs/msg/DiagGraphStruct
-    global: /diagnostics_graph/struct
+    remap_target: /diagnostics_graph/struct
   - name: diag_graph_status
     message_type: tier4_system_msgs/msg/DiagGraphStatus
-    global: /diagnostics_graph/status
+    remap_target: /diagnostics_graph/status
   - name: emergency_holding
     message_type: tier4_system_msgs/msg/EmergencyHoldingState
     remap_target: ~/input/emergency_holding


### PR DESCRIPTION
> [!NOTE]
> Superseded by autowarefoundation/autoware_universe#13298, which now carries this batch together with the rest of the node design audit. Review there; this PR is kept only for the split-out discussion and will not be merged on its own.

## Description

Declares the fixed-name interfaces of eight node designs as `remap_target` instead of `global`, in the packages maintained by the ADAPI / system group.

A port pinned with `global:` connects outside the design graph on a fixed topic, so a system design cannot wire it: `link_manager` skips any connection whose target is a global input port, and the exporter emits no remap. With `remap_target:` the port takes part in the graph like any other, while the launcher still binds it to the official topic name.

Split out of #13298 so the packages of one reviewer group can be reviewed on their own; the remaining designs of that batch (common, control gate, localization, perception, planning, sensing, evaluator) stay there.

| package | designs |
| --- | --- |
| `autoware_automatic_pose_initializer` | `AutomaticPoseInitializer` |
| `autoware_diagnostic_graph_utils` | `DiagnosticGraphConverter`, `DiagnosticGraphDump`, `DiagnosticGraphLogging` |
| `autoware_hazard_status_converter` | `HazardStatusConverter` |
| `autoware_evaluation_adapter` | `AutowareEngage`, `VelocityLimit` |
| `autoware_operation_mode_transition_manager` | `AutonomousModeTransitionFlag` |

`AutomaticPoseInitializer` is the one that unblocks a concrete connection today: `LocalizationUtil.module.yaml` in autowarefoundation/autoware_launch#1971 connects `pose_initializer.pub_state` and `pose_initializer.initialize` to it, and both are currently discarded.

## Related links

**Parent Issue:**

- None

**Related:**

- autowarefoundation/autoware_universe#13298 — the full batch this is split from
- autowarefoundation/autoware_launch#1971 — the localization migration whose `LocalizationUtil` connections depend on the `AutomaticPoseInitializer` change

## How was this PR tested?

`autoware_sample_designs` deployment build (`AutowareSample` system) before and after, same workspace:

| | skipped connections | designer warning lines |
| --- | --- | --- |
| before | 4 | 39 |
| after | 2 | 33 |

The two that clear are `pose_initializer.pub_state -> automatic_pose_initializer.initialization_state` and `pose_initializer.initialize -> automatic_pose_initializer.initialize`. The two that remain target `VehicleCmdGate`, which stays in #13298.

`pre-commit` on the changed files passes (prettier, yamllint, Autoware System Design Format lint).

## Notes for reviewers

Design-only change (`design/*.node.yaml`); no launch file or source code is touched. The exported launcher keeps the same topic names, so runtime wiring is unchanged.

## Interface changes

None.

## Effects on system behavior

None.

