### PR TITLE
feat(autoware_cuda_pointcloud_preprocessor): add standalone CUDA crop box and random downsample filters

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -91,6 +91,7 @@ cuda_add_library(cuda_pointcloud_preprocessor_lib SHARED
   src/cuda_pointcloud_preprocessor/undistort_kernels.cu
   src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.cu
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.cu
+  src/cuda_crop_box_filter/cuda_crop_box_filter.cu
 )
 
 target_link_libraries(cuda_pointcloud_preprocessor_lib
@@ -131,6 +132,7 @@ ament_auto_add_library(cuda_pointcloud_preprocessor SHARED
   src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
   src/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.cpp
+  src/cuda_crop_box_filter/cuda_crop_box_filter_node.cpp
 )
 
 target_link_libraries(cuda_pointcloud_preprocessor
@@ -168,6 +170,12 @@ rclcpp_components_register_node(cuda_pointcloud_preprocessor
   EXECUTABLE cuda_polar_voxel_noise_filter_node
 )
 
+# ========== CropBox filter ==========
+rclcpp_components_register_node(cuda_pointcloud_preprocessor
+  PLUGIN "autoware::cuda_pointcloud_preprocessor::CudaCropBoxFilterNode"
+  EXECUTABLE cuda_crop_box_filter_node
+)
+
 ################################################################################
 # Install
 install(DIRECTORY launch config
@@ -178,6 +186,18 @@ install(
   TARGETS cuda_pointcloud_preprocessor_lib
   LIBRARY DESTINATION lib
 )
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_cuda_pointcloud_preprocessor_filters
+    test/test_cuda_crop_box_filter.cpp
+  )
+  target_link_libraries(test_cuda_pointcloud_preprocessor_filters
+    cuda_pointcloud_preprocessor_lib
+    ${CUDA_LIBRARIES}
+  )
+  target_include_directories(test_cuda_pointcloud_preprocessor_filters PRIVATE include)
+endif()
 
 ament_auto_package()
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -90,6 +90,7 @@ cuda_add_library(cuda_pointcloud_preprocessor_lib SHARED
   src/cuda_outlier_filter/cuda_polar_voxel_noise_filter.cu
   src/cuda_pointcloud_preprocessor/undistort_kernels.cu
   src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.cu
+  src/cuda_downsample_filter/cuda_random_downsample_filter.cu
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.cu
   src/cuda_crop_box_filter/cuda_crop_box_filter.cu
 )
@@ -133,6 +134,7 @@ ament_auto_add_library(cuda_pointcloud_preprocessor SHARED
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
   src/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.cpp
   src/cuda_crop_box_filter/cuda_crop_box_filter_node.cpp
+  src/cuda_downsample_filter/cuda_random_downsample_filter_node.cpp
 )
 
 target_link_libraries(cuda_pointcloud_preprocessor
@@ -176,6 +178,12 @@ rclcpp_components_register_node(cuda_pointcloud_preprocessor
   EXECUTABLE cuda_crop_box_filter_node
 )
 
+# ========== Random downsample filter ==========
+rclcpp_components_register_node(cuda_pointcloud_preprocessor
+  PLUGIN "autoware::cuda_pointcloud_preprocessor::CudaRandomDownsampleFilterNode"
+  EXECUTABLE cuda_random_downsample_filter_node
+)
+
 ################################################################################
 # Install
 install(DIRECTORY launch config
@@ -191,6 +199,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(test_cuda_pointcloud_preprocessor_filters
     test/test_cuda_crop_box_filter.cpp
+    test/test_cuda_random_downsample_filter.cpp
   )
   target_link_libraries(test_cuda_pointcloud_preprocessor_filters
     cuda_pointcloud_preprocessor_lib

--- a/sensing/autoware_cuda_pointcloud_preprocessor/README.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/README.md
@@ -17,6 +17,7 @@ A detailed description of each filter's algorithm is available in the following 
 | cuda_voxel_grid_downsample_filter   | Implements voxel downsample filtering of the `autoware_pointcloud_preprocessor`'s CPU version                                                | [link](docs/cuda-voxel-grid-downsample.md)      |
 | cuda_polar_voxel_outlier_filter     | Implements polar voxel outlier filtering of the `autoware_pointcloud_preprocessor`'s CPU version                                             | [link](docs/cuda-polar-voxel-outlier-filter.md) |
 | cuda_crop_box_filter                | Implements a standalone crop box, the cropping in `cuda_pointcloud_preprocessor` being fused with distortion correction and unusable alone   | [link](docs/cuda-crop-box-filter.md)            |
+| cuda_random_downsample_filter       | Implements random downsampling of the `autoware_pointcloud_preprocessor`'s CPU version                                                      | [link](docs/cuda-random-downsample-filter.md)   |
 
 ## (Optional) Future extensions / Unimplemented parts
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/README.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/README.md
@@ -16,6 +16,7 @@ A detailed description of each filter's algorithm is available in the following 
 | cuda_concatenate_and_time_sync_node | Implements pointcloud concatenation an synchronization following `autoware_pointcloud_preprocessor`'s CPU implementation.                    | [link](docs/cuda-concatenate-data.md)           |
 | cuda_voxel_grid_downsample_filter   | Implements voxel downsample filtering of the `autoware_pointcloud_preprocessor`'s CPU version                                                | [link](docs/cuda-voxel-grid-downsample.md)      |
 | cuda_polar_voxel_outlier_filter     | Implements polar voxel outlier filtering of the `autoware_pointcloud_preprocessor`'s CPU version                                             | [link](docs/cuda-polar-voxel-outlier-filter.md) |
+| cuda_crop_box_filter                | Implements a standalone crop box, the cropping in `cuda_pointcloud_preprocessor` being fused with distortion correction and unusable alone   | [link](docs/cuda-crop-box-filter.md)            |
 
 ## (Optional) Future extensions / Unimplemented parts
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_crop_box_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_crop_box_filter.param.yaml
@@ -1,0 +1,10 @@
+/**:
+  ros__parameters:
+    min_x: -60.0
+    max_x: 60.0
+    min_y: -60.0
+    max_y: 60.0
+    min_z: -30.0
+    max_z: 50.0
+    negative: false
+    input_frame: ""

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_random_downsample_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_random_downsample_filter.param.yaml
@@ -1,0 +1,5 @@
+/**:
+  ros__parameters:
+    # Matches the CPU chain's random_downsample_filter.param.yaml, so switching
+    # backends does not change NDT's input budget along with the backend.
+    sample_num: 5000

--- a/sensing/autoware_cuda_pointcloud_preprocessor/design/CudaCropBoxFilter.node.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/design/CudaCropBoxFilter.node.yaml
@@ -1,0 +1,32 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: CudaCropBoxFilter.node
+
+package:
+  name: autoware_cuda_pointcloud_preprocessor
+  provider: autoware
+
+launch:
+  plugin: autoware::cuda_pointcloud_preprocessor::CudaCropBoxFilterNode
+  executable: cuda_crop_box_filter_node
+  node_output: screen
+
+# interfaces
+# NOTE: pointcloud I/O uses cuda_blackboard transport (CudaPointCloud2);
+# represented as sensor_msgs/msg/PointCloud2 (the negotiated ROS-graph type).
+subscribers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/input/pointcloud
+
+publishers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/output/pointcloud
+
+# parameters
+param_files:
+  - name: param_file
+    path: config/cuda_crop_box_filter.param.yaml
+    schema: schema/cuda_crop_box_filter.schema.json

--- a/sensing/autoware_cuda_pointcloud_preprocessor/design/CudaRandomDownsampleFilter.node.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/design/CudaRandomDownsampleFilter.node.yaml
@@ -1,0 +1,32 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: CudaRandomDownsampleFilter.node
+
+package:
+  name: autoware_cuda_pointcloud_preprocessor
+  provider: autoware
+
+launch:
+  plugin: autoware::cuda_pointcloud_preprocessor::CudaRandomDownsampleFilterNode
+  executable: cuda_random_downsample_filter_node
+  node_output: screen
+
+# interfaces
+# NOTE: pointcloud I/O uses cuda_blackboard transport (CudaPointCloud2);
+# represented as sensor_msgs/msg/PointCloud2 (the negotiated ROS-graph type).
+subscribers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/input/pointcloud
+
+publishers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/output/pointcloud
+
+# parameters
+param_files:
+  - name: param_file
+    path: config/cuda_random_downsample_filter.param.yaml
+    schema: schema/cuda_random_downsample_filter.schema.json

--- a/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-crop-box-filter.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-crop-box-filter.md
@@ -1,0 +1,45 @@
+# cuda_crop_box_filter
+
+## Purpose
+
+This node is a CUDA accelerated version of the `CropBoxFilter` available in [autoware_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor/README.md).
+
+It exists so that a preprocessing chain can stay GPU-resident. The cropping this package already performs lives inside `CudaPointcloudPreprocessorNode`, fused with distortion correction and ring outlier filtering and requiring a per-point time field, so it cannot be used on its own. Without a standalone crop box, a chain that crops before downsampling has to return to the host and come back.
+
+## Inner-workings / Algorithms
+
+Each point is tested against an axis-aligned box in a single kernel, producing a 0/1 mask. An exclusive scan over that mask gives every kept point its output slot, and a second kernel copies the selected points.
+
+Two properties follow from that shape and are worth stating:
+
+- **The point layout passes through untouched.** Selection copies whole points of `point_step` bytes, so intensity, ring, timestamp and any vendor field survive without this node needing to know they exist. Only the `x`, `y` and `z` offsets are read, and they are taken from the input's `fields` rather than assumed.
+- **Bounds are inclusive**, matching the CPU filter: a point exactly on a face is inside.
+
+Non-finite points are dropped in **both** polarities. A NaN coordinate compares false against every bound, so it is never "inside"; a naive `negative` would therefore keep it and hand NaN downstream, which is not what the CPU filter does.
+
+## Inputs / Outputs
+
+### Input
+
+| Name                      | Type                                             | Description                               |
+| ------------------------- | ------------------------------------------------ | ----------------------------------------- |
+| `~/input/pointcloud`      | `sensor_msgs::msg::PointCloud2`                  | Input pointcloud's topic.                 |
+| `~/input/pointcloud/cuda` | `negotiated_interfaces/msg/NegotiatedTopicsInfo` | Input pointcloud's type negotiation topic |
+
+### Output
+
+| Name                       | Type                                             | Description                                |
+| -------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| `~/output/pointcloud`      | `sensor_msgs::msg::PointCloud2`                  | Cropped pointcloud's topic                 |
+| `~/output/pointcloud/cuda` | `negotiated_interfaces/msg/NegotiatedTopicsInfo` | Cropped pointcloud's negotiation topic     |
+
+## Parameters
+
+### Core Parameters
+
+{{ json_to_markdown("sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_crop_box_filter.schema.json") }}
+
+## Assumptions / Known limits
+
+- **This node does not transform between frames.** The CPU `CropBoxFilter` can crop in a frame other than the cloud's own and looks up tf to do it. Here the box is required to be in the cloud's frame. `input_frame`, when set, is an assertion: a cloud arriving in a different frame is dropped with an error rather than cropped against the wrong region, because cropping the right box in the wrong frame removes the wrong points and nothing downstream would report it.
+- The input must carry `x`, `y` and `z` as `FLOAT32` fields lying wholly within `point_step`. A cloud that does not is dropped with an error; no conversion is attempted.

--- a/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-random-downsample-filter.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-random-downsample-filter.md
@@ -1,0 +1,54 @@
+# cuda_random_downsample_filter
+
+## Purpose
+
+This node is a CUDA accelerated version of the `RandomDownsampleFilter` available in [autoware_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor/README.md).
+
+It bounds the number of points handed to scan matching, which is what makes NDT's per-frame cost predictable. It exists as a standalone node so that a preprocessing chain can stay GPU-resident: with a CUDA crop box in front of it and a CUDA consumer behind it, cropping and downsampling happen without a round trip through host memory.
+
+## Inner-workings / Algorithms
+
+The selection is "random key, full sort, take the prefix":
+
+1. A kernel gives every point a pseudo-random 32-bit key and writes its own index alongside. The key is a counter-based mixer — the finaliser from Murmur3's avalanche family — evaluated on `(seed, index)`. Counter-based rather than stateful, because a per-point `curand` state would have to be allocated, initialised and carried across frames to stay reproducible, whereas a pure function of the index and the seed needs none of that.
+2. `thrust::sort_by_key` sorts the index array by those keys.
+3. The first `sample_num` indices of the sorted array are the selection.
+4. Those indices are sorted ascending again — a sort over `sample_num` elements, not over all `N` — and a gather kernel copies the selected points, whole, into consecutive output slots.
+
+Properties that follow from that shape, and are the reason for it:
+
+- **The count is exact.** Exactly `min(N, sample_num)` points come out. The obvious cheaper alternative is thresholding: keep point `i` when its key is below `sample_num / N * UINT32_MAX`, which is one kernel plus a scan and no sort at all. But its kept count is binomial around `sample_num` rather than equal to it, so a frame can land over budget and a nearly-empty frame can come out empty. The CPU `RandomDownsampleFilterComponent` promises **at most** `sample_num`, and the budgets written against that promise — NDT's per-frame cost, the memory a downstream stage sizes — are what the sort buys. Running once per scan over a few hundred thousand points, the sort is not the bottleneck.
+- **The output preserves input order**, because of the second sort in step 4. Nothing in NDT requires it, but a cloud whose points still run in scan order stays readable in RViz and diffable against its input.
+- **The point layout passes through untouched.** Selection copies whole points of `point_step` bytes, so intensity, ring, timestamp and any vendor field survive without this node needing to know they exist. Unlike the crop box, no coordinate is ever read — the fields are counted, never interpreted — so there is no layout this node can fail to understand and no rejection path.
+- **`num_points <= sample_num` short-circuits.** Nothing has to be chosen, so the sort is skipped entirely and the input is copied device-to-device. That is not only cheaper: it makes the pass-through case bit-exact and order-preserving, matching what the CPU component does.
+
+The seed is a call counter, incremented once per processed cloud. A given sequence of calls therefore produces a given sequence of selections, which is what makes a bag replay — and a failing test with it — reproducible. It is not a cryptographic or statistically audited stream and does not need to be.
+
+## Inputs / Outputs
+
+### Input
+
+| Name                      | Type                                             | Description                               |
+| ------------------------- | ------------------------------------------------ | ----------------------------------------- |
+| `~/input/pointcloud`      | `sensor_msgs::msg::PointCloud2`                  | Input pointcloud's topic.                 |
+| `~/input/pointcloud/cuda` | `negotiated_interfaces/msg/NegotiatedTopicsInfo` | Input pointcloud's type negotiation topic |
+
+### Output
+
+| Name                       | Type                                             | Description                                |
+| -------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| `~/output/pointcloud`      | `sensor_msgs::msg::PointCloud2`                  | Downsampled pointcloud's topic             |
+| `~/output/pointcloud/cuda` | `negotiated_interfaces/msg/NegotiatedTopicsInfo` | Downsampled pointcloud's negotiation topic |
+
+## Parameters
+
+### Core Parameters
+
+{{ json_to_markdown("sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_random_downsample_filter.schema.json") }}
+
+## Assumptions / Known limits
+
+- **`sample_num` has no default.** A point budget is a tuning decision per map and per LiDAR, and a wrong one degrades localization quietly rather than failing, so the node refuses to start rather than invent one. A non-positive value is rejected at construction: it would publish empty clouds and stall scan matching with no error anywhere downstream.
+- **Keys collide.** 32-bit keys tie by the birthday bound well before the ~10^5 points a 32-beam scan carries. Ties are broken arbitrarily by the sort, which perturbs uniformity slightly among tied points. It cannot perturb the count, which stays exactly `sample_num`.
+- **An empty cloud is republished, not dropped.** Downstream timeout diagnostics can only tell "the LiDAR stopped" from "the scan was empty" if the empty scan still arrives.
+- The selection is uniform over points, not over space: a dense region contributes proportionally more survivors than a sparse one. Where an even spatial distribution matters, use the voxel grid downsample filter instead.

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_crop_box_filter/cuda_crop_box_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_crop_box_filter/cuda_crop_box_filter.hpp
@@ -1,0 +1,96 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROP_BOX_FILTER__CUDA_CROP_BOX_FILTER_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROP_BOX_FILTER__CUDA_CROP_BOX_FILTER_HPP_
+
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+
+#include <cuda_runtime.h>
+
+#include <memory>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+/// Axis-aligned crop box, on the GPU.
+///
+/// Mirrors `autoware::pointcloud_preprocessor::CropBoxFilterComponent`: keep the
+/// points inside the box, or with `negative` keep the ones outside it. The
+/// bounds are inclusive on both ends, matching the CPU filter — a point exactly
+/// on a face is inside.
+///
+/// The point layout is passed through untouched. Cropping selects whole points
+/// and copies `point_step` bytes each, so intensity, ring, timestamp and any
+/// vendor field survive without this filter needing to know they exist. Only the
+/// x, y and z offsets are read, which is why the input's fields are inspected
+/// rather than assumed.
+///
+/// No frame transform is performed. The CPU component can crop in a frame other
+/// than the cloud's own and looks up tf to do it; here the box is required to be
+/// in the cloud's frame, and the node rejects a mismatch rather than silently
+/// cropping the wrong region. The localization chain uses base_link for both.
+class CudaCropBoxFilter
+{
+public:
+  struct BoxParams
+  {
+    float min_x;
+    float max_x;
+    float min_y;
+    float max_y;
+    float min_z;
+    float max_z;
+    bool negative;
+  };
+
+  explicit CudaCropBoxFilter(const BoxParams & params);
+  ~CudaCropBoxFilter();
+
+  CudaCropBoxFilter(const CudaCropBoxFilter &) = delete;
+  CudaCropBoxFilter & operator=(const CudaCropBoxFilter &) = delete;
+
+  /// Crop `input`, returning a new cloud with the same fields and point_step.
+  ///
+  /// Returns nullptr when the input carries no usable x/y/z float32 fields; the
+  /// caller is expected to log and drop the message rather than publish a cloud
+  /// built from a layout this cannot read.
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> filter(
+    const cuda_blackboard::CudaPointCloud2 & input);
+
+  /// The stream every kernel here runs on, so the subscriber can hand it over
+  /// and avoid a synchronise between the producer and this filter.
+  cudaStream_t stream() const { return stream_; }
+
+  /// Offsets of the x, y, z fields, or false when the layout is unusable.
+  static bool findXyzOffsets(
+    const cuda_blackboard::CudaPointCloud2 & cloud, std::size_t offsets[3]);
+
+private:
+  BoxParams params_;
+  cudaStream_t stream_{};
+
+  // Scratch, grown on demand and kept between calls. A scan needs somewhere to
+  // put the per-point mask and its prefix sum, and reallocating those every
+  // scan is the cost this whole package exists to avoid.
+  std::uint32_t * d_mask_{nullptr};
+  std::uint32_t * d_indices_{nullptr};
+  std::size_t capacity_{0};
+
+  void ensureCapacity(std::size_t num_points);
+};
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROP_BOX_FILTER__CUDA_CROP_BOX_FILTER_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_crop_box_filter/cuda_crop_box_filter_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_crop_box_filter/cuda_crop_box_filter_node.hpp
@@ -1,0 +1,58 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROP_BOX_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROP_BOX_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_crop_box_filter/cuda_crop_box_filter.hpp"
+
+#include <cuda_blackboard/cuda_adaptation.hpp>
+#include <cuda_blackboard/cuda_blackboard_publisher.hpp>
+#include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+/// GPU crop box, shaped to drop into the localization preprocessing chain.
+///
+/// Reads and writes `cuda_blackboard::CudaPointCloud2`, so it chains
+/// GPU-resident with `CudaVoxelGridDownsampleFilterNode` downstream. The
+/// blackboard publisher also carries a plain `PointCloud2` for anything that has
+/// not been converted, which is how the chain still feeds a subscriber outside
+/// this process.
+class CudaCropBoxFilterNode : public rclcpp::Node
+{
+public:
+  explicit CudaCropBoxFilterNode(const rclcpp::NodeOptions & node_options);
+
+private:
+  void pointcloudCallback(const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg);
+
+  std::string expected_frame_;
+  bool warned_about_frame_{false};
+  bool warned_about_layout_{false};
+
+  std::unique_ptr<CudaCropBoxFilter> filter_;
+  std::shared_ptr<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>> sub_;
+  std::unique_ptr<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>> pub_;
+};
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROP_BOX_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp
@@ -1,0 +1,86 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_HPP_
+
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+/// Uniform random downsample to a fixed point budget, on the GPU.
+///
+/// Mirrors `autoware::pointcloud_preprocessor::RandomDownsampleFilterComponent`:
+/// at most `sample_num` points survive, chosen uniformly at random, and an input
+/// already at or below the budget passes through whole. NDT cares about the
+/// budget, not about which points make it, so this is the cheapest way to bound
+/// scan-matching cost per frame.
+///
+/// The point layout is passed through untouched. Selection works on whole points
+/// and copies `point_step` bytes each, so intensity, ring, timestamp and any
+/// vendor field survive without this filter needing to know they exist. Unlike
+/// the crop box, nothing here reads a coordinate at all — the fields are never
+/// interpreted, only counted — which is why there is no layout rejection path.
+class CudaRandomDownsampleFilter
+{
+public:
+  explicit CudaRandomDownsampleFilter(std::size_t sample_num);
+  ~CudaRandomDownsampleFilter();
+
+  CudaRandomDownsampleFilter(const CudaRandomDownsampleFilter &) = delete;
+  CudaRandomDownsampleFilter & operator=(const CudaRandomDownsampleFilter &) = delete;
+
+  /// Downsample `input`, returning a new cloud with the same fields and
+  /// point_step and `min(input points, sample_num)` points.
+  ///
+  /// Never returns nullptr: there is no layout this cannot handle. The signature
+  /// still matches `CudaCropBoxFilter::filter` so the two chain interchangeably.
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> filter(
+    const cuda_blackboard::CudaPointCloud2 & input);
+
+  /// The stream every kernel here runs on, so the subscriber can hand it over
+  /// and avoid a synchronise between the producer and this filter.
+  cudaStream_t stream() const { return stream_; }
+
+private:
+  std::size_t sample_num_;
+  cudaStream_t stream_{};
+
+  // Seeds the per-call hash. A counter rather than a clock or a device RNG
+  // state: a given sequence of calls then produces a given sequence of
+  // selections, which is what makes a bag replay reproducible and a failing
+  // test reproducible with it. It is not a cryptographic or a statistically
+  // audited stream, and does not need to be.
+  std::uint32_t call_counter_{0};
+
+  // Scratch, grown on demand and kept between calls. The sort needs a key and a
+  // value array per point, and reallocating those every frame is the cost this
+  // whole package exists to avoid.
+  std::uint32_t * d_keys_{nullptr};
+  std::uint32_t * d_indices_{nullptr};
+  std::size_t capacity_{0};
+
+  void ensureCapacity(std::size_t num_points);
+};
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter_node.hpp
@@ -1,0 +1,54 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_NODE_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_NODE_HPP_
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp"
+
+#include <cuda_blackboard/cuda_adaptation.hpp>
+#include <cuda_blackboard/cuda_blackboard_publisher.hpp>
+#include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+/// GPU random downsample, shaped to drop into the localization preprocessing
+/// chain in place of `autoware::pointcloud_preprocessor::RandomDownsampleFilterComponent`.
+///
+/// Reads and writes `cuda_blackboard::CudaPointCloud2`, so it chains
+/// GPU-resident behind `CudaCropBoxFilterNode` without a round trip through
+/// host memory. The blackboard publisher also carries a plain `PointCloud2` for
+/// anything that has not been converted, which is how the chain still feeds a
+/// subscriber outside this process.
+class CudaRandomDownsampleFilterNode : public rclcpp::Node
+{
+public:
+  explicit CudaRandomDownsampleFilterNode(const rclcpp::NodeOptions & node_options);
+
+private:
+  void pointcloudCallback(const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg);
+
+  std::unique_ptr<CudaRandomDownsampleFilter> filter_;
+  std::shared_ptr<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>> sub_;
+  std::unique_ptr<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>> pub_;
+};
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_NODE_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_crop_box_filter.launch.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_crop_box_filter.launch.xml
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="input/pointcloud" default="/sensing/lidar/concatenated/pointcloud"/>
+  <arg name="output/pointcloud" default="/sensing/lidar/cropped/pointcloud"/>
+
+  <arg name="cuda_crop_box_filter_param_file" default="$(find-pkg-share autoware_cuda_pointcloud_preprocessor)/config/cuda_crop_box_filter.param.yaml"/>
+
+  <node pkg="autoware_cuda_pointcloud_preprocessor" exec="cuda_crop_box_filter_node" name="cuda_crop_box_filter" output="screen">
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+    <param from="$(var cuda_crop_box_filter_param_file)"/>
+  </node>
+</launch>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_random_downsample_filter.launch.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_random_downsample_filter.launch.xml
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="input/pointcloud" default="/sensing/lidar/cropped/pointcloud"/>
+  <arg name="output/pointcloud" default="/sensing/lidar/downsampled/pointcloud"/>
+
+  <arg name="cuda_random_downsample_filter_param_file" default="$(find-pkg-share autoware_cuda_pointcloud_preprocessor)/config/cuda_random_downsample_filter.param.yaml"/>
+
+  <node pkg="autoware_cuda_pointcloud_preprocessor" exec="cuda_random_downsample_filter_node" name="cuda_random_downsample_filter" output="screen">
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+    <param from="$(var cuda_random_downsample_filter_param_file)"/>
+  </node>
+</launch>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
@@ -33,6 +33,7 @@
   <depend>tier4_debug_msgs</depend>
 
   <test_depend>ament_clang_format</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_crop_box_filter.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_crop_box_filter.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for the cuda_crop_box_filter",
+  "type": "object",
+  "definitions": {
+    "cuda_crop_box_filter": {
+      "type": "object",
+      "properties": {
+        "min_x": {
+          "type": "number",
+          "description": "the lower bound along x-axis [m], inclusive",
+          "default": "-60.0"
+        },
+        "max_x": {
+          "type": "number",
+          "description": "the upper bound along x-axis [m], inclusive",
+          "default": "60.0"
+        },
+        "min_y": {
+          "type": "number",
+          "description": "the lower bound along y-axis [m], inclusive",
+          "default": "-60.0"
+        },
+        "max_y": {
+          "type": "number",
+          "description": "the upper bound along y-axis [m], inclusive",
+          "default": "60.0"
+        },
+        "min_z": {
+          "type": "number",
+          "description": "the lower bound along z-axis [m], inclusive",
+          "default": "-30.0"
+        },
+        "max_z": {
+          "type": "number",
+          "description": "the upper bound along z-axis [m], inclusive",
+          "default": "50.0"
+        },
+        "negative": {
+          "type": "boolean",
+          "description": "when true, keep the points outside the box instead of inside it. Non-finite points are dropped in both polarities: a NaN coordinate compares false against every bound, so inverting the test would otherwise let it through.",
+          "default": false
+        },
+        "input_frame": {
+          "type": "string",
+          "description": "the frame the box is expressed in. This node does not transform; a cloud arriving in a different frame is dropped with an error rather than cropped against the wrong region. Leave empty to accept any frame.",
+          "default": ""
+        }
+      },
+      "required": ["min_x", "max_x", "min_y", "max_y", "min_z", "max_z"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/cuda_crop_box_filter"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_random_downsample_filter.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_random_downsample_filter.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for the cuda_random_downsample_filter",
+  "type": "object",
+  "definitions": {
+    "cuda_random_downsample_filter": {
+      "type": "object",
+      "properties": {
+        "sample_num": {
+          "type": "integer",
+          "description": "the maximum number of points to keep; an input with no more points than this passes through whole",
+          "default": "5000",
+          "minimum": 1
+        }
+      },
+      "required": ["sample_num"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/cuda_random_downsample_filter"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_crop_box_filter/cuda_crop_box_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_crop_box_filter/cuda_crop_box_filter.cu
@@ -1,0 +1,229 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_crop_box_filter/cuda_crop_box_filter.hpp"
+
+#include <thrust/execution_policy.h>
+#include <thrust/scan.h>
+
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+namespace
+{
+
+constexpr int kBlockSize = 256;
+
+/// Mark each point 1 when it is kept, 0 when it is dropped.
+///
+/// NaN is dropped in both polarities. Every comparison against a NaN coordinate
+/// is false, so `inside` is false and a naive `negative` would keep it — which
+/// would hand NDT a NaN and is not what the CPU filter does.
+__global__ void markKernel(
+  const std::uint8_t * __restrict__ data, std::uint32_t * __restrict__ mask, std::size_t num_points,
+  std::size_t point_step, std::size_t off_x, std::size_t off_y, std::size_t off_z, float min_x,
+  float max_x, float min_y, float max_y, float min_z, float max_z, bool negative)
+{
+  const std::size_t i = blockIdx.x * static_cast<std::size_t>(blockDim.x) + threadIdx.x;
+  if (i >= num_points) {
+    return;
+  }
+  const std::uint8_t * p = data + i * point_step;
+  float x;
+  float y;
+  float z;
+  memcpy(&x, p + off_x, sizeof(float));
+  memcpy(&y, p + off_y, sizeof(float));
+  memcpy(&z, p + off_z, sizeof(float));
+
+  const bool finite = isfinite(x) && isfinite(y) && isfinite(z);
+  const bool inside =
+    x >= min_x && x <= max_x && y >= min_y && y <= max_y && z >= min_z && z <= max_z;
+  const bool keep = finite && (negative ? !inside : inside);
+  mask[i] = keep ? 1u : 0u;
+}
+
+/// Copy the kept points to the slots the exclusive scan assigned them.
+__global__ void scatterKernel(
+  const std::uint8_t * __restrict__ in, std::uint8_t * __restrict__ out,
+  const std::uint32_t * __restrict__ mask, const std::uint32_t * __restrict__ indices,
+  std::size_t num_points, std::size_t point_step)
+{
+  const std::size_t i = blockIdx.x * static_cast<std::size_t>(blockDim.x) + threadIdx.x;
+  if (i >= num_points || mask[i] == 0u) {
+    return;
+  }
+  const std::uint8_t * src = in + i * point_step;
+  std::uint8_t * dst = out + static_cast<std::size_t>(indices[i]) * point_step;
+  for (std::size_t b = 0; b < point_step; ++b) {
+    dst[b] = src[b];
+  }
+}
+
+void check(cudaError_t err, const char * what)
+{
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(what) + ": " + cudaGetErrorString(err));
+  }
+}
+
+}  // namespace
+
+CudaCropBoxFilter::CudaCropBoxFilter(const BoxParams & params) : params_(params)
+{
+  check(cudaStreamCreate(&stream_), "cudaStreamCreate");
+}
+
+CudaCropBoxFilter::~CudaCropBoxFilter()
+{
+  if (d_mask_ != nullptr) {
+    cudaFree(d_mask_);
+  }
+  if (d_indices_ != nullptr) {
+    cudaFree(d_indices_);
+  }
+  if (stream_ != nullptr) {
+    cudaStreamDestroy(stream_);
+  }
+}
+
+bool CudaCropBoxFilter::findXyzOffsets(
+  const cuda_blackboard::CudaPointCloud2 & cloud, std::size_t offsets[3])
+{
+  bool found[3] = {false, false, false};
+  for (const auto & f : cloud.fields) {
+    // FLOAT32 == 7 in sensor_msgs::msg::PointField. Anything else would need a
+    // conversion this filter deliberately does not do.
+    if (f.datatype != 7 || f.count != 1) {
+      continue;
+    }
+    // A field must lie wholly inside the point. Without this a malformed cloud
+    // declaring x at offset 60 with point_step 20 would have the kernel read
+    // past the end of every point -- out of bounds on the device, where it
+    // fails as corrupt output rather than a fault.
+    if (f.offset + sizeof(float) > cloud.point_step) {
+      continue;
+    }
+    if (f.name == "x") {
+      offsets[0] = f.offset;
+      found[0] = true;
+    } else if (f.name == "y") {
+      offsets[1] = f.offset;
+      found[1] = true;
+    } else if (f.name == "z") {
+      offsets[2] = f.offset;
+      found[2] = true;
+    }
+  }
+  return found[0] && found[1] && found[2];
+}
+
+void CudaCropBoxFilter::ensureCapacity(std::size_t num_points)
+{
+  if (num_points <= capacity_) {
+    return;
+  }
+  if (d_mask_ != nullptr) {
+    cudaFree(d_mask_);
+    d_mask_ = nullptr;
+  }
+  if (d_indices_ != nullptr) {
+    cudaFree(d_indices_);
+    d_indices_ = nullptr;
+  }
+  check(cudaMalloc(&d_mask_, num_points * sizeof(std::uint32_t)), "cudaMalloc mask");
+  check(cudaMalloc(&d_indices_, num_points * sizeof(std::uint32_t)), "cudaMalloc indices");
+  capacity_ = num_points;
+}
+
+std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaCropBoxFilter::filter(
+  const cuda_blackboard::CudaPointCloud2 & input)
+{
+  std::size_t off[3];
+  if (!findXyzOffsets(input, off)) {
+    return nullptr;
+  }
+
+  const std::size_t point_step = input.point_step;
+  const std::size_t num_points =
+    static_cast<std::size_t>(input.width) * static_cast<std::size_t>(input.height);
+
+  auto output = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+  output->header = input.header;
+  output->fields = input.fields;
+  output->point_step = input.point_step;
+  output->is_bigendian = input.is_bigendian;
+  output->is_dense = true;
+  output->height = 1;
+
+  if (num_points == 0 || point_step == 0) {
+    output->width = 0;
+    output->row_step = 0;
+    output->data = cuda_blackboard::CudaUniquePtr<std::uint8_t[]>();
+    return output;
+  }
+
+  ensureCapacity(num_points);
+
+  const int blocks = static_cast<int>((num_points + kBlockSize - 1) / kBlockSize);
+  markKernel<<<blocks, kBlockSize, 0, stream_>>>(
+    input.data.get(), d_mask_, num_points, point_step, off[0], off[1], off[2], params_.min_x,
+    params_.max_x, params_.min_y, params_.max_y, params_.min_z, params_.max_z, params_.negative);
+  check(cudaGetLastError(), "markKernel");
+
+  thrust::exclusive_scan(thrust::cuda::par.on(stream_), d_mask_, d_mask_ + num_points, d_indices_);
+
+  // The scan is exclusive, so the kept count is the last index plus the last
+  // mask entry. Two small copies rather than a separate reduction kernel.
+  std::uint32_t last_index = 0;
+  std::uint32_t last_mask = 0;
+  check(
+    cudaMemcpyAsync(
+      &last_index, d_indices_ + num_points - 1, sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
+      stream_),
+    "copy last index");
+  check(
+    cudaMemcpyAsync(
+      &last_mask, d_mask_ + num_points - 1, sizeof(std::uint32_t), cudaMemcpyDeviceToHost, stream_),
+    "copy last mask");
+  check(cudaStreamSynchronize(stream_), "sync after scan");
+
+  const std::size_t kept = last_index + last_mask;
+
+  output->width = static_cast<std::uint32_t>(kept);
+  output->row_step = static_cast<std::uint32_t>(kept * point_step);
+
+  if (kept == 0) {
+    output->data = cuda_blackboard::CudaUniquePtr<std::uint8_t[]>();
+    return output;
+  }
+
+  // Allocated through the blackboard's own helper so the buffer carries the
+  // deleter the library expects; a raw cudaMalloc here would be freed by a
+  // deleter that did not allocate it.
+  output->data = cuda_blackboard::make_unique<std::uint8_t[]>(kept * point_step);
+  std::uint8_t * out_raw = output->data.get();
+
+  scatterKernel<<<blocks, kBlockSize, 0, stream_>>>(
+    input.data.get(), out_raw, d_mask_, d_indices_, num_points, point_step);
+  check(cudaGetLastError(), "scatterKernel");
+  check(cudaStreamSynchronize(stream_), "sync after scatter");
+
+  return output;
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_crop_box_filter/cuda_crop_box_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_crop_box_filter/cuda_crop_box_filter_node.cpp
@@ -1,0 +1,91 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_crop_box_filter/cuda_crop_box_filter_node.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+CudaCropBoxFilterNode::CudaCropBoxFilterNode(const rclcpp::NodeOptions & node_options)
+: Node("cuda_crop_box_filter", node_options)
+{
+  CudaCropBoxFilter::BoxParams params{};
+  params.min_x = static_cast<float>(declare_parameter<double>("min_x"));
+  params.max_x = static_cast<float>(declare_parameter<double>("max_x"));
+  params.min_y = static_cast<float>(declare_parameter<double>("min_y"));
+  params.max_y = static_cast<float>(declare_parameter<double>("max_y"));
+  params.min_z = static_cast<float>(declare_parameter<double>("min_z"));
+  params.max_z = static_cast<float>(declare_parameter<double>("max_z"));
+  params.negative = declare_parameter<bool>("negative", false);
+
+  // The CPU component can crop in a different frame and looks up tf to do it.
+  // This one cannot, so it is told which frame the box is expressed in and
+  // refuses to guess: cropping the right box in the wrong frame removes the
+  // wrong points and nothing downstream would report it.
+  expected_frame_ = declare_parameter<std::string>("input_frame", "");
+
+  if (params.min_x > params.max_x || params.min_y > params.max_y || params.min_z > params.max_z) {
+    throw std::runtime_error(
+      "cuda_crop_box_filter: an inverted bound was given (min greater than max); "
+      "this would silently drop every point");
+  }
+
+  filter_ = std::make_unique<CudaCropBoxFilter>(params);
+
+  pub_ =
+    std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/output/pointcloud");
+
+  sub_ =
+    std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/input/pointcloud",
+      std::bind(&CudaCropBoxFilterNode::pointcloudCallback, this, std::placeholders::_1));
+}
+
+void CudaCropBoxFilterNode::pointcloudCallback(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg)
+{
+  if (!expected_frame_.empty() && msg->header.frame_id != expected_frame_) {
+    if (!warned_about_frame_) {
+      RCLCPP_ERROR(
+        get_logger(),
+        "Cloud is in frame '%s' but the crop box is configured for '%s'. This filter does not "
+        "transform; dropping. Set input_frame to match, or crop upstream.",
+        msg->header.frame_id.c_str(), expected_frame_.c_str());
+      warned_about_frame_ = true;
+    }
+    return;
+  }
+
+  auto output = filter_->filter(*msg);
+  if (!output) {
+    if (!warned_about_layout_) {
+      RCLCPP_ERROR(
+        get_logger(), "Cloud has no float32 x/y/z fields; this filter cannot read it. Dropping.");
+      warned_about_layout_ = true;
+    }
+    return;
+  }
+
+  pub_->publish(std::move(output));
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::cuda_pointcloud_preprocessor::CudaCropBoxFilterNode)

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_random_downsample_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_random_downsample_filter.cu
@@ -1,0 +1,216 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp"
+
+#include <thrust/execution_policy.h>
+#include <thrust/sort.h>
+
+#include <stdexcept>
+#include <string>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+namespace
+{
+
+constexpr int kBlockSize = 256;
+
+/// A counter-based 32-bit mixer (the finaliser from Murmur3's avalanche family).
+///
+/// Counter-based rather than stateful, because a per-point curand state would
+/// have to be allocated, initialised and carried across frames to stay
+/// reproducible; a pure function of (index, seed) needs none of that and still
+/// gives keys with no visible structure along the scan line.
+__device__ inline std::uint32_t mix32(std::uint32_t x)
+{
+  x ^= x >> 16;
+  x *= 0x7feb352dU;
+  x ^= x >> 15;
+  x *= 0x846ca68bU;
+  x ^= x >> 16;
+  return x;
+}
+
+/// Give every point a pseudo-random sort key and its own identity as the value.
+__global__ void keyKernel(
+  std::uint32_t * __restrict__ keys, std::uint32_t * __restrict__ indices, std::size_t num_points,
+  std::uint32_t seed)
+{
+  const std::size_t i = blockIdx.x * static_cast<std::size_t>(blockDim.x) + threadIdx.x;
+  if (i >= num_points) {
+    return;
+  }
+  // The golden-ratio stride keeps consecutive indices far apart before mixing,
+  // so the low bits of i do not survive into the low bits of the key.
+  keys[i] = mix32(mix32(seed) + static_cast<std::uint32_t>(i) * 0x9e3779b9U);
+  indices[i] = static_cast<std::uint32_t>(i);
+}
+
+/// Copy the selected points, whole, into consecutive output slots.
+__global__ void gatherKernel(
+  const std::uint8_t * __restrict__ in, std::uint8_t * __restrict__ out,
+  const std::uint32_t * __restrict__ indices, std::size_t kept, std::size_t point_step)
+{
+  const std::size_t j = blockIdx.x * static_cast<std::size_t>(blockDim.x) + threadIdx.x;
+  if (j >= kept) {
+    return;
+  }
+  const std::uint8_t * src = in + static_cast<std::size_t>(indices[j]) * point_step;
+  std::uint8_t * dst = out + j * point_step;
+  for (std::size_t b = 0; b < point_step; ++b) {
+    dst[b] = src[b];
+  }
+}
+
+void check(cudaError_t err, const char * what)
+{
+  if (err != cudaSuccess) {
+    throw std::runtime_error(std::string(what) + ": " + cudaGetErrorString(err));
+  }
+}
+
+}  // namespace
+
+CudaRandomDownsampleFilter::CudaRandomDownsampleFilter(std::size_t sample_num)
+: sample_num_(sample_num)
+{
+  check(cudaStreamCreate(&stream_), "cudaStreamCreate");
+}
+
+CudaRandomDownsampleFilter::~CudaRandomDownsampleFilter()
+{
+  if (d_keys_ != nullptr) {
+    cudaFree(d_keys_);
+  }
+  if (d_indices_ != nullptr) {
+    cudaFree(d_indices_);
+  }
+  if (stream_ != nullptr) {
+    cudaStreamDestroy(stream_);
+  }
+}
+
+void CudaRandomDownsampleFilter::ensureCapacity(std::size_t num_points)
+{
+  if (num_points <= capacity_) {
+    return;
+  }
+  if (d_keys_ != nullptr) {
+    cudaFree(d_keys_);
+    d_keys_ = nullptr;
+  }
+  if (d_indices_ != nullptr) {
+    cudaFree(d_indices_);
+    d_indices_ = nullptr;
+  }
+  check(cudaMalloc(&d_keys_, num_points * sizeof(std::uint32_t)), "cudaMalloc keys");
+  check(cudaMalloc(&d_indices_, num_points * sizeof(std::uint32_t)), "cudaMalloc indices");
+  capacity_ = num_points;
+}
+
+// Algorithm: random key, full sort, take the prefix.
+//
+// Give point i a pseudo-random key, sort the index array by that key, and keep
+// the first `sample_num` indices. That yields an EXACT count, which is the
+// property worth paying for: the CPU component promises "at most sample_num",
+// and everything downstream — NDT's per-frame budget, the memory the
+// concatenator sizes — is written against that promise.
+//
+// The obvious cheaper alternative is thresholding: keep point i when its key is
+// below sample_num/N * UINT32_MAX. That is a single kernel plus the scan the
+// crop box already uses, no sort at all, but the kept count is binomial around
+// sample_num rather than equal to it — a frame can come out 3% over budget, and
+// a nearly-empty frame can come out empty. Since this runs once per scan on a
+// few hundred thousand points, the sort is not the bottleneck (the driver and
+// the NDT iterations are), so exactness is the better trade here.
+//
+// Two details that are deliberate rather than incidental:
+//
+// - The selected indices are sorted ascending again before the gather, so the
+//   output preserves input order. Nothing in NDT requires it, but a cloud whose
+//   points still run in scan order stays readable in RViz and diffable against
+//   the input, and the second sort is over `sample_num` elements, not N.
+//
+// - 32-bit keys collide by the birthday bound well before the ~10^5 points a
+//   VLP-32C scan carries, so some keys tie. Ties are broken arbitrarily by the
+//   sort, which perturbs uniformity slightly among tied points; it cannot
+//   perturb the count, which stays exactly sample_num.
+std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaRandomDownsampleFilter::filter(
+  const cuda_blackboard::CudaPointCloud2 & input)
+{
+  const std::size_t point_step = input.point_step;
+  const std::size_t num_points =
+    static_cast<std::size_t>(input.width) * static_cast<std::size_t>(input.height);
+
+  auto output = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+  output->header = input.header;
+  output->fields = input.fields;
+  output->point_step = input.point_step;
+  output->is_bigendian = input.is_bigendian;
+  // Unlike the crop box, this filter never inspects a coordinate, so it neither
+  // removes nor introduces invalid points: whatever the input claimed about
+  // density is still true of a random subset of it.
+  output->is_dense = input.is_dense;
+  output->height = 1;
+
+  if (num_points == 0 || point_step == 0) {
+    output->width = 0;
+    output->row_step = 0;
+    output->data = cuda_blackboard::CudaUniquePtr<std::uint8_t[]>();
+    return output;
+  }
+
+  const std::size_t kept = num_points < sample_num_ ? num_points : sample_num_;
+
+  output->width = static_cast<std::uint32_t>(kept);
+  output->row_step = static_cast<std::uint32_t>(kept * point_step);
+
+  // Allocated through the blackboard's own helper so the buffer carries the
+  // deleter the library expects; a raw cudaMalloc here would be freed by a
+  // deleter that did not allocate it.
+  output->data = cuda_blackboard::make_unique<std::uint8_t[]>(kept * point_step);
+  std::uint8_t * out_raw = output->data.get();
+
+  if (kept == num_points) {
+    // Everything survives, so there is nothing to choose. Skipping the sort here
+    // is not just an optimisation: it also makes the pass-through case bit-exact
+    // and order-preserving, which is what the CPU component does.
+    check(
+      cudaMemcpyAsync(
+        out_raw, input.data.get(), kept * point_step, cudaMemcpyDeviceToDevice, stream_),
+      "copy pass-through");
+    check(cudaStreamSynchronize(stream_), "sync after pass-through");
+    return output;
+  }
+
+  ensureCapacity(num_points);
+
+  const int blocks = static_cast<int>((num_points + kBlockSize - 1) / kBlockSize);
+  keyKernel<<<blocks, kBlockSize, 0, stream_>>>(d_keys_, d_indices_, num_points, call_counter_++);
+  check(cudaGetLastError(), "keyKernel");
+
+  thrust::sort_by_key(thrust::cuda::par.on(stream_), d_keys_, d_keys_ + num_points, d_indices_);
+  thrust::sort(thrust::cuda::par.on(stream_), d_indices_, d_indices_ + kept);
+
+  const int gather_blocks = static_cast<int>((kept + kBlockSize - 1) / kBlockSize);
+  gatherKernel<<<gather_blocks, kBlockSize, 0, stream_>>>(
+    input.data.get(), out_raw, d_indices_, kept, point_step);
+  check(cudaGetLastError(), "gatherKernel");
+  check(cudaStreamSynchronize(stream_), "sync after gather");
+
+  return output;
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_random_downsample_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_random_downsample_filter_node.cpp
@@ -1,0 +1,68 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter_node.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+CudaRandomDownsampleFilterNode::CudaRandomDownsampleFilterNode(
+  const rclcpp::NodeOptions & node_options)
+: Node("cuda_random_downsample_filter", node_options)
+{
+  // No default: a point budget is a tuning decision per map and per LiDAR, and
+  // a wrong one degrades localization quietly rather than failing. Better to
+  // refuse to start than to invent one.
+  const std::int64_t sample_num = declare_parameter<std::int64_t>("sample_num");
+
+  if (sample_num <= 0) {
+    throw std::runtime_error(
+      "cuda_random_downsample_filter: sample_num must be positive, got " +
+      std::to_string(sample_num) +
+      "; a non-positive budget would publish empty clouds "
+      "and stall NDT with no error anywhere downstream");
+  }
+
+  filter_ = std::make_unique<CudaRandomDownsampleFilter>(static_cast<std::size_t>(sample_num));
+
+  pub_ =
+    std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/output/pointcloud");
+
+  sub_ =
+    std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/input/pointcloud",
+      std::bind(&CudaRandomDownsampleFilterNode::pointcloudCallback, this, std::placeholders::_1));
+}
+
+void CudaRandomDownsampleFilterNode::pointcloudCallback(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg)
+{
+  // An empty cloud is republished rather than dropped: downstream timeout
+  // diagnostics distinguish "the LiDAR stopped" from "the scan was empty" only
+  // if the empty scan still arrives.
+  pub_->publish(filter_->filter(*msg));
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  autoware::cuda_pointcloud_preprocessor::CudaRandomDownsampleFilterNode)

--- a/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_crop_box_filter.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_crop_box_filter.cpp
@@ -1,0 +1,361 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_crop_box_filter/cuda_crop_box_filter.hpp"
+
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/point_field.hpp>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+using autoware::cuda_pointcloud_preprocessor::CudaCropBoxFilter;
+
+/// A layout with payload past xyz, so a test can prove the filter moves whole
+/// points rather than reconstructing them from the three fields it reads.
+/// The trailing pad is deliberate: real driver layouts have alignment holes, and
+/// they must survive too, because whatever wrote them may put meaning there.
+struct TestPoint
+{
+  float x;
+  float y;
+  float z;
+  float intensity;
+  std::uint16_t ring;
+  std::uint16_t pad;
+};
+static_assert(sizeof(TestPoint) == 20, "the test relies on a hole-free 20-byte layout");
+
+sensor_msgs::msg::PointField makeField(
+  const std::string & name, std::uint32_t offset, std::uint8_t datatype)
+{
+  sensor_msgs::msg::PointField field;
+  field.name = name;
+  field.offset = offset;
+  field.datatype = datatype;
+  field.count = 1;
+  return field;
+}
+
+/// Build a device-resident cloud from host points.
+///
+/// `xyz_datatype` is a parameter only so a test can hand the filter a layout it
+/// is supposed to refuse.
+cuda_blackboard::CudaPointCloud2 makeCloud(
+  const std::vector<TestPoint> & points,
+  std::uint8_t xyz_datatype = sensor_msgs::msg::PointField::FLOAT32)
+{
+  cuda_blackboard::CudaPointCloud2 cloud;
+  cloud.header.frame_id = "base_link";
+  cloud.fields = {
+    makeField("x", 0, xyz_datatype), makeField("y", 4, xyz_datatype),
+    makeField("z", 8, xyz_datatype),
+    makeField("intensity", 12, sensor_msgs::msg::PointField::FLOAT32),
+    makeField("ring", 16, sensor_msgs::msg::PointField::UINT16)};
+  cloud.point_step = sizeof(TestPoint);
+  cloud.height = 1;
+  cloud.width = static_cast<std::uint32_t>(points.size());
+  cloud.row_step = cloud.width * cloud.point_step;
+  cloud.is_bigendian = false;
+  cloud.is_dense = false;
+
+  if (points.empty()) {
+    return cloud;
+  }
+
+  const std::size_t bytes = points.size() * sizeof(TestPoint);
+  cloud.data = cuda_blackboard::make_unique<std::uint8_t[]>(bytes);
+  EXPECT_EQ(
+    cudaMemcpy(cloud.data.get(), points.data(), bytes, cudaMemcpyHostToDevice), cudaSuccess);
+  return cloud;
+}
+
+/// Copy a result back as raw bytes, which is what the byte-for-byte assertions
+/// need; the typed view is a reinterpretation of the same buffer.
+std::vector<std::uint8_t> readBack(const cuda_blackboard::CudaPointCloud2 & cloud)
+{
+  const std::size_t bytes = static_cast<std::size_t>(cloud.width) *
+                            static_cast<std::size_t>(cloud.height) * cloud.point_step;
+  std::vector<std::uint8_t> host(bytes);
+  if (bytes == 0) {
+    return host;
+  }
+  EXPECT_EQ(cudaMemcpy(host.data(), cloud.data.get(), bytes, cudaMemcpyDeviceToHost), cudaSuccess);
+  return host;
+}
+
+std::vector<TestPoint> readBackPoints(const cuda_blackboard::CudaPointCloud2 & cloud)
+{
+  const auto bytes = readBack(cloud);
+  std::vector<TestPoint> points(bytes.size() / sizeof(TestPoint));
+  if (!points.empty()) {
+    std::memcpy(points.data(), bytes.data(), bytes.size());
+  }
+  return points;
+}
+
+/// A box the tests share: [-10, 10] on x and y, [-5, 5] on z.
+CudaCropBoxFilter::BoxParams box(bool negative)
+{
+  CudaCropBoxFilter::BoxParams params{};
+  params.min_x = -10.0f;
+  params.max_x = 10.0f;
+  params.min_y = -10.0f;
+  params.max_y = 10.0f;
+  params.min_z = -5.0f;
+  params.max_z = 5.0f;
+  params.negative = negative;
+  return params;
+}
+
+TestPoint point(float x, float y, float z, float intensity = 0.0f, std::uint16_t ring = 0)
+{
+  return TestPoint{x, y, z, intensity, ring, 0};
+}
+
+bool haveCudaDevice()
+{
+  int count = 0;
+  return cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+class CudaCropBoxFilterTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    if (!haveCudaDevice()) {
+      GTEST_SKIP() << "no CUDA device available; the crop box has no CPU path to fall back to";
+    }
+  }
+};
+
+TEST_F(CudaCropBoxFilterTest, KeepsInsideDropsOutside)
+{
+  CudaCropBoxFilter filter(box(false));
+
+  const std::vector<TestPoint> input = {
+    point(0.0f, 0.0f, 0.0f),     // origin, inside
+    point(9.9f, -9.9f, 4.9f),    // just inside every bound
+    point(10.1f, 0.0f, 0.0f),    // past max_x
+    point(-10.1f, 0.0f, 0.0f),   // past min_x
+    point(0.0f, 10.1f, 0.0f),    // past max_y
+    point(0.0f, -10.1f, 0.0f),   // past min_y
+    point(0.0f, 0.0f, 5.1f),     // past max_z
+    point(0.0f, 0.0f, -5.1f),    // past min_z
+    point(-1.0f, 2.0f, -3.0f)};  // inside
+
+  const auto cloud = makeCloud(input);
+  const auto output = filter.filter(cloud);
+  ASSERT_NE(output, nullptr);
+
+  const auto kept = readBackPoints(*output);
+  ASSERT_EQ(output->width, 3u);
+  ASSERT_EQ(kept.size(), 3u);
+  EXPECT_FLOAT_EQ(kept[0].x, 0.0f);
+  EXPECT_FLOAT_EQ(kept[1].x, 9.9f);
+  EXPECT_FLOAT_EQ(kept[2].x, -1.0f);
+
+  // The output is a flat cloud regardless of the input's organisation, and the
+  // cropped result has no non-finite points left in it.
+  EXPECT_EQ(output->height, 1u);
+  EXPECT_TRUE(output->is_dense);
+  EXPECT_EQ(output->row_step, output->width * output->point_step);
+}
+
+TEST_F(CudaCropBoxFilterTest, BoundsAreInclusiveOnAllSixFaces)
+{
+  CudaCropBoxFilter filter(box(false));
+
+  // One point per face, exactly on the plane and interior on the other two axes.
+  // The CPU component uses >= / <=, so a point on a face belongs to the box; an
+  // off-by-one to strict comparison here would quietly shave the map edges.
+  const std::vector<TestPoint> input = {point(-10.0f, 0.0f, 0.0f), point(10.0f, 0.0f, 0.0f),
+                                        point(0.0f, -10.0f, 0.0f), point(0.0f, 10.0f, 0.0f),
+                                        point(0.0f, 0.0f, -5.0f),  point(0.0f, 0.0f, 5.0f)};
+
+  const auto cloud = makeCloud(input);
+  const auto output = filter.filter(cloud);
+  ASSERT_NE(output, nullptr);
+  EXPECT_EQ(output->width, 6u);
+
+  // The corner where three faces meet is the same rule applied three times.
+  const std::vector<TestPoint> corner = {point(10.0f, 10.0f, 5.0f), point(-10.0f, -10.0f, -5.0f)};
+  const auto corner_cloud = makeCloud(corner);
+  const auto corner_output = filter.filter(corner_cloud);
+  ASSERT_NE(corner_output, nullptr);
+  EXPECT_EQ(corner_output->width, 2u);
+}
+
+TEST_F(CudaCropBoxFilterTest, NegativeInvertsTheSelection)
+{
+  const std::vector<TestPoint> input = {
+    point(0.0f, 0.0f, 0.0f), point(20.0f, 0.0f, 0.0f), point(0.0f, -30.0f, 0.0f),
+    point(1.0f, 1.0f, 1.0f)};
+
+  CudaCropBoxFilter positive(box(false));
+  const auto inside_cloud = makeCloud(input);
+  const auto inside = positive.filter(inside_cloud);
+  ASSERT_NE(inside, nullptr);
+  EXPECT_EQ(inside->width, 2u);
+
+  CudaCropBoxFilter negative(box(true));
+  const auto outside_cloud = makeCloud(input);
+  const auto outside = negative.filter(outside_cloud);
+  ASSERT_NE(outside, nullptr);
+  ASSERT_EQ(outside->width, 2u);
+
+  const auto kept = readBackPoints(*outside);
+  EXPECT_FLOAT_EQ(kept[0].x, 20.0f);
+  EXPECT_FLOAT_EQ(kept[1].y, -30.0f);
+
+  // A face point is inside, so negative must exclude it -- the inclusive bound
+  // and the inversion have to agree, or a point lands in both halves or neither.
+  const std::vector<TestPoint> face = {point(10.0f, 0.0f, 0.0f)};
+  const auto face_cloud = makeCloud(face);
+  const auto face_output = negative.filter(face_cloud);
+  ASSERT_NE(face_output, nullptr);
+  EXPECT_EQ(face_output->width, 0u);
+}
+
+TEST_F(CudaCropBoxFilterTest, NonFinitePointsAreDroppedInBothPolarities)
+{
+  const float nan_value = std::numeric_limits<float>::quiet_NaN();
+  const float inf_value = std::numeric_limits<float>::infinity();
+
+  const std::vector<TestPoint> input = {point(nan_value, 0.0f, 0.0f), point(0.0f, nan_value, 0.0f),
+                                        point(0.0f, 0.0f, nan_value), point(inf_value, 0.0f, 0.0f),
+                                        point(1.0f, 1.0f, 1.0f),      point(50.0f, 50.0f, 50.0f)};
+
+  CudaCropBoxFilter positive(box(false));
+  const auto positive_cloud = makeCloud(input);
+  const auto inside = positive.filter(positive_cloud);
+  ASSERT_NE(inside, nullptr);
+  ASSERT_EQ(inside->width, 1u);
+  EXPECT_FLOAT_EQ(readBackPoints(*inside)[0].x, 1.0f);
+
+  // The one that matters: every comparison against NaN is false, so a filter
+  // that computed keep as !inside would hand NDT four NaN points here.
+  CudaCropBoxFilter negative(box(true));
+  const auto negative_cloud = makeCloud(input);
+  const auto outside = negative.filter(negative_cloud);
+  ASSERT_NE(outside, nullptr);
+  ASSERT_EQ(outside->width, 1u);
+
+  const auto kept = readBackPoints(*outside);
+  EXPECT_FLOAT_EQ(kept[0].x, 50.0f);
+  EXPECT_TRUE(std::isfinite(kept[0].x));
+  EXPECT_TRUE(std::isfinite(kept[0].y));
+  EXPECT_TRUE(std::isfinite(kept[0].z));
+}
+
+TEST_F(CudaCropBoxFilterTest, WholePointBlobSurvivesByteForByte)
+{
+  CudaCropBoxFilter filter(box(false));
+
+  std::vector<TestPoint> input;
+  for (int i = 0; i < 64; ++i) {
+    // Alternate inside and outside so the kept points are not contiguous in the
+    // input and the scatter actually has to move them.
+    const float radius = (i % 2 == 0) ? 1.0f : 40.0f;
+    TestPoint p = point(
+      radius * static_cast<float>(i % 5 - 2), radius, 0.5f * static_cast<float>(i % 7 - 3),
+      static_cast<float>(i) * 1.25f, static_cast<std::uint16_t>(i * 37));
+    p.pad = static_cast<std::uint16_t>(0xA5A5u ^ i);  // a real layout's hole carries bits too
+    input.push_back(p);
+  }
+
+  std::vector<std::uint8_t> input_bytes(input.size() * sizeof(TestPoint));
+  std::memcpy(input_bytes.data(), input.data(), input_bytes.size());
+
+  const auto cloud = makeCloud(input);
+  const auto output = filter.filter(cloud);
+  ASSERT_NE(output, nullptr);
+  ASSERT_GT(output->width, 0u);
+  EXPECT_EQ(output->point_step, cloud.point_step);
+  EXPECT_EQ(output->fields.size(), cloud.fields.size());
+
+  // Recompute the expected selection on the host, then compare the raw
+  // point_step blobs. Comparing fields would only prove the fields this filter
+  // already reads survived.
+  std::vector<std::size_t> expected;
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    const TestPoint & p = input[i];
+    if (
+      p.x >= -10.0f && p.x <= 10.0f && p.y >= -10.0f && p.y <= 10.0f && p.z >= -5.0f &&
+      p.z <= 5.0f) {
+      expected.push_back(i);
+    }
+  }
+  ASSERT_EQ(output->width, expected.size());
+
+  const auto output_bytes = readBack(*output);
+  const std::size_t step = cloud.point_step;
+  for (std::size_t k = 0; k < expected.size(); ++k) {
+    const std::uint8_t * src = input_bytes.data() + expected[k] * step;
+    const std::uint8_t * dst = output_bytes.data() + k * step;
+    EXPECT_EQ(std::memcmp(src, dst, step), 0)
+      << "point " << k << " (input index " << expected[k] << ") was not copied verbatim";
+  }
+}
+
+TEST_F(CudaCropBoxFilterTest, EmptyInputYieldsEmptyOutput)
+{
+  CudaCropBoxFilter filter(box(false));
+
+  const auto cloud = makeCloud({});
+  const auto output = filter.filter(cloud);
+  ASSERT_NE(output, nullptr);
+  EXPECT_EQ(output->width, 0u);
+  EXPECT_EQ(output->height, 1u);
+  EXPECT_EQ(output->row_step, 0u);
+  EXPECT_EQ(output->fields.size(), cloud.fields.size());
+
+  // A cloud whose points are all rejected takes the same path as an empty one.
+  const auto all_outside = makeCloud({point(100.0f, 100.0f, 100.0f)});
+  const auto empty_result = filter.filter(all_outside);
+  ASSERT_NE(empty_result, nullptr);
+  EXPECT_EQ(empty_result->width, 0u);
+  EXPECT_EQ(empty_result->row_step, 0u);
+}
+
+TEST_F(CudaCropBoxFilterTest, RejectsALayoutWithoutFloat32Xyz)
+{
+  CudaCropBoxFilter filter(box(false));
+
+  // Same field names and offsets, declared FLOAT64. Reading four bytes at those
+  // offsets would produce plausible-looking garbage, so the filter must refuse
+  // rather than crop on it.
+  const auto cloud = makeCloud({point(0.0f, 0.0f, 0.0f)}, sensor_msgs::msg::PointField::FLOAT64);
+  EXPECT_EQ(filter.filter(cloud), nullptr);
+
+  // A cloud missing z entirely is refused for the same reason.
+  auto missing_z = makeCloud({point(0.0f, 0.0f, 0.0f)});
+  missing_z.fields.erase(missing_z.fields.begin() + 2);
+  EXPECT_EQ(filter.filter(missing_z), nullptr);
+}
+
+}  // namespace

--- a/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_random_downsample_filter.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_random_downsample_filter.cpp
@@ -1,0 +1,244 @@
+// Copyright 2026 NEWSLab, National Taiwan University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp"
+
+#include <sensor_msgs/msg/point_field.hpp>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+using autoware::cuda_pointcloud_preprocessor::CudaRandomDownsampleFilter;
+
+// x, y, z, intensity as float32 then ring as uint16, padded to a 4-byte
+// multiple the way a real Velodyne layout is. The payload past xyz is the point
+// of the test: this filter must never interpret it, only move it whole, so a
+// torn or reordered copy shows up as a blob that matches no input point.
+constexpr std::size_t kOffX = 0;
+constexpr std::size_t kOffY = 4;
+constexpr std::size_t kOffZ = 8;
+constexpr std::size_t kOffIntensity = 12;
+constexpr std::size_t kOffRing = 16;
+constexpr std::size_t kPointStep = 20;
+
+/// True when this machine has a usable GPU. The suite is written for the AGX
+/// Orin; on a CI box without a device every test skips rather than fails,
+/// because "no GPU here" is not evidence about the filter.
+bool haveCudaDevice()
+{
+  int count = 0;
+  return cudaGetDeviceCount(&count) == cudaSuccess && count > 0;
+}
+
+void addField(
+  cuda_blackboard::CudaPointCloud2 & cloud, const std::string & name, std::uint32_t offset,
+  std::uint8_t datatype)
+{
+  sensor_msgs::msg::PointField f;
+  f.name = name;
+  f.offset = offset;
+  f.datatype = datatype;
+  f.count = 1;
+  cloud.fields.push_back(f);
+}
+
+/// Host-side bytes for `n` points, each carrying a payload unique to its index.
+std::vector<std::uint8_t> makeHostPoints(std::size_t n)
+{
+  // Zeroed so the padding bytes are deterministic; otherwise a byte-for-byte
+  // comparison would be testing the allocator.
+  std::vector<std::uint8_t> bytes(n * kPointStep, 0);
+  for (std::size_t i = 0; i < n; ++i) {
+    std::uint8_t * p = bytes.data() + i * kPointStep;
+    const float x = static_cast<float>(i);
+    const float y = static_cast<float>(i) + 0.5f;
+    const float z = -static_cast<float>(i);
+    const float intensity = static_cast<float>(i) * 3.0f + 1.0f;
+    const std::uint16_t ring = static_cast<std::uint16_t>(i % 32);
+    std::memcpy(p + kOffX, &x, sizeof(float));
+    std::memcpy(p + kOffY, &y, sizeof(float));
+    std::memcpy(p + kOffZ, &z, sizeof(float));
+    std::memcpy(p + kOffIntensity, &intensity, sizeof(float));
+    std::memcpy(p + kOffRing, &ring, sizeof(std::uint16_t));
+  }
+  return bytes;
+}
+
+cuda_blackboard::CudaPointCloud2 makeCloud(const std::vector<std::uint8_t> & host_bytes)
+{
+  cuda_blackboard::CudaPointCloud2 cloud;
+  cloud.header.frame_id = "base_link";
+  addField(cloud, "x", kOffX, sensor_msgs::msg::PointField::FLOAT32);
+  addField(cloud, "y", kOffY, sensor_msgs::msg::PointField::FLOAT32);
+  addField(cloud, "z", kOffZ, sensor_msgs::msg::PointField::FLOAT32);
+  addField(cloud, "intensity", kOffIntensity, sensor_msgs::msg::PointField::FLOAT32);
+  addField(cloud, "ring", kOffRing, sensor_msgs::msg::PointField::UINT16);
+  cloud.point_step = kPointStep;
+  cloud.height = 1;
+  cloud.width = static_cast<std::uint32_t>(host_bytes.size() / kPointStep);
+  cloud.row_step = static_cast<std::uint32_t>(host_bytes.size());
+  cloud.is_bigendian = false;
+  cloud.is_dense = true;
+
+  if (!host_bytes.empty()) {
+    cloud.data = cuda_blackboard::make_unique<std::uint8_t[]>(host_bytes.size());
+    EXPECT_EQ(
+      cudaSuccess,
+      cudaMemcpy(cloud.data.get(), host_bytes.data(), host_bytes.size(), cudaMemcpyHostToDevice));
+  }
+  return cloud;
+}
+
+std::vector<std::uint8_t> readBack(const cuda_blackboard::CudaPointCloud2 & cloud)
+{
+  const std::size_t n = static_cast<std::size_t>(cloud.width) * cloud.height * cloud.point_step;
+  std::vector<std::uint8_t> bytes(n, 0);
+  if (n > 0) {
+    EXPECT_EQ(cudaSuccess, cudaMemcpy(bytes.data(), cloud.data.get(), n, cudaMemcpyDeviceToHost));
+  }
+  return bytes;
+}
+
+/// The set of whole-point blobs, as opaque strings — the comparison the filter's
+/// contract is actually about.
+std::set<std::string> blobs(const std::vector<std::uint8_t> & bytes)
+{
+  std::set<std::string> out;
+  for (std::size_t i = 0; i + kPointStep <= bytes.size(); i += kPointStep) {
+    out.emplace(reinterpret_cast<const char *>(bytes.data() + i), kPointStep);
+  }
+  return out;
+}
+
+}  // namespace
+
+TEST(CudaRandomDownsampleFilter, FewerPointsThanBudgetPassThroughUnchanged)
+{
+  if (!haveCudaDevice()) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+  const auto host = makeHostPoints(100);
+  const auto input = makeCloud(host);
+
+  CudaRandomDownsampleFilter filter(5000);
+  const auto output = filter.filter(input);
+
+  ASSERT_NE(nullptr, output);
+  EXPECT_EQ(100u, output->width);
+  EXPECT_EQ(1u, output->height);
+  EXPECT_EQ(kPointStep, output->point_step);
+  EXPECT_EQ(100u * kPointStep, output->row_step);
+  EXPECT_EQ(input.fields.size(), output->fields.size());
+  // Not merely the same set: under the budget nothing is chosen, so the order
+  // must survive too.
+  EXPECT_EQ(host, readBack(*output));
+}
+
+TEST(CudaRandomDownsampleFilter, BudgetIsExactWhenInputIsLarger)
+{
+  if (!haveCudaDevice()) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+  const auto host = makeHostPoints(10000);
+  const auto input = makeCloud(host);
+
+  CudaRandomDownsampleFilter filter(5000);
+
+  // Repeated, because the seed advances per call: an off-by-one in the sort
+  // prefix would only show on some seeds.
+  for (int call = 0; call < 3; ++call) {
+    const auto output = filter.filter(input);
+    ASSERT_NE(nullptr, output);
+    EXPECT_EQ(5000u, output->width);
+    EXPECT_EQ(1u, output->height);
+    EXPECT_EQ(5000u * kPointStep, output->row_step);
+  }
+}
+
+TEST(CudaRandomDownsampleFilter, EveryOutputPointIsAWholeInputPoint)
+{
+  if (!haveCudaDevice()) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+  const auto host = makeHostPoints(4096);
+  const auto input = makeCloud(host);
+
+  CudaRandomDownsampleFilter filter(1000);
+  const auto output = filter.filter(input);
+
+  ASSERT_NE(nullptr, output);
+  ASSERT_EQ(1000u, output->width);
+
+  const auto input_blobs = blobs(host);
+  const auto out_bytes = readBack(*output);
+  const auto output_blobs = blobs(out_bytes);
+
+  // Distinct, so a duplicated selection cannot hide behind the count.
+  EXPECT_EQ(1000u, output_blobs.size());
+  for (const auto & blob : output_blobs) {
+    EXPECT_EQ(1u, input_blobs.count(blob))
+      << "an output point does not byte-match any input point: the payload past "
+         "xyz was torn or reassembled";
+  }
+}
+
+TEST(CudaRandomDownsampleFilter, EmptyInputYieldsEmptyCloud)
+{
+  if (!haveCudaDevice()) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+  const auto input = makeCloud({});
+
+  CudaRandomDownsampleFilter filter(5000);
+  const auto output = filter.filter(input);
+
+  ASSERT_NE(nullptr, output);
+  EXPECT_EQ(0u, output->width);
+  EXPECT_EQ(0u, output->row_step);
+  EXPECT_EQ(1u, output->height);
+  EXPECT_EQ(nullptr, output->data.get());
+}
+
+TEST(CudaRandomDownsampleFilter, SelectionIsRandomAndAdvancesPerCall)
+{
+  if (!haveCudaDevice()) {
+    GTEST_SKIP() << "no CUDA device";
+  }
+  const auto host = makeHostPoints(4096);
+  const auto input = makeCloud(host);
+
+  CudaRandomDownsampleFilter filter(1000);
+  const auto first = blobs(readBack(*filter.filter(input)));
+  const auto second = blobs(readBack(*filter.filter(input)));
+
+  // Guards the two ways this can look right and be wrong: taking the first
+  // sample_num points (a subset in input order, which the ascending re-sort
+  // would disguise), and reusing one seed for every frame (which would bias
+  // NDT towards the same points scan after scan). Two independent draws of
+  // 1000 from 4096 agreeing exactly has probability far below any flake budget.
+  EXPECT_NE(first, second);
+
+  const auto prefix = blobs(std::vector<std::uint8_t>(
+    host.begin(), host.begin() + static_cast<std::ptrdiff_t>(1000 * kPointStep)));
+  EXPECT_NE(prefix, first);
+}


### PR DESCRIPTION
## Description

Adds two standalone GPU filters, both subscribing and publishing through `cuda_blackboard`:

- `CudaCropBoxFilterNode`
- `CudaRandomDownsampleFilterNode`

This package already crops and downsamples, but only inside `CudaPointcloudPreprocessorNode`, fused with distortion correction and ring outlier filtering. A pipeline needing just one of them has no GPU node to call and must round-trip through the CPU.

The case in hand is localization preprocessing: crop to the measurement range, then downsample to a fixed budget. Both nodes together make that chain GPU-resident end to end. Either alone still round-trips, so they are proposed together.

Parameters mirror the `autoware_pointcloud_preprocessor` counterparts, so one parameter file drives either backend.

**Crop box.** Mark against the box, prefix-sum the mask, gather survivors. Output compact, point order preserved. Bounds inclusive on all six faces; `negative` inverts.

Two deliberate divergences from the CPU component:

- No `output_frame`. Transforming on the device costs a second pass over every point, or the host round trip this path exists to avoid.
- `input_frame` checks rather than transforms: empty accepts anything, set drops mismatched clouds with one warning. Cropping in the wrong frame fails silently and looks plausible.

**Random downsample.** Assign each point a random key, sort, take the first `sample_num` indices, sort those so output preserves input order.

Thresholding a per-point random draw would be cheaper and wrong: it gives a binomial count around the budget, while the CPU component promises at most `sample_num`. Consumers sizing buffers from that promise would see it broken intermittently.

Input below the budget passes through unchanged. `sample_num` is validated at construction; non-positive throws, because a zero budget publishes empty clouds indefinitely and surfaces only as a scan matcher that never converges.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

12 gtest cases, 7 crop box and 5 downsample — the package's first tests. They cover inclusive bounds on all six faces, the negative sense, field preservation, the exact-count guarantee, order preservation, pass-through below budget, empty input, and that successive calls select differently.

All pass on an AGX Orin (JetPack 6.2, CUDA 12.6, sm_87).

**Draft, because CI is the first full build.** My Autoware install exports `pointcloud_preprocessor_filter_base` with include paths from its build container, so `colcon` cannot configure this package locally; a pristine `main` fails identically. Sources were compiled directly and tests linked against those objects. Unexercised here: the CMake wiring, the link step, both launch files.

No benchmark against the CPU filters. The argument is capability, not throughput.

## Notes for reviewers

- First tests in this package. Happy to move or reshape them.
- The two crop box divergences above are choices. Say the word and I will match the CPU component instead.

Portions of this work were drafted with AI assistance and reviewed by me.

## Interface changes

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name | Message Type | Description |
|:------------|:-----------|:-----------|:-------------|:------------|
| Added | Sub | `~/input/pointcloud` | `CudaPointCloud2` | Input cloud, both nodes |
| Added | Pub | `~/output/pointcloud` | `CudaPointCloud2` | Filtered cloud, both nodes |

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `min_x` | `double` | required, `-60.0` | Crop box lower X bound, inclusive |
| Added | `max_x` | `double` | required, `60.0` | Crop box upper X bound, inclusive |
| Added | `min_y` | `double` | required, `-60.0` | Crop box lower Y bound, inclusive |
| Added | `max_y` | `double` | required, `60.0` | Crop box upper Y bound, inclusive |
| Added | `min_z` | `double` | required, `-30.0` | Crop box lower Z bound, inclusive |
| Added | `max_z` | `double` | required, `50.0` | Crop box upper Z bound, inclusive |
| Added | `negative` | `bool` | `false` | Keep points outside the box instead of inside |
| Added | `input_frame` | `string` | `""` | If set, mismatched clouds are dropped, not transformed |
| Added | `sample_num` | `int` | required, `5000` | Downsample budget; must be positive |

The six bounds and `sample_num` have no default, so a missing one is a startup error rather than a silently wrong crop. Values shown are what the shipped parameter files set; `sample_num` matches the CPU chain's `random_downsample_filter.param.yaml`.

## Effects on system behavior

None. Nothing launches either node. The shared library gains two components and the package two executables. No existing node, topic, or parameter changes.
