### PR TITLE
fix(autoware_cuda_utils): export CCCL for host compilation with CUDA 13

### DIFF
--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -86,6 +86,11 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     SYSTEM PUBLIC
     ${autoware_cuda_utils_INCLUDE_DIRS}
   )
+
+  target_link_libraries(${PROJECT_NAME}_cuda_lib
+    autoware_cuda_utils::autoware_cuda_utils
+  )
+
   ament_target_dependencies(${PROJECT_NAME}_cuda_lib
     autoware_point_types
   )

--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -87,6 +87,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     ${autoware_cuda_utils_INCLUDE_DIRS}
   )
 
+  # detection3d_postprocess_test needs this: it host-compiles Thrust and gets no ament_target_dependencies.
   target_link_libraries(${PROJECT_NAME}_cuda_lib
     autoware_cuda_utils::autoware_cuda_utils
   )

--- a/sensing/autoware_cuda_utils/CMakeLists.txt
+++ b/sensing/autoware_cuda_utils/CMakeLists.txt
@@ -11,6 +11,19 @@ if(NOT ${CUDA_FOUND})
   return()
 endif()
 
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/find_cccl.cmake)
+
+# The installed headers use Thrust, so consumers need the CCCL include path.
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(${PROJECT_NAME} INTERFACE CCCL::CCCL)
+
+install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
+ament_export_targets(export_${PROJECT_NAME})
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
@@ -28,6 +41,7 @@ if(BUILD_TESTING)
   )
 
   target_link_libraries(test_autoware_cuda_utils
+    ${PROJECT_NAME}
     ${GTEST_LIBRARIES}
     ${GTEST_MAIN_LIBRARIES}
   )
@@ -43,4 +57,4 @@ if(BUILD_TESTING)
   ament_add_gtest_test(test_autoware_cuda_utils)
 endif()
 
-ament_auto_package()
+ament_auto_package(CONFIG_EXTRAS cmake/find_cccl.cmake)

--- a/sensing/autoware_cuda_utils/CMakeLists.txt
+++ b/sensing/autoware_cuda_utils/CMakeLists.txt
@@ -13,13 +13,13 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/find_cccl.cmake)
 
-# The installed headers use Thrust, so consumers need the CCCL include path.
+# The installed headers use Thrust and cuda_runtime_api.h, so consumers need both include paths.
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(${PROJECT_NAME} INTERFACE CCCL::CCCL)
+target_link_libraries(${PROJECT_NAME} INTERFACE CCCL::CCCL autoware_cuda_utils::cccl_system CUDA::cudart)
 
 install(TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})

--- a/sensing/autoware_cuda_utils/cmake/find_cccl.cmake
+++ b/sensing/autoware_cuda_utils/cmake/find_cccl.cmake
@@ -12,15 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# CUDA 13 moved the CCCL headers (Thrust, CUB, libcu++) to include/cccl/.
-# Only nvcc adds that directory to its include path. The CCCL CMake config
-# is outside the default search path, so find_package needs the hints.
-# find_package searches the hints after CCCL_ROOT and CMAKE_PREFIX_PATH but
-# before the system prefixes, so the toolkit config wins over a system copy
-# and explicit user overrides still win over the hints.
+# CUDA 13 moved the CCCL headers to include/cccl/. The CCCL CMake config sits
+# outside the default CMake search path, so find_package needs the hints.
 
 find_package(CUDAToolkit REQUIRED)
 find_package(CCCL CONFIG REQUIRED HINTS
   "${CUDAToolkit_LIBRARY_DIR}/cmake"
   "${CUDAToolkit_TARGET_DIR}/lib64/cmake"
   "${CUDAToolkit_TARGET_DIR}/lib/cmake")
+
+# The CCCL targets are not imported, so this marker re-marks their include
+# directory as a system include for consumers.
+if(NOT TARGET autoware_cuda_utils::cccl_system)
+  add_library(autoware_cuda_utils::cccl_system INTERFACE IMPORTED GLOBAL)
+  get_target_property(_autoware_cuda_utils_cccl_dir CCCL::libcudacxx
+    INTERFACE_INCLUDE_DIRECTORIES)
+  if(_autoware_cuda_utils_cccl_dir)
+    set_property(TARGET autoware_cuda_utils::cccl_system PROPERTY
+      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_autoware_cuda_utils_cccl_dir}")
+  endif()
+  unset(_autoware_cuda_utils_cccl_dir)
+endif()

--- a/sensing/autoware_cuda_utils/cmake/find_cccl.cmake
+++ b/sensing/autoware_cuda_utils/cmake/find_cccl.cmake
@@ -1,0 +1,26 @@
+# Copyright 2026 The Autoware Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CUDA 13 moved the CCCL headers (Thrust, CUB, libcu++) to include/cccl/.
+# Only nvcc adds that directory to its include path. The CCCL CMake config
+# is outside the default search path, so find_package needs the hints.
+# find_package searches the hints after CCCL_ROOT and CMAKE_PREFIX_PATH but
+# before the system prefixes, so the toolkit config wins over a system copy
+# and explicit user overrides still win over the hints.
+
+find_package(CUDAToolkit REQUIRED)
+find_package(CCCL CONFIG REQUIRED HINTS
+  "${CUDAToolkit_LIBRARY_DIR}/cmake"
+  "${CUDAToolkit_TARGET_DIR}/lib64/cmake"
+  "${CUDAToolkit_TARGET_DIR}/lib/cmake")


### PR DESCRIPTION
## Problem

On native Ubuntu 24.04 installation these packages fail to compile with the recommended CUDA 13.0.

CUDA 13 moved the Thrust, CUB and libcu++ headers from `include/` to `include/cccl/`. `nvcc` adds the new directory by itself. The host compiler does not. A full workspace build on a native CUDA 13 install fails in two packages:

```text
autoware_cuda_pointcloud_preprocessor
  .../cuda_utils/thrust_utils.hpp:19: fatal error: thrust/count.h
  .../thrust_custom_allocator.hpp:21:  fatal error: thrust/device_malloc_allocator.h
  .../cuda_polar_voxel_noise_filter.hpp:22:   fatal error: cuda/std/optional
  .../cuda_polar_voxel_outlier_filter.hpp:22: fatal error: cuda/std/optional
autoware_ptv3
  .../ptv3/postprocess/detection3d_postprocess.hpp:24: fatal error: thrust/device_vector.h
```

- <https://developer.nvidia.com/blog/whats-new-and-important-in-cuda-toolkit-13-0/#cccl_headers_have_moved_in_cuda_130>

The Docker images hide this failure, because `autowarefoundation/autoware` sets `CPATH=/usr/local/cuda/include/cccl` for the whole image. A native install through Ansible has no such bridge. So CI is green and native builds fail.

## Fix

The first header that fails is `thrust_utils.hpp`, which `autoware_cuda_utils` installs. A header that uses Thrust makes the CCCL include directory part of the public interface of that package. So `autoware_cuda_utils` now exports a CMake target that carries its own headers, `CCCL::CCCL` and `CUDA::cudart`. Every package that already depends on `autoware_cuda_utils` gets the include directory through that target, with no change on its side.

The only consumer edit is one link line in `autoware_ptv3`, for a test target that has no other route to the export.

<details>
<summary>How the export reaches consumers</summary>

`cmake/find_cccl.cmake` locates the toolkit CCCL config. It ships to consumers through `ament_auto_package(CONFIG_EXTRAS ...)`, so it runs in the scope of every consumer before the export file loads. The config sits outside the default CMake search path, at `<toolkit>/lib64/cmake/cccl`. So the file passes three hints. `${CUDAToolkit_LIBRARY_DIR}/cmake` serves a native x86_64 install. The `lib64/cmake` and `lib/cmake` forms under `${CUDAToolkit_TARGET_DIR}` serve the cross layout on Jetson and SBSA.

`find_package` searches the hints after `CCCL_ROOT` and `CMAKE_PREFIX_PATH`, but before the system prefixes. As a result, the toolkit config wins over a system copy, and an explicit user override still wins over the hints. `CCCL::CCCL` is correct on CUDA 12 and 13, so the export needs no version guard. On 12.8 the config resolves the plain toolkit include directory.

`CUDA::cudart` is in the interface because `thrust_utils.hpp` also includes `cuda_runtime_api.h`, which the package and CCCL include directories alone cannot resolve.

17 of the 18 packages that depend on `autoware_cuda_utils` reach the target through `ament_auto_add_library`. That macro calls `ament_target_dependencies`, which prefers `${pkg}_TARGETS` over the classic variables. The 18th, `autoware_tensorrt_plugins`, uses neither and never sees the target. It needs no change, because its three CUB includes are all in `.cu` files.

</details>

<details>
<summary>Why there is a marker target for <code>-isystem</code></summary>

The CCCL config creates non-imported targets, so their include directory reaches consumers as plain `-I`. Under the warnings-as-errors flags of the repository, one warning in a future CCCL header then breaks the build. `find_cccl.cmake` therefore also defines `autoware_cuda_utils::cccl_system`, a small imported marker target that carries the same directory in `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES` only. CMake merges the system include sets across the link closure, so every consumer gets `-isystem`, and this file modifies no NVIDIA target.

The property is explicit because `mrt_cmake_modules` sets `CMAKE_NO_SYSTEM_FROM_IMPORTED YES` in the scope of every package that loads that module, which disables the imported-implies-system default. An explicit entry survives that variable, in the same way that `FindCUDAToolkit` marks `CUDA::cudart`.

</details>

<details>
<summary>Why <code>autoware_ptv3</code> needs the link</summary>

The `.cu` sources of `autoware_ptv3` do not need the directory, because nvcc finds CCCL by itself. `autoware_ptv3_lib` does need it, and gets it from `ament_auto_add_library`.

One test target has no other route. `ament_add_gtest` creates `detection3d_postprocess_test`, so that target never gets `ament_target_dependencies`. It host-compiles `<thrust/device_vector.h>` through `detection3d_postprocess.hpp`. The plain signature is public, so the link carries CCCL from `${PROJECT_NAME}_cuda_lib` into every target that links it. A comment above the link records this reason, so a maintainer cannot mistake the line for dead code.

</details>

## Why a target and not an include directory

The direct alternative is `include_directories(SYSTEM ${CUDA_INCLUDE_DIRS}/cccl)` under a `CUDA_VERSION` guard, repeated in each package.

- The requirement belongs to the package that installs the header. Every future host consumer must rediscover a per-package copy. CI cannot detect an omitted copy, because the CI images bridge the directory with `CPATH`.
- `find_package` finds `CCCL::CCCL`, and the target is correct on CUDA 12 and 13. The `include_directories` form hardcodes a layout and needs a version guard.
- `include_directories` is directory-scoped. It reaches every target in the file, also the targets that do not use CCCL, and it reaches no consumer.

## Known limitation

A toolkit without the CCCL CMake config stops the configure step of every consumer of `autoware_cuda_utils`. Every toolkit that apt installs ships the config.

<details>
<summary>Details</summary>

`cmake/find_cccl.cmake` uses `find_package(... REQUIRED)` and ships as a config extra. `CCCL::CCCL` also enters the installed export file as a link interface entry. So no consumer-side guard avoids the stop, and a `QUIET` find does not help either. apt toolkits always ship the config, because `cuda-cudart-dev-*` depends on `cuda-cccl-*`. The exposure is a toolkit that apt did not install:

- conda with the cccl package deselected
- a runfile install with components deselected
- a slimmed container image

</details>

## Related links

This PR supersedes an earlier PR. That PR fixes the same build error with a per-package include directory in `autoware_cuda_pointcloud_preprocessor` alone, and leaves `autoware_ptv3` broken:

- Superseded: #12131

The same build error in `bevdet_vendor` has its own fix:

- Sibling: autowarefoundation/bevdet_vendor#5

**AI usage:** written with Claude Code: the full workspace build, the root-cause analysis, the CMake change, three review passes that reshaped the design, and this PR text.

**Self-review:** Read and investigated how the cmake commands work and also explained the complicated parts down below. Also confirmed it compiles on jazzy with both CUDA 12.8 and 13.0.

<details>
<summary><strong>Verification:</strong> full workspace builds and <code>colcon test</code> on CUDA 13.0 and 12.8 for the first revision. A 4-package rebuild and the same 227 tests on CUDA 13.0 then verified the system-include marker and <code>CUDA::cudart</code>. The full builds did not rerun after that change.</summary>

Ubuntu 24.04, ROS 2 Jazzy, CUDA 13.0.88 and CUDA 12.8.93, GCC 13.3, CMake 3.28.3, x86_64, 24 cores. `autoware_universe` at `1822b91e0a`.

### Workspace build, first revision

Command: `colcon build --symlink-install --event-handlers=console_cohesion+ --cmake-args -DCMAKE_BUILD_TYPE=Release --continue-on-error`

- Before this change: `2 packages failed: autoware_cuda_pointcloud_preprocessor autoware_ptv3`, and colcon did not process 16 reverse dependencies.
- After this change: `Summary: 538 packages finished [20min 48s]`, exit code 0, zero failures.
- A second workspace build ran against CUDA 12.8.93, into a separate build and install base. The consumer flags carry no `cccl` entry there, because the directory does not exist on 12.8. So one export is correct on both toolkits with no version guard.
- `colcon test --packages-select autoware_cuda_utils autoware_ptv3 autoware_cuda_pointcloud_preprocessor`: `227 tests, 0 errors, 0 failures, 59 skipped`, on both toolkits.
- A first test run failed `ament_copyright` on the new `cmake/find_cccl.cmake`, which had no license header. I added the header and repeated the run.

### The export reaches consumers

- `autoware_cuda_pointcloud_preprocessor/CMakeLists.txt` contains zero occurrences of `cccl`. Its compile flags carry the CCCL directory through the dependency that it already declares.
- The installed `autoware_cuda_utilsConfig.cmake` lists `find_cccl.cmake` before `ament_cmake_export_targets-extras.cmake`, so all targets exist before the export file references them.
- The installed export file records `INTERFACE_LINK_LIBRARIES "CCCL::CCCL;autoware_cuda_utils::cccl_system;CUDA::cudart"` and no toolkit directory.

### System-include marker and CUDA::cudart, CUDA 13.0

- A rebuild of `autoware_cuda_utils`, `autoware_cuda_pointcloud_preprocessor`, `autoware_ptv3` and `autoware_ground_segmentation_cuda`: all four finish.
- 9 `flags.make` files carry `-isystem /usr/local/cuda/include/cccl`, and zero carry a plain `-I` for it. Before the marker, 79 files carried plain `-I` and zero carried `-isystem`.
- `mrt_cmake_modules-macros.cmake:26` sets `CMAKE_NO_SYSTEM_FROM_IMPORTED YES`, which strips the imported-implies-system default in every scope that loads it. An isolated provider and consumer probe reproduced the degradation and the survival of the marker. The two affected workspace targets then verified both.
- A compilation of `thrust_utils.hpp` against only the package and CCCL include directories fails with `fatal error: cuda_runtime_api.h`. With `CUDA::cudart` in the interface, a consumer translation unit that includes `<thrust/count.h>` compiles through the export alone.
- `colcon test` on the three packages: `227 tests, 0 errors, 0 failures, 59 skipped`.

### Not run

- The full workspace builds and full test runs on the final revision. They ran on the first revision, which differed by the marker target and the `CUDA::cudart` link.
- CUDA 12.8 against the final revision. On 12.8 the CCCL config resolves the plain toolkit include directory, so the marker marks that directory system. In packages that add `${CUDA_INCLUDE_DIRS}` without `SYSTEM`, this marking flips the toolkit include from `-I` to `-isystem`. That is reasoning, not a run.
- aarch64 and SBSA. The `lib/cmake` hint is for the cross layout. It rests on the toolkit directory layout, not on a build on such a device.
- Ubuntu 22.04 and Humble.
- CI cannot exercise this fix. The `-cuda` images set `CPATH=/usr/local/cuda/include/cccl`, so the jobs pass with or without this change.
- The workspace tree carried the `bevdet_vendor` fix from its own open PR. Upstream `bevdet_vendor` still fails on CUDA 13 without it.
- An import of the installed export file with CCCL absent reproduced the `REQUIRED` limitation. No run on a machine without `cuda-cccl` reproduced it.

</details>
