### PR TITLE
fix(design): align the planning and control node interfaces with the design graph

### DIFF
--- a/control/autoware_collision_detector/design/CollisionDetector.node.yaml
+++ b/control/autoware_collision_detector/design/CollisionDetector.node.yaml
@@ -21,7 +21,7 @@ subscribers:
     message_type: autoware_perception_msgs/msg/PredictedObjects
   - name: operation_mode_state
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
-    global: /api/operation_mode/state
+    remap_target: /api/operation_mode/state
 
 publishers: []
 

--- a/control/autoware_trajectory_follower_node/design/TrajectoryFollower.node.yaml
+++ b/control/autoware_trajectory_follower_node/design/TrajectoryFollower.node.yaml
@@ -35,8 +35,6 @@ publishers:
     message_type: std_msgs/msg/Float32Stamped
   - name: longitudinal_diagnostic
     message_type: diagnostic_msgs/msg/DiagnosticStatus
-  - name: stop_reason
-    message_type: tier4_planning_msgs/msg/StopReasonArray
   - name: control_cmd
     message_type: autoware_control_msgs/msg/Control
 

--- a/control/autoware_vehicle_cmd_gate/design/VehicleCmdGate.node.yaml
+++ b/control/autoware_vehicle_cmd_gate/design/VehicleCmdGate.node.yaml
@@ -48,7 +48,6 @@ subscribers:
     remap_target: input/external_emergency_stop_heartbeat
   - name: gate_mode
     message_type: tier4_control_msgs/msg/GateMode
-    global: /control/gate_mode_cmd
     remap_target: input/gate_mode
   - name: emergency_control_cmd
     message_type: autoware_control_msgs/msg/Control
@@ -73,7 +72,6 @@ subscribers:
     remap_target: input/acceleration
   - name: engage
     message_type: autoware_vehicle_msgs/msg/Engage
-    global: /autoware/engage
     remap_target: input/engage
 
 publishers:

--- a/planning/autoware_external_velocity_limit_selector/design/ExternalVelocityLimitSelector.node.yaml
+++ b/planning/autoware_external_velocity_limit_selector/design/ExternalVelocityLimitSelector.node.yaml
@@ -16,6 +16,7 @@ launch:
 subscribers:
   - name: api_limit
     message_type: autoware_internal_planning_msgs/msg/VelocityLimit
+    global: /planning/scenario_planning/max_velocity_default
     remap_target: input/velocity_limit_from_api
   - name: internal_limit
     message_type: autoware_internal_planning_msgs/msg/VelocityLimit

--- a/planning/autoware_hazard_lights_selector/design/HazardLightsSelector.node.yaml
+++ b/planning/autoware_hazard_lights_selector/design/HazardLightsSelector.node.yaml
@@ -17,7 +17,7 @@ subscribers:
   - name: lane_driving_hazard_lights_cmd
     message_type: autoware_vehicle_msgs/msg/HazardLightsCommand
     remap_target: input/planning/hazard_lights_command
-  - name: parking_hazard_lights_cmd
+  - name: system_hazard_lights_cmd
     message_type: autoware_vehicle_msgs/msg/HazardLightsCommand
     remap_target: input/system/hazard_lights_command
 

--- a/planning/autoware_remaining_distance_time_calculator/design/RemainingDistanceTimeCalculator.node.yaml
+++ b/planning/autoware_remaining_distance_time_calculator/design/RemainingDistanceTimeCalculator.node.yaml
@@ -23,7 +23,7 @@ subscribers:
     message_type: autoware_internal_planning_msgs/msg/Scenario
   - name: planning_velocity
     message_type: autoware_internal_planning_msgs/msg/VelocityLimit
-    global: /planning/scenario_planning/current_max_velocity
+    remap_target: /planning/scenario_planning/current_max_velocity
 
 publishers:
   - name: mission_remaining_distance_time

--- a/planning/autoware_surround_obstacle_checker/design/SurroundObstacleChecker.node.yaml
+++ b/planning/autoware_surround_obstacle_checker/design/SurroundObstacleChecker.node.yaml
@@ -22,13 +22,9 @@ subscribers:
 
 publishers:
   - name: max_velocity
-    message_type: tier4_planning_msgs/msg/VelocityLimit
+    message_type: autoware_internal_planning_msgs/msg/VelocityLimit
   - name: velocity_limit_clear_command
-    message_type: tier4_planning_msgs/msg/VelocityLimitClearCommand
-  - name: stop_reasons
-    message_type: tier4_planning_msgs/msg/StopReasonArray
-  - name: no_start_reason
-    message_type: tier4_planning_msgs/msg/StopReasonArray
+    message_type: autoware_internal_planning_msgs/msg/VelocityLimitClearCommand
 
 # parameters
 param_files:


### PR DESCRIPTION
> [!NOTE]
> Superseded by autowarefoundation/autoware_universe#13298, which now carries this batch together with the rest of the node design audit. Review there; this PR is kept only for the split-out discussion and will not be merged on its own.

## Description

Aligns seven planning and control node designs with the design graph.

- `global:` → `remap_target:`, so a system design wires these ports like any other while the launcher keeps the official topic names: `CollisionDetector` (`/api/operation_mode/state`), `RemainingDistanceTimeCalculator` (`/planning/scenario_planning/current_max_velocity`), `VehicleCmdGate` (`gate_mode`, `engage`).
- `ExternalVelocityLimitSelector`: pins `api_limit` to `/planning/scenario_planning/max_velocity_default`. That topic is published only by AD API adaptors outside the design graph, so it stays `global:`.
- `SurroundObstacleChecker`, `TrajectoryFollower`: pre-migration `tier4_planning_msgs` types, and publishers the nodes never create.
- `HazardLightsSelector`: renames `parking_hazard_lights_cmd` to `system_hazard_lights_cmd`; the port maps to `input/system/hazard_lights_command` (default `/system/hazard_lights_cmd`) and carries the MRM command.

Scoped to planning and control so the reviewer set stays small.

## Related links

- autowarefoundation/autoware_launch#1972 — the matching module connections. Paired; each needs the other.

## How was this PR tested?

- `autoware_sample_designs` builds clean with #1972 in the workspace, and the exported launcher keeps the official names (`input/gate_mode` → `/control/gate_mode_cmd`, `input/engage` → `/autoware/engage`, `~/input/api_operation_mode_state` → `/api/operation_mode/state`).
- `pre-commit` on the changed files.

## Notes for reviewers

Design-only change (`design/*.node.yaml`); no launch file or source code is touched.

## Interface changes

`HazardLightsSelector` renames one port. The node-side topic is unchanged; #1972 follows the rename.

## Effects on system behavior

None.

