### PR TITLE
refactor(autoware_ptv3): distinguish encoder levels from pooling stages

### DIFF
--- a/perception/autoware_ptv3/README.md
+++ b/perception/autoware_ptv3/README.md
@@ -10,6 +10,32 @@ This package implements a TensorRT powered inference node for Point Transformers
 The sparse convolution backend corresponds to [spconv](https://github.com/traveller59/spconv).
 Autoware installs it automatically in its setup script. If needed, the user can also build it and install it following the [following instructions](https://github.com/autowarefoundation/spconv_cpp).
 
+### Terminology: level vs. stage
+
+A **level** is a resolution: a set of voxels. A **pooling stage** is the transition between two
+levels. There is always one more level than stage — with `pooling_strides: [2, 2, 2, 2]` and
+`enc_channels: [32, 64, 128, 256, 512]`, five levels and four stages:
+
+```text
+level 0 --stage 0--> level 1 --stage 1--> level 2 --stage 2--> level 3 --stage 3--> level 4
+```
+
+Level 0 is the input voxels. A level owns a voxel count, a `grid_coord`, a serialization order and
+inverse, and a point feature output. A stage owns the machinery of one downsampling: `indices`,
+`indptr`, `head_indices` and `cluster`.
+
+| indexed by level (`0..N`)                    | indexed by pooling stage (`0..N-1`)                    |
+| -------------------------------------------- | ------------------------------------------------------ |
+| `point_feat_i`, `enc_channels`, `dec_depths` | `pooling_strides`, `pooling_cluster_i`                 |
+| `levelFeatureName`, `levelProfileCounts`     | `serialized_pooling_<i>_{indices,indptr,head_indices}` |
+| `level_voxel_capacity`, `level_num_voxels_`  | `serialized_pooling_stages_d_`                         |
+
+Note that `serialized_pooling_<i>_grid_coord`, `_serialized_order` and `_serialized_inverse` are
+named after stage `i` but describe **level `i+1`** — the level that stage produced. That off-by-one
+is why code addressing both families shifts indices. `indices` and `indptr` cannot be levelled at
+all: `indices` is level-`i`-sized and `indptr` is level-`i+1`-sized plus one, so they span the
+transition and belong to the stage.
+
 ## Inputs / Outputs
 
 ### Input

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -82,8 +82,8 @@ public:
    * @param serialized_code Codes of the input voxels, laid out [num_orders, num_voxels].
    * @param num_voxels Number of input voxels; clamped to max_num_voxels internally.
    * @param stages Output device buffers to fill, one per pooling stage.
-   * @param stage_counts Output voxel count per level, laid out [num_stages + 1]; entry 0 is the
-   * (clamped) input count.
+   * @param level_counts Output voxel count per level, laid out [num_pooling_stages + 1]; entry 0 is
+   * the (clamped) input count.
    * @pre The input voxels are sorted by their order-0 serialized code (`serialized_code` row 0),
    * as generateFeatures emits them. The coarser levels are derived with prefix scans that rely on
    * this ordering; an unsorted input silently produces wrong metadata. Asserted on device in
@@ -91,7 +91,7 @@ public:
    */
   void generateSerializedPoolingMetadata(
     const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
-    const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts);
+    const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * level_counts);
 
   [[nodiscard]] const std::uint32_t * cropMask() const { return crop_mask_d_.get(); }
   [[nodiscard]] const std::uint32_t * cropIndices() const { return crop_indices_d_.get(); }

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -133,15 +133,15 @@ public:
       filter_apply_to_segmentation_ = filter_apply_to_segmentation;
       source_reconstruction_ = parse_source_reconstruction(source_reconstruction);
 
-      // dec_depths drives the seg-head engine input set: block stages consume their
+      // dec_depths drives the seg-head engine input set: block levels consume their
       if (dec_depths.size() != pooling_strides_.size()) {
         throw std::runtime_error(
-          "dec_depths must contain one entry per decoder stage (pooling_strides size = " +
+          "dec_depths must contain one entry per decoder level (pooling_strides size = " +
           std::to_string(pooling_strides_.size()) + "), got " + std::to_string(dec_depths.size()) +
           ".");
       }
-      for (std::size_t stage = 0; stage < dec_depths.size(); ++stage) {
-        if (dec_depths[stage] < 0) {
+      for (std::size_t level = 0; level < dec_depths.size(); ++level) {
+        if (dec_depths[level] < 0) {
           throw std::runtime_error("dec_depths entries must be non-negative.");
         }
       }
@@ -191,25 +191,25 @@ public:
       bbox_voxel_x_size_ = bbox_voxel_size[0];
       bbox_voxel_y_size_ = bbox_voxel_size[1];
 
-      // The exporter taps encoder stages S-2 (BEV resolution) and S-1, so the detection grid
-      // resolution must equal the voxel size at stage S-2's cumulative pooling depth.
-      std::int64_t skip_stage_depth = 0;
+      // The exporter taps encoder levels S-2 (BEV resolution) and S-1, so the detection grid
+      // resolution must equal the voxel size at level S-2's cumulative pooling depth.
+      std::int64_t skip_level_depth = 0;
       for (std::size_t stage = 0; stage + 1 < pooling_strides_.size(); ++stage) {
         for (auto value = pooling_strides_[stage]; value > 1; value >>= 1) {
-          ++skip_stage_depth;
+          ++skip_level_depth;
         }
       }
-      const auto skip_stage_scale = static_cast<float>(std::int64_t{1} << skip_stage_depth);
+      const auto skip_level_scale = static_cast<float>(std::int64_t{1} << skip_level_depth);
       constexpr float eps = 1e-3F;
-      if (std::abs(bbox_voxel_x_size_ - voxel_x_size_ * skip_stage_scale) > eps) {
+      if (std::abs(bbox_voxel_x_size_ - voxel_x_size_ * skip_level_scale) > eps) {
         throw std::runtime_error(
           "x component of bbox_voxel_size must equal voxel_size * 2^" +
-          std::to_string(skip_stage_depth) + " (the detection branch taps that encoder stage).");
+          std::to_string(skip_level_depth) + " (the detection branch taps that encoder level).");
       }
-      if (std::abs(bbox_voxel_y_size_ - voxel_y_size_ * skip_stage_scale) > eps) {
+      if (std::abs(bbox_voxel_y_size_ - voxel_y_size_ * skip_level_scale) > eps) {
         throw std::runtime_error(
           "y component of bbox_voxel_size must equal voxel_size * 2^" +
-          std::to_string(skip_stage_depth) + " (the detection branch taps that encoder stage).");
+          std::to_string(skip_level_depth) + " (the detection branch taps that encoder level).");
       }
 
       distance_bin_upper_limits_ = distance_bin_upper_limits;
@@ -375,7 +375,7 @@ public:
   {
     if (enc_channels.size() != expected_size) {
       throw std::runtime_error(
-        "enc_channels must contain one entry per encoder stage (pooling_strides size + 1 = " +
+        "enc_channels must contain one entry per encoder level (pooling_strides size + 1 = " +
         std::to_string(expected_size) + "), got " + std::to_string(enc_channels.size()) + ".");
     }
     for (const auto channels : enc_channels) {
@@ -386,13 +386,13 @@ public:
     return enc_channels;
   }
 
-  // Hard voxel-count bound for one encoder stage: a stage cannot hold more voxels than the grid
+  // Hard voxel-count bound for one encoder level: a level cannot hold more voxels than the grid
   // has cells at its cumulative pooling depth, and pooling never grows the voxel count. Sizes the
-  // encoder stage buffers and TensorRT profiles.
-  [[nodiscard]] std::int64_t stage_voxel_capacity(const std::size_t stage_index) const
+  // encoder level buffers and TensorRT profiles.
+  [[nodiscard]] std::int64_t level_voxel_capacity(const std::size_t level) const
   {
     std::int64_t cumulative_depth = 0;
-    for (std::size_t stage = 0; stage < stage_index; ++stage) {
+    for (std::size_t stage = 0; stage < level; ++stage) {
       for (auto value = pooling_strides_[stage]; value > 1; value >>= 1) {
         ++cumulative_depth;
       }
@@ -424,10 +424,10 @@ public:
   std::vector<std::string> segmentation_class_names_;
   std::vector<std::string> serialization_orders_;
   std::vector<std::int64_t> pooling_strides_;
-  std::vector<std::int64_t> enc_channels_;  // per encoder stage, finest to deepest
+  std::vector<std::int64_t> enc_channels_;  // per encoder level, finest to deepest
 
   // Segmentation head
-  std::vector<std::int64_t> dec_depths_;  // decoder block counts per stage
+  std::vector<std::int64_t> dec_depths_;  // decoder block counts per level
   std::vector<float> colors_rgb_;
   // class id (index into segmentation_class_names_) -> PointCloudClassification
   std::vector<std::uint8_t> class_id_to_classification_;

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
@@ -73,7 +73,7 @@ public:
 protected:
   void initPtr();
   void initEncoderTrt(const tensorrt_common::TrtCommonConfig & trt_config);
-  [[nodiscard]] std::array<std::int64_t, 3> stageProfileCounts(std::size_t stage_index) const;
+  [[nodiscard]] std::array<std::int64_t, 3> levelProfileCounts(std::size_t level) const;
   void initSeg3dHeadTrt(const tensorrt_common::TrtCommonConfig & trt_config);
   void initDetection3DHeadTrt(const tensorrt_common::TrtCommonConfig & trt_config);
   void createPointFields();
@@ -140,8 +140,8 @@ protected:
   };
 
   std::vector<SerializedPoolingDeviceStage> serialized_pooling_stages_d_;
-  CudaUniquePtr<std::int64_t[]> serialized_pooling_num_voxels_d_{nullptr};
-  CudaUniquePtrHost<std::int64_t[]> serialized_pooling_num_voxels_;
+  CudaUniquePtr<std::int64_t[]> level_num_voxels_d_{nullptr};
+  CudaUniquePtrHost<std::int64_t[]> level_num_voxels_;
   std::vector<std::int64_t> serialized_pooling_depths_;
 
   // Preprocess outputs
@@ -160,9 +160,9 @@ protected:
   CudaUniquePtr<float[]> feat_d_{nullptr};
   CudaUniquePtr<std::int64_t[]> serialized_code_d_{nullptr};
 
-  // Encoder outputs shared with all the heads: per-stage point features,
-  // finest to deepest, sized by each stage's geometric voxel capacity.
-  std::vector<CudaUniquePtr<float[]>> stage_feat_d_;
+  // Encoder outputs shared with all the heads: per-level point features,
+  // finest to deepest, sized by each level's geometric voxel capacity.
+  std::vector<CudaUniquePtr<float[]>> level_feat_d_;
 
   // Segmentation head outputs
   CudaUniquePtr<std::int64_t[]> pred_labels_d_{nullptr};

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -356,10 +356,10 @@ __global__ void computeGridCoordsAndSerializationKernel(
   codes[idx + num_points] = serializeCoord(coord.x, coord.y, coord.z, depth, true);
 }
 
-__global__ void setInitialStageCountKernel(
-  std::int64_t * __restrict__ stage_counts_out, std::int64_t num_voxels)
+__global__ void setInitialLevelCountKernel(
+  std::int64_t * __restrict__ level_counts_out, std::int64_t num_voxels)
 {
-  *stage_counts_out = num_voxels;
+  *level_counts_out = num_voxels;
 }
 
 /**
@@ -409,15 +409,15 @@ __global__ void prepareInputLevelOrderSortKernel(
  *
  * @param serialized_code_in Input level's codes, laid out [num_orders, input_count]; only the
  * order-0 row is read.
- * @param stage_counts_in Per-level voxel counts; entry `stage_index` is the input level's count.
+ * @param level_counts_in Per-level voxel counts; entry `stage_index` is the input level's count.
  * @param run_flags_out Flags: 1 at each parent run start, 0 elsewhere (including padding).
- * @param stage_index Level the input arrays describe.
+ * @param stage_index Pooling stage the input arrays describe; its input is level `stage_index`.
  * @param pooling_depth Bits each grid coordinate is shifted right by, i.e. log2(pooling stride).
  * @param capacity Padded length of the arrays (max_num_voxels).
  */
 __global__ void markPoolingRunsKernel(
   const std::int64_t * __restrict__ serialized_code_in,
-  const std::int64_t * __restrict__ stage_counts_in, std::int64_t * __restrict__ run_flags_out,
+  const std::int64_t * __restrict__ level_counts_in, std::int64_t * __restrict__ run_flags_out,
   std::int32_t stage_index, std::int32_t pooling_depth, std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -425,7 +425,7 @@ __global__ void markPoolingRunsKernel(
     return;
   }
 
-  const auto input_count = stage_counts_in[stage_index];
+  const auto input_count = level_counts_in[stage_index];
   if (idx >= input_count) {
     run_flags_out[idx] = 0;
     return;
@@ -462,9 +462,9 @@ __global__ void markPoolingRunsKernel(
  * @param order_out Output pooled serialization orders, [num_orders, pooled_count]; only the
  * order-0 row is written here, the rest by fillOrderAndInverseKernel.
  * @param inverse_out Output inverse permutations of `order_out`, same layout and coverage.
- * @param stage_counts_inout Per-level voxel counts; entry `stage_index` is the input level's
+ * @param level_counts_inout Per-level voxel counts; entry `stage_index` is the input level's
  * count and entry `stage_index + 1` is set to the pooled count.
- * @param stage_index Level the input arrays describe.
+ * @param stage_index Pooling stage the input arrays describe; its input is level `stage_index`.
  * @param pooling_depth Bits each grid coordinate is shifted right by, i.e. log2(pooling stride).
  * @param num_orders Number of serialization orders.
  * @param capacity Padded length of the arrays (max_num_voxels).
@@ -477,7 +477,7 @@ __global__ void fillPoolingStageKernel(
   std::int64_t * __restrict__ head_indices_out, std::int64_t * __restrict__ cluster_out,
   std::int32_t * __restrict__ grid_coord_out, std::int64_t * __restrict__ serialized_code_out,
   std::int64_t * __restrict__ order_out, std::int64_t * __restrict__ inverse_out,
-  std::int64_t * __restrict__ stage_counts_inout, std::int32_t stage_index,
+  std::int64_t * __restrict__ level_counts_inout, std::int32_t stage_index,
   std::int32_t pooling_depth, std::int32_t num_orders, std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -490,10 +490,10 @@ __global__ void fillPoolingStageKernel(
   // stage's input count (the original serialized_code is laid out [2, num_voxels]) and the output
   // by the stage's output count. Using `capacity` as the stride here would both misread the
   // dense input and produce a non-dense output that TensorRT cannot consume.
-  const auto input_count = stage_counts_inout[stage_index];
+  const auto input_count = level_counts_inout[stage_index];
   const auto next_count = run_ids_in[capacity - 1];
   if (idx == 0) {
-    stage_counts_inout[stage_index + 1] = next_count;
+    level_counts_inout[stage_index + 1] = next_count;
     indptr_out[next_count] = input_count;
   }
 
@@ -536,15 +536,15 @@ __global__ void fillPoolingStageKernel(
  *
  * @param order_in Input level's serialization orders, laid out [num_orders, input_count].
  * @param cluster_in Parent segment index of each input voxel (see fillPoolingStageKernel).
- * @param stage_counts_in Per-level voxel counts; entry `stage_index` is the input level's count.
+ * @param level_counts_in Per-level voxel counts; entry `stage_index` is the input level's count.
  * @param run_flags_out Flags: 1 where the parent changes, 0 elsewhere (including padding).
- * @param stage_index Level the input arrays describe.
+ * @param stage_index Pooling stage the input arrays describe; its input is level `stage_index`.
  * @param order_index Serialization order being walked.
  * @param capacity Padded length of the arrays (max_num_voxels).
  */
 __global__ void markOrderRunsKernel(
   const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster_in,
-  const std::int64_t * __restrict__ stage_counts_in, std::int64_t * __restrict__ run_flags_out,
+  const std::int64_t * __restrict__ level_counts_in, std::int64_t * __restrict__ run_flags_out,
   std::int32_t stage_index, std::int32_t order_index, std::int64_t capacity)
 {
   const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
@@ -552,7 +552,7 @@ __global__ void markOrderRunsKernel(
     return;
   }
 
-  const auto input_count = stage_counts_in[stage_index];
+  const auto input_count = level_counts_in[stage_index];
   if (idx >= input_count) {
     run_flags_out[idx] = 0;
     return;
@@ -567,7 +567,7 @@ __global__ void markOrderRunsKernel(
 __global__ void fillOrderAndInverseKernel(
   const std::int64_t * __restrict__ order_in, const std::int64_t * __restrict__ cluster_in,
   const std::int64_t * __restrict__ run_flags_in, const std::int64_t * __restrict__ run_ids_in,
-  const std::int64_t * __restrict__ stage_counts_in, std::int64_t * __restrict__ order_out,
+  const std::int64_t * __restrict__ level_counts_in, std::int64_t * __restrict__ order_out,
   std::int64_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
   std::int64_t capacity)
 {
@@ -576,13 +576,13 @@ __global__ void fillOrderAndInverseKernel(
     return;
   }
 
-  const auto input_count = stage_counts_in[stage_index];
+  const auto input_count = level_counts_in[stage_index];
   if (idx >= input_count || run_flags_in[idx] == 0) {
     return;
   }
 
   // order/inverse are stored densely as [num_orders, out_count] to match the engine input layout.
-  const auto out_count = stage_counts_in[stage_index + 1];
+  const auto out_count = level_counts_in[stage_index + 1];
   const auto out_idx = run_ids_in[idx] - 1;
   const auto segment_index = cluster_in[order_in[order_index * input_count + idx]];
   order_out[order_index * out_count + out_idx] = segment_index;
@@ -600,7 +600,7 @@ std::int32_t poolingDepth(const std::int64_t stride)
 
 void PreprocessCuda::generateSerializedPoolingMetadata(
   const std::int32_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
-  const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts)
+  const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * level_counts)
 {
   if (stages.size() != config_.pooling_strides_.size()) {
     throw std::runtime_error("Serialized pooling stage buffer count does not match config.");
@@ -614,7 +614,7 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
     static_cast<std::size_t>(std::max<std::int64_t>(clamped_num_voxels, 1)),
     config_.threads_per_block_);
 
-  setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, clamped_num_voxels);
+  setInitialLevelCountKernel<<<1, 1, 0, stream_>>>(level_counts, clamped_num_voxels);
   CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
   // The input level is already sorted by order-0 code, so its order-0 row is simply 0..n-1. The
@@ -649,7 +649,7 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
     const auto pooling_depth = poolingDepth(config_.pooling_strides_[stage_index]);
 
     markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-      current_serialized_code, stage_counts, run_flags_d_.get(),
+      current_serialized_code, level_counts, run_flags_d_.get(),
       static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
@@ -661,14 +661,14 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
     fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       current_grid_coord, current_serialized_code, run_flags_d_.get(), run_ids_d_.get(),
       stage.indices, stage.indptr, stage.head_indices, stage.cluster, stage.grid_coord,
-      stage.serialized_code, stage.serialized_order, stage.serialized_inverse, stage_counts,
+      stage.serialized_code, stage.serialized_order, stage.serialized_inverse, level_counts,
       static_cast<std::int32_t>(stage_index), pooling_depth, num_orders, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
     // Order 0 was already written as the identity by fillPoolingStageKernel above.
     for (std::int32_t order_index = 1; order_index < num_orders; ++order_index) {
       markOrderRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-        current_order, stage.cluster, stage_counts, run_flags_d_.get(),
+        current_order, stage.cluster, level_counts, run_flags_d_.get(),
         static_cast<std::int32_t>(stage_index), order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
@@ -678,7 +678,7 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
           capacity, stream_));
 
       fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
-        current_order, stage.cluster, run_flags_d_.get(), run_ids_d_.get(), stage_counts,
+        current_order, stage.cluster, run_flags_d_.get(), run_ids_d_.get(), level_counts,
         stage.serialized_order, stage.serialized_inverse, static_cast<std::int32_t>(stage_index),
         order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -49,9 +49,9 @@ std::int64_t poolingDepth(const std::int64_t stride)
   return depth;
 }
 
-std::string stageFeatureName(const std::size_t stage_index)
+std::string levelFeatureName(const std::size_t level)
 {
-  return "point_feat_" + std::to_string(stage_index);
+  return "point_feat_" + std::to_string(level);
 }
 
 std::string poolingClusterName(const std::size_t stage_index)
@@ -59,9 +59,9 @@ std::string poolingClusterName(const std::size_t stage_index)
   return "pooling_cluster_" + std::to_string(stage_index);
 }
 
-std::string stageGridCoordName(const std::size_t stage_index)
+std::string levelGridCoordName(const std::size_t level)
 {
-  return "point_grid_coord_" + std::to_string(stage_index);
+  return "point_grid_coord_" + std::to_string(level);
 }
 
 }  // namespace
@@ -177,13 +177,13 @@ void PTv3TRT::initPtr()
   serialized_code_d_ =
     autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_ * 2);
 
-  // Encoder outputs shared with all the heads: one feature buffer per stage.
-  stage_feat_d_.clear();
-  stage_feat_d_.reserve(config_.enc_channels_.size());
-  for (std::size_t stage = 0; stage < config_.enc_channels_.size(); ++stage) {
-    stage_feat_d_.push_back(
+  // Encoder outputs shared with all the heads: one feature buffer per level.
+  level_feat_d_.clear();
+  level_feat_d_.reserve(config_.enc_channels_.size());
+  for (std::size_t level = 0; level < config_.enc_channels_.size(); ++level) {
+    level_feat_d_.push_back(
       autoware::cuda_utils::make_unique<float[]>(
-        config_.stage_voxel_capacity(stage) * config_.enc_channels_[stage]));
+        config_.level_voxel_capacity(level) * config_.enc_channels_[level]));
   }
 
   compact_points_d_ = autoware::cuda_utils::make_unique<std::uint8_t[]>(
@@ -261,11 +261,11 @@ void PTv3TRT::allocateSerializedPoolingBuffers()
     serialized_pooling_stages_d_.push_back(std::move(stage));
   }
 
-  serialized_pooling_num_voxels_d_ =
+  level_num_voxels_d_ =
     autoware::cuda_utils::make_unique<std::int64_t[]>(config_.pooling_strides_.size() + 1);
-  serialized_pooling_num_voxels_ = autoware::cuda_utils::make_unique_host<std::int64_t[]>(
+  level_num_voxels_ = autoware::cuda_utils::make_unique_host<std::int64_t[]>(
     config_.pooling_strides_.size() + 1, cudaHostAllocDefault);
-  std::fill_n(serialized_pooling_num_voxels_.get(), config_.pooling_strides_.size() + 1, 0);
+  std::fill_n(level_num_voxels_.get(), config_.pooling_strides_.size() + 1, 0);
   serialized_pooling_depths_.resize(config_.pooling_strides_.size());
   for (std::size_t stage_index = 0; stage_index < config_.pooling_strides_.size(); ++stage_index) {
     serialized_pooling_depths_[stage_index] = poolingDepth(config_.pooling_strides_[stage_index]);
@@ -306,11 +306,11 @@ void PTv3TRT::initEncoderTrt(const tensorrt_common::TrtCommonConfig & trt_config
   network_io.emplace_back(
     "serialized_code", nvinfer1::Dims{2, {2, -1}}, nvinfer1::DataType::kINT64);
 
-  // Outputs: per-encoder-stage point features point_feat_i [N_i, enc_channels[i]],
+  // Outputs: per-encoder-level point features point_feat_i [N_i, enc_channels[i]],
   // finest to deepest.
-  for (std::size_t stage = 0; stage < config_.enc_channels_.size(); ++stage) {
+  for (std::size_t level = 0; level < config_.enc_channels_.size(); ++level) {
     network_io.emplace_back(
-      stageFeatureName(stage), nvinfer1::Dims{2, {-1, config_.enc_channels_[stage]}},
+      levelFeatureName(level), nvinfer1::Dims{2, {-1, config_.enc_channels_[level]}},
       nvinfer1::DataType::kFLOAT);
   }
 
@@ -392,22 +392,21 @@ void PTv3TRT::initEncoderTrt(const tensorrt_common::TrtCommonConfig & trt_config
   encoder_trt_ptr_->setTensorAddress("grid_coord", grid_coord_d_.get());
   encoder_trt_ptr_->setTensorAddress("feat", feat_d_.get());
   encoder_trt_ptr_->setTensorAddress("serialized_code", serialized_code_d_.get());
-  for (std::size_t stage = 0; stage < stage_feat_d_.size(); ++stage) {
-    encoder_trt_ptr_->setTensorAddress(stageFeatureName(stage).c_str(), stage_feat_d_[stage].get());
+  for (std::size_t level = 0; level < level_feat_d_.size(); ++level) {
+    encoder_trt_ptr_->setTensorAddress(levelFeatureName(level).c_str(), level_feat_d_[level].get());
   }
   bindSerializedPoolingAddresses();
 }
 
-std::array<std::int64_t, 3> PTv3TRT::stageProfileCounts(const std::size_t stage_index) const
+std::array<std::int64_t, 3> PTv3TRT::levelProfileCounts(const std::size_t level) const
 {
-  // Head-engine [min, opt, max] profile counts for stage-sized inputs. Stage 0 consumes the
-  // original voxels and shares their lower bound; deeper stages consume an already-pooled
-  // count. The opt entry is only a tactic-selection hint (halving per stage approximates real
+  // Head-engine [min, opt, max] profile counts for level-sized inputs. Level 0 consumes the
+  // original voxels and shares their lower bound; deeper levels consume an already-pooled
+  // count. The opt entry is only a tactic-selection hint (halving per level approximates real
   // pooling); the max entry is the hard geometric bound.
-  const std::int64_t max_count = config_.stage_voxel_capacity(stage_index);
-  const std::int64_t min_count = stage_index == 0 ? config_.voxels_num_[0] : 1;
-  const std::int64_t opt_count =
-    std::clamp(config_.voxels_num_[1] >> stage_index, min_count, max_count);
+  const std::int64_t max_count = config_.level_voxel_capacity(level);
+  const std::int64_t min_count = level == 0 ? config_.voxels_num_[0] : 1;
+  const std::int64_t opt_count = std::clamp(config_.voxels_num_[1] >> level, min_count, max_count);
   return {min_count, opt_count, max_count};
 }
 
@@ -416,36 +415,36 @@ void PTv3TRT::initSeg3dHeadTrt(const tensorrt_common::TrtCommonConfig & trt_conf
   std::vector<autoware::tensorrt_common::NetworkIO> network_io;
   std::vector<autoware::tensorrt_common::ProfileDims> profile_dims;
 
-  // Inputs: per-encoder-stage features plus the per-pooling cluster tensors that drive the
-  // segmentation decoder's unpooling. Cluster s maps every stage-s voxel to its pooled voxel,
-  // so it is stage-s-count-sized.
-  const auto stage_count = config_.enc_channels_.size();
-  for (std::size_t stage = 0; stage < stage_count; ++stage) {
-    const auto counts = stageProfileCounts(stage);
-    const auto channels = config_.enc_channels_[stage];
+  // Inputs: per-encoder-level features plus the per-pooling cluster tensors that drive the
+  // segmentation decoder's unpooling. Cluster s maps every level-s voxel to its pooled voxel,
+  // so it is level-s-count-sized.
+  const auto level_count = config_.enc_channels_.size();
+  for (std::size_t level = 0; level < level_count; ++level) {
+    const auto counts = levelProfileCounts(level);
+    const auto channels = config_.enc_channels_[level];
     network_io.emplace_back(
-      stageFeatureName(stage), nvinfer1::Dims{2, {-1, channels}}, nvinfer1::DataType::kFLOAT);
+      levelFeatureName(level), nvinfer1::Dims{2, {-1, channels}}, nvinfer1::DataType::kFLOAT);
     profile_dims.emplace_back(
-      stageFeatureName(stage), nvinfer1::Dims{2, {counts[0], channels}},
+      levelFeatureName(level), nvinfer1::Dims{2, {counts[0], channels}},
       nvinfer1::Dims{2, {counts[1], channels}}, nvinfer1::Dims{2, {counts[2], channels}});
   }
-  for (std::size_t stage = 0; stage + 1 < stage_count; ++stage) {
-    const auto counts = stageProfileCounts(stage);
+  for (std::size_t level = 0; level + 1 < level_count; ++level) {
+    const auto counts = levelProfileCounts(level);
     network_io.emplace_back(
-      poolingClusterName(stage), nvinfer1::Dims{1, {-1}}, nvinfer1::DataType::kINT64);
+      poolingClusterName(level), nvinfer1::Dims{1, {-1}}, nvinfer1::DataType::kINT64);
     profile_dims.emplace_back(
-      poolingClusterName(stage), nvinfer1::Dims{1, {counts[0]}}, nvinfer1::Dims{1, {counts[1]}},
+      poolingClusterName(level), nvinfer1::Dims{1, {counts[0]}}, nvinfer1::Dims{1, {counts[1]}},
       nvinfer1::Dims{1, {counts[2]}});
   }
 
-  // Stages with decoder blocks additionally consume their serialization metadata
+  // Levels with decoder blocks additionally consume their serialization metadata
   const auto num_orders = static_cast<std::int64_t>(config_.serialization_orders_.size());
-  for (std::size_t stage = 0; stage + 1 < stage_count; ++stage) {
-    if (config_.dec_depths_[stage] == 0) {
+  for (std::size_t level = 0; level + 1 < level_count; ++level) {
+    if (config_.dec_depths_[level] == 0) {
       continue;
     }
-    const auto counts = stageProfileCounts(stage);
-    if (stage == 0) {
+    const auto counts = levelProfileCounts(level);
+    if (level == 0) {
       network_io.emplace_back(
         "serialized_code", nvinfer1::Dims{2, {num_orders, -1}}, nvinfer1::DataType::kINT64);
       profile_dims.emplace_back(
@@ -457,7 +456,7 @@ void PTv3TRT::initSeg3dHeadTrt(const tensorrt_common::TrtCommonConfig & trt_conf
         nvinfer1::Dims{2, {counts[2], 3}});
       continue;
     }
-    const auto prefix = "serialized_pooling_" + std::to_string(stage - 1) + "_";
+    const auto prefix = "serialized_pooling_" + std::to_string(level - 1) + "_";
     for (const auto & field :
          {std::string("serialized_order"), std::string("serialized_inverse")}) {
       network_io.emplace_back(
@@ -491,25 +490,25 @@ void PTv3TRT::initSeg3dHeadTrt(const tensorrt_common::TrtCommonConfig & trt_conf
 
   // Feature buffers are encoder outputs; cluster buffers are preprocessing outputs consumed
   // by the head engines. All addresses are stable (allocated once).
-  for (std::size_t stage = 0; stage < stage_count; ++stage) {
+  for (std::size_t level = 0; level < level_count; ++level) {
     seg3d_head_trt_ptr_->setTensorAddress(
-      stageFeatureName(stage).c_str(), stage_feat_d_[stage].get());
+      levelFeatureName(level).c_str(), level_feat_d_[level].get());
   }
-  for (std::size_t stage = 0; stage + 1 < stage_count; ++stage) {
+  for (std::size_t level = 0; level + 1 < level_count; ++level) {
     seg3d_head_trt_ptr_->setTensorAddress(
-      poolingClusterName(stage).c_str(), serialized_pooling_stages_d_[stage].cluster.get());
+      poolingClusterName(level).c_str(), serialized_pooling_stages_d_[level].cluster.get());
   }
-  for (std::size_t stage = 0; stage + 1 < stage_count; ++stage) {
-    if (config_.dec_depths_[stage] == 0) {
+  for (std::size_t level = 0; level + 1 < level_count; ++level) {
+    if (config_.dec_depths_[level] == 0) {
       continue;
     }
-    if (stage == 0) {
+    if (level == 0) {
       seg3d_head_trt_ptr_->setTensorAddress("serialized_code", serialized_code_d_.get());
       seg3d_head_trt_ptr_->setTensorAddress("grid_coord", grid_coord_d_.get());
       continue;
     }
-    const auto prefix = "serialized_pooling_" + std::to_string(stage - 1) + "_";
-    auto & buffers = serialized_pooling_stages_d_[stage - 1];
+    const auto prefix = "serialized_pooling_" + std::to_string(level - 1) + "_";
+    auto & buffers = serialized_pooling_stages_d_[level - 1];
     seg3d_head_trt_ptr_->setTensorAddress(
       (prefix + "serialized_order").c_str(), buffers.serialized_order.get());
     seg3d_head_trt_ptr_->setTensorAddress(
@@ -560,9 +559,9 @@ void PTv3TRT::precomputeSerializedPoolingMetadata()
 
   pre_ptr_->generateSerializedPoolingMetadata(
     grid_coord_d_.get(), serialized_code_d_.get(), num_voxels_, stage_views,
-    serialized_pooling_num_voxels_d_.get());
+    level_num_voxels_d_.get());
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
-    serialized_pooling_num_voxels_.get(), serialized_pooling_num_voxels_d_.get(),
+    level_num_voxels_.get(), level_num_voxels_d_.get(),
     (config_.pooling_strides_.size() + 1) * sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream_));
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 }
@@ -572,13 +571,14 @@ bool PTv3TRT::setSerializedPoolingInputShapes()
   bool success = true;
   const auto num_orders = static_cast<std::int64_t>(config_.serialization_orders_.size());
 
-  // serialized_pooling_num_voxels_[s] is the input count of stage s (entry 0 is num_voxels_).
+  // level_num_voxels_[l] is level l's voxel count (entry 0 is num_voxels_); pooling stage s
+  // consumes level s and produces level s + 1.
   // [s + 1] is its pooled output count, which sets the SegmentCSR output shape and the shape of
   // the metadata consumed by later PTv3 blocks.
   for (std::size_t stage = 0; stage < serialized_pooling_stages_d_.size(); ++stage) {
     const auto prefix = "serialized_pooling_" + std::to_string(stage) + "_";
-    const auto in_count = serialized_pooling_num_voxels_[stage];
-    const auto out_count = serialized_pooling_num_voxels_[stage + 1];
+    const auto in_count = level_num_voxels_[stage];
+    const auto out_count = level_num_voxels_[stage + 1];
     success &=
       encoder_trt_ptr_->setInputShape((prefix + "indices").c_str(), nvinfer1::Dims{1, {in_count}});
     success &= encoder_trt_ptr_->setInputShape(
@@ -601,42 +601,42 @@ void PTv3TRT::initDetection3DHeadTrt(const tensorrt_common::TrtCommonConfig & tr
   std::vector<autoware::tensorrt_common::NetworkIO> network_io;
   std::vector<autoware::tensorrt_common::ProfileDims> profile_dims;
 
-  // Inputs: the two coarsest encoder stages plus the pooling metadata that fuses them
-  // (the batch offset is computed in-graph from the skip-stage feature shape).
-  const auto stage_count = config_.enc_channels_.size();
-  const auto skip_stage = stage_count - 2;
-  const auto deep_stage = stage_count - 1;
-  const auto skip_counts = stageProfileCounts(skip_stage);
-  const auto deep_counts = stageProfileCounts(deep_stage);
-  const auto skip_channels = config_.enc_channels_[skip_stage];
-  const auto deep_channels = config_.enc_channels_[deep_stage];
+  // Inputs: the two coarsest encoder levels plus the pooling metadata that fuses them
+  // (the batch offset is computed in-graph from the skip-level feature shape).
+  const auto level_count = config_.enc_channels_.size();
+  const auto skip_level = level_count - 2;
+  const auto deep_level = level_count - 1;
+  const auto skip_counts = levelProfileCounts(skip_level);
+  const auto deep_counts = levelProfileCounts(deep_level);
+  const auto skip_channels = config_.enc_channels_[skip_level];
+  const auto deep_channels = config_.enc_channels_[deep_level];
 
   network_io.emplace_back(
-    stageFeatureName(skip_stage), nvinfer1::Dims{2, {-1, skip_channels}},
+    levelFeatureName(skip_level), nvinfer1::Dims{2, {-1, skip_channels}},
     nvinfer1::DataType::kFLOAT);
   profile_dims.emplace_back(
-    stageFeatureName(skip_stage), nvinfer1::Dims{2, {skip_counts[0], skip_channels}},
+    levelFeatureName(skip_level), nvinfer1::Dims{2, {skip_counts[0], skip_channels}},
     nvinfer1::Dims{2, {skip_counts[1], skip_channels}},
     nvinfer1::Dims{2, {skip_counts[2], skip_channels}});
 
   network_io.emplace_back(
-    stageFeatureName(deep_stage), nvinfer1::Dims{2, {-1, deep_channels}},
+    levelFeatureName(deep_level), nvinfer1::Dims{2, {-1, deep_channels}},
     nvinfer1::DataType::kFLOAT);
   profile_dims.emplace_back(
-    stageFeatureName(deep_stage), nvinfer1::Dims{2, {deep_counts[0], deep_channels}},
+    levelFeatureName(deep_level), nvinfer1::Dims{2, {deep_counts[0], deep_channels}},
     nvinfer1::Dims{2, {deep_counts[1], deep_channels}},
     nvinfer1::Dims{2, {deep_counts[2], deep_channels}});
 
   network_io.emplace_back(
-    poolingClusterName(skip_stage), nvinfer1::Dims{1, {-1}}, nvinfer1::DataType::kINT64);
+    poolingClusterName(skip_level), nvinfer1::Dims{1, {-1}}, nvinfer1::DataType::kINT64);
   profile_dims.emplace_back(
-    poolingClusterName(skip_stage), nvinfer1::Dims{1, {skip_counts[0]}},
+    poolingClusterName(skip_level), nvinfer1::Dims{1, {skip_counts[0]}},
     nvinfer1::Dims{1, {skip_counts[1]}}, nvinfer1::Dims{1, {skip_counts[2]}});
 
   network_io.emplace_back(
-    stageGridCoordName(skip_stage), nvinfer1::Dims{2, {-1, 3}}, nvinfer1::DataType::kINT32);
+    levelGridCoordName(skip_level), nvinfer1::Dims{2, {-1, 3}}, nvinfer1::DataType::kINT32);
   profile_dims.emplace_back(
-    stageGridCoordName(skip_stage), nvinfer1::Dims{2, {skip_counts[0], 3}},
+    levelGridCoordName(skip_level), nvinfer1::Dims{2, {skip_counts[0], 3}},
     nvinfer1::Dims{2, {skip_counts[1], 3}}, nvinfer1::Dims{2, {skip_counts[2], 3}});
 
   const auto det_cls = static_cast<std::int64_t>(config_.detection_class_names_.size());
@@ -670,17 +670,17 @@ void PTv3TRT::initDetection3DHeadTrt(const tensorrt_common::TrtCommonConfig & tr
   }
 
   detection3d_head_trt_ptr_->setTensorAddress(
-    stageFeatureName(skip_stage).c_str(), stage_feat_d_[skip_stage].get());
+    levelFeatureName(skip_level).c_str(), level_feat_d_[skip_level].get());
   detection3d_head_trt_ptr_->setTensorAddress(
-    stageFeatureName(deep_stage).c_str(), stage_feat_d_[deep_stage].get());
+    levelFeatureName(deep_level).c_str(), level_feat_d_[deep_level].get());
   detection3d_head_trt_ptr_->setTensorAddress(
-    poolingClusterName(skip_stage).c_str(), serialized_pooling_stages_d_[skip_stage].cluster.get());
-  // Pooled coordinates of the skip stage are the previous pooling stage's grid_coord output;
-  // a two-stage encoder would fall back to the input voxel coordinates.
+    poolingClusterName(skip_level).c_str(), serialized_pooling_stages_d_[skip_level].cluster.get());
+  // Pooled coordinates of the skip level are the previous pooling stage's grid_coord output;
+  // a two-level encoder would fall back to the input voxel coordinates.
   detection3d_head_trt_ptr_->setTensorAddress(
-    stageGridCoordName(skip_stage).c_str(),
-    skip_stage == 0 ? grid_coord_d_.get()
-                    : serialized_pooling_stages_d_[skip_stage - 1].grid_coord.get());
+    levelGridCoordName(skip_level).c_str(),
+    skip_level == 0 ? grid_coord_d_.get()
+                    : serialized_pooling_stages_d_[skip_level - 1].grid_coord.get());
   detection3d_head_trt_ptr_->setTensorAddress("dense_heatmap", dense_heatmap_d_.get());
   detection3d_head_trt_ptr_->setTensorAddress("query_heatmap_score", query_heatmap_score_d_.get());
   detection3d_head_trt_ptr_->setTensorAddress("query_labels", query_labels_d_.get());
@@ -978,39 +978,38 @@ bool PTv3TRT::inferenceEncoder()
 
 bool PTv3TRT::inferenceSeg3dHead()
 {
-  // serialized_pooling_num_voxels_[i] holds every encoder stage count (entry 0 is num_voxels_).
+  // level_num_voxels_[i] holds every encoder level count (entry 0 is num_voxels_).
   bool success = true;
-  const auto stage_count = config_.enc_channels_.size();
+  const auto level_count = config_.enc_channels_.size();
   const auto num_orders = static_cast<std::int64_t>(config_.serialization_orders_.size());
-  for (std::size_t stage = 0; stage < stage_count; ++stage) {
+  for (std::size_t level = 0; level < level_count; ++level) {
     success &= seg3d_head_trt_ptr_->setInputShape(
-      stageFeatureName(stage).c_str(),
-      nvinfer1::Dims{2, {serialized_pooling_num_voxels_[stage], config_.enc_channels_[stage]}});
+      levelFeatureName(level).c_str(),
+      nvinfer1::Dims{2, {level_num_voxels_[level], config_.enc_channels_[level]}});
   }
-  for (std::size_t stage = 0; stage + 1 < stage_count; ++stage) {
+  for (std::size_t level = 0; level + 1 < level_count; ++level) {
     success &= seg3d_head_trt_ptr_->setInputShape(
-      poolingClusterName(stage).c_str(),
-      nvinfer1::Dims{1, {serialized_pooling_num_voxels_[stage]}});
+      poolingClusterName(level).c_str(), nvinfer1::Dims{1, {level_num_voxels_[level]}});
   }
-  for (std::size_t stage = 0; stage + 1 < stage_count; ++stage) {
-    if (config_.dec_depths_[stage] == 0) {
+  for (std::size_t level = 0; level + 1 < level_count; ++level) {
+    if (config_.dec_depths_[level] == 0) {
       continue;
     }
-    const auto stage_count_voxels = serialized_pooling_num_voxels_[stage];
-    if (stage == 0) {
+    const auto level_num_voxels = level_num_voxels_[level];
+    if (level == 0) {
       success &= seg3d_head_trt_ptr_->setInputShape(
-        "serialized_code", nvinfer1::Dims{2, {num_orders, stage_count_voxels}});
-      success &= seg3d_head_trt_ptr_->setInputShape(
-        "grid_coord", nvinfer1::Dims{2, {stage_count_voxels, 3}});
+        "serialized_code", nvinfer1::Dims{2, {num_orders, level_num_voxels}});
+      success &=
+        seg3d_head_trt_ptr_->setInputShape("grid_coord", nvinfer1::Dims{2, {level_num_voxels, 3}});
       continue;
     }
-    const auto prefix = "serialized_pooling_" + std::to_string(stage - 1) + "_";
+    const auto prefix = "serialized_pooling_" + std::to_string(level - 1) + "_";
     success &= seg3d_head_trt_ptr_->setInputShape(
-      (prefix + "serialized_order").c_str(), nvinfer1::Dims{2, {num_orders, stage_count_voxels}});
+      (prefix + "serialized_order").c_str(), nvinfer1::Dims{2, {num_orders, level_num_voxels}});
     success &= seg3d_head_trt_ptr_->setInputShape(
-      (prefix + "serialized_inverse").c_str(), nvinfer1::Dims{2, {num_orders, stage_count_voxels}});
+      (prefix + "serialized_inverse").c_str(), nvinfer1::Dims{2, {num_orders, level_num_voxels}});
     success &= seg3d_head_trt_ptr_->setInputShape(
-      (prefix + "grid_coord").c_str(), nvinfer1::Dims{2, {stage_count_voxels, 3}});
+      (prefix + "grid_coord").c_str(), nvinfer1::Dims{2, {level_num_voxels, 3}});
   }
   if (!success) {
     RCLCPP_ERROR(rclcpp::get_logger("ptv3"), "Failed to set seg3d head input shapes.");
@@ -1025,23 +1024,23 @@ bool PTv3TRT::inferenceSeg3dHead()
 
 bool PTv3TRT::inferenceDetection3DHead()
 {
-  const auto stage_count = config_.enc_channels_.size();
-  const auto skip_stage = stage_count - 2;
-  const auto deep_stage = stage_count - 1;
-  const auto skip_count = serialized_pooling_num_voxels_[skip_stage];
-  const auto deep_count = serialized_pooling_num_voxels_[deep_stage];
+  const auto level_count = config_.enc_channels_.size();
+  const auto skip_level = level_count - 2;
+  const auto deep_level = level_count - 1;
+  const auto skip_count = level_num_voxels_[skip_level];
+  const auto deep_count = level_num_voxels_[deep_level];
 
   bool success = true;
   success &= detection3d_head_trt_ptr_->setInputShape(
-    stageFeatureName(skip_stage).c_str(),
-    nvinfer1::Dims{2, {skip_count, config_.enc_channels_[skip_stage]}});
+    levelFeatureName(skip_level).c_str(),
+    nvinfer1::Dims{2, {skip_count, config_.enc_channels_[skip_level]}});
   success &= detection3d_head_trt_ptr_->setInputShape(
-    stageFeatureName(deep_stage).c_str(),
-    nvinfer1::Dims{2, {deep_count, config_.enc_channels_[deep_stage]}});
+    levelFeatureName(deep_level).c_str(),
+    nvinfer1::Dims{2, {deep_count, config_.enc_channels_[deep_level]}});
   success &= detection3d_head_trt_ptr_->setInputShape(
-    poolingClusterName(skip_stage).c_str(), nvinfer1::Dims{1, {skip_count}});
+    poolingClusterName(skip_level).c_str(), nvinfer1::Dims{1, {skip_count}});
   success &= detection3d_head_trt_ptr_->setInputShape(
-    stageGridCoordName(skip_stage).c_str(), nvinfer1::Dims{2, {skip_count, 3}});
+    levelGridCoordName(skip_level).c_str(), nvinfer1::Dims{2, {skip_count, 3}});
   if (!success) {
     RCLCPP_ERROR(rclcpp::get_logger("ptv3"), "Failed to set Detection3D head input shapes.");
     return false;

--- a/perception/autoware_ptv3/test/ptv3_config_test.cpp
+++ b/perception/autoware_ptv3/test/ptv3_config_test.cpp
@@ -178,17 +178,17 @@ TEST(PTv3ConfigTest, SerializationDepthCoversUnalignedRangeBoundary)
   EXPECT_EQ(unaligned.serialization_depth_, 5);
 }
 
-// The same boundary coordinates count toward the per-stage voxel bound: 17 x 17 x 5 cells at
-// stage 0, ceil'd per stride-2 stage. A 16 x 16 x 4 bound would under-size the encoder stage
-// buffers and TensorRT profiles.
-TEST(PTv3ConfigTest, StageVoxelCapacityCoversUnalignedRangeBoundary)
+// The same boundary coordinates count toward the per-level voxel bound: 17 x 17 x 5 cells at
+// level 0, ceil'd per stride-2 pooling stage. A 16 x 16 x 4 bound would under-size the encoder
+// level buffers and TensorRT profiles.
+TEST(PTv3ConfigTest, LevelVoxelCapacityCoversUnalignedRangeBoundary)
 {
   const auto config = makeDetectionConfig(
     {0.5F, 0.5F, 0.5F, 16.5F, 16.5F, 4.5F}, {8.0F, 8.0F, 4.0F}, {10.0F, 20.0F},
     {0.1F, 0.2F, 0.3F, 0.4F}, {0.1F, 0.2F}, {1.0F, 1.0F, 1.0F}, {1, 1024, 4096});
-  EXPECT_EQ(config.stage_voxel_capacity(0), 17 * 17 * 5);
-  EXPECT_EQ(config.stage_voxel_capacity(1), 9 * 9 * 3);
-  EXPECT_EQ(config.stage_voxel_capacity(4), 2 * 2 * 1);
+  EXPECT_EQ(config.level_voxel_capacity(0), 17 * 17 * 5);
+  EXPECT_EQ(config.level_voxel_capacity(1), 9 * 9 * 3);
+  EXPECT_EQ(config.level_voxel_capacity(4), 2 * 2 * 1);
 }
 
 // Borders that are voxel-aligned in decimal but not exactly representable in binary (neither 102.4

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -292,7 +292,7 @@ TEST_F(SerializedPoolingMetadataTest, DetectionGridCoord3StaysInsideBevGrid)
   PreprocessCuda preprocess(config, stream_);
   auto grid_coord_d = makeDeviceBuffer<std::int32_t>(grid_coord.size());
   auto serialized_code_d = makeDeviceBuffer<std::int64_t>(serialized_code.size());
-  auto stage_counts_d = makeDeviceBuffer<std::int64_t>(config.pooling_strides_.size() + 1);
+  auto level_counts_d = makeDeviceBuffer<std::int64_t>(config.pooling_strides_.size() + 1);
   std::vector<DeviceStage> device_stages;
   std::vector<SerializedPoolingDeviceStageView> stage_views;
   for (std::size_t stage = 0; stage < config.pooling_strides_.size(); ++stage) {
@@ -309,14 +309,14 @@ TEST_F(SerializedPoolingMetadataTest, DetectionGridCoord3StaysInsideBevGrid)
   copyToDevice(grid_coord_d.get(), grid_coord);
   copyToDevice(serialized_code_d.get(), serialized_code);
   preprocess.generateSerializedPoolingMetadata(
-    grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, stage_counts_d.get());
+    grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, level_counts_d.get());
   ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
 
-  const auto stage_counts = copyToHost(stage_counts_d.get(), config.pooling_strides_.size() + 1);
+  const auto level_counts = copyToHost(level_counts_d.get(), config.pooling_strides_.size() + 1);
   // TODO(mojomex): generalize to other detection feature depth settings.
   const std::size_t point_grid_coord_3_stage = 2;
   const auto point_grid_coord_3_count =
-    static_cast<std::size_t>(stage_counts[point_grid_coord_3_stage + 1]);
+    static_cast<std::size_t>(level_counts[point_grid_coord_3_stage + 1]);
   const auto point_grid_coord_3 = copyToHost(
     device_stages[point_grid_coord_3_stage].grid_coord.get(), point_grid_coord_3_count * 3);
   for (std::size_t i = 0; i < point_grid_coord_3_count; ++i) {
@@ -343,7 +343,7 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForEdgeCaseClouds)
     // by order-0 code before upload.
     std::vector<std::int32_t> grid_coord;
     // Hand-verified voxel count per level: input, then one entry per pooling stage.
-    std::vector<std::int64_t> expected_stage_counts;
+    std::vector<std::int64_t> expected_level_counts;
     // Whether every level of two or more voxels must satisfy expect_orders_diverge.
     bool orders_diverge;
   };
@@ -382,7 +382,7 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForEdgeCaseClouds)
   PreprocessCuda preprocess(config, stream_);
   auto grid_coord_d = makeDeviceBuffer<std::int32_t>(config.max_num_voxels_ * 3);
   auto serialized_code_d = makeDeviceBuffer<std::int64_t>(config.max_num_voxels_ * kNumOrders);
-  auto stage_counts_d = makeDeviceBuffer<std::int64_t>(stage_count + 1);
+  auto level_counts_d = makeDeviceBuffer<std::int64_t>(stage_count + 1);
   std::vector<DeviceStage> device_stages;
   std::vector<SerializedPoolingDeviceStageView> stage_views;
   for (std::size_t stage = 0; stage < stage_count; ++stage) {
@@ -405,7 +405,7 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForEdgeCaseClouds)
     copyToDevice(grid_coord_d.get(), grid_coord);
     copyToDevice(serialized_code_d.get(), serialized_code);
     preprocess.generateSerializedPoolingMetadata(
-      grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, stage_counts_d.get());
+      grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, level_counts_d.get());
     ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
 
     std::vector<CpuStage> references;
@@ -417,14 +417,14 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForEdgeCaseClouds)
         config.pooling_strides_[stage]));
     }
 
-    const auto stage_counts = copyToHost(stage_counts_d.get(), stage_count + 1);
-    ASSERT_EQ(stage_counts, edge_case.expected_stage_counts) << edge_case.name;
+    const auto level_counts = copyToHost(level_counts_d.get(), stage_count + 1);
+    ASSERT_EQ(level_counts, edge_case.expected_level_counts) << edge_case.name;
 
     for (std::size_t stage_index = 0; stage_index < references.size(); ++stage_index) {
       const auto & expected = references[stage_index];
       const auto & actual = device_stages[stage_index];
-      const auto in_count = static_cast<std::size_t>(stage_counts[stage_index]);
-      const auto out_count = static_cast<std::size_t>(stage_counts[stage_index + 1]);
+      const auto in_count = static_cast<std::size_t>(level_counts[stage_index]);
+      const auto out_count = static_cast<std::size_t>(level_counts[stage_index + 1]);
       const auto prefix = edge_case.name + " stage " + std::to_string(stage_index) + " ";
 
       ASSERT_EQ(out_count, expected.head_indices.size()) << prefix + "out_count";
@@ -472,7 +472,7 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
   PreprocessCuda preprocess(config, stream_);
   auto grid_coord_d = makeDeviceBuffer<std::int32_t>(grid_coord.size());
   auto serialized_code_d = makeDeviceBuffer<std::int64_t>(serialized_code.size());
-  auto stage_counts_d = makeDeviceBuffer<std::int64_t>(config.pooling_strides_.size() + 1);
+  auto level_counts_d = makeDeviceBuffer<std::int64_t>(config.pooling_strides_.size() + 1);
   std::vector<DeviceStage> device_stages;
   std::vector<SerializedPoolingDeviceStageView> stage_views;
   for (std::size_t stage = 0; stage < config.pooling_strides_.size(); ++stage) {
@@ -490,7 +490,7 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
   copyToDevice(serialized_code_d.get(), serialized_code);
 
   preprocess.generateSerializedPoolingMetadata(
-    grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, stage_counts_d.get());
+    grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, level_counts_d.get());
   ASSERT_EQ(cudaStreamSynchronize(stream_), cudaSuccess);
 
   std::vector<CpuStage> references;
@@ -500,16 +500,16 @@ TEST_F(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     references[0].grid_coord, references[0].serialized_code, kNumOrders,
     config.pooling_strides_[1]));
 
-  const auto stage_counts = copyToHost(stage_counts_d.get(), config.pooling_strides_.size() + 1);
-  ASSERT_EQ(stage_counts[0], num_voxels);
-  ASSERT_EQ(stage_counts[1], static_cast<std::int64_t>(references[0].head_indices.size()));
-  ASSERT_EQ(stage_counts[2], static_cast<std::int64_t>(references[1].head_indices.size()));
+  const auto level_counts = copyToHost(level_counts_d.get(), config.pooling_strides_.size() + 1);
+  ASSERT_EQ(level_counts[0], num_voxels);
+  ASSERT_EQ(level_counts[1], static_cast<std::int64_t>(references[0].head_indices.size()));
+  ASSERT_EQ(level_counts[2], static_cast<std::int64_t>(references[1].head_indices.size()));
 
   for (std::size_t stage_index = 0; stage_index < references.size(); ++stage_index) {
     const auto & expected = references[stage_index];
     const auto & actual = device_stages[stage_index];
-    const auto in_count = static_cast<std::size_t>(stage_counts[stage_index]);
-    const auto out_count = static_cast<std::size_t>(stage_counts[stage_index + 1]);
+    const auto in_count = static_cast<std::size_t>(level_counts[stage_index]);
+    const auto out_count = static_cast<std::size_t>(level_counts[stage_index + 1]);
     const auto prefix = "stage " + std::to_string(stage_index) + " ";
 
     const auto indices = copyToHost(actual.indices.get(), in_count);


### PR DESCRIPTION
## Description

The package used one word, "stage", for two different things, so the same name indexed two
families of different cardinality. Point features, `enc_channels` and `dec_depths` run over the
encoder's **resolutions** — five of them for `enc_channels: [32, 64, 128, 256, 512]`. `pooling_strides`,
the pooling metadata and the `serialized_pooling_<i>_` tensors run over the **transitions** between
those resolutions — four of them. Code touching both families had to shift indices, and a comment
saying "stage" could not tell you which was meant.

This PR fixes the vocabulary. A **level** is a resolution; a **pooling stage** is
the transition between two levels, so there is always one more level than stage:

```text
level 0 --stage 0--> level 1 --stage 1--> level 2 --stage 2--> level 3 --stage 3--> level 4
```

Identifiers that index levels are renamed to say so:

| before                            | after                             |
| --------------------------------- | --------------------------------- |
| `stageFeatureName`                | `levelFeatureName`                |
| `stageGridCoordName`              | `levelGridCoordName`              |
| `stageProfileCounts`              | `levelProfileCounts`              |
| `stage_voxel_capacity`            | `level_voxel_capacity`            |
| `stage_feat_d_`                   | `level_feat_d_`                   |
| `serialized_pooling_num_voxels_`  | `level_num_voxels_`               |
| `stage_counts` (kernel parameter) | `level_counts`                    |
| `setInitialStageCountKernel`      | `setInitialLevelCountKernel`      |
| `skip_stage` / `deep_stage`       | `skip_level` / `deep_level`       |

Loop variables and the remaining locals follow. `serialized_pooling_num_voxels_` is the clearest
case: it is sized `pooling_strides_.size() + 1` and entry 0 is `num_voxels_`, so it was always a
per-level array wearing a per-stage name — `inferenceSeg3dHead` already indexed it by level.

Everything genuinely indexed by pooling stage keeps its name: `serialized_pooling_stages_d_`,
`serialized_pooling_depths_`, `pooling_strides_`, `poolingClusterName`, `SerializedPoolingDeviceStageView`,
and the `serialized_pooling_<i>_` ONNX prefix. In `serialized_pooling_metadata_test.cpp`, `stage_count`
really is `pooling_strides_.size()` and stays as it is.

`README.md` gains a short Terminology section, because the convention cannot be inferred from the
ONNX contract: `serialized_pooling_<i>_grid_coord`, `_serialized_order` and `_serialized_inverse`
are named after stage `i` but describe **level `i+1`**, the level that stage produced. That
off-by-one is exactly why code addressing both families shifts indices. `indices` and `indptr`
cannot be levelled at all — `indices` is level-`i`-sized and `indptr` is level-`i+1`-sized plus one,
so they span the transition and belong to the stage.

## Related links

**Parent Issue:**

- None

This is intended as the base for #13155, which makes the input level a uniform level 0 and reads
much more clearly in this vocabulary.

## How was this PR tested?

Rename-only, no special testing done.

## Notes for reviewers

The rename set was chosen by asking, for each identifier, whether its index runs `0..N` (level) or
`0..N-1` (stage). Two `stage == 0` conditionals survive and are deliberate: the `indices` profile
lower bound in `initEncoderTrt`, which really is about pooling stage 0's *input* count, and the
detection head's `point_grid_coord_<n>` buffer choice, which uses a different naming scheme.

`TEST(PTv3ConfigTest, StageVoxelCapacityCoversUnalignedRangeBoundary)` is renamed to
`LevelVoxelCapacity...` to match the method it exercises.

## Interface changes

None.

## Effects on system behavior

None.
