### PR TITLE
fix(autoware_bevfusion): reject point clouds with an unexpected point_step

### DIFF
--- a/perception/autoware_bevfusion/lib/bevfusion_trt.cpp
+++ b/perception/autoware_bevfusion/lib/bevfusion_trt.cpp
@@ -470,8 +470,14 @@ void BEVFusionTRT::setIntrinsicsExtrinsics(
 bool BEVFusionTRT::validatePointCloud(
   const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & pc_msg_ptr)
 {
-  if (!autoware::point_types::is_data_layout_compatible_with_point_xyzirc(pc_msg_ptr->fields)) {
-    RCLCPP_ERROR(rclcpp::get_logger("bevfusion"), "Invalid point type. Skipping detection.");
+  // The voxel generator strides the buffer by sizeof(InputPointType), so a prefix-compatible but
+  // wider layout would be misread.
+  if (
+    !autoware::point_types::is_data_layout_compatible_with_point_xyzirc(pc_msg_ptr->fields) ||
+    pc_msg_ptr->point_step != sizeof(InputPointType)) {
+    RCLCPP_ERROR_ONCE(
+      rclcpp::get_logger("bevfusion"), "Expected PointXYZIRC (point_step %zu), got %u. Skipping.",
+      sizeof(InputPointType), pc_msg_ptr->point_step);
     return false;
   }
 


### PR DESCRIPTION
## Description

[autoware::point_types::is_data_layout_compatible_with_point_xyzirc()](https://github.com/autowarefoundation/autoware_core/blob/f051fb98726f1a68ae3ebca7358eb64736882b32/common/autoware_point_types/include/autoware/point_types/memory.hpp#L66) accepts any point type that has XYZIRC's layout as a prefix. So, longer point types such as `PointXYZIRCAEDT` or the new autowarefoundation/autoware_core#1422 `PointXYZIRCT` pass this check.

However, BEVFusion expects exactly the 16B `PointXYZIRC`:

https://github.com/autowarefoundation/autoware_universe/blob/5bdcd2f825d2f00602f96c1d555997e5c6ba7641/perception/autoware_bevfusion/lib/preprocess/voxel_generator.cpp#L84

So, feeding point types like `PointXYZIRCAEDT` etc. would silently corrupt the model output.

This PR strengthens the guard clause to match only `PointXYZIRC` without extra bytes.

Groundwork for letting the concatenation node emit a per-point timestamp (`PointXYZIRCT`), which is exactly such a wider type.

## Related links

None.

## How was this PR tested?

N/A

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Clouds whose `point_step` is not `sizeof(InputPointType)` are skipped with an error instead of misread. No effect on correct input.
