### PR TITLE
fix(autoware_collision_detector): declare the operation mode state input as a remap target

### DIFF
--- a/control/autoware_collision_detector/design/CollisionDetector.node.yaml
+++ b/control/autoware_collision_detector/design/CollisionDetector.node.yaml
@@ -21,7 +21,7 @@ subscribers:
     message_type: autoware_perception_msgs/msg/PredictedObjects
   - name: operation_mode_state
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
-    global: /api/operation_mode/state
+    remap_target: /api/operation_mode/state
 
 publishers: []
 


### PR DESCRIPTION
## Description

`CollisionDetector.node.yaml` declares its `operation_mode_state` subscriber with `global: /api/operation_mode/state`. A global port cannot be the target of a design connection, so the `api_operation_mode_state` link that autowarefoundation/autoware_launch#1965 wires into `collision_detector` inside `ControlChecker.module` is dropped, and the sample system deployment fails with:

```
[E_PORT_MISSING] input port 'api_operation_mode_state' not in 'control_checker'
```

This PR switches the declaration to `remap_target: /api/operation_mode/state`. The node still resolves to the same topic when the port is left unconnected; the port simply becomes connectable.

One-line change in one package. Carved out of #13298 so the launch-side design work is not blocked on the full audit.

## Related links

- autowarefoundation/autoware_launch#1970 (map design modules; its `autoware_sample_designs` build hits the error above on current `main`)
- autowarefoundation/autoware_launch#1965 (introduced the `ControlChecker.module` link)
- #13298 (full node-design audit this is extracted from)

## How was this PR tested?

- `colcon build --packages-select autoware_sample_designs` with `autoware_launch` `main` and the #1970 branch: the `E_PORT_MISSING` error above disappears and the deployment exports all four modes.
- The node subscribes to the absolute name `/api/operation_mode/state` in code, so with the port unconnected the exported `control.launch.xml` carries an identity remap for that topic and the subscription is unchanged.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
