### PR TITLE
fix(autoware_lidar_centerpoint): reject point clouds with an unexpected point_step

### DIFF
--- a/perception/autoware_lidar_centerpoint/lib/centerpoint_trt.cpp
+++ b/perception/autoware_lidar_centerpoint/lib/centerpoint_trt.cpp
@@ -19,6 +19,7 @@
 #include "autoware/lidar_centerpoint/preprocess/preprocess_kernel.hpp"
 
 #include <autoware/cuda_utils/cuda_utils.hpp>
+#include <autoware/point_types/memory.hpp>
 #include <autoware_utils/math/constants.hpp>
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 
@@ -216,6 +217,19 @@ bool CenterPointTRT::preprocess(
   const tf2_ros::Buffer & tf_buffer)
 {
   using autoware::cuda_utils::clear_async;
+
+  // The voxel generator strides the buffer by sizeof(InputPointType), so a prefix-compatible but
+  // wider layout would be misread.
+  if (
+    !autoware::point_types::is_data_layout_compatible_with_point_xyzirc(
+      input_pointcloud_msg_ptr->fields) ||
+    input_pointcloud_msg_ptr->point_step != sizeof(InputPointType)) {
+    RCLCPP_ERROR_ONCE(
+      rclcpp::get_logger(config_.logger_name_.c_str()),
+      "Expected PointXYZIRC (point_step %zu), got %u. Skipping.", sizeof(InputPointType),
+      input_pointcloud_msg_ptr->point_step);
+    return false;
+  }
 
   bool is_success = vg_ptr_->enqueuePointCloud(input_pointcloud_msg_ptr, tf_buffer);
   if (!is_success) {

--- a/perception/autoware_lidar_centerpoint/package.xml
+++ b/perception/autoware_lidar_centerpoint/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_cuda_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_point_types</depend>
   <depend>autoware_tensorrt_common</depend>
   <depend>autoware_utils</depend>
   <depend>cuda_blackboard</depend>


### PR DESCRIPTION
## Description

[autoware::point_types::is_data_layout_compatible_with_point_xyzirc()](https://github.com/autowarefoundation/autoware_core/blob/f051fb98726f1a68ae3ebca7358eb64736882b32/common/autoware_point_types/include/autoware/point_types/memory.hpp#L66) accepts any point type that has XYZIRC's layout as a prefix. So, longer point types such as `PointXYZIRCAEDT` or the new autowarefoundation/autoware_core#1422 `PointXYZIRCT` pass this check.

However, CenterPoint expects exactly the 16B `PointXYZIRC`:

https://github.com/autowarefoundation/autoware_universe/blob/5bdcd2f825d2f00602f96c1d555997e5c6ba7641/perception/autoware_lidar_centerpoint/lib/preprocess/voxel_generator.cpp#L87

So, feeding point types like `PointXYZIRCAEDT` etc. would silently corrupt the model output. CenterPoint had no layout check at all so far.

This PR adds a guard clause that matches only `PointXYZIRC` without extra bytes.

Groundwork for letting the concatenation node emit a per-point timestamp (`PointXYZIRCT`), which is exactly such a wider type.

## Related links

None.

## How was this PR tested?

N/A

## Notes for reviewers

The check is in `CenterPointTRT::preprocess()` rather than `detect()`, so `PointPaintingTRT`, which has its own overloads of both and consumes a painted cloud, is unaffected.

## Interface changes

None.

## Effects on system behavior

Clouds whose `point_step` is not `sizeof(InputPointType)` are skipped with an error instead of misread. No effect on correct input.
