### PR TITLE
fix(autoware_ground_segmentation_cuda): reject point clouds with an unexpected point_step

### DIFF
--- a/perception/autoware_ground_segmentation_cuda/src/cuda_scan_ground_segmentation/cuda_scan_ground_segmentation_filter_node.cpp
+++ b/perception/autoware_ground_segmentation_cuda/src/cuda_scan_ground_segmentation/cuda_scan_ground_segmentation_filter_node.cpp
@@ -118,6 +118,18 @@ CudaScanGroundSegmentationFilterNode::CudaScanGroundSegmentationFilterNode(
 void CudaScanGroundSegmentationFilterNode::cudaPointCloudCallback(
   const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & msg)
 {
+  // The kernels stride the buffer by sizeof(PointTypeStruct), so a prefix-compatible but wider
+  // layout would be misread.
+  if (
+    !autoware::pointcloud_preprocessor::utils::is_data_layout_compatible_with_point_xyzirc(
+      msg->fields) ||
+    msg->point_step != sizeof(PointTypeStruct)) {
+    RCLCPP_ERROR_ONCE(
+      get_logger(), "Expected PointXYZIRC (point_step %zu), got %u. Skipping.",
+      sizeof(PointTypeStruct), msg->point_step);
+    return;
+  }
+
   // start time measurement
   if (stop_watch_ptr_) {
     stop_watch_ptr_->tic("processing_time");


### PR DESCRIPTION
## Description

[autoware::pointcloud_preprocessor::utils::is_data_layout_compatible_with_point_xyzirc()](https://github.com/autowarefoundation/autoware_universe/blob/5bdcd2f825d2f00602f96c1d555997e5c6ba7641/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/memory.hpp#L35) accepts any point type that has XYZIRC's layout as a prefix. So, longer point types such as `PointXYZIRCAEDT` or the new autowarefoundation/autoware_core#1422 `PointXYZIRCT` pass this check.

However, the CUDA scan ground filter expects exactly the 16B `PointXYZIRC`:

https://github.com/autowarefoundation/autoware_universe/blob/5bdcd2f825d2f00602f96c1d555997e5c6ba7641/perception/autoware_ground_segmentation_cuda/src/cuda_scan_ground_segmentation/cuda_scan_ground_segmentation_filter.cu#L798

So, feeding point types like `PointXYZIRCAEDT` etc. would silently corrupt the filter output. The node had no layout check at all so far.

This PR adds a guard clause that matches only `PointXYZIRC` without extra bytes.

Groundwork for letting the concatenation node emit a per-point timestamp (`PointXYZIRCT`), which is exactly such a wider type.

## Related links

None.

## How was this PR tested?

N/A

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Clouds whose `point_step` is not `sizeof(PointTypeStruct)` are skipped with an error instead of misread. No effect on correct input.
