### PR TITLE
fix(autoware_ptv3): validate point_step for XYZIRC input

### DIFF
--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -705,7 +705,10 @@ CloudFormat PTv3TRT::detectCloudFormat(const cuda_blackboard::CudaPointCloud2 & 
   if (num_fields == 9 && point_types::is_data_layout_compatible_with_point_xyziradrt(fields)) {
     return CloudFormat::XYZIRADRT;
   }
-  if (num_fields == 6 && point_types::is_data_layout_compatible_with_point_xyzirc(fields)) {
+  // A 6-field cloud can still be padded, so pin the stride preprocessing assumes.
+  if (
+    num_fields == 6 && point_types::is_data_layout_compatible_with_point_xyzirc(fields) &&
+    cloud.point_step == get_point_step(CloudFormat::XYZIRC)) {
     return CloudFormat::XYZIRC;
   }
   if (num_fields == 4 && point_types::is_data_layout_compatible_with_point_xyzi(fields)) {


### PR DESCRIPTION
## Description

`detectCloudFormat()` matches XYZIRC from a prefix layout check, so a 6-field cloud with a padded `point_step` matched and was then preprocessed at `get_point_step(format)` — the wrong stride, with no error. Require `point_step` to match for that branch.

Groundwork for a concatenated cloud carrying a per-point timestamp (`PointXYZIRCT`).

## Related links

**Parent Issue:**

- None

## How was this PR tested?

`colcon build` + `colcon test` on the package, plus `pre-commit`.

## Notes for reviewers

Only the XYZIRC branch needs this; the other formats are pinned by their exact field-count checks.

A mismatch yields `UNKNOWN`, which the existing startup check already turns into a descriptive `std::runtime_error`.

## Interface changes

None.

## Effects on system behavior

Such clouds now fail at startup with the existing "unsupported point cloud type" error instead of being misread. No effect on correct input.
