### PR TITLE
feat(autoware_mission_planner_universe): apply agnocast_wrapper::Node to MissionPlanner

### DIFF
--- a/planning/autoware_mission_planner_universe/CMakeLists.txt
+++ b/planning/autoware_mission_planner_universe/CMakeLists.txt
@@ -26,9 +26,11 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
 )
 target_link_libraries(${PROJECT_NAME}_component ${PROJECT_NAME}_lanelet2_plugins)
 
-rclcpp_components_register_node(${PROJECT_NAME}_component
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_component
   PLUGIN "autoware::mission_planner_universe::MissionPlanner"
   EXECUTABLE mission_planner
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}_component

--- a/planning/autoware_mission_planner_universe/launch/mission_planner.launch.xml
+++ b/planning/autoware_mission_planner_universe/launch/mission_planner.launch.xml
@@ -9,18 +9,22 @@
   <arg name="visualization_topic_name" default="/planning/mission_planning/route_marker"/>
   <arg name="mission_planner_param_path" default="$(find-pkg-share autoware_mission_planner_universe)/config/mission_planner.param.yaml"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
+  <node pkg="autoware_mission_planner_universe" exec="mission_planner" name="mission_planner" namespace="" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+    <param from="$(var mission_planner_param_path)"/>
+    <remap from="~/input/modified_goal" to="$(var modified_goal_topic_name)"/>
+    <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
+    <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+    <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
+    <remap from="~/input/reroute_availability" to="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/output/is_reroute_available"/>
+    <remap from="~/route" to="route"/>
+    <remap from="~/state" to="state"/>
+    <remap from="~/debug/route_marker" to="$(var visualization_topic_name)"/>
+  </node>
+
   <node_container pkg="rclcpp_components" exec="component_container_mt" name="mission_planner_container" namespace="">
-    <composable_node pkg="autoware_mission_planner_universe" plugin="autoware::mission_planner_universe::MissionPlanner" name="mission_planner" namespace="">
-      <param from="$(var mission_planner_param_path)"/>
-      <remap from="~/input/modified_goal" to="$(var modified_goal_topic_name)"/>
-      <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
-      <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-      <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
-      <remap from="~/input/reroute_availability" to="/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/output/is_reroute_available"/>
-      <remap from="~/route" to="route"/>
-      <remap from="~/state" to="state"/>
-      <remap from="~/debug/route_marker" to="$(var visualization_topic_name)"/>
-    </composable_node>
     <composable_node pkg="autoware_mission_planner_universe" plugin="autoware::mission_planner_universe::RouteSelector" name="route_selector" namespace="">
       <remap from="~/planner/clear_route" to="mission_planner/clear_route"/>
       <remap from="~/planner/set_lanelet_route" to="mission_planner/set_lanelet_route"/>

--- a/planning/autoware_mission_planner_universe/package.xml
+++ b/planning/autoware_mission_planner_universe/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -56,7 +56,7 @@ std::string route_state_to_string(const uint8_t state)
   }
 }
 
-ArrivalCheckerThreshold get_arrival_checker_threshold(rclcpp::Node & node)
+ArrivalCheckerThreshold get_arrival_checker_threshold(autoware::agnocast_wrapper::Node & node)
 {
   ArrivalCheckerThreshold threshold;
   threshold.angle =
@@ -72,10 +72,10 @@ ArrivalCheckerThreshold get_arrival_checker_threshold(rclcpp::Node & node)
 }  // namespace
 
 MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
-: Node("mission_planner", options),
+: autoware::agnocast_wrapper::Node("mission_planner", options),
   arrival_checker_(get_arrival_checker_threshold(*this)),
   tf_buffer_(get_clock()),
-  tf_listener_(tf_buffer_),
+  tf_listener_(tf_buffer_, *this),
   odometry_(nullptr),
   map_ptr_(nullptr)
 {
@@ -133,11 +133,13 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   // Route state will be published when the node gets ready for route api after initialization,
   // otherwise the mission planner rejects the request for the API.
   using namespace std::literals::chrono_literals;
-  data_check_timer_ =
-    rclcpp::create_timer(this, get_clock(), 0.1s, [this] { check_initialization(); });
+  data_check_timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), 0.1s, [this] { check_initialization(); });
   is_mission_planner_ready_ = false;
 
-  logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
+  logger_configure_ =
+    std::make_unique<autoware_utils::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>(
+      this);
   pub_processing_time_ = this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "~/debug/processing_time_ms", 1);
 }
@@ -195,7 +197,7 @@ void MissionPlanner::check_initialization()
   data_check_timer_ = nullptr;
 }
 
-void MissionPlanner::on_odometry(const Odometry::ConstSharedPtr msg)
+void MissionPlanner::on_odometry(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Odometry) & msg)
 {
   odometry_ = msg;
   arrival_checker_.update(*msg);
@@ -208,12 +210,13 @@ void MissionPlanner::on_odometry(const Odometry::ConstSharedPtr msg)
   }
 }
 
-void MissionPlanner::on_operation_mode_state(const OperationModeState::ConstSharedPtr msg)
+void MissionPlanner::on_operation_mode_state(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(OperationModeState) & msg)
 {
   operation_mode_state_ = msg;
 }
 
-void MissionPlanner::on_map(const LaneletMapBin::ConstSharedPtr msg)
+void MissionPlanner::on_map(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg)
 {
   map_ptr_ = msg;
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
@@ -241,7 +244,8 @@ void MissionPlanner::change_state(RouteState::_state_type state)
   pub_state_->publish(state_);
 }
 
-void MissionPlanner::on_modified_goal(const PoseWithUuidStamped::ConstSharedPtr msg)
+void MissionPlanner::on_modified_goal(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(PoseWithUuidStamped) & msg)
 {
   RCLCPP_INFO(get_logger(), "Received modified goal.");
 
@@ -328,7 +332,7 @@ void MissionPlanner::on_set_lanelet_route(
   }
 
   if (is_reroute && is_autonomous_driving) {
-    const auto reroute_availability = sub_reroute_availability_.take_data();
+    const auto reroute_availability = sub_reroute_availability_->take_data();
     if (!reroute_availability || !reroute_availability->availability) {
       throw service_utils::ServiceException(
         ResponseCode::ERROR_INVALID_STATE,
@@ -407,7 +411,7 @@ void MissionPlanner::on_set_preferred_primitive(
                           : false;
 
   if (is_reroute && is_autonomous_driving) {
-    const auto reroute_availability = sub_reroute_availability_.take_data();
+    const auto reroute_availability = sub_reroute_availability_->take_data();
     if (!reroute_availability || !reroute_availability->availability) {
       throw service_utils::ServiceException(
         autoware_adapi_v1_msgs::srv::SetRoute::Response::ERROR_INVALID_STATE,
@@ -482,7 +486,7 @@ void MissionPlanner::on_set_waypoint_route(
                           : false;
 
   if (is_reroute && is_autonomous_driving) {
-    const auto reroute_availability = sub_reroute_availability_.take_data();
+    const auto reroute_availability = sub_reroute_availability_->take_data();
     if (!reroute_availability || !reroute_availability->availability) {
       throw service_utils::ServiceException(
         ResponseCode::ERROR_INVALID_STATE,

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.hpp
@@ -16,8 +16,11 @@
 #define MISSION_PLANNER__MISSION_PLANNER_HPP_
 
 #include "arrival_checker.hpp"
-#include "autoware_utils/ros/polling_subscriber.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware/mission_planner_universe/default_planner.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils/ros/logger_level_configure.hpp>
@@ -36,9 +39,6 @@
 #include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
 #include <tier4_planning_msgs/msg/reroute_availability.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <memory>
 #include <string>
@@ -65,7 +65,7 @@ using tier4_planning_msgs::msg::RerouteAvailability;
 using unique_identifier_msgs::msg::UUID;
 using visualization_msgs::msg::MarkerArray;
 
-class MissionPlanner : public rclcpp::Node
+class MissionPlanner : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit MissionPlanner(const rclcpp::NodeOptions & options);
@@ -76,39 +76,40 @@ private:
   std::shared_ptr<lanelet2::DefaultPlanner> planner_;
 
   std::string map_frame_;
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  autoware::agnocast_wrapper::TransformListener tf_listener_;
   Pose transform_pose(const Pose & pose, const Header & header);
 
-  rclcpp::Service<ClearRoute>::SharedPtr srv_clear_route;
-  rclcpp::Service<SetLaneletRoute>::SharedPtr srv_set_lanelet_route;
-  rclcpp::Service<SetPreferredPrimitive>::SharedPtr srv_set_preferred_primitive;
-  rclcpp::Service<SetWaypointRoute>::SharedPtr srv_set_waypoint_route;
-  rclcpp::Publisher<RouteState>::SharedPtr pub_state_;
-  rclcpp::Publisher<LaneletRoute>::SharedPtr pub_route_;
+  AUTOWARE_SERVICE_PTR(ClearRoute) srv_clear_route;
+  AUTOWARE_SERVICE_PTR(SetLaneletRoute) srv_set_lanelet_route;
+  AUTOWARE_SERVICE_PTR(SetPreferredPrimitive) srv_set_preferred_primitive;
+  AUTOWARE_SERVICE_PTR(SetWaypointRoute) srv_set_waypoint_route;
+  AUTOWARE_PUBLISHER_PTR(RouteState) pub_state_;
+  AUTOWARE_PUBLISHER_PTR(LaneletRoute) pub_route_;
 
-  rclcpp::Subscription<PoseWithUuidStamped>::SharedPtr sub_modified_goal_;
-  rclcpp::Subscription<Odometry>::SharedPtr sub_odometry_;
-  rclcpp::Subscription<OperationModeState>::SharedPtr sub_operation_mode_state_;
-  autoware_utils::InterProcessPollingSubscriber<RerouteAvailability> sub_reroute_availability_{
-    this, "~/input/reroute_availability"};
+  AUTOWARE_SUBSCRIPTION_PTR(PoseWithUuidStamped) sub_modified_goal_;
+  AUTOWARE_SUBSCRIPTION_PTR(Odometry) sub_odometry_;
+  AUTOWARE_SUBSCRIPTION_PTR(OperationModeState) sub_operation_mode_state_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<RerouteAvailability>::SharedPtr
+    sub_reroute_availability_{
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<RerouteAvailability>(
+        this, "~/input/reroute_availability")};
 
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_vector_map_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_goal_footprint_marker_;
-  Odometry::ConstSharedPtr odometry_;
-  OperationModeState::ConstSharedPtr operation_mode_state_;
-  LaneletMapBin::ConstSharedPtr map_ptr_;
+  AUTOWARE_SUBSCRIPTION_PTR(LaneletMapBin) sub_vector_map_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) pub_marker_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) pub_goal_footprint_marker_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(Odometry) odometry_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(OperationModeState) operation_mode_state_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) map_ptr_;
   RouteState state_;
   std::optional<LaneletRoute::SharedPtr> original_route_;
   LaneletRoute::ConstSharedPtr current_route_;
   lanelet::LaneletMapPtr lanelet_map_ptr_{nullptr};
 
-  void on_odometry(const Odometry::ConstSharedPtr msg);
-  void on_operation_mode_state(const OperationModeState::ConstSharedPtr msg);
-  void on_map(const LaneletMapBin::ConstSharedPtr msg);
-  void on_reroute_availability(const RerouteAvailability::ConstSharedPtr msg);
-  void on_modified_goal(const PoseWithUuidStamped::ConstSharedPtr msg);
+  void on_odometry(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Odometry) & msg);
+  void on_operation_mode_state(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(OperationModeState) & msg);
+  void on_map(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg);
+  void on_modified_goal(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(PoseWithUuidStamped) & msg);
 
   void on_clear_route(
     const ClearRoute::Request::SharedPtr req, const ClearRoute::Response::SharedPtr res);
@@ -138,7 +139,7 @@ private:
   void print_pose_log(
     const std::string & route_type, const Pose & initial_pose, const Pose & goal_pose);
 
-  rclcpp::TimerBase::SharedPtr data_check_timer_;
+  AUTOWARE_TIMER_PTR data_check_timer_;
   void check_initialization();
   bool is_mission_planner_ready_;
 
@@ -150,9 +151,9 @@ private:
   float goal_lanelet_transparency_;
   bool check_reroute_safety(const LaneletRoute & original_route, const LaneletRoute & target_route);
 
-  std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    pub_processing_time_;
+  std::unique_ptr<autoware_utils::BasicLoggerLevelConfigure<autoware::agnocast_wrapper::Node>>
+    logger_configure_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped) pub_processing_time_;
 };
 
 }  // namespace autoware::mission_planner_universe


### PR DESCRIPTION
## Description

Apply `agnocast_wrapper::Node` to `autoware_mission_planner_universe` (`MissionPlanner`).
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption.
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node takes [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integration methods.

This PR supersedes #13057, which will be closed once this one is merged.
#13057 was written on top of #13120, and #13120 was superseded by #13283, which removed pluginlib from `DefaultPlanner` rather than threading a `Context` struct through it.
Rebasing #13057 onto that was no longer meaningful, so the change was rewritten against current `main`, which brought the diff down from 9 files to 5.

**AgnocastOnlyCallbackIsolatedExecutor:**
When built and run with `ENABLE_AGNOCAST=1`, the node runs on a `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

1. It was originally running on a `SingleThreadedExecutor`.
2. It has multiple callback groups (the default is one).
3. Shared variables are accessed across those callback groups without mutex protection.

`MissionPlanner` does not meet condition 2: it never calls `create_callback_group`, so every callback stays in the node's single default mutually exclusive group.
CIE spawns one single-threaded executor per callback group, so with a single group the callbacks stay serialized, exactly as they were under the `MultiThreadedExecutor` of `component_container_mt`.
`ROS2_EXECUTOR` is set to `MultiThreadedExecutor` so that the `ENABLE_AGNOCAST=0` path keeps the executor the container used.

## Related links

- https://github.com/autowarefoundation/autoware/issues/7007
- https://github.com/orgs/autowarefoundation/discussions/6804
- #13057 (superseded by this PR)
- #13283 (prerequisite, merged)

## How was this PR tested?

Built with `ENABLE_AGNOCAST=1` against agnocast `2.4.0`, and ran `planning_simulator` on `sample-map-planning` from the same initial pose to the same goal in both runtime modes, recording `/localization/kinematic_state` for 30 s after engaging autonomous:

| | driven distance | top speed | time stopped | `mission_planner` errors |
|---|---|---|---|---|
| `ENABLE_AGNOCAST=1` | 124.3 m | 4.31 m/s | 0 % | 0 |
| `ENABLE_AGNOCAST=0` | 124.4 m | 4.30 m/s | 0 % | 0 |

Under `=1` the node starts as a standalone node with the heaphook preloaded by `agnocast_env.launch.xml` and logs `Starti
Two processes exit non-zero at shutdown, `motion_planning_container` with SIGSEGV and `map_hash_generator` with exit code 1, but they do so identically with and without agnocast, so they are pre-existing and unrelated to this change.

The package's gtest suites pass under `=1`: 14 cases for `DefaultPlanner` and the utility functions, 21 cases for `ArrivalChecker`, 0 failures.
None of the three test files constructs an `rclcpp::Node` or calls `rclcpp::init`, so no `ENABLE_AGNOCAST` gating was nee

## Notes for reviewers

`mission_planner` is moved out of `mission_planner_container` and launched as a standalone node, since a Method 2 node caontainer.
`route_selector` is the only other node in that container and is untouched; `goal_pose_visualizer` already had its own launch file as a standalone node.
`launch/mission_planner.launch.xml` now includes `agnocast_env.launch.xml` and sets `LD_PRELOAD` itself, so `tier4_planni change and no `autoware_launch` PR accompanies this one.

One dead declaration was removed while migrating: `MissionPlanner::on_reroute_availability(const RerouteAvailability::Con the header but never defined or used, and `reroute_availability` is read through the polling subscriber's `take_data()`.

If you verify the `=1` case in a simulator, note that autowarefoundation/autoware_core#1418 is needed for the vehicle to
`autoware_velocity_smoother` still calls `rclcpp::ok()` in `resample.cpp`, which is always false under an agnocast-only executor, so the trajectory comes out with zero velocity regardless of this PR.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
