### PR TITLE
feat(autoware_cuda_pointcloud_preprocessor): add output_point_type to emit PointXYZIRCT

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
@@ -1,6 +1,7 @@
 /**:
   ros__parameters:
     base_frame: base_link
+    output_point_type: XYZIRC
     use_imu: true
     use_3d_distortion_correction: false
     distance_ratio: 1.03

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/common_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/common_kernels.hpp
@@ -35,10 +35,13 @@ void combineMasksLaunch(
   const std::uint32_t * mask1, const std::uint32_t * mask2, int num_points,
   std::uint32_t * output_mask, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
+/// Compacts the masked points into `output_points`. OutputPointT is either OutputPointType
+/// (XYZIRC) or autoware::point_types::PointXYZIRCT, which additionally receives the input's
+/// time_stamp.
+template <typename OutputPointT>
 void extractPointsLaunch(
   InputPointType * input_points, std::uint32_t * masks, std::uint32_t * indices, int num_points,
-  OutputPointType * output_points, int threads_per_block, int blocks_per_grid,
-  cudaStream_t & stream);
+  OutputPointT * output_points, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
 }  // namespace autoware::cuda_pointcloud_preprocessor
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -59,8 +59,10 @@ class CudaPointcloudPreprocessor
 {
 public:
   enum class UndistortionType { Invalid, Undistortion2D, Undistortion3D };
+  enum class OutputPointFormat { XYZIRC, XYZIRCT };
 
-  explicit CudaPointcloudPreprocessor(const PreprocessorCapacity & capacity);
+  CudaPointcloudPreprocessor(
+    const PreprocessorCapacity & capacity, OutputPointFormat output_point_format);
 
   void setCropBoxParameters(const std::vector<CropBoxParameters> & crop_box_parameters);
   void setRingOutlierFilterParameters(const RingOutlierFilterParameters & ring_outlier_parameters);
@@ -95,6 +97,8 @@ private:
   std::size_t num_organized_points_{};
   std::size_t num_raw_points_{};
 
+  OutputPointFormat output_point_format_;
+  std::size_t output_point_step_{};
   std::vector<sensor_msgs::msg::PointField> point_fields_;
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> output_pointcloud_ptr_;
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
@@ -11,6 +11,12 @@
           "description": "The undistortion algorithm is based on a base frame, which must be the same as the twist frame.",
           "default": "base_link"
         },
+        "output_point_type": {
+          "type": "string",
+          "enum": ["XYZIRC", "XYZIRCT"],
+          "description": "Point type of the published cloud. XYZIRCT additionally carries each point's time_stamp (nanoseconds relative to the header stamp), copied from the input.",
+          "default": "XYZIRC"
+        },
         "use_imu": {
           "type": "boolean",
           "description": "Use IMU angular velocity, otherwise, use twist angular velocity.",
@@ -116,6 +122,7 @@
       },
       "required": [
         "base_frame",
+        "output_point_type",
         "use_imu",
         "use_3d_distortion_correction",
         "distance_ratio",

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
@@ -17,6 +17,10 @@
 #include "autoware/cuda_pointcloud_preprocessor/types.hpp"
 
 #include <autoware/cuda_utils/cuda_check_error.hpp>
+#include <autoware/point_types/types.hpp>
+
+#include <cstdint>
+#include <type_traits>
 
 namespace autoware::cuda_pointcloud_preprocessor
 {
@@ -94,21 +98,24 @@ __global__ void combineMasksKernel(
   }
 }
 
+template <typename OutputPointT>
 __global__ void extractPointsKernel(
   InputPointType * __restrict__ input_points, std::uint32_t * __restrict__ masks,
-  std::uint32_t * __restrict__ indices, int num_points,
-  OutputPointType * __restrict__ output_points)
+  std::uint32_t * __restrict__ indices, int num_points, OutputPointT * __restrict__ output_points)
 {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_points && masks[idx] == 1) {
     InputPointType & input_point = input_points[idx];
-    OutputPointType & output_point = output_points[indices[idx] - 1];
+    OutputPointT & output_point = output_points[indices[idx] - 1];
     output_point.x = input_point.x;
     output_point.y = input_point.y;
     output_point.z = input_point.z;
     output_point.intensity = input_point.intensity;
     output_point.return_type = input_point.return_type;
     output_point.channel = input_point.channel;
+    if constexpr (std::is_same_v<OutputPointT, autoware::point_types::PointXYZIRCT>) {
+      output_point.time_stamp = input_point.time_stamp;
+    }
   }
 }
 
@@ -141,14 +148,21 @@ void combineMasksLaunch(
   CHECK_CUDA_ERROR(cudaGetLastError());
 }
 
+template <typename OutputPointT>
 void extractPointsLaunch(
   InputPointType * input_points, std::uint32_t * masks, std::uint32_t * indices, int num_points,
-  OutputPointType * output_points, int threads_per_block, int blocks_per_grid,
-  cudaStream_t & stream)
+  OutputPointT * output_points, int threads_per_block, int blocks_per_grid, cudaStream_t & stream)
 {
   extractPointsKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
     input_points, masks, indices, num_points, output_points);
   CHECK_CUDA_ERROR(cudaGetLastError());
 }
+
+template void extractPointsLaunch<OutputPointType>(
+  InputPointType *, std::uint32_t *, std::uint32_t *, int, OutputPointType *, int, int,
+  cudaStream_t &);
+template void extractPointsLaunch<autoware::point_types::PointXYZIRCT>(
+  InputPointType *, std::uint32_t *, std::uint32_t *, int, autoware::point_types::PointXYZIRCT *,
+  int, int, cudaStream_t &);
 
 }  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -24,6 +24,8 @@
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 #include <autoware/cuda_utils/cuda_check_error.hpp>
+#include <autoware/point_types/memory.hpp>
+#include <autoware/point_types/types.hpp>
 #include <cub/cub.cuh>
 
 #include <sensor_msgs/msg/point_field.hpp>
@@ -119,35 +121,22 @@ PreprocessorCapacity validate_capacity(const PreprocessorCapacity & capacity)
 
 }  // namespace
 
-CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(const PreprocessorCapacity & capacity)
+CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(
+  const PreprocessorCapacity & capacity, OutputPointFormat output_point_format)
 : capacity_(validate_capacity(capacity)),
   num_rings_(capacity_.max_ring_count),
   max_points_per_ring_(capacity_.max_points_per_ring),
   num_organized_points_(static_cast<std::size_t>(num_rings_) * max_points_per_ring_),
+  output_point_format_(output_point_format),
   stream_(initialize_stream())
 {
-  using sensor_msgs::msg::PointField;
-
-  auto make_point_field = [](
-                            const std::string & name, std::size_t offset,
-                            sensor_msgs::msg::PointField::_datatype_type datatype,
-                            std::size_t count) {
-    PointField field;
-    field.name = name;
-    field.offset = offset;
-    field.datatype = datatype;
-    field.count = count;
-    return field;
-  };
-
-  point_fields_ = {
-    make_point_field("x", 0, PointField::FLOAT32, 1),
-    make_point_field("y", 4, PointField::FLOAT32, 1),
-    make_point_field("z", 8, PointField::FLOAT32, 1),
-    make_point_field("intensity", 12, PointField::UINT8, 1),
-    make_point_field("return_type", 13, PointField::UINT8, 1),
-    make_point_field("channel", 14, PointField::UINT16, 1),
-  };
+  if (output_point_format_ == OutputPointFormat::XYZIRCT) {
+    point_fields_ = autoware::point_types::create_fields_point_xyzirct();
+    output_point_step_ = sizeof(autoware::point_types::PointXYZIRCT);
+  } else {
+    point_fields_ = autoware::point_types::create_fields_point_xyzirc();
+    output_point_step_ = sizeof(OutputPointType);
+  }
 
   int num_sm{};
   CHECK_CUDA_ERROR(cudaDeviceGetAttribute(&num_sm, cudaDevAttrMultiProcessorCount, 0));
@@ -255,7 +244,7 @@ void CudaPointcloudPreprocessor::preallocateOutput()
 {
   output_pointcloud_ptr_ = std::make_unique<cuda_blackboard::CudaPointCloud2>();
   output_pointcloud_ptr_->data = cuda_blackboard::make_unique<std::uint8_t[]>(
-    num_rings_ * max_points_per_ring_ * sizeof(OutputPointType));
+    num_rings_ * max_points_per_ring_ * output_point_step_);
 }
 
 void CudaPointcloudPreprocessor::organizePointcloud()
@@ -330,7 +319,7 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     output_pointcloud_ptr_->fields = point_fields_;
     output_pointcloud_ptr_->is_dense = true;
     output_pointcloud_ptr_->is_bigendian = input_pointcloud_msg.is_bigendian;
-    output_pointcloud_ptr_->point_step = sizeof(OutputPointType);
+    output_pointcloud_ptr_->point_step = output_point_step_;
     output_pointcloud_ptr_->header.stamp = input_pointcloud_msg.header.stamp;
 
     return std::move(output_pointcloud_ptr_);
@@ -523,23 +512,30 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   stats_.mismatch_count = static_cast<int>(processing_stats[mismatch_stat_index]);
 
   if (num_output_points > 0) {
-    extractPointsLaunch(
-      device_transformed_points, device_ring_outlier_mask, device_indices, num_organized_points_,
-      reinterpret_cast<OutputPointType *>(output_pointcloud_ptr_->data.get()), threads_per_block_,
-      blocks_per_grid, stream_);
+    if (output_point_format_ == OutputPointFormat::XYZIRCT) {
+      extractPointsLaunch(
+        device_transformed_points, device_ring_outlier_mask, device_indices, num_organized_points_,
+        reinterpret_cast<autoware::point_types::PointXYZIRCT *>(output_pointcloud_ptr_->data.get()),
+        threads_per_block_, blocks_per_grid, stream_);
+    } else {
+      extractPointsLaunch(
+        device_transformed_points, device_ring_outlier_mask, device_indices, num_organized_points_,
+        reinterpret_cast<OutputPointType *>(output_pointcloud_ptr_->data.get()), threads_per_block_,
+        blocks_per_grid, stream_);
+    }
   }
 
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 
   // Copy the transformed points back
-  output_pointcloud_ptr_->row_step = num_output_points * sizeof(OutputPointType);
+  output_pointcloud_ptr_->row_step = num_output_points * output_point_step_;
   output_pointcloud_ptr_->width = num_output_points;
   output_pointcloud_ptr_->height = 1;
 
   output_pointcloud_ptr_->fields = point_fields_;
   output_pointcloud_ptr_->is_dense = true;
   output_pointcloud_ptr_->is_bigendian = input_pointcloud_msg.is_bigendian;
-  output_pointcloud_ptr_->point_step = sizeof(OutputPointType);
+  output_pointcloud_ptr_->point_step = output_point_step_;
   output_pointcloud_ptr_->header.stamp = input_pointcloud_msg.header.stamp;
 
   return std::move(output_pointcloud_ptr_);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -41,6 +41,7 @@
 #include <cmath>
 #include <deque>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -142,6 +143,7 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   use_3d_undistortion_ = declare_parameter<bool>("use_3d_distortion_correction");
   use_imu_ = declare_parameter<bool>("use_imu");
   bool enable_ring_outlier_filter = declare_parameter<bool>("enable_ring_outlier_filter");
+  const auto output_point_type = declare_parameter<std::string>("output_point_type");
   input_bounds_params_.max_input_point_count =
     static_cast<std::size_t>(declare_parameter<int64_t>("max_input_point_count"));
   input_bounds_params_.max_ring_count =
@@ -252,12 +254,22 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
     use_3d_undistortion_ ? CudaPointcloudPreprocessor::UndistortionType::Undistortion3D
                          : CudaPointcloudPreprocessor::UndistortionType::Undistortion2D;
 
+  CudaPointcloudPreprocessor::OutputPointFormat output_point_format;
+  if (output_point_type == "XYZIRC") {
+    output_point_format = CudaPointcloudPreprocessor::OutputPointFormat::XYZIRC;
+  } else if (output_point_type == "XYZIRCT") {
+    output_point_format = CudaPointcloudPreprocessor::OutputPointFormat::XYZIRCT;
+  } else {
+    throw std::runtime_error(
+      "output_point_type must be 'XYZIRC' or 'XYZIRCT', got '" + output_point_type + "'");
+  }
+
   const PreprocessorCapacity preprocessor_capacity{
     input_bounds_params_.max_input_point_count, input_bounds_params_.max_ring_count,
     input_bounds_params_.max_points_per_ring,
     input_bounds_params_.max_twist_queue_size + input_bounds_params_.max_imu_queue_size};
   cuda_pointcloud_preprocessor_ =
-    std::make_unique<CudaPointcloudPreprocessor>(preprocessor_capacity);
+    std::make_unique<CudaPointcloudPreprocessor>(preprocessor_capacity, output_point_format);
   cuda_pointcloud_preprocessor_->setRingOutlierFilterParameters(ring_outlier_filter_parameters);
   cuda_pointcloud_preprocessor_->setRingOutlierFilterActive(enable_ring_outlier_filter);
   cuda_pointcloud_preprocessor_->setCropBoxParameters(crop_box_parameters);


### PR DESCRIPTION
## Description

`cuda_pointcloud_preprocessor` consumes `PointXYZIRCAEDT` and always emits the 16-byte `PointXYZIRC`, dropping the per-point `time_stamp` here:

https://github.com/autowarefoundation/autoware_universe/blob/5bdcd2f825d2f00602f96c1d555997e5c6ba7641/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu#L98-L112

Time-aware models downstream of the concatenation node need that stamp. This PR adds the required parameter `output_point_type` (`XYZIRC` | `XYZIRCT`). With `XYZIRCT` the node emits `PointXYZIRCT` (autowarefoundation/autoware_core#1422) and copies `time_stamp` through unchanged; it stays relative to the header stamp, which this node does not alter.

The extract kernel is templated on the output point type, and `point_fields_` now come from the `autoware_point_types` field factories instead of a hand-written list.

Groundwork for letting the concatenation node emit `PointXYZIRCT` (autowarefoundation/autoware_universe#13324). Independent of that PR, but the CUDA concatenation node only receives point times once this one is merged and enabled.

## Related links

None.

## How was this PR tested?

Built and linted locally. Runtime check on a recorded `PointXYZIRCAEDT` bag with `output_point_type: XYZIRCT`: for 8 consecutive clouds the output had `point_step` 20, exactly the `PointXYZIRCT` fields, and every output `time_stamp` value was present in the corresponding input cloud (~39.5k points in, ~32.8k out after crop box and ring outlier filtering).

## Notes for reviewers

`output_point_type` is a new required parameter (no C++ default, by project policy). Schema and default config set `XYZIRC`, which reproduces the current output byte for byte. autoware_launch carries no copy of this config.

## Interface changes

### ROS Parameter Changes

| Change type | Parameter Name      | Type     | Default Value | Description                                                  |
| :---------- | :------------------ | :------- | :------------ | :----------------------------------------------------------- |
| Added       | `output_point_type` | `string` | `XYZIRC`      | Point type of the published cloud, `XYZIRC` or `XYZIRCT`. |

## Effects on system behavior

None with the default. With `XYZIRCT`, the published cloud is 20 bytes per point and carries `time_stamp`; consumers that stride by `sizeof(PointXYZIRC)` must reject or handle it (#13311, #13313, #13314 do).
