### PR TITLE
feat(autoware_pointcloud_preprocessor, autoware_cuda_pointcloud_preprocessor): add output_point_type to the concatenation nodes

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -14,9 +14,11 @@
 
 #pragma once
 
+#include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
 #include "autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -41,11 +43,16 @@ protected:
   std::size_t max_concat_pointcloud_size_{0};
   std::mutex mutex_;
 
+  /// Dispatches transform_launch on the configured output point type.
+  void launch_transform(
+    const std::uint8_t * input, int num_points, const TransformStruct & transform,
+    std::uint32_t time_offset_ns, std::uint8_t * output, cudaStream_t & stream) const;
+
 public:
   CombineCloudHandler(
     rclcpp::Node & node, const std::vector<std::string> & input_topics, std::string output_frame,
     bool is_motion_compensated, bool publish_synchronized_pointcloud,
-    bool keep_input_frame_in_synchronized_pointcloud);
+    bool keep_input_frame_in_synchronized_pointcloud, OutputPointType output_point_type);
 
   ConcatenatedCloudResult<CudaPointCloud2Traits> combine_pointclouds(
     std::unordered_map<
@@ -54,6 +61,8 @@ public:
     const std::shared_ptr<CollectorInfoBase> & collector_info);
 
   void allocate_pointclouds() override;
+
+  bool is_input_layout_supported(const sensor_msgs::msg::PointCloud2 & cloud) const override;
 
   /// Returns the per-topic CUDA stream used while consuming that topic's cloud.
   /// Enables stream-ordered producer/consumer lifetime handling.

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp
@@ -15,6 +15,8 @@
 #ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CONCATENATE_DATA__CUDA_COMBINE_CLOUD_HANDLER_KERNEL_HPP_
 #define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CONCATENATE_DATA__CUDA_COMBINE_CLOUD_HANDLER_KERNEL_HPP_
 
+#include <autoware/point_types/types.hpp>
+
 #include <cuda_runtime.h>
 
 #include <cstdint>
@@ -38,19 +40,13 @@ struct TransformStruct
   float m33;
 };
 
-struct PointTypeStruct
-{
-  float x;
-  float y;
-  float z;
-  std::uint8_t intensity;
-  std::uint8_t return_type;
-  std::uint16_t channel;
-};
-
+/// Applies `transform` to `input_points` and writes the result to `output_points`. PointT is
+/// autoware::point_types::PointXYZIRC or PointXYZIRCT; for the latter, `time_offset_ns` is added
+/// to every point's time_stamp.
+template <typename PointT>
 void transform_launch(
-  const PointTypeStruct * input_points, int num_points, TransformStruct transform,
-  PointTypeStruct * output_points, cudaStream_t & stream);
+  const PointT * input_points, int num_points, TransformStruct transform,
+  std::uint32_t time_offset_ns, PointT * output_points, cudaStream_t & stream);
 
 }  // namespace autoware::pointcloud_preprocessor
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -23,34 +23,11 @@
 
 #include <cuda_runtime.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#define CHECK_OFFSET(structure1, structure2, field)             \
-  static_assert(                                                \
-    offsetof(structure1, field) == offsetof(structure2, field), \
-    "Offset of " #field " in " #structure1 " does not match expected offset.")
-
-static_assert(
-  sizeof(autoware::pointcloud_preprocessor::PointTypeStruct) ==
-  sizeof(autoware::point_types::PointXYZIRC));
-
-CHECK_OFFSET(
-  autoware::pointcloud_preprocessor::PointTypeStruct, autoware::point_types::PointXYZIRC, x);
-CHECK_OFFSET(
-  autoware::pointcloud_preprocessor::PointTypeStruct, autoware::point_types::PointXYZIRC, y);
-CHECK_OFFSET(
-  autoware::pointcloud_preprocessor::PointTypeStruct, autoware::point_types::PointXYZIRC, z);
-CHECK_OFFSET(
-  autoware::pointcloud_preprocessor::PointTypeStruct, autoware::point_types::PointXYZIRC,
-  intensity);
-CHECK_OFFSET(
-  autoware::pointcloud_preprocessor::PointTypeStruct, autoware::point_types::PointXYZIRC,
-  return_type);
-CHECK_OFFSET(
-  autoware::pointcloud_preprocessor::PointTypeStruct, autoware::point_types::PointXYZIRC, channel);
 
 namespace autoware::pointcloud_preprocessor
 {
@@ -58,10 +35,10 @@ namespace autoware::pointcloud_preprocessor
 CombineCloudHandler<CudaPointCloud2Traits>::CombineCloudHandler(
   rclcpp::Node & node, const std::vector<std::string> & input_topics, std::string output_frame,
   bool is_motion_compensated, bool publish_synchronized_pointcloud,
-  bool keep_input_frame_in_synchronized_pointcloud)
+  bool keep_input_frame_in_synchronized_pointcloud, OutputPointType output_point_type)
 : CombineCloudHandlerBase(
     node, input_topics, output_frame, is_motion_compensated, publish_synchronized_pointcloud,
-    keep_input_frame_in_synchronized_pointcloud)
+    keep_input_frame_in_synchronized_pointcloud, output_point_type)
 {
   for (const auto & topic : input_topics_) {
     CudaConcatStruct cuda_concat_struct;
@@ -84,6 +61,34 @@ void CombineCloudHandler<CudaPointCloud2Traits>::allocate_pointclouds()
   concatenated_cloud_ptr_ = std::make_unique<cuda_blackboard::CudaPointCloud2>();
   concatenated_cloud_ptr_->data =
     cuda_blackboard::make_unique<std::uint8_t[]>(max_concat_pointcloud_size_);
+}
+
+bool CombineCloudHandler<CudaPointCloud2Traits>::is_input_layout_supported(
+  const sensor_msgs::msg::PointCloud2 & cloud) const
+{
+  // The kernels stride the buffer by the output point size, so the input must have exactly the
+  // output layout.
+  if (cloud.point_step != output_point_step_) {
+    return false;
+  }
+  return output_point_type_ == OutputPointType::XYZIRCT
+           ? autoware::point_types::is_data_layout_compatible_with_point_xyzirct(cloud.fields)
+           : autoware::point_types::is_data_layout_compatible_with_point_xyzirc(cloud.fields);
+}
+
+void CombineCloudHandler<CudaPointCloud2Traits>::launch_transform(
+  const std::uint8_t * input, int num_points, const TransformStruct & transform,
+  std::uint32_t time_offset_ns, std::uint8_t * output, cudaStream_t & stream) const
+{
+  if (output_point_type_ == OutputPointType::XYZIRCT) {
+    transform_launch(
+      reinterpret_cast<const PointXYZIRCT *>(input), num_points, transform, time_offset_ns,
+      reinterpret_cast<PointXYZIRCT *>(output), stream);
+  } else {
+    transform_launch(
+      reinterpret_cast<const PointXYZIRC *>(input), num_points, transform, time_offset_ns,
+      reinterpret_cast<PointXYZIRC *>(output), stream);
+  }
 }
 
 ConcatenatedCloudResult<CudaPointCloud2Traits>
@@ -124,7 +129,6 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
     total_data_size += (cloud->height * cloud->row_step);
   }
 
-  const auto point_fields = topic_to_cloud_map.begin()->second->fields;
   constexpr int CHUNK_SIZE = 1024;
 
   // Resize concatenated cloud if needed to the next multiple of CHUNK_SIZE to reduce the number of
@@ -138,8 +142,7 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
 
   concatenate_cloud_result.concatenate_cloud_ptr = std::move(concatenated_cloud_ptr_);
 
-  auto * output_points =
-    reinterpret_cast<PointTypeStruct *>(concatenate_cloud_result.concatenate_cloud_ptr->data.get());
+  auto * output_points = concatenate_cloud_result.concatenate_cloud_ptr->data.get();
   std::size_t concatenated_start_index = 0;
 
   for (const auto & [topic, cloud] : topic_to_cloud_map) {
@@ -178,10 +181,13 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
     transform_struct.m32 = transform(2, 1);
     transform_struct.m33 = transform(2, 2);
 
+    // Point times, if kept, are rebased from this cloud's header stamp onto oldest_stamp.
+    const auto time_offset_ns =
+      static_cast<std::uint32_t>((current_cloud_stamp - oldest_stamp).nanoseconds());
     auto & stream = cuda_concat_struct_map_[topic].stream;
-    transform_launch(
-      reinterpret_cast<PointTypeStruct *>(cloud->data.get()), num_points, transform_struct,
-      output_points + concatenated_start_index, stream);
+    launch_transform(
+      cloud->data.get(), num_points, transform_struct, time_offset_ns,
+      output_points + concatenated_start_index * output_point_step_, stream);
     concatenated_start_index += num_points;
     concatenation_info_manager_.update_source_from_point_cloud(
       *cloud, topic, autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
@@ -191,10 +197,10 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
   concatenate_cloud_result.concatenate_cloud_ptr->header.frame_id = output_frame_;
   concatenate_cloud_result.concatenate_cloud_ptr->width = concatenated_start_index;
   concatenate_cloud_result.concatenate_cloud_ptr->height = 1;
-  concatenate_cloud_result.concatenate_cloud_ptr->point_step = sizeof(PointTypeStruct);
+  concatenate_cloud_result.concatenate_cloud_ptr->point_step = output_point_step_;
   concatenate_cloud_result.concatenate_cloud_ptr->row_step =
-    concatenated_start_index * sizeof(PointTypeStruct);
-  concatenate_cloud_result.concatenate_cloud_ptr->fields = point_fields;
+    concatenated_start_index * output_point_step_;
+  concatenate_cloud_result.concatenate_cloud_ptr->fields = output_fields_;
   concatenate_cloud_result.concatenate_cloud_ptr->is_bigendian = false;
   concatenate_cloud_result.concatenate_cloud_ptr->is_dense = true;
 
@@ -252,23 +258,24 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
         transform_struct.m32 = transform(2, 1);
         transform_struct.m33 = transform(2, 2);
 
-        transform_launch(
-          output_points + concatenated_start_index, num_points, transform_struct,
-          reinterpret_cast<PointTypeStruct *>(output_cloud->data.get()), stream);
+        // Point times were already rebased in the first round.
+        launch_transform(
+          output_points + concatenated_start_index * output_point_step_, num_points,
+          transform_struct, 0U, output_cloud->data.get(), stream);
         output_cloud->header.frame_id = cloud->header.frame_id;
       } else {
         CHECK_CUDA_ERROR(cudaMemcpyAsync(
-          output_cloud->data.get(), output_points + concatenated_start_index, data_size,
-          cudaMemcpyDeviceToDevice, stream));
+          output_cloud->data.get(), output_points + concatenated_start_index * output_point_step_,
+          data_size, cudaMemcpyDeviceToDevice, stream));
         output_cloud->header.frame_id = output_frame_;
       }
 
       output_cloud->header.stamp = oldest_stamp;
       output_cloud->width = cloud->width;
       output_cloud->height = cloud->height;
-      output_cloud->point_step = sizeof(PointTypeStruct);
-      output_cloud->row_step = cloud->width * sizeof(PointTypeStruct);
-      output_cloud->fields = point_fields;
+      output_cloud->point_step = output_point_step_;
+      output_cloud->row_step = cloud->width * output_point_step_;
+      output_cloud->fields = output_fields_;
       output_cloud->is_bigendian = false;
       output_cloud->is_dense = true;
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.cu
@@ -15,15 +15,20 @@
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp"
 
 #include <autoware/cuda_utils/cuda_check_error.hpp>
+#include <autoware/point_types/types.hpp>
 
 #include <cuda_runtime.h>
+
+#include <cstdint>
+#include <type_traits>
 
 namespace autoware::pointcloud_preprocessor
 {
 
+template <typename PointT>
 __global__ void transform_kernel(
-  const PointTypeStruct * input_points, int num_points, TransformStruct transform,
-  PointTypeStruct * output_points)
+  const PointT * input_points, int num_points, TransformStruct transform,
+  std::uint32_t time_offset_ns, PointT * output_points)
 {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_points) {
@@ -40,12 +45,16 @@ __global__ void transform_kernel(
     output_points[idx].intensity = input_points[idx].intensity;
     output_points[idx].return_type = input_points[idx].return_type;
     output_points[idx].channel = input_points[idx].channel;
+    if constexpr (std::is_same_v<PointT, autoware::point_types::PointXYZIRCT>) {
+      output_points[idx].time_stamp = input_points[idx].time_stamp + time_offset_ns;
+    }
   }
 }
 
+template <typename PointT>
 void transform_launch(
-  const PointTypeStruct * input_points, int num_points, TransformStruct transform,
-  PointTypeStruct * output_points, cudaStream_t & stream)
+  const PointT * input_points, int num_points, TransformStruct transform,
+  std::uint32_t time_offset_ns, PointT * output_points, cudaStream_t & stream)
 {
   // `num_points <= 0` would result in an invalid number of `blocks_per_grid`,
   // causing a `cudaErrorInvalidConfiguration`. Exit early instead.
@@ -57,8 +66,15 @@ void transform_launch(
   const int block_per_grid = (num_points + threads_per_block - 1) / threads_per_block;
 
   transform_kernel<<<block_per_grid, threads_per_block, 0, stream>>>(
-    input_points, num_points, transform, output_points);
+    input_points, num_points, transform, time_offset_ns, output_points);
   CHECK_CUDA_ERROR(cudaGetLastError());
 }
+
+template void transform_launch<autoware::point_types::PointXYZIRC>(
+  const autoware::point_types::PointXYZIRC *, int, TransformStruct, std::uint32_t,
+  autoware::point_types::PointXYZIRC *, cudaStream_t &);
+template void transform_launch<autoware::point_types::PointXYZIRCT>(
+  const autoware::point_types::PointXYZIRCT *, int, TransformStruct, std::uint32_t,
+  autoware::point_types::PointXYZIRCT *, cudaStream_t &);
 
 }  // namespace autoware::pointcloud_preprocessor

--- a/sensing/autoware_pointcloud_preprocessor/config/concatenate_and_time_sync_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/concatenate_and_time_sync_node.param.yaml
@@ -16,5 +16,6 @@
                     "/sensing/lidar/left/pointcloud_before_sync",
                 ]
     output_frame: base_link
+    output_point_type: XYZIRC
     matching_strategy:
       type: naive

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp
@@ -18,6 +18,7 @@
 #include "combine_cloud_handler_base.hpp"
 #include "traits.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -29,6 +30,7 @@
 namespace autoware::pointcloud_preprocessor
 {
 using autoware::point_types::PointXYZIRC;
+using autoware::point_types::PointXYZIRCT;
 using point_cloud_msg_wrapper::PointCloud2Modifier;
 
 template <typename MsgTraits>
@@ -41,10 +43,10 @@ public:
   CombineCloudHandler(
     rclcpp::Node & node, const std::vector<std::string> & input_topics, std::string output_frame,
     bool is_motion_compensated, bool publish_synchronized_pointcloud,
-    bool keep_input_frame_in_synchronized_pointcloud)
+    bool keep_input_frame_in_synchronized_pointcloud, OutputPointType output_point_type)
   : CombineCloudHandlerBase(
       node, input_topics, output_frame, is_motion_compensated, publish_synchronized_pointcloud,
-      keep_input_frame_in_synchronized_pointcloud)
+      keep_input_frame_in_synchronized_pointcloud, output_point_type)
   {
   }
 
@@ -57,6 +59,8 @@ public:
 
   void allocate_pointclouds() override {};
 
+  bool is_input_layout_supported(const sensor_msgs::msg::PointCloud2 & cloud) const override;
+
 protected:
   /// @brief RclcppTimeHash structure defines a custom hash function for the rclcpp::Time type by
   /// using its nanoseconds representation as the hash value.
@@ -68,9 +72,18 @@ protected:
     }
   };
 
-  static void convert_to_xyzirc_cloud(
+  /// Rewrites `input_cloud` into the configured output point type. For XYZIRCT,
+  /// `time_offset_ns` is added to every point's time_stamp.
+  void convert_to_output_cloud(
     const typename PointCloud2Traits::PointCloudMessage::ConstSharedPtr & input_cloud,
-    typename PointCloud2Traits::PointCloudMessage::UniquePtr & xyzirc_cloud);
+    typename PointCloud2Traits::PointCloudMessage::UniquePtr & output_cloud,
+    std::uint32_t time_offset_ns) const;
+
+  template <typename PointT, typename GeneratorT>
+  static void convert_cloud(
+    const typename PointCloud2Traits::PointCloudMessage::ConstSharedPtr & input_cloud,
+    typename PointCloud2Traits::PointCloudMessage::UniquePtr & output_cloud,
+    std::uint32_t time_offset_ns);
 
   void correct_pointcloud_motion(
     const std::unique_ptr<PointCloud2Traits::PointCloudMessage> & transformed_cloud_ptr,

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler_base.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler_base.hpp
@@ -17,6 +17,7 @@
 #include "concatenation_info_manager.hpp"
 #include "traits.hpp"
 
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <optional>
@@ -25,6 +26,8 @@
 #include <vector>
 
 // ROS includes
+#include <autoware/point_types/memory.hpp>
+#include <autoware/point_types/types.hpp>
 #include <managed_transform_buffer/managed_transform_buffer.hpp>
 
 #include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
@@ -34,6 +37,10 @@
 
 namespace autoware::pointcloud_preprocessor
 {
+
+/// Point type of the published clouds. XYZIRCT keeps each point's time_stamp, rebased onto the
+/// concatenated cloud's header stamp.
+enum class OutputPointType { XYZIRC, XYZIRCT };
 
 template <typename MsgTraits>
 struct ConcatenatedCloudResult
@@ -51,13 +58,21 @@ public:
   CombineCloudHandlerBase(
     rclcpp::Node & node, const std::vector<std::string> & input_topics, std::string output_frame,
     bool is_motion_compensated, bool publish_synchronized_pointcloud,
-    bool keep_input_frame_in_synchronized_pointcloud)
+    bool keep_input_frame_in_synchronized_pointcloud, OutputPointType output_point_type)
   : node_(node),
     input_topics_(input_topics),
     output_frame_(output_frame),
     is_motion_compensated_(is_motion_compensated),
     publish_synchronized_pointcloud_(publish_synchronized_pointcloud),
     keep_input_frame_in_synchronized_pointcloud_(keep_input_frame_in_synchronized_pointcloud),
+    output_point_type_(output_point_type),
+    output_fields_(
+      output_point_type == OutputPointType::XYZIRCT
+        ? autoware::point_types::create_fields_point_xyzirct()
+        : autoware::point_types::create_fields_point_xyzirc()),
+    output_point_step_(
+      output_point_type == OutputPointType::XYZIRCT ? sizeof(autoware::point_types::PointXYZIRCT)
+                                                    : sizeof(autoware::point_types::PointXYZIRC)),
     managed_tf_buffer_(std::make_unique<managed_transform_buffer::ManagedTransformBuffer>()),
     concatenation_info_manager_(
       node.get_parameter("matching_strategy.type").as_string(), input_topics)
@@ -76,6 +91,10 @@ public:
 
   virtual void allocate_pointclouds() = 0;
 
+  /// Whether `cloud` can be consumed for the configured output point type. Checked per input
+  /// message before it enters a collector.
+  virtual bool is_input_layout_supported(const sensor_msgs::msg::PointCloud2 & cloud) const = 0;
+
 protected:
   rclcpp::Node & node_;
   std::vector<std::string> input_topics_;
@@ -83,6 +102,9 @@ protected:
   bool is_motion_compensated_;
   bool publish_synchronized_pointcloud_;
   bool keep_input_frame_in_synchronized_pointcloud_;
+  OutputPointType output_point_type_;
+  std::vector<sensor_msgs::msg::PointField> output_fields_;
+  std::uint32_t output_point_step_;
   std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
   ConcatenationInfoManager concatenation_info_manager_;
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
@@ -89,6 +89,7 @@ private:
     std::string input_twist_topic_type;
     std::vector<std::string> input_topics;
     std::string output_frame;
+    OutputPointType output_point_type;
     std::string matching_strategy;
   } params_;
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
@@ -62,6 +62,7 @@ PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::
   params_.input_twist_topic_type = declare_parameter<std::string>("input_twist_topic_type");
   params_.input_topics = declare_parameter<std::vector<std::string>>("input_topics");
   params_.output_frame = declare_parameter<std::string>("output_frame");
+  const auto output_point_type = declare_parameter<std::string>("output_point_type");
 
   if (params_.input_topics.empty()) {
     throw std::runtime_error("Need a 'input_topics' parameter to be set before continuing.");
@@ -72,6 +73,14 @@ PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::
 
   if (params_.output_frame.empty()) {
     throw std::runtime_error("Need an 'output_frame' parameter to be set before continuing.");
+  }
+
+  if (output_point_type == "XYZIRC") {
+    params_.output_point_type = OutputPointType::XYZIRC;
+  } else if (output_point_type == "XYZIRCT") {
+    params_.output_point_type = OutputPointType::XYZIRCT;
+  } else {
+    throw std::runtime_error("output_point_type must be 'XYZIRC' or 'XYZIRCT'");
   }
 
   params_.matching_strategy = declare_parameter<std::string>("matching_strategy.type");
@@ -108,7 +117,8 @@ PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::
   // Combine cloud handler
   combine_cloud_handler_ = std::make_shared<CombineCloudHandler<MsgTraits>>(
     *this, params_.input_topics, params_.output_frame, params_.is_motion_compensated,
-    params_.publish_synchronized_pointcloud, params_.keep_input_frame_in_synchronized_pointcloud);
+    params_.publish_synchronized_pointcloud, params_.keep_input_frame_in_synchronized_pointcloud,
+    params_.output_point_type);
 
   // Diagnostic Updater
   diagnostics_interface_ =
@@ -178,12 +188,14 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::cloud_c
   double cloud_arrival_time = this->get_clock()->now().seconds();
   manage_collector_list();
 
-  if (!utils::is_data_layout_compatible_with_point_xyzirc(*input_ptr)) {
-    RCLCPP_ERROR(
-      get_logger(), "The pointcloud layout is not compatible with PointXYZIRC. Aborting");
+  if (!combine_cloud_handler_->is_input_layout_supported(*input_ptr)) {
+    RCLCPP_ERROR_ONCE(
+      get_logger(), "The pointcloud layout of '%s' is not supported for output_point_type %s. Dropping.",
+      topic_name.c_str(),
+      params_.output_point_type == OutputPointType::XYZIRCT ? "XYZIRCT" : "XYZIRC");
 
     if (utils::is_data_layout_compatible_with_point_xyzi(*input_ptr)) {
-      RCLCPP_ERROR(
+      RCLCPP_ERROR_ONCE(
         get_logger(),
         "The pointcloud layout is compatible with PointXYZI. You may be using legacy code/data");
     }

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
@@ -190,7 +190,8 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::cloud_c
 
   if (!combine_cloud_handler_->is_input_layout_supported(*input_ptr)) {
     RCLCPP_ERROR_ONCE(
-      get_logger(), "The pointcloud layout of '%s' is not supported for output_point_type %s. Dropping.",
+      get_logger(),
+      "The pointcloud layout of '%s' is not supported for output_point_type %s. Dropping.",
       topic_name.c_str(),
       params_.output_point_type == OutputPointType::XYZIRCT ? "XYZIRCT" : "XYZIRC");
 

--- a/sensing/autoware_pointcloud_preprocessor/schema/concatenate_and_time_sync_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/concatenate_and_time_sync_node.schema.json
@@ -76,6 +76,12 @@
           "minLength": 1,
           "description": "Output frame."
         },
+        "output_point_type": {
+          "type": "string",
+          "enum": ["XYZIRC", "XYZIRCT"],
+          "default": "XYZIRC",
+          "description": "Point type of the published clouds. XYZIRCT additionally carries each point's time_stamp in nanoseconds relative to the published header stamp and requires every input cloud to provide a time_stamp field. Inputs that cannot be converted are dropped."
+        },
         "matching_strategy": {
           "type": "object",
           "properties": {
@@ -138,6 +144,7 @@
         "input_twist_topic_type",
         "input_topics",
         "output_frame",
+        "output_point_type",
         "matching_strategy"
       ]
     }

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
@@ -23,9 +23,12 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -33,58 +36,65 @@
 namespace autoware::pointcloud_preprocessor
 {
 
-void CombineCloudHandler<PointCloud2Traits>::convert_to_xyzirc_cloud(
-  const typename PointCloud2Traits::PointCloudMessage::ConstSharedPtr & input_cloud,
-  typename PointCloud2Traits::PointCloudMessage::UniquePtr & xyzirc_cloud)
+bool CombineCloudHandler<PointCloud2Traits>::is_input_layout_supported(
+  const sensor_msgs::msg::PointCloud2 & cloud) const
 {
-  xyzirc_cloud->header = input_cloud->header;
+  // Fields are read by name, so any cloud that carries the output fields can be rewritten.
+  return autoware::point_types::is_data_convertible_to(cloud.fields, output_fields_);
+}
 
-  PointCloud2Modifier<PointXYZIRC, autoware::point_types::PointXYZIRCGenerator> output_modifier{
-    *xyzirc_cloud, input_cloud->header.frame_id};
+template <typename PointT, typename GeneratorT>
+void CombineCloudHandler<PointCloud2Traits>::convert_cloud(
+  const typename PointCloud2Traits::PointCloudMessage::ConstSharedPtr & input_cloud,
+  typename PointCloud2Traits::PointCloudMessage::UniquePtr & output_cloud,
+  std::uint32_t time_offset_ns)
+{
+  constexpr bool has_time_stamp = std::is_same_v<PointT, PointXYZIRCT>;
+
+  output_cloud->header = input_cloud->header;
+
+  PointCloud2Modifier<PointT, GeneratorT> output_modifier{
+    *output_cloud, input_cloud->header.frame_id};
   output_modifier.reserve(input_cloud->width);
-
-  bool has_valid_intensity =
-    std::any_of(input_cloud->fields.begin(), input_cloud->fields.end(), [](const auto & field) {
-      return field.name == "intensity" && field.datatype == sensor_msgs::msg::PointField::UINT8;
-    });
-
-  bool has_valid_return_type =
-    std::any_of(input_cloud->fields.begin(), input_cloud->fields.end(), [](const auto & field) {
-      return field.name == "return_type" && field.datatype == sensor_msgs::msg::PointField::UINT8;
-    });
-
-  bool has_valid_channel =
-    std::any_of(input_cloud->fields.begin(), input_cloud->fields.end(), [](const auto & field) {
-      return field.name == "channel" && field.datatype == sensor_msgs::msg::PointField::UINT16;
-    });
 
   sensor_msgs::PointCloud2ConstIterator<float> it_x(*input_cloud, "x");
   sensor_msgs::PointCloud2ConstIterator<float> it_y(*input_cloud, "y");
   sensor_msgs::PointCloud2ConstIterator<float> it_z(*input_cloud, "z");
+  sensor_msgs::PointCloud2ConstIterator<std::uint8_t> it_i(*input_cloud, "intensity");
+  sensor_msgs::PointCloud2ConstIterator<std::uint8_t> it_r(*input_cloud, "return_type");
+  sensor_msgs::PointCloud2ConstIterator<std::uint16_t> it_c(*input_cloud, "channel");
+  std::optional<sensor_msgs::PointCloud2ConstIterator<std::uint32_t>> it_t;
+  if constexpr (has_time_stamp) {
+    it_t.emplace(*input_cloud, "time_stamp");
+  }
 
-  if (has_valid_intensity && has_valid_return_type && has_valid_channel) {
-    sensor_msgs::PointCloud2ConstIterator<std::uint8_t> it_i(*input_cloud, "intensity");
-    sensor_msgs::PointCloud2ConstIterator<std::uint8_t> it_r(*input_cloud, "return_type");
-    sensor_msgs::PointCloud2ConstIterator<std::uint16_t> it_c(*input_cloud, "channel");
-
-    for (; it_x != it_x.end(); ++it_x, ++it_y, ++it_z, ++it_i, ++it_r, ++it_c) {
-      PointXYZIRC point;
-      point.x = *it_x;
-      point.y = *it_y;
-      point.z = *it_z;
-      point.intensity = *it_i;
-      point.return_type = *it_r;
-      point.channel = *it_c;
-      output_modifier.push_back(std::move(point));
+  for (; it_x != it_x.end(); ++it_x, ++it_y, ++it_z, ++it_i, ++it_r, ++it_c) {
+    PointT point;
+    point.x = *it_x;
+    point.y = *it_y;
+    point.z = *it_z;
+    point.intensity = *it_i;
+    point.return_type = *it_r;
+    point.channel = *it_c;
+    if constexpr (has_time_stamp) {
+      point.time_stamp = time_offset_ns + **it_t;
+      ++*it_t;
     }
+    output_modifier.push_back(std::move(point));
+  }
+}
+
+void CombineCloudHandler<PointCloud2Traits>::convert_to_output_cloud(
+  const typename PointCloud2Traits::PointCloudMessage::ConstSharedPtr & input_cloud,
+  typename PointCloud2Traits::PointCloudMessage::UniquePtr & output_cloud,
+  std::uint32_t time_offset_ns) const
+{
+  if (output_point_type_ == OutputPointType::XYZIRCT) {
+    convert_cloud<PointXYZIRCT, autoware::point_types::PointXYZIRCTGenerator>(
+      input_cloud, output_cloud, time_offset_ns);
   } else {
-    for (; it_x != it_x.end(); ++it_x, ++it_y, ++it_z) {
-      PointXYZIRC point;
-      point.x = *it_x;
-      point.y = *it_y;
-      point.z = *it_z;
-      output_modifier.push_back(std::move(point));
-    }
+    convert_cloud<PointXYZIRC, autoware::point_types::PointXYZIRCGenerator>(
+      input_cloud, output_cloud, 0U);
   }
 }
 
@@ -150,11 +160,17 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
     //
     // However, if all input clouds in topic_to_cloud_map are empty,
     // the function receives two empty point clouds and does nothing,
-    // resulting in concatenate_cloud_ptr not being compatible with the XYZIRC format.
+    // resulting in concatenate_cloud_ptr not carrying the output layout.
     //
-    // To avoid this, we explicitly set the fields of concatenate_cloud_ptr to XYZIRC here.
-    PointCloud2Modifier<PointXYZIRC, autoware::point_types::PointXYZIRCGenerator>
-      concatenate_cloud_modifier{*concatenate_cloud_result.concatenate_cloud_ptr, output_frame_};
+    // To avoid this, we explicitly set the fields of concatenate_cloud_ptr here.
+    auto & concatenate_cloud = *concatenate_cloud_result.concatenate_cloud_ptr;
+    if (output_point_type_ == OutputPointType::XYZIRCT) {
+      PointCloud2Modifier<PointXYZIRCT, autoware::point_types::PointXYZIRCTGenerator>
+        concatenate_cloud_modifier{concatenate_cloud, output_frame_};
+    } else {
+      PointCloud2Modifier<PointXYZIRC, autoware::point_types::PointXYZIRCGenerator>
+        concatenate_cloud_modifier{concatenate_cloud, output_frame_};
+    }
   }
   bool is_concatenated_cloud_dense = true;
 
@@ -167,13 +183,16 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
   concatenate_cloud_result.concatenate_cloud_ptr->data.reserve(total_data_size);
 
   for (const auto & [topic, cloud] : topic_to_cloud_map) {
-    // convert to XYZIRC pointcloud if pointcloud is not empty
-    auto xyzirc_cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
-    convert_to_xyzirc_cloud(cloud, xyzirc_cloud);
+    // Rewrite into the output point type. Point times, if kept, are rebased from this cloud's
+    // header stamp onto the concatenated cloud's (oldest_stamp).
+    const auto time_offset_ns =
+      static_cast<std::uint32_t>((rclcpp::Time(cloud->header.stamp) - oldest_stamp).nanoseconds());
+    auto converted_cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
+    convert_to_output_cloud(cloud, converted_cloud, time_offset_ns);
 
     auto transformed_cloud_ptr = std::make_unique<sensor_msgs::msg::PointCloud2>();
     managed_tf_buffer_->transformPointcloud(
-      output_frame_, *xyzirc_cloud, *transformed_cloud_ptr, xyzirc_cloud->header.stamp,
+      output_frame_, *converted_cloud, *transformed_cloud_ptr, converted_cloud->header.stamp,
       rclcpp::Duration::from_seconds(1.0), node_.get_logger());
 
     // compensate pointcloud

--- a/sensing/autoware_pointcloud_preprocessor/test/test_concatenate_node_component.py
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_concatenate_node_component.py
@@ -99,6 +99,7 @@ def generate_test_description():
                     "input_twist_topic_type": "twist",
                     "input_topics": INPUT_LIDAR_TOPICS,
                     "output_frame": "base_link",
+                    "output_point_type": "XYZIRC",
                     "matching_strategy.type": "advanced",
                     "matching_strategy.lidar_timestamp_offsets": TIMESTAMP_OFFSET,
                     "matching_strategy.lidar_timestamp_noise_window": [

--- a/sensing/autoware_pointcloud_preprocessor/test/test_concatenate_node_unit.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_concatenate_node_unit.cpp
@@ -20,6 +20,7 @@
 #include "autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp"
 #include "autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp"
 
+#include <autoware/point_types/memory.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -30,6 +31,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <thread>
@@ -38,6 +40,7 @@
 
 using autoware::pointcloud_preprocessor::CloudCollector;
 using autoware::pointcloud_preprocessor::CombineCloudHandler;
+using autoware::pointcloud_preprocessor::OutputPointType;
 using autoware::pointcloud_preprocessor::PointCloud2Traits;
 using autoware::pointcloud_preprocessor::PointCloudConcatenateDataSynchronizerComponent;
 
@@ -63,6 +66,7 @@ protected:
        {"input_twist_topic_type", "twist"},
        {"input_topics", input_topics},
        {"output_frame", "base_link"},
+       {"output_point_type", "XYZIRC"},
        {"matching_strategy.type", "advanced"},
        {"matching_strategy.lidar_timestamp_offsets", std::vector<double>{0.0, 0.04, 0.08}},
        {"matching_strategy.lidar_timestamp_noise_window", std::vector<double>{0.01, 0.01, 0.01}}});
@@ -70,7 +74,9 @@ protected:
     concatenate_node_ =
       std::make_shared<PointCloudConcatenateDataSynchronizerComponent>(node_options);
     combine_cloud_handler_ = std::make_shared<CombineCloudHandler<PointCloud2Traits>>(
-      *concatenate_node_, input_topics, "base_link", true, true, true);
+      *concatenate_node_, input_topics, "base_link", true, true, true, OutputPointType::XYZIRC);
+    combine_cloud_handler_xyzirct_ = std::make_shared<CombineCloudHandler<PointCloud2Traits>>(
+      *concatenate_node_, input_topics, "base_link", true, true, true, OutputPointType::XYZIRCT);
 
     collector_ = std::make_shared<CloudCollector<PointCloud2Traits>>(
       std::dynamic_pointer_cast<PointCloudConcatenateDataSynchronizerComponent>(
@@ -148,7 +154,7 @@ protected:
         *iter_x = points[i].x();
         *iter_y = points[i].y();
         *iter_z = points[i].z();
-        *iter_t = 0;
+        *iter_t = static_cast<std::uint32_t>(i) * point_time_step_ns;
         ++iter_x;
         ++iter_y;
         ++iter_z;
@@ -162,6 +168,31 @@ protected:
     return pointcloud_msg;
   }
 
+  static std::unordered_map<std::string, sensor_msgs::msg::PointCloud2::ConstSharedPtr>
+  generate_topic_to_cloud_map(
+    const rclcpp::Time & top_stamp, const rclcpp::Time & left_stamp,
+    const rclcpp::Time & right_stamp)
+  {
+    std::unordered_map<std::string, sensor_msgs::msg::PointCloud2::ConstSharedPtr> map;
+    map["lidar_top"] = std::make_shared<sensor_msgs::msg::PointCloud2>(
+      generate_pointcloud_msg(true, false, "lidar_top", top_stamp));
+    map["lidar_left"] = std::make_shared<sensor_msgs::msg::PointCloud2>(
+      generate_pointcloud_msg(true, false, "lidar_left", left_stamp));
+    map["lidar_right"] = std::make_shared<sensor_msgs::msg::PointCloud2>(
+      generate_pointcloud_msg(true, false, "lidar_right", right_stamp));
+    return map;
+  }
+
+  static std::vector<std::uint32_t> read_time_stamps(const sensor_msgs::msg::PointCloud2 & cloud)
+  {
+    std::vector<std::uint32_t> time_stamps;
+    for (sensor_msgs::PointCloud2ConstIterator<std::uint32_t> it(cloud, "time_stamp");
+         it != it.end(); ++it) {
+      time_stamps.push_back(*it);
+    }
+    return time_stamps;
+  }
+
   static std::vector<geometry_msgs::msg::TransformStamped> generate_static_transform_msgs()
   {
     // generate defined transformations
@@ -173,12 +204,14 @@ protected:
 
   std::shared_ptr<PointCloudConcatenateDataSynchronizerComponent> concatenate_node_;
   std::shared_ptr<CombineCloudHandler<PointCloud2Traits>> combine_cloud_handler_;
+  std::shared_ptr<CombineCloudHandler<PointCloud2Traits>> combine_cloud_handler_xyzirct_;
   std::shared_ptr<CloudCollector<PointCloud2Traits>> collector_;
   std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
 
   static constexpr int32_t timestamp_seconds{10};
   static constexpr uint32_t timestamp_nanoseconds{100'000'000};
   static constexpr size_t number_of_points{3};
+  static constexpr std::uint32_t point_time_step_ns{10'000'000};  // per-point time within a cloud
   static constexpr float standard_tolerance{1e-4};
   static constexpr int number_of_pointcloud{3};
   static constexpr float timeout_sec{0.2};
@@ -540,6 +573,97 @@ TEST_F(ConcatenateCloudTest, TestProcessMultipleCloud)
   EXPECT_EQ(
     concatenate_node_->get_cloud_collectors().front()->get_status(),
     autoware::pointcloud_preprocessor::CollectorStatus::Idle);
+}
+
+//////////////////////////////// Test output_point_type ////////////////////////////////
+
+TEST_F(ConcatenateCloudTest, TestInputLayoutSupport)
+{
+  rclcpp::Time stamp(timestamp_seconds, timestamp_nanoseconds, RCL_ROS_TIME);
+  const auto xyzircaedt_cloud = generate_pointcloud_msg(true, false, "lidar_top", stamp);
+  sensor_msgs::msg::PointCloud2 xyzirc_cloud;
+  xyzirc_cloud.fields = autoware::point_types::create_fields_point_xyzirc();
+
+  // XYZIRC output accepts any cloud that carries its fields
+  EXPECT_TRUE(combine_cloud_handler_->is_input_layout_supported(xyzircaedt_cloud));
+  EXPECT_TRUE(combine_cloud_handler_->is_input_layout_supported(xyzirc_cloud));
+  // XYZIRCT output additionally requires a time_stamp field
+  EXPECT_TRUE(combine_cloud_handler_xyzirct_->is_input_layout_supported(xyzircaedt_cloud));
+  EXPECT_FALSE(combine_cloud_handler_xyzirct_->is_input_layout_supported(xyzirc_cloud));
+}
+
+TEST_F(ConcatenateCloudTest, TestConcatenateCloudsXYZIRC)
+{
+  rclcpp::Time top_timestamp(timestamp_seconds, timestamp_nanoseconds, RCL_ROS_TIME);
+  rclcpp::Time left_timestamp(timestamp_seconds, timestamp_nanoseconds + 40'000'000, RCL_ROS_TIME);
+  rclcpp::Time right_timestamp(timestamp_seconds, timestamp_nanoseconds + 80'000'000, RCL_ROS_TIME);
+  auto topic_to_cloud_map =
+    generate_topic_to_cloud_map(top_timestamp, left_timestamp, right_timestamp);
+
+  const auto result = combine_cloud_handler_->combine_pointclouds(topic_to_cloud_map, nullptr);
+
+  // XYZIRC output drops the inputs' time_stamp
+  EXPECT_EQ(
+    result.concatenate_cloud_ptr->fields, autoware::point_types::create_fields_point_xyzirc());
+  EXPECT_EQ(result.concatenate_cloud_ptr->point_step, sizeof(autoware::point_types::PointXYZIRC));
+  EXPECT_EQ(result.concatenate_cloud_ptr->width, 3 * number_of_points);
+}
+
+TEST_F(ConcatenateCloudTest, TestConcatenateCloudsXYZIRCT)
+{
+  constexpr std::uint32_t ms = 1'000'000;
+  // Header stamps 0 / +40 ms / +80 ms, per-point times 0 / 10 / 20 ms within each cloud
+  rclcpp::Time top_timestamp(timestamp_seconds, timestamp_nanoseconds, RCL_ROS_TIME);
+  rclcpp::Time left_timestamp(timestamp_seconds, timestamp_nanoseconds + 40 * ms, RCL_ROS_TIME);
+  rclcpp::Time right_timestamp(timestamp_seconds, timestamp_nanoseconds + 80 * ms, RCL_ROS_TIME);
+  auto topic_to_cloud_map =
+    generate_topic_to_cloud_map(top_timestamp, left_timestamp, right_timestamp);
+
+  const auto result =
+    combine_cloud_handler_xyzirct_->combine_pointclouds(topic_to_cloud_map, nullptr);
+  const auto & concatenated = *result.concatenate_cloud_ptr;
+
+  EXPECT_EQ(concatenated.fields, autoware::point_types::create_fields_point_xyzirct());
+  EXPECT_EQ(concatenated.point_step, sizeof(autoware::point_types::PointXYZIRCT));
+  EXPECT_EQ(rclcpp::Time(concatenated.header.stamp), top_timestamp);
+
+  // Point times are rebased onto the concatenated cloud's header stamp (the oldest input stamp).
+  // The concatenation order follows the input map, so compare as sorted multisets.
+  auto times = read_time_stamps(concatenated);
+  std::sort(times.begin(), times.end());
+  const std::vector<std::uint32_t> expected_times{0,       10 * ms, 20 * ms, 40 * ms, 50 * ms,
+                                                  60 * ms, 80 * ms, 90 * ms, 100 * ms};
+  EXPECT_EQ(times, expected_times);
+
+  // The synchronized per-topic clouds carry the same header stamp and the rebased times
+  const auto & sync_clouds = result.topic_to_transformed_cloud_map.value();
+  EXPECT_EQ(rclcpp::Time(sync_clouds.at("lidar_left")->header.stamp), top_timestamp);
+  EXPECT_EQ(
+    read_time_stamps(*sync_clouds.at("lidar_top")),
+    (std::vector<std::uint32_t>{0, 10 * ms, 20 * ms}));
+  EXPECT_EQ(
+    read_time_stamps(*sync_clouds.at("lidar_left")),
+    (std::vector<std::uint32_t>{40 * ms, 50 * ms, 60 * ms}));
+  EXPECT_EQ(
+    read_time_stamps(*sync_clouds.at("lidar_right")),
+    (std::vector<std::uint32_t>{80 * ms, 90 * ms, 100 * ms}));
+}
+
+TEST_F(ConcatenateCloudTest, TestConcatenateCloudsXYZIRCTIdenticalStamps)
+{
+  constexpr std::uint32_t ms = 1'000'000;
+  rclcpp::Time stamp(timestamp_seconds, timestamp_nanoseconds, RCL_ROS_TIME);
+  auto topic_to_cloud_map = generate_topic_to_cloud_map(stamp, stamp, stamp);
+
+  const auto result =
+    combine_cloud_handler_xyzirct_->combine_pointclouds(topic_to_cloud_map, nullptr);
+
+  // Identical header stamps leave the per-point times unchanged
+  auto times = read_time_stamps(*result.concatenate_cloud_ptr);
+  std::sort(times.begin(), times.end());
+  const std::vector<std::uint32_t> expected_times{0,       0,       0,       10 * ms, 10 * ms,
+                                                  10 * ms, 20 * ms, 20 * ms, 20 * ms};
+  EXPECT_EQ(times, expected_times);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

The concatenation node rewrites every input into `PointXYZIRC`, dropping the per-point `time_stamp` that time-aware ML models need:

https://github.com/autowarefoundation/autoware_universe/blob/5bdcd2f825d2f00602f96c1d555997e5c6ba7641/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp#L36-L44

This PR adds the required parameter `output_point_type` (`XYZIRC` | `XYZIRCT`) to the CPU and the CUDA node. With `XYZIRCT` the output is `PointXYZIRCT` (autowarefoundation/autoware_core#1422) and every point time is rebased onto the concatenated cloud's header stamp. That stamp is the oldest input stamp, so the result is never negative:

`t_out = (input.header.stamp - output.header.stamp) + t_in`

The synchronized per-topic clouds get the same treatment; they already carry the oldest stamp (#13318).

Input gating moves into the handlers because what is acceptable now depends on the backend:

- CPU reads fields by name and accepts any input that carries the output fields (`is_data_convertible_to`, autowarefoundation/autoware_core#1428), so `PointXYZIRCAEDT` from the distortion corrector works for both output types.
- CUDA strides the buffer by the output point size and requires exactly the output layout. This also closes an existing misread: the kernel used `sizeof(PointTypeStruct)` while the output copied the input's `fields`, same class as #13311, #13313, #13314.

Inputs that fail the check are dropped with a one-time error.

**Depends on** autowarefoundation/autoware_core#1428 (`is_data_convertible_to`).
**Depends on** autowarefoundation/autoware_launch#1975 being merged first (adds the new required parameter to the launch configs).
The CUDA node only receives `PointXYZIRCT` input once autowarefoundation/autoware_universe#13323 is merged and enabled.

## Related links

None.

## How was this PR tested?

New unit tests in `test_concatenate_node_unit.cpp`: input gating per output type, XYZIRC drops the stamp, XYZIRCT rebasing with distinct and with identical input stamps (concatenated and synchronized clouds). Full `colcon test` of both packages passes. CUDA node: end-to-end on a recorded `PointXYZIRCAEDT` bag, replayed as two inputs (the second with header stamps shifted by +40 ms), each through `cuda_pointcloud_preprocessor` with `output_point_type: XYZIRCT` (#13323) into `cuda_concatenate_and_time_sync_node` with `output_point_type: XYZIRCT`. Over ~535 concatenations the output had `point_step` 20 and the `PointXYZIRCT` fields, the synchronized cloud of the oldest input kept its point times, and the shifted input's point times came out exactly 40 ms later than they went in.

## Notes for reviewers

`output_point_type` is a new required parameter (no C++ default, by project policy). Schema and default config set `XYZIRC`, which reproduces today's output.

The CUDA kernel now uses `autoware::point_types::PointXYZIRC` / `PointXYZIRCT` directly instead of a private mirror struct plus offset asserts, as `autoware_ptv3` already does.

The CPU converter's fallback for inputs without `intensity`/`return_type`/`channel` was unreachable through the node (the previous gate already required them) and is removed.

## Interface changes

### ROS Parameter Changes

| Change type | Parameter Name      | Type     | Default Value | Description                                                   |
| :---------- | :------------------ | :------- | :------------ | :------------------------------------------------------------ |
| Added       | `output_point_type` | `string` | `XYZIRC`      | Point type of the published clouds, `XYZIRC` or `XYZIRCT`. |

## Effects on system behavior

With the default, none for valid input: the CPU check accepts a superset of what the prefix check accepted, and the CUDA node additionally rejects inputs whose `point_step` is not 16, which it misread before. With `XYZIRCT`, clouds are 20 bytes per point and carry `time_stamp`; consumers that stride by `sizeof(PointXYZIRC)` must reject or handle them (#13311, #13313, #13314 do).
