### PR TITLE
fix(autoware_behavior_path_static_obstacle_avoidance_module): stop extending lanes forever on a looping road

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_behavior_path_planner</depend>
   <depend>autoware_behavior_path_planner_common</depend>
   <depend>autoware_lanelet2_extension</depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -1785,7 +1785,20 @@ lanelet::ConstLanelets getExtendLanes(
       break;
     }
 
-    extend_lanelets.push_back(next_lanelets.front());
+    // A road network that loops back on itself (a city block, for instance)
+    // hands back a lanelet that is already in the sequence.  Appending it makes
+    // the ego project onto the second lap, so the arc coordinate grows with the
+    // sequence and forward_length never reaches forward_path_length: the loop
+    // would extend the lanes forever.
+    const auto & next_lanelet = next_lanelets.front();
+    const auto is_already_extended = std::any_of(
+      extend_lanelets.begin(), extend_lanelets.end(),
+      [&next_lanelet](const auto & lanelet) { return lanelet.id() == next_lanelet.id(); });
+    if (is_already_extended) {
+      break;
+    }
+
+    extend_lanelets.push_back(next_lanelet);
   }
 
   return extend_lanelets;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
@@ -23,11 +23,14 @@
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <autoware_perception_msgs/msg/shape.hpp>
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <limits>
 #include <memory>
+#include <set>
 
 namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
@@ -1583,5 +1586,57 @@ TEST(TestUtils, calcErrorEclipseLongRadius)
        0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0});
 
   EXPECT_DOUBLE_EQ(calcErrorEclipseLongRadius(pose_with_covariance), 3.0);
+}
+
+TEST(TestUtils, getExtendLanesTerminatesOnLoopingMap)
+{
+  // Regression test for getExtendLanes() extending lanes forever on a road
+  // network that loops back on itself. The fixture map (test_data/loop_map.osm)
+  // is a four-lanelet ring 1010 -> 1013 -> 1016 -> 1019 -> 1010, so walking
+  // getNextLanelets() eventually returns a lanelet that is already in the
+  // sequence. Without the guard the walk keeps re-appending the ring, so the
+  // returned sequence is longer than the loop and full of duplicates (and, for
+  // an ego that projects onto a later lap, never terminates at all).
+
+  // getExtendLanes() spins in a while (rclcpp::ok()) loop, so the context must
+  // be up for the walk to run.
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+
+  const auto map_path =
+    ament_index_cpp::get_package_share_directory(
+      "autoware_behavior_path_static_obstacle_avoidance_module") +
+    "/test_data/loop_map.osm";
+  const auto map_bin = autoware::test_utils::make_map_bin_msg(map_path);
+
+  auto planner_data = std::make_shared<PlannerData>();
+  planner_data->route_handler->setMap(map_bin);
+  // Longer than the 80 m ring, so the walk has to loop back on itself to reach it.
+  planner_data->parameters.forward_path_length = 200.0;
+  planner_data->parameters.backward_path_length = 5.0;
+
+  const auto start_lane = planner_data->route_handler->getLaneletsFromId(1010);
+  // Place the ego at the start of the ring, derived from the loaded geometry so
+  // the test is independent of the map projection.
+  const auto centerline = start_lane.centerline2d();
+  const auto & p0 = centerline.front();
+  const auto & p1 = centerline[1];
+  const double yaw = std::atan2(p1.y() - p0.y(), p1.x() - p0.x());
+  const auto ego_pose = geometry_msgs::build<geometry_msgs::msg::Pose>()
+                          .position(create_point(p0.x(), p0.y(), 0.0))
+                          .orientation(create_quaternion_from_rpy(0.0, 0.0, yaw));
+
+  const auto extend_lanelets = getExtendLanes({start_lane}, ego_pose, planner_data);
+
+  // The walk terminates without revisiting a lanelet ...
+  std::set<lanelet::Id> seen_ids;
+  for (const auto & lane : extend_lanelets) {
+    EXPECT_TRUE(seen_ids.insert(lane.id()).second)
+      << "lanelet " << lane.id() << " appears more than once in the extended sequence";
+  }
+  // ... and cannot return more lanelets than the single loop contains.
+  EXPECT_FALSE(extend_lanelets.empty());
+  EXPECT_LE(extend_lanelets.size(), 4U);
 }
 }  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
@@ -1600,8 +1600,11 @@ TEST(TestUtils, getExtendLanesTerminatesOnLoopingMap)
   // an ego that projects onto a later lap, never terminates at all).
 
   // getExtendLanes() spins in a while (rclcpp::ok()) loop, so the context must
-  // be up for the walk to run.
-  if (!rclcpp::ok()) {
+  // be up for the walk to run. Shut it back down at the end if we brought it up,
+  // otherwise the node tests that run afterwards throw "context is already
+  // initialized" when they call rclcpp::init() themselves.
+  const bool initialized_context = !rclcpp::ok();
+  if (initialized_context) {
     rclcpp::init(0, nullptr);
   }
 
@@ -1638,5 +1641,9 @@ TEST(TestUtils, getExtendLanesTerminatesOnLoopingMap)
   // ... and cannot return more lanelets than the single loop contains.
   EXPECT_FALSE(extend_lanelets.empty());
   EXPECT_LE(extend_lanelets.size(), 4U);
+
+  if (initialized_context) {
+    rclcpp::shutdown();
+  }
 }
 }  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
@@ -1602,11 +1602,18 @@ TEST(TestUtils, getExtendLanesTerminatesOnLoopingMap)
   // getExtendLanes() spins in a while (rclcpp::ok()) loop, so the context must
   // be up for the walk to run. Shut it back down at the end if we brought it up,
   // otherwise the node tests that run afterwards throw "context is already
-  // initialized" when they call rclcpp::init() themselves.
+  // initialized" when they call rclcpp::init() themselves. The scope guard makes
+  // the shutdown failure-safe: it runs even if an assertion or exception unwinds
+  // the test early.
   const bool initialized_context = !rclcpp::ok();
   if (initialized_context) {
     rclcpp::init(0, nullptr);
   }
+  const auto context_guard = std::shared_ptr<void>(nullptr, [initialized_context](void *) {
+    if (initialized_context) {
+      rclcpp::shutdown();
+    }
+  });
 
   const auto map_path = ament_index_cpp::get_package_share_directory(
                           "autoware_behavior_path_static_obstacle_avoidance_module") +
@@ -1641,9 +1648,5 @@ TEST(TestUtils, getExtendLanesTerminatesOnLoopingMap)
   // ... and cannot return more lanelets than the single loop contains.
   EXPECT_FALSE(extend_lanelets.empty());
   EXPECT_LE(extend_lanelets.size(), 4U);
-
-  if (initialized_context) {
-    rclcpp::shutdown();
-  }
 }
 }  // namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
@@ -20,10 +20,11 @@
 #include "autoware_test_utils/autoware_test_utils.hpp"
 #include "autoware_utils/math/unit_conversion.hpp"
 
+#include <ament_index_cpp/get_package_share_directory.hpp>
+
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <autoware_perception_msgs/msg/shape.hpp>
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -1604,10 +1605,9 @@ TEST(TestUtils, getExtendLanesTerminatesOnLoopingMap)
     rclcpp::init(0, nullptr);
   }
 
-  const auto map_path =
-    ament_index_cpp::get_package_share_directory(
-      "autoware_behavior_path_static_obstacle_avoidance_module") +
-    "/test_data/loop_map.osm";
+  const auto map_path = ament_index_cpp::get_package_share_directory(
+                          "autoware_behavior_path_static_obstacle_avoidance_module") +
+                        "/test_data/loop_map.osm";
   const auto map_bin = autoware::test_utils::make_map_bin_msg(map_path);
 
   auto planner_data = std::make_shared<PlannerData>();

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test_data/loop_map.osm
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test_data/loop_map.osm
@@ -1,0 +1,103 @@
+<?xml version="1.0"?>
+<osm version="0.6" upload="false" generator="lanelet2">
+  <node id="1000" visible="true" version="1" lat="34.99998621134" lon="138.99998390104">
+    <tag k="local_x" v="-1.5" />
+    <tag k="local_y" v="-1.5" />
+  </node>
+  <node id="1001" visible="true" version="1" lat="34.99999036278" lon="139.00023579724">
+    <tag k="local_x" v="21.5" />
+    <tag k="local_y" v="-1.5" />
+  </node>
+  <node id="1002" visible="true" version="1" lat="35.00019763724" lon="139.00023075237">
+    <tag k="local_x" v="21.5" />
+    <tag k="local_y" v="21.5" />
+  </node>
+  <node id="1003" visible="true" version="1" lat="35.00019348577" lon="138.99997885554">
+    <tag k="local_x" v="-1.5" />
+    <tag k="local_y" v="21.5" />
+  </node>
+  <node id="1004" visible="true" version="1" lat="35.00001378866" lon="139.00001609897">
+    <tag k="local_x" v="1.5" />
+    <tag k="local_y" v="1.5" />
+  </node>
+  <node id="1005" visible="true" version="1" lat="35.00001685711" lon="139.00020228317">
+    <tag k="local_x" v="18.5" />
+    <tag k="local_y" v="1.5" />
+  </node>
+  <node id="1006" visible="true" version="1" lat="35.00017005997" lon="139.0001985543">
+    <tag k="local_x" v="18.5" />
+    <tag k="local_y" v="18.5" />
+  </node>
+  <node id="1007" visible="true" version="1" lat="35.0001669915" lon="139.00001236975">
+    <tag k="local_x" v="1.5" />
+    <tag k="local_y" v="18.5" />
+  </node>
+  <way id="1008" visible="true" version="1">
+    <nd ref="1004" />
+    <nd ref="1005" />
+  </way>
+  <way id="1009" visible="true" version="1">
+    <nd ref="1000" />
+    <nd ref="1001" />
+  </way>
+  <way id="1011" visible="true" version="1">
+    <nd ref="1005" />
+    <nd ref="1006" />
+  </way>
+  <way id="1012" visible="true" version="1">
+    <nd ref="1001" />
+    <nd ref="1002" />
+  </way>
+  <way id="1014" visible="true" version="1">
+    <nd ref="1006" />
+    <nd ref="1007" />
+  </way>
+  <way id="1015" visible="true" version="1">
+    <nd ref="1002" />
+    <nd ref="1003" />
+  </way>
+  <way id="1017" visible="true" version="1">
+    <nd ref="1007" />
+    <nd ref="1004" />
+  </way>
+  <way id="1018" visible="true" version="1">
+    <nd ref="1003" />
+    <nd ref="1000" />
+  </way>
+  <relation id="1010" visible="true" version="1">
+    <member type="way" ref="1008" role="left" />
+    <member type="way" ref="1009" role="right" />
+    <tag k="location" v="urban" />
+    <tag k="one_way" v="yes" />
+    <tag k="speed_limit" v="30" />
+    <tag k="subtype" v="road" />
+    <tag k="type" v="lanelet" />
+  </relation>
+  <relation id="1013" visible="true" version="1">
+    <member type="way" ref="1011" role="left" />
+    <member type="way" ref="1012" role="right" />
+    <tag k="location" v="urban" />
+    <tag k="one_way" v="yes" />
+    <tag k="speed_limit" v="30" />
+    <tag k="subtype" v="road" />
+    <tag k="type" v="lanelet" />
+  </relation>
+  <relation id="1016" visible="true" version="1">
+    <member type="way" ref="1014" role="left" />
+    <member type="way" ref="1015" role="right" />
+    <tag k="location" v="urban" />
+    <tag k="one_way" v="yes" />
+    <tag k="speed_limit" v="30" />
+    <tag k="subtype" v="road" />
+    <tag k="type" v="lanelet" />
+  </relation>
+  <relation id="1019" visible="true" version="1">
+    <member type="way" ref="1017" role="left" />
+    <member type="way" ref="1018" role="right" />
+    <tag k="location" v="urban" />
+    <tag k="one_way" v="yes" />
+    <tag k="speed_limit" v="30" />
+    <tag k="subtype" v="road" />
+    <tag k="type" v="lanelet" />
+  </relation>
+</osm>


### PR DESCRIPTION
## Description

`getExtendLanes()` walks `getNextLanelets()` until the lane sequence reaches `forward_path_length` ahead of the ego. On a road network that loops back on itself — a city block — that walk eventually returns a lanelet that is *already* in the sequence. Appending it makes the ego project onto the second lap, so `arc_coordinates.length` grows in step with `lane_length`, `forward_length` never reaches the threshold, and the loop extends the lanes forever.

The symptom is not a crash: `behavior_path_planner` spins at 100% of a core inside its own timer callback and publishes **no path at all**. `/planning/.../path_with_lane_id` goes silent, so planning and control report ERROR (`topic_rate_check/trajectory`, `topic_rate_check/control_command`), autonomous mode never becomes available and the vehicle never moves. Nothing in the logs points at the avoidance module; it took a stack sample to find it:

```
#0  ...static_obstacle_avoidance::getExtendLanes(...)
#1  ...StaticObstacleAvoidanceModule::fillFundamentalData(...)
#2  ...StaticObstacleAvoidanceModule::updateData()
#3  ...SceneModuleManagerInterface::isExecutionRequested(...)
```

The fix stops the walk when the next lanelet is already in the sequence: there is nothing further ahead for it to reach that the sequence does not already cover, and the walk is now bounded by the number of lanelets it can visit. Routes on non-looping maps are unaffected — a lanelet only repeats once the network has come back round to it.

## Related links

None.

## How was this PR tested?

Added a unit regression test — `TestUtils.getExtendLanesTerminatesOnLoopingMap` in `autoware_behavior_path_static_obstacle_avoidance_module` — that reproduces the hang on a minimal looping map and locks in the fix.

The fixture map `test_data/loop_map.osm` is a four-lanelet ring (`1010 → 1013 → 1016 → 1019 → 1010`), generated with [simple_lanelet2](https://github.com/hakuturu583/simple_lanelet2) so `getNextLanelets()` forms a cycle. **Click the map to open it in the WASM viewer:**

<a href="https://hakuturu583.github.io/simple_lanelet2/embed.html?map=https%3A%2F%2Fraw.githubusercontent.com%2Fhakuturu583%2Fautoware.universe%2Ffix%2Favoidance-extend-lanes-loop%2Fplanning%2Fbehavior_path_planner%2Fautoware_behavior_path_static_obstacle_avoidance_module%2Ftest_data%2Floop_map.osm&theme=dark"><img width="2400" height="1500" alt="loop_map_dark" src="https://github.com/user-attachments/assets/5112eeee-a72c-4d6d-ac72-3224b32c00e3" /></a>

The test places the ego at the start of the ring (derived from the loaded geometry, so it stays independent of the map projection), calls `getExtendLanes()` with `forward_path_length` set longer than the 80 m loop, and asserts the returned sequence:

- contains no repeated lanelet id, and
- is no longer than the four lanelets of a single loop.

With the guard, `getExtendLanes()` returns the four ring lanelets once. Without it the walk keeps re-appending the ring, so both assertions fail — the test fails cleanly instead of hanging CI. The whole `test_utils` suite (18 tests) passes with the fix in place.

The bug itself was originally found on a Lanelet2 map converted from a CARLA town (Town10HD), where every block loops: the planner hung the moment a route made a lane change possible beside the ego.


## Notes for reviewers

The guard is a linear scan of the sequence being built, which stays short by construction: it is bounded by `forward_path_length` on any map where the loop terminated before.

## Interface changes

None.

## Effects on system behavior

On a looping map, the avoidance module returns a finite lane sequence instead of hanging. On every other map, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B5Gc9n8qQgHyNTd3gsow8z

