### PR TITLE
fix(autoware_goal_distance_calculator): declare the route input as a remap target

### DIFF
--- a/common/autoware_goal_distance_calculator/design/GoalDistanceCalculator.node.yaml
+++ b/common/autoware_goal_distance_calculator/design/GoalDistanceCalculator.node.yaml
@@ -21,7 +21,7 @@ subscribers:
     global: /tf_static
   - name: route
     message_type: autoware_planning_msgs/msg/LaneletRoute
-    global: /planning/mission_planning/route
+    remap_target: /planning/mission_planning/route
 
 publishers:
   - name: deviation/lateral


### PR DESCRIPTION
## Description

Split of #13298 — the `common` slice.

`GoalDistanceCalculator` pins its `route` subscriber to `/planning/mission_planning/route` with `global:`. A port pinned with `global:` connects outside the design graph on a fixed topic: `link_manager` skips any connection whose target is a global input port, and the exporter emits no remap. With `remap_target:` the port takes part in the graph like any other, while the launcher still binds it to the official name.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it

## How was this PR tested?

- `pre-commit run --files common/autoware_goal_distance_calculator/design/GoalDistanceCalculator.node.yaml` (Autoware System Design Format lint, prettier, yamllint) passes.
- The change is byte-identical to the corresponding file on #13298, which was validated by an `autoware_sample_designs` deployment build.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched.

## Interface changes

None. The topic name is unchanged.

## Effects on system behavior

None.

