### PR TITLE
fix(autoware_geo_pose_projector): declare the map projector info input as a remap target

### DIFF
--- a/localization/autoware_geo_pose_projector/design/GeoPoseProjector.node.yaml
+++ b/localization/autoware_geo_pose_projector/design/GeoPoseProjector.node.yaml
@@ -11,7 +11,7 @@ launch:
 subscribers:
   - name: map_projector_info
     message_type: autoware_map_msgs/msg/MapProjectorInfo
-    global: /map/map_projector_info
+    remap_target: /map/map_projector_info
   - name: geo_pose
     message_type: geographic_msgs/msg/GeoPoseWithCovarianceStamped
     remap_target: input_geo_pose


### PR DESCRIPTION
## Description

Split of #13298 — the `localization` slice.

`GeoPoseProjector` pins its `map_projector_info` subscriber to `/map/map_projector_info` with `global:`. A port pinned with `global:` connects outside the design graph on a fixed topic: `link_manager` skips any connection whose target is a global input port, and the exporter emits no remap. With `remap_target:` the port takes part in the graph like any other, while the launcher still binds it to the official name.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it
- autowarefoundation/autoware_core#1416 — the same class of fix on the core side

## How was this PR tested?

- `pre-commit run --files localization/autoware_geo_pose_projector/design/GeoPoseProjector.node.yaml` (Autoware System Design Format lint, prettier, yamllint) passes.
- The change is byte-identical to the corresponding file on #13298, which was validated by an `autoware_sample_designs` deployment build.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched.

## Interface changes

None. The topic name is unchanged.

## Effects on system behavior

None.

