### PR TITLE
fix(design): align the simulator node designs with the packages they describe

### DIFF
--- a/simulator/autoware_dummy_diag_publisher/design/DummyDiagPublisher.node.yaml
+++ b/simulator/autoware_dummy_diag_publisher/design/DummyDiagPublisher.node.yaml
@@ -21,11 +21,16 @@ publishers:
     global: /diagnostics
 
 # parameters
+# the required diagnostics come from the system-side parameter files; the package defaults are empty.
 param_files:
   - name: param_file
-    default: config/dummy_diag_publisher.param.yaml
+    default: config/_empty.param.yaml
+  - name: extra_param_file
+    default: config/_empty.param.yaml
 
-param_values: []
+param_values:
+  - name: update_rate
+    default: 10.0
 
 # processes
 processes:

--- a/simulator/autoware_vehicle_door_simulator/design/VehicleDoorSimulator.node.yaml
+++ b/simulator/autoware_vehicle_door_simulator/design/VehicleDoorSimulator.node.yaml
@@ -8,7 +8,6 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::vehicle_door_simulator::DummyDoors
   executable: autoware_vehicle_door_simulator_node
   node_output: screen
 


### PR DESCRIPTION
## Description

Split of #13298 — the `simulator` slice.

`VehicleDoorSimulator.node.yaml` declares `plugin: autoware::vehicle_door_simulator::DummyDoors`, but `autoware_vehicle_door_simulator` builds its node with `ament_auto_add_executable` and registers no component with `RCLCPP_COMPONENTS_REGISTER_NODE`. The `plugin:` field is dropped; the design keeps its `executable:`.


`DummyDiagPublisher` declares the parameters its launcher passes: the required diagnostics come from the system-side parameter files, so the package defaults are empty and the node takes a second parameter file.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it

## How was this PR tested?

- `pre-commit run --files simulator/autoware_vehicle_door_simulator/design/VehicleDoorSimulator.node.yaml` (Autoware System Design Format lint, prettier, yamllint) passes.
- Checked against `CMakeLists.txt` and the absence of `RCLCPP_COMPONENTS_REGISTER_NODE` in the package.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched.

## Interface changes

None.

## Effects on system behavior

None.


