### PR TITLE
fix(design): align the vehicle node designs with the packages they build

### DIFF
--- a/vehicle/autoware_accel_brake_map_calibrator/design/AccelBrakeMapCalibrator.node.yaml
+++ b/vehicle/autoware_accel_brake_map_calibrator/design/AccelBrakeMapCalibrator.node.yaml
@@ -8,7 +8,6 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::accel_brake_map_calibrator::AccelBrakeMapCalibrator
   executable: accel_brake_map_calibrator
   node_output: screen
 

--- a/vehicle/autoware_raw_vehicle_cmd_converter/design/RawVehicleCmdConverter.node.yaml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/design/RawVehicleCmdConverter.node.yaml
@@ -8,7 +8,7 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::raw_vehicle_cmd_converter::RawVehicleCmdConverterNode
+  plugin: autoware::raw_vehicle_cmd_converter::RawVehicleCommandConverterNode
   executable: autoware_raw_vehicle_cmd_converter_node
   node_output: screen
 


### PR DESCRIPTION
## Description

Split of #13298 — the `vehicle` slice. Both designs name a launch field that does not match what the package builds, checked against `CMakeLists.txt` and `RCLCPP_COMPONENTS_REGISTER_NODE`.

| design | field | was | is |
| --- | --- | --- | --- |
| `RawVehicleCmdConverter` | plugin | `autoware::raw_vehicle_cmd_converter::RawVehicleCmdConverterNode` | `…::RawVehicleCommandConverterNode` |

`AccelBrakeMapCalibrator` is built with `ament_auto_add_executable` and registers no component, so its `plugin:` field is dropped; the design keeps its `executable:`.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it

## How was this PR tested?

- `pre-commit run --files` on both changed designs (Autoware System Design Format lint, prettier, yamllint) passes.
- Each launch field re-checked against the package `CMakeLists.txt` and the `RCLCPP_COMPONENTS_REGISTER_NODE` call site.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched.

## Interface changes

None.

## Effects on system behavior

None.

