### PR TITLE
fix(design): align the sensing node designs with the packages they describe

### DIFF
--- a/sensing/autoware_calibration_status_classifier/design/CalibrationStatusClassifier.node.yaml
+++ b/sensing/autoware_calibration_status_classifier/design/CalibrationStatusClassifier.node.yaml
@@ -33,10 +33,7 @@ subscribers:
     message_type: autoware_perception_msgs/msg/PredictedObjects
     remap_target: ~/input/objects
 
-publishers:
-  - name: preview_image
-    message_type: sensor_msgs/msg/Image
-    global: /sensing/camera/camera8/calibration_status_classifier/preview_image
+publishers: []
 
 servers:
   - name: validate_calibration_srv
@@ -59,5 +56,4 @@ processes:
       - and:
           - on_input: lidar
           - on_input: camera
-    outcomes:
-      - to_output: preview_image
+    outcomes: []

--- a/sensing/autoware_pointcloud_preprocessor/design/ConcatenatePointcloud8.node.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/design/ConcatenatePointcloud8.node.yaml
@@ -9,7 +9,7 @@ package:
 
 launch:
   plugin: autoware::pointcloud_preprocessor::PointCloudConcatenationComponent
-  executable: concatenate_pointcloud_node
+  executable: concatenate_pointclouds_node
   node_output: screen
 
 # interfaces


### PR DESCRIPTION
## Description

Split of #13298 — the `sensing` slice.

**`ConcatenatePointcloud8`** names `executable: concatenate_pointcloud_node`; `autoware_pointcloud_preprocessor` builds `concatenate_pointclouds_node`.

**`CalibrationStatusClassifier`** declares a `preview_image` publisher pinned to a hardcoded per-camera topic (`/sensing/camera/camera8/calibration_status_classifier/preview_image`) that the node no longer creates, and names it as the outcome of the `classify` process. Both the publisher and the process outcome are dropped.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it

## How was this PR tested?

- `pre-commit run --files` on both changed designs (Autoware System Design Format lint, prettier, yamllint) passes.
- The executable name checked against `CMakeLists.txt`; the dropped publisher checked against the `create_publisher` call sites in `autoware_calibration_status_classifier`.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched.

## Interface changes

None. `preview_image` is removed from the design because the node does not publish it; there is no node-side change.

## Effects on system behavior

None.

