### PR TITLE
fix(design): align the system node designs with the packages they describe

### DIFF
--- a/system/autoware_component_state_monitor/design/ComponentStateMonitor.node.yaml
+++ b/system/autoware_component_state_monitor/design/ComponentStateMonitor.node.yaml
@@ -1,0 +1,151 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: ComponentStateMonitor.node
+
+description: Aggregates the topic state monitor diagnostics into per-component launch and autonomous availability flags.
+
+package:
+  name: autoware_component_state_monitor
+  provider: autoware
+
+launch:
+  plugin: autoware::component_state_monitor::StateMonitor
+  executable: component_state_monitor_node
+  node_output: screen
+
+# interfaces
+# the monitored diagnostic names are given by the launch.<component> and
+# autonomous.<component> list parameters.
+subscribers:
+  - name: diagnostics
+    message_type: diagnostic_msgs/msg/DiagnosticArray
+    description: Topic state monitor statuses, matched by hardware_id and status name.
+    global: /diagnostics
+
+publishers:
+  - name: launch/sensing
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/launch/sensing
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: launch/perception
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/launch/perception
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: launch/map
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/launch/map
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: launch/localization
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/launch/localization
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: launch/planning
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/launch/planning
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: launch/control
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/launch/control
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: launch/vehicle
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/launch/vehicle
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: launch/system
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/launch/system
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: autonomous/sensing
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/autonomous/sensing
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: autonomous/perception
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/autonomous/perception
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: autonomous/map
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/autonomous/map
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: autonomous/localization
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/autonomous/localization
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: autonomous/planning
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/autonomous/planning
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: autonomous/control
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/autonomous/control
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: autonomous/vehicle
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/autonomous/vehicle
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: autonomous/system
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    remap_target: ~/autonomous/system
+    qos:
+      reliability: reliable
+      durability: transient_local
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: monitor
+    description: Publishes a component flag whenever all of its monitored statuses are OK and the flag changes.
+    trigger_conditions:
+      - periodic: 10.0
+    outcomes:
+      - to_output: launch/sensing
+      - to_output: launch/perception
+      - to_output: launch/map
+      - to_output: launch/localization
+      - to_output: launch/planning
+      - to_output: launch/control
+      - to_output: launch/vehicle
+      - to_output: launch/system
+      - to_output: autonomous/sensing
+      - to_output: autonomous/perception
+      - to_output: autonomous/map
+      - to_output: autonomous/localization
+      - to_output: autonomous/planning
+      - to_output: autonomous/control
+      - to_output: autonomous/vehicle
+      - to_output: autonomous/system

--- a/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer/design/AutomaticPoseInitializer.node.yaml
+++ b/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer/design/AutomaticPoseInitializer.node.yaml
@@ -18,14 +18,14 @@ launch:
 subscribers:
   - name: initialization_state
     message_type: autoware_adapi_v1_msgs/msg/LocalizationInitializationState
-    global: /localization/initialization_state
+    remap_target: /localization/initialization_state
 
 publishers: []
 
 clients:
   - name: initialize
     message_type: autoware_localization_msgs/srv/InitializeLocalization
-    global: /localization/initialize
+    remap_target: /localization/initialize
 
 # parameters
 param_files: []

--- a/system/autoware_default_adapi_universe/design/AdapiAutowareState.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiAutowareState.node.yaml
@@ -1,0 +1,90 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiAutowareState.node
+
+description: Publishes the legacy Autoware state derived from the localization, routing and operation mode API states and the component launch states.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::AutowareStateNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: localization_state
+    message_type: autoware_adapi_v1_msgs/msg/LocalizationInitializationState
+    description: Localization initialization state from the API.
+    remap_target: /api/localization/initialization_state
+  - name: routing_state
+    message_type: autoware_adapi_v1_msgs/msg/RouteState
+    description: Route state from the API.
+    remap_target: /api/routing/state
+  - name: operation_mode_state
+    message_type: autoware_adapi_v1_msgs/msg/OperationModeState
+    description: Operation mode state from the API.
+    remap_target: /api/operation_mode/state
+  - name: launch_state_sensing
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    description: Launch state of the sensing component.
+    remap_target: /system/component_state_monitor/component/launch/sensing
+  - name: launch_state_perception
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    description: Launch state of the perception component.
+    remap_target: /system/component_state_monitor/component/launch/perception
+  - name: launch_state_map
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    description: Launch state of the map component.
+    remap_target: /system/component_state_monitor/component/launch/map
+  - name: launch_state_localization
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    description: Launch state of the localization component.
+    remap_target: /system/component_state_monitor/component/launch/localization
+  - name: launch_state_planning
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    description: Launch state of the planning component.
+    remap_target: /system/component_state_monitor/component/launch/planning
+  - name: launch_state_control
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    description: Launch state of the control component.
+    remap_target: /system/component_state_monitor/component/launch/control
+  - name: launch_state_vehicle
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    description: Launch state of the vehicle component.
+    remap_target: /system/component_state_monitor/component/launch/vehicle
+  - name: launch_state_system
+    message_type: tier4_system_msgs/msg/ModeChangeAvailable
+    description: Launch state of the system component.
+    remap_target: /system/component_state_monitor/component/launch/system
+
+publishers:
+  - name: autoware_state
+    message_type: autoware_system_msgs/msg/AutowareState
+    description: Autoware state converted from the API states.
+    remap_target: /autoware/state
+
+servers:
+  - name: shutdown
+    message_type: std_srvs/srv/Trigger
+    description: Puts the Autoware state into finalizing.
+    remap_target: /autoware/shutdown
+
+# parameters
+param_files: []
+
+param_values:
+  - name: update_rate
+    type: double
+    default: 10.0
+    description: Publish rate of the Autoware state [Hz].
+
+# processes
+processes:
+  - name: publish_state
+    description: Periodically converts the latest API and launch states into the Autoware state and publishes it.
+    trigger_conditions: []
+    outcomes:
+      - to_output: autoware_state

--- a/system/autoware_default_adapi_universe/design/AdapiDiagnostics.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiDiagnostics.node.yaml
@@ -1,0 +1,71 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiDiagnostics.node
+
+description: Relays the internal diagnostics graph structure and status to the API and forwards graph reset requests while the MRM state allows it.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::DiagnosticsNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: struct
+    message_type: tier4_system_msgs/msg/DiagGraphStruct
+    description: Diagnostics graph structure from the aggregator.
+    remap_target: /diagnostics_graph/struct
+  - name: status
+    message_type: tier4_system_msgs/msg/DiagGraphStatus
+    description: Diagnostics graph status from the aggregator.
+    remap_target: /diagnostics_graph/status
+  - name: mrm_state
+    message_type: autoware_adapi_v1_msgs/msg/MrmState
+    description: MRM state from the API, gates the graph reset.
+    remap_target: /api/fail_safe/mrm_state
+
+publishers:
+  - name: struct
+    message_type: autoware_adapi_v1_msgs/msg/DiagGraphStruct
+    description: Diagnostics graph structure for the API.
+    remap_target: /api/system/diagnostics/struct
+  - name: status
+    message_type: autoware_adapi_v1_msgs/msg/DiagGraphStatus
+    description: Diagnostics graph status for the API.
+    remap_target: /api/system/diagnostics/status
+
+servers:
+  - name: reset
+    message_type: autoware_adapi_v1_msgs/srv/ResetDiagGraph
+    description: Diagnostics graph reset request from the API.
+    remap_target: /api/system/diagnostics/reset
+
+clients:
+  - name: reset
+    message_type: tier4_system_msgs/srv/ResetDiagGraph
+    description: Diagnostics graph reset of the aggregator.
+    remap_target: /diagnostics_graph/reset
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: relay_struct
+    description: Converts the internal graph structure to the API message.
+    trigger_conditions:
+      - on_input: struct
+    outcomes:
+      - to_output: struct
+  - name: relay_status
+    description: Converts the internal graph status to the API message.
+    trigger_conditions:
+      - on_input: status
+    outcomes:
+      - to_output: status

--- a/system/autoware_default_adapi_universe/design/AdapiFailSafe.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiFailSafe.node.yaml
@@ -1,0 +1,63 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiFailSafe.node
+
+description: Relays the MRM state to the API and serves the list of MRM descriptions configured by parameters.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::FailSafeNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: mrm_state
+    message_type: autoware_adapi_v1_msgs/msg/MrmState
+    description: MRM state from the MRM handler.
+    remap_target: /system/fail_safe/mrm_state
+
+publishers:
+  - name: mrm_state
+    message_type: autoware_adapi_v1_msgs/msg/MrmState
+    description: MRM state for the API.
+    remap_target: /api/fail_safe/mrm_state
+
+servers:
+  - name: list_mrm_description
+    message_type: autoware_adapi_v1_msgs/srv/ListMrmDescription
+    description: Lists the configured MRM descriptions.
+    remap_target: /api/fail_safe/list_mrm_description
+
+# parameters
+param_files: []
+
+param_values:
+  - name: mrm_descriptions.emergency_stop.behavior
+    type: int
+    default: 2
+    description: MRM state behavior value of the emergency stop.
+  - name: mrm_descriptions.emergency_stop.description
+    type: string
+    default: Emergency stop
+    description: Human readable description of the emergency stop.
+  - name: mrm_descriptions.comfortable_stop.behavior
+    type: int
+    default: 3
+    description: MRM state behavior value of the comfortable stop.
+  - name: mrm_descriptions.comfortable_stop.description
+    type: string
+    default: Comfortable stop
+    description: Human readable description of the comfortable stop.
+
+# processes
+processes:
+  - name: relay_mrm_state
+    description: Publishes the MRM state to the API when it changes.
+    trigger_conditions:
+      - on_input: mrm_state
+    outcomes:
+      - to_output: mrm_state

--- a/system/autoware_default_adapi_universe/design/AdapiHeartbeat.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiHeartbeat.node.yaml
@@ -1,0 +1,36 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiHeartbeat.node
+
+description: Publishes the API heartbeat with a sequence number at 10 Hz.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::HeartbeatNode
+  node_output: screen
+
+# interfaces
+subscribers: []
+
+publishers:
+  - name: heartbeat
+    message_type: autoware_adapi_v1_msgs/msg/Heartbeat
+    description: Heartbeat with a wrapping sequence number.
+    remap_target: /api/system/heartbeat
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: publish_heartbeat
+    description: Periodically publishes the stamped heartbeat.
+    trigger_conditions: []
+    outcomes:
+      - to_output: heartbeat

--- a/system/autoware_default_adapi_universe/design/AdapiManualControl.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiManualControl.node.yaml
@@ -1,0 +1,119 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiManualControl.node
+
+description: Bridges manual control commands from the API to the external command topics for the selected operation mode, and monitors the operator heartbeat.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::ManualControlNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: operation_mode_state
+    message_type: autoware_adapi_v1_msgs/msg/OperationModeState
+    description: Operation mode state, blocks mode selection during operation.
+    remap_target: /api/operation_mode/state
+  - name: operator_heartbeat
+    message_type: autoware_adapi_v1_msgs/msg/ManualOperatorHeartbeat
+    description: Operator heartbeat from the API; the topic derives from the mode parameter.
+  - name: pedals
+    message_type: autoware_adapi_v1_msgs/msg/PedalsCommand
+    description: Pedals command from the API; the topic derives from the mode parameter.
+  - name: steering
+    message_type: autoware_adapi_v1_msgs/msg/SteeringCommand
+    description: Steering command from the API; the topic derives from the mode parameter.
+  - name: gear
+    message_type: autoware_adapi_v1_msgs/msg/GearCommand
+    description: Gear command from the API; the topic derives from the mode parameter.
+  - name: turn_indicators
+    message_type: autoware_adapi_v1_msgs/msg/TurnIndicatorsCommand
+    description: Turn indicators command from the API; the topic derives from the mode parameter.
+  - name: hazard_lights
+    message_type: autoware_adapi_v1_msgs/msg/HazardLightsCommand
+    description: Hazard lights command from the API; the topic derives from the mode parameter.
+
+publishers:
+  - name: control_mode_status
+    message_type: autoware_adapi_v1_msgs/msg/ManualControlModeStatus
+    description: Current manual control mode; the topic derives from the mode parameter.
+  - name: heartbeat
+    message_type: autoware_adapi_v1_msgs/msg/ManualOperatorHeartbeat
+    description: Operator heartbeat relayed to the external interface; the topic derives from the mode parameter.
+  - name: pedals_cmd
+    message_type: autoware_adapi_v1_msgs/msg/PedalsCommand
+    description: Pedals command relayed to the external interface; the topic derives from the mode parameter.
+  - name: steering_cmd
+    message_type: autoware_adapi_v1_msgs/msg/SteeringCommand
+    description: Steering command relayed to the external interface; the topic derives from the mode parameter.
+  - name: gear_cmd
+    message_type: autoware_vehicle_msgs/msg/GearCommand
+    description: Gear command converted to the vehicle message; the topic derives from the mode parameter.
+  - name: turn_indicators_cmd
+    message_type: autoware_vehicle_msgs/msg/TurnIndicatorsCommand
+    description: Turn indicators command converted to the vehicle message; the topic derives from the mode parameter.
+  - name: hazard_lights_cmd
+    message_type: autoware_vehicle_msgs/msg/HazardLightsCommand
+    description: Hazard lights command converted to the vehicle message; the topic derives from the mode parameter.
+
+servers:
+  - name: control_mode_list
+    message_type: autoware_adapi_v1_msgs/srv/ListManualControlMode
+    description: Lists the supported manual control modes; the service name derives from the mode parameter.
+  - name: control_mode_select
+    message_type: autoware_adapi_v1_msgs/srv/SelectManualControlMode
+    description: Selects the manual control mode and enables its command interfaces; the service name derives from the mode parameter.
+
+# parameters
+param_files: []
+
+param_values:
+  - name: mode
+    type: string
+    default: local
+    description: Target operation mode of the manual control, local or remote.
+  - name: diag_timeout_warn_duration
+    type: double
+    default: 1.0
+    description: Operator heartbeat timeout for the diagnostics warning [s].
+  - name: diag_timeout_error_duration
+    type: double
+    default: 2.0
+    description: Operator heartbeat timeout for the diagnostics error [s].
+  - name: diagnostic_updater.period
+    type: double
+    default: 1.0
+    description: Diagnostic updater publish period [s].
+  - name: diagnostic_updater.use_fqn
+    type: bool
+    default: true
+    description: Uses the fully-qualified node name for diagnostic hardware ID.
+
+# processes
+processes:
+  - name: select_control_mode
+    description: Handles a mode selection request; enables the command interfaces of the selected mode and publishes the mode status.
+    trigger_conditions: []
+    outcomes:
+      - to_output: control_mode_status
+  - name: relay_commands
+    description: Relays the operator heartbeat and manual commands of the enabled mode to the external interface, converting the gear and lights commands to vehicle messages.
+    trigger_conditions:
+      - on_input: operator_heartbeat
+      - on_input: pedals
+      - on_input: steering
+      - on_input: gear
+      - on_input: turn_indicators
+      - on_input: hazard_lights
+    outcomes:
+      - to_output: heartbeat
+      - to_output: pedals_cmd
+      - to_output: steering_cmd
+      - to_output: gear_cmd
+      - to_output: turn_indicators_cmd
+      - to_output: hazard_lights_cmd

--- a/system/autoware_default_adapi_universe/design/AdapiMotion.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiMotion.node.yaml
@@ -1,0 +1,70 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiMotion.node
+
+description: Publishes the motion state derived from the vehicle stop check and the vehicle command gate pause states, and controls the pause to hold the vehicle until a start is accepted.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::MotionNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: kinematic_state
+    message_type: nav_msgs/msg/Odometry
+    description: Ego odometry for the vehicle stop check.
+    remap_target: /localization/kinematic_state
+  - name: is_paused
+    message_type: tier4_control_msgs/msg/IsPaused
+    description: Pause state of the vehicle command gate.
+    remap_target: /control/vehicle_cmd_gate/is_paused
+  - name: is_start_requested
+    message_type: tier4_control_msgs/msg/IsStartRequested
+    description: Start request state of the vehicle command gate.
+    remap_target: /control/vehicle_cmd_gate/is_start_requested
+
+publishers:
+  - name: state
+    message_type: autoware_adapi_v1_msgs/msg/MotionState
+    description: Motion state for the API.
+    remap_target: /api/motion/state
+
+servers:
+  - name: accept_start
+    message_type: autoware_adapi_v1_msgs/srv/AcceptStart
+    description: Accepts the vehicle start in the starting state.
+    remap_target: /api/motion/accept_start
+
+clients:
+  - name: set_pause
+    message_type: tier4_control_msgs/srv/SetPause
+    description: Sets the pause of the vehicle command gate.
+    remap_target: /control/vehicle_cmd_gate/set_pause
+
+# parameters
+param_files: []
+
+param_values:
+  - name: require_accept_start
+    type: bool
+    default: false
+    description: If true, the accept start service is required to leave the starting state.
+  - name: stop_check_duration
+    type: double
+    default: 1.0
+    description: The duration used for the stop check [s].
+
+# processes
+processes:
+  - name: update_state
+    description: Updates the motion state from the pause and stop check states, publishes it on change, and requests the gate pause on the pausing and resuming transitions.
+    trigger_conditions:
+      - on_input: is_paused
+      - on_input: is_start_requested
+    outcomes:
+      - to_output: state

--- a/system/autoware_default_adapi_universe/design/AdapiMrmRequest.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiMrmRequest.node.yaml
@@ -1,0 +1,50 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiMrmRequest.node
+
+description: Accepts MRM requests from the API, publishes the current request list, and reports the delegate requests to the diagnostics.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::MrmRequestNode
+  node_output: screen
+
+# interfaces
+subscribers: []
+
+publishers:
+  - name: mrm_request/list
+    message_type: autoware_adapi_v1_msgs/msg/MrmRequestList
+    description: Current MRM requests for the API.
+    remap_target: /api/fail_safe/mrm_request/list
+
+servers:
+  - name: mrm_request/send
+    message_type: autoware_adapi_v1_msgs/srv/SendMrmRequest
+    description: Registers or cancels an MRM request per sender.
+    remap_target: /api/fail_safe/mrm_request/send
+
+# parameters
+param_files: []
+
+param_values:
+  - name: diagnostic_updater.period
+    type: double
+    default: 1.0
+    description: Diagnostic updater publish period [s].
+  - name: diagnostic_updater.use_fqn
+    type: bool
+    default: true
+    description: Uses the fully-qualified node name for diagnostic hardware ID.
+
+# processes
+processes:
+  - name: handle_request
+    description: Handles an MRM request; updates the request map, refreshes the delegate diagnostics, and publishes the request list.
+    trigger_conditions: []
+    outcomes:
+      - to_output: mrm_request/list

--- a/system/autoware_default_adapi_universe/design/AdapiOperationMode.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiOperationMode.node.yaml
@@ -1,0 +1,87 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiOperationMode.node
+
+description: Serves the operation mode API; publishes the operation mode state filtered by the system availability and forwards mode and control change requests to the system.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::OperationModeNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: operation_mode_state
+    message_type: autoware_adapi_v1_msgs/msg/OperationModeState
+    description: Operation mode state from the operation mode transition manager.
+    remap_target: /system/operation_mode/state
+  - name: availability
+    message_type: tier4_system_msgs/msg/OperationModeAvailability
+    description: Availability of each operation mode from the system.
+    remap_target: /system/operation_mode/availability
+
+publishers:
+  - name: state
+    message_type: autoware_adapi_v1_msgs/msg/OperationModeState
+    description: Operation mode state for the API, availability flags masked by the system availability.
+    remap_target: /api/operation_mode/state
+
+servers:
+  - name: change_to_stop
+    message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
+    description: Changes the operation mode to stop.
+    remap_target: /api/operation_mode/change_to_stop
+  - name: change_to_autonomous
+    message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
+    description: Changes the operation mode to autonomous.
+    remap_target: /api/operation_mode/change_to_autonomous
+  - name: change_to_local
+    message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
+    description: Changes the operation mode to local.
+    remap_target: /api/operation_mode/change_to_local
+  - name: change_to_remote
+    message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
+    description: Changes the operation mode to remote.
+    remap_target: /api/operation_mode/change_to_remote
+  - name: enable_autoware_control
+    message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
+    description: Enables the vehicle control by Autoware.
+    remap_target: /api/operation_mode/enable_autoware_control
+  - name: disable_autoware_control
+    message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
+    description: Disables the vehicle control by Autoware.
+    remap_target: /api/operation_mode/disable_autoware_control
+
+clients:
+  - name: change_operation_mode
+    message_type: autoware_system_msgs/srv/ChangeOperationMode
+    description: Operation mode change of the operation mode transition manager.
+    remap_target: /system/operation_mode/change_operation_mode
+  - name: change_autoware_control
+    message_type: autoware_system_msgs/srv/ChangeAutowareControl
+    description: Autoware control change of the operation mode transition manager.
+    remap_target: /system/operation_mode/change_autoware_control
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: publish_state
+    description: Masks the operation mode state with the system availability and publishes it on change.
+    trigger_conditions:
+      - on_input: operation_mode_state
+      - on_input: availability
+    outcomes:
+      - to_output: state
+  - name: change_mode
+    description: Handles a mode or control change request; rejects unavailable modes and forwards the request to the system.
+    trigger_conditions: []
+    outcomes:
+      - terminal: null

--- a/system/autoware_default_adapi_universe/design/AdapiPerception.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiPerception.node.yaml
@@ -1,0 +1,41 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiPerception.node
+
+description: Converts the recognized objects into the API dynamic object format.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::PerceptionNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: objects
+    message_type: autoware_perception_msgs/msg/PredictedObjects
+    description: Predicted objects from the object recognition.
+    remap_target: /perception/object_recognition/objects
+
+publishers:
+  - name: objects
+    message_type: autoware_adapi_v1_msgs/msg/DynamicObjectArray
+    description: Dynamic objects for the API.
+    remap_target: /api/perception/objects
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: relay_objects
+    description: Converts each predicted object message to the API message.
+    trigger_conditions:
+      - on_input: objects
+    outcomes:
+      - to_output: objects

--- a/system/autoware_default_adapi_universe/design/AdapiPlanning.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiPlanning.node.yaml
@@ -1,0 +1,174 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiPlanning.node
+
+description: Merges the planning factors of all planning modules and publishes them as the API velocity and steering factors, completing distance and status from the trajectory and ego kinematics.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::PlanningNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: trajectory
+    message_type: autoware_planning_msgs/msg/Trajectory
+    description: Planned trajectory used to compute factor distances.
+    remap_target: /planning/trajectory
+  - name: kinematic_state
+    message_type: nav_msgs/msg/Odometry
+    description: Ego kinematics for the stop check and factor distances.
+    remap_target: /localization/kinematic_state
+  - name: planning_factors/behavior_path_planner
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the behavior path planner module.
+    remap_target: /planning/planning_factors/behavior_path_planner
+  - name: planning_factors/blind_spot
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the blind spot module.
+    remap_target: /planning/planning_factors/blind_spot
+  - name: planning_factors/crosswalk
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the crosswalk module.
+    remap_target: /planning/planning_factors/crosswalk
+  - name: planning_factors/detection_area
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the detection area module.
+    remap_target: /planning/planning_factors/detection_area
+  - name: planning_factors/dynamic_obstacle_stop
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the dynamic obstacle stop module.
+    remap_target: /planning/planning_factors/dynamic_obstacle_stop
+  - name: planning_factors/intersection
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the intersection module.
+    remap_target: /planning/planning_factors/intersection
+  - name: planning_factors/merge_from_private
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the merge from private module.
+    remap_target: /planning/planning_factors/merge_from_private
+  - name: planning_factors/no_stopping_area
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the no stopping area module.
+    remap_target: /planning/planning_factors/no_stopping_area
+  - name: planning_factors/obstacle_cruise_planner
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the obstacle cruise planner module.
+    remap_target: /planning/planning_factors/obstacle_cruise_planner
+  - name: planning_factors/obstacle_stop_planner
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the obstacle stop planner module.
+    remap_target: /planning/planning_factors/obstacle_stop_planner
+  - name: planning_factors/obstacle_stop
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the obstacle stop module.
+    remap_target: /planning/planning_factors/obstacle_stop
+  - name: planning_factors/obstacle_cruise
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the obstacle cruise module.
+    remap_target: /planning/planning_factors/obstacle_cruise
+  - name: planning_factors/obstacle_slow_down
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the obstacle slow down module.
+    remap_target: /planning/planning_factors/obstacle_slow_down
+  - name: planning_factors/occlusion_spot
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the occlusion spot module.
+    remap_target: /planning/planning_factors/occlusion_spot
+  - name: planning_factors/run_out
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the run out module.
+    remap_target: /planning/planning_factors/run_out
+  - name: planning_factors/stop_line
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the stop line module.
+    remap_target: /planning/planning_factors/stop_line
+  - name: planning_factors/surround_obstacle_checker
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the surround obstacle checker module.
+    remap_target: /planning/planning_factors/surround_obstacle_checker
+  - name: planning_factors/traffic_light
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the traffic light module.
+    remap_target: /planning/planning_factors/traffic_light
+  - name: planning_factors/virtual_traffic_light
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the virtual traffic light module.
+    remap_target: /planning/planning_factors/virtual_traffic_light
+  - name: planning_factors/walkway
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the walkway module.
+    remap_target: /planning/planning_factors/walkway
+  - name: planning_factors/motion_velocity_planner
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the motion velocity planner module.
+    remap_target: /planning/planning_factors/motion_velocity_planner
+  - name: planning_factors/static_obstacle_avoidance
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the static obstacle avoidance module.
+    remap_target: /planning/planning_factors/static_obstacle_avoidance
+  - name: planning_factors/dynamic_obstacle_avoidance
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the dynamic obstacle avoidance module.
+    remap_target: /planning/planning_factors/dynamic_obstacle_avoidance
+  - name: planning_factors/avoidance_by_lane_change
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the avoidance by lane change module.
+    remap_target: /planning/planning_factors/avoidance_by_lane_change
+  - name: planning_factors/lane_change_left
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the lane change left module.
+    remap_target: /planning/planning_factors/lane_change_left
+  - name: planning_factors/lane_change_right
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the lane change right module.
+    remap_target: /planning/planning_factors/lane_change_right
+  - name: planning_factors/start_planner
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the start planner module.
+    remap_target: /planning/planning_factors/start_planner
+  - name: planning_factors/goal_planner
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the goal planner module.
+    remap_target: /planning/planning_factors/goal_planner
+  - name: planning_factors/roundabout
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    description: Planning factors of the roundabout module.
+    remap_target: /planning/planning_factors/roundabout
+
+publishers:
+  - name: velocity_factors
+    message_type: autoware_adapi_v1_msgs/msg/VelocityFactorArray
+    description: Merged velocity factors for the API.
+    remap_target: /api/planning/velocity_factors
+  - name: steering_factors
+    message_type: autoware_adapi_v1_msgs/msg/SteeringFactorArray
+    description: Merged steering factors for the API.
+    remap_target: /api/planning/steering_factors
+
+# parameters
+param_files: []
+
+param_values:
+  - name: stop_distance
+    type: double
+    default: 1.0
+    description: Distance to the factor point below which a stopped vehicle marks the factor as stopped [m].
+  - name: stop_duration
+    type: double
+    default: 1.0
+    description: Duration the vehicle must be stationary to be considered stopped [s].
+
+# processes
+processes:
+  - name: publish_factors
+    description: Periodically merges the latest planning factors of all modules, fills distance and status, and publishes the velocity and steering factors.
+    trigger_conditions:
+      - periodic: 5.0
+    outcomes:
+      - to_output: velocity_factors
+      - to_output: steering_factors

--- a/system/autoware_default_adapi_universe/design/AdapiVehicleCommand.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiVehicleCommand.node.yaml
@@ -1,0 +1,65 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiVehicleCommand.node
+
+description: Relays the internal control and actuation commands to the API vehicle command topics.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::VehicleCommandNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: control_cmd
+    message_type: autoware_control_msgs/msg/Control
+    description: Control command from the control component.
+    remap_target: /control/command/control_cmd
+  - name: actuation_cmd
+    message_type: tier4_vehicle_msgs/msg/ActuationCommandStamped
+    description: Actuation command from the control component.
+    remap_target: /control/command/actuation_cmd
+
+publishers:
+  - name: pedals
+    message_type: autoware_adapi_v1_msgs/msg/PedalsCommand
+    description: Pedals command for the API.
+    remap_target: /api/control/command/pedals
+  - name: acceleration
+    message_type: autoware_adapi_v1_msgs/msg/AccelerationCommand
+    description: Acceleration command for the API.
+    remap_target: /api/control/command/acceleration
+  - name: velocity
+    message_type: autoware_adapi_v1_msgs/msg/VelocityCommand
+    description: Velocity command for the API.
+    remap_target: /api/control/command/velocity
+  - name: steering
+    message_type: autoware_adapi_v1_msgs/msg/SteeringCommand
+    description: Steering command for the API.
+    remap_target: /api/control/command/steering
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: relay_control
+    description: Splits the control command into the API acceleration, velocity and steering commands.
+    trigger_conditions:
+      - on_input: control_cmd
+    outcomes:
+      - to_output: acceleration
+      - to_output: velocity
+      - to_output: steering
+  - name: relay_actuation
+    description: Converts the actuation command into the API pedals command.
+    trigger_conditions:
+      - on_input: actuation_cmd
+    outcomes:
+      - to_output: pedals

--- a/system/autoware_default_adapi_universe/design/AdapiVehicleDoor.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiVehicleDoor.node.yaml
@@ -1,0 +1,81 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiVehicleDoor.node
+
+description: Bridges the API door interfaces to the vehicle door services, gating open commands by the operation mode, and diagnoses the door state.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::VehicleDoorNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: door_status
+    message_type: autoware_adapi_v1_msgs/msg/DoorStatusArray
+    description: Door status from the vehicle.
+    remap_target: /vehicle/doors/status
+  - name: operation_mode_state
+    message_type: autoware_adapi_v1_msgs/msg/OperationModeState
+    description: Operation mode state, gates the door command.
+    remap_target: /system/operation_mode/state
+
+publishers:
+  - name: status
+    message_type: autoware_adapi_v1_msgs/msg/DoorStatusArray
+    description: Door status for the API.
+    remap_target: /api/vehicle/doors/status
+
+servers:
+  - name: command
+    message_type: autoware_adapi_v1_msgs/srv/SetDoorCommand
+    description: Door command request from the API.
+    remap_target: /api/vehicle/doors/command
+  - name: layout
+    message_type: autoware_adapi_v1_msgs/srv/GetDoorLayout
+    description: Door layout request from the API.
+    remap_target: /api/vehicle/doors/layout
+
+clients:
+  - name: command
+    message_type: autoware_adapi_v1_msgs/srv/SetDoorCommand
+    description: Door command of the vehicle interface.
+    remap_target: /vehicle/doors/command
+  - name: layout
+    message_type: autoware_adapi_v1_msgs/srv/GetDoorLayout
+    description: Door layout of the vehicle interface.
+    remap_target: /vehicle/doors/layout
+
+# parameters
+param_files: []
+
+param_values:
+  - name: check_autoware_control
+    type: bool
+    default: true
+    description: If true, door commands are accepted only while autoware control is enabled.
+  - name: diagnostic_updater.period
+    type: double
+    default: 1.0
+    description: Diagnostic updater publish period [s].
+  - name: diagnostic_updater.use_fqn
+    type: bool
+    default: true
+    description: Uses the fully-qualified node name for diagnostic hardware ID.
+
+# processes
+processes:
+  - name: relay_status
+    description: Notifies the API of door status changes.
+    trigger_conditions:
+      - on_input: door_status
+    outcomes:
+      - to_output: status
+  - name: handle_command
+    description: Checks the operation mode and forwards accepted door commands to the vehicle interface.
+    trigger_conditions: []
+    outcomes: []

--- a/system/autoware_default_adapi_universe/design/AdapiVehicleInfo.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiVehicleInfo.node.yaml
@@ -1,0 +1,40 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiVehicleInfo.node
+
+description: Serves the vehicle dimensions and footprint composed from the vehicle info parameters.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::VehicleInfoNode
+  node_output: screen
+
+# interfaces
+subscribers: []
+
+publishers: []
+
+servers:
+  - name: dimensions
+    message_type: autoware_adapi_v1_msgs/srv/GetVehicleDimensions
+    description: Vehicle dimensions request from the API.
+    remap_target: /api/vehicle/dimensions
+
+# parameters
+param_files:
+  - name: vehicle_param
+    default: $(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml
+    description: Vehicle dimensions served through the API.
+
+param_values: []
+
+# processes
+processes:
+  - name: get_dimensions
+    description: Responds to dimension requests with the values loaded from the vehicle info parameters.
+    trigger_conditions: []
+    outcomes: []

--- a/system/autoware_default_adapi_universe/design/AdapiVehicleMetrics.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiVehicleMetrics.node.yaml
@@ -1,0 +1,48 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiVehicleMetrics.node
+
+description: Publishes the vehicle metrics with the energy level normalized by the maximum capacity.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::VehicleMetricsNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: battery_charge
+    message_type: tier4_vehicle_msgs/msg/BatteryStatus
+    description: Battery status from the vehicle.
+    remap_target: /vehicle/status/battery_charge
+
+publishers:
+  - name: metrics
+    message_type: autoware_adapi_v1_msgs/msg/VehicleMetrics
+    description: Vehicle metrics for the API.
+    remap_target: /api/vehicle/metrics
+
+# parameters
+param_files: []
+
+param_values:
+  - name: update_rate
+    type: double
+    default: 0.1
+    description: Publish rate of the vehicle metrics [Hz].
+  - name: max_energy_level
+    type: double
+    default: 1.0
+    description: Maximum energy level used to normalize the battery charge.
+
+# processes
+processes:
+  - name: publish_metrics
+    description: Periodically publishes the normalized energy level from the latest battery status.
+    trigger_conditions: []
+    outcomes:
+      - to_output: metrics

--- a/system/autoware_default_adapi_universe/design/AdapiVehicleStatus.node.yaml
+++ b/system/autoware_default_adapi_universe/design/AdapiVehicleStatus.node.yaml
@@ -1,0 +1,74 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: AdapiVehicleStatus.node
+
+description: Publishes the vehicle kinematics with a geographic pose and the vehicle status converted from the vehicle reports.
+
+package:
+  name: autoware_default_adapi_universe
+  provider: autoware
+
+launch:
+  plugin: autoware::default_adapi::VehicleStatusNode
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: kinematic_state
+    message_type: nav_msgs/msg/Odometry
+    description: Ego kinematics from the localization.
+    remap_target: /localization/kinematic_state
+  - name: acceleration
+    message_type: geometry_msgs/msg/AccelWithCovarianceStamped
+    description: Ego acceleration from the localization.
+    remap_target: /localization/acceleration
+  - name: map_projector_info
+    message_type: autoware_map_msgs/msg/MapProjectorInfo
+    description: Map projector info used to compute the geographic pose.
+    remap_target: /map/map_projector_info
+  - name: gear_status
+    message_type: autoware_vehicle_msgs/msg/GearReport
+    description: Gear report from the vehicle.
+    remap_target: /vehicle/status/gear_status
+  - name: steering_status
+    message_type: autoware_vehicle_msgs/msg/SteeringReport
+    description: Steering report from the vehicle.
+    remap_target: /vehicle/status/steering_status
+  - name: turn_indicators_status
+    message_type: autoware_vehicle_msgs/msg/TurnIndicatorsReport
+    description: Turn indicators report from the vehicle.
+    remap_target: /vehicle/status/turn_indicators_status
+  - name: hazard_lights_status
+    message_type: autoware_vehicle_msgs/msg/HazardLightsReport
+    description: Hazard lights report from the vehicle.
+    remap_target: /vehicle/status/hazard_lights_status
+  - name: battery_charge
+    message_type: tier4_vehicle_msgs/msg/BatteryStatus
+    description: Battery status from the vehicle.
+    remap_target: /vehicle/status/battery_charge
+
+publishers:
+  - name: kinematics
+    message_type: autoware_adapi_v1_msgs/msg/VehicleKinematics
+    description: Vehicle kinematics for the API.
+    remap_target: /api/vehicle/kinematics
+  - name: status
+    message_type: autoware_adapi_v1_msgs/msg/VehicleStatus
+    description: Vehicle status for the API.
+    remap_target: /api/vehicle/status
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: publish_status
+    description: Periodically converts the latest localization and vehicle reports into the API kinematics and status.
+    trigger_conditions:
+      - periodic: 10.0
+    outcomes:
+      - to_output: kinematics
+      - to_output: status

--- a/system/autoware_diagnostic_graph_aggregator/design/DiagnosticGraphAggregator.node.yaml
+++ b/system/autoware_diagnostic_graph_aggregator/design/DiagnosticGraphAggregator.node.yaml
@@ -1,0 +1,90 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: DiagnosticGraphAggregator.node
+
+description: Aggregates /diagnostics into the diagnostic graph and publishes its structure, status, and the command and driving mode availability derived from the graph units.
+
+package:
+  name: autoware_diagnostic_graph_aggregator
+  provider: autoware
+
+launch:
+  plugin: autoware::diagnostic_graph_aggregator::AggregatorNode
+  executable: aggregator_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: diagnostics
+    message_type: diagnostic_msgs/msg/DiagnosticArray
+    description: Diagnostic status of every node; the graph leaves are matched by status name.
+    global: /diagnostics
+    remap_target: ~/diagnostics
+
+publishers:
+  - name: struct
+    message_type: tier4_system_msgs/msg/DiagGraphStruct
+    description: Graph structure, published once per graph id.
+    remap_target: ~/struct
+    qos:
+      reliability: reliable
+      durability: transient_local
+  - name: status
+    message_type: tier4_system_msgs/msg/DiagGraphStatus
+    description: Level of every graph unit at the aggregation rate.
+    remap_target: ~/status
+  - name: unknowns
+    message_type: diagnostic_msgs/msg/DiagnosticArray
+    description: Diagnostic statuses that match no graph leaf.
+    remap_target: ~/unknowns
+  - name: command_mode_availability
+    message_type: tier4_system_msgs/msg/CommandModeAvailability
+    description: Availability of each command mode mapped from the graph units (use_command_mode_mappings).
+    remap_target: ~/availability
+  - name: driving_mode_available
+    message_type: tier4_system_msgs/msg/DrivingModeFlag
+    description: Availability flag of each driving mode mapped from the graph units (use_driving_mode_mappings).
+    remap_target: /system/driving_mode/available
+  - name: driving_mode_continuable
+    message_type: tier4_system_msgs/msg/DrivingModeFlag
+    description: Continuable flag of each driving mode mapped from the graph units (use_driving_mode_mappings).
+    remap_target: /system/driving_mode/continuable
+
+servers:
+  - name: reset
+    message_type: tier4_system_msgs/srv/ResetDiagGraph
+    description: Resets the latched graph levels.
+    remap_target: ~/reset
+  - name: set_initializing
+    message_type: tier4_system_msgs/srv/SetInitializing
+    description: Sets the initializing state that suppresses latching.
+    remap_target: ~/set_initializing
+  - name: set_override
+    message_type: tier4_system_msgs/srv/SetOverride
+    description: Overrides a graph unit level for debugging (allow_override_for_debugging).
+    remap_target: ~/set_override
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/default.param.yaml
+
+param_values:
+  - name: graph_file
+    default: $(find-pkg-share autoware_diagnostic_graph_aggregator)/example/graph/main.yaml
+  - name: graph_vars
+    default: ""
+
+# processes
+processes:
+  - name: aggregate
+    description: Updates the graph unit levels from the received statuses and the timeouts, then publishes the status and availability.
+    trigger_conditions:
+      - periodic: 10.0
+    outcomes:
+      - to_output: status
+      - to_output: unknowns
+      - to_output: command_mode_availability
+      - to_output: driving_mode_available
+      - to_output: driving_mode_continuable

--- a/system/autoware_diagnostic_graph_aggregator/design/OperationModeAvailabilityConverter.node.yaml
+++ b/system/autoware_diagnostic_graph_aggregator/design/OperationModeAvailabilityConverter.node.yaml
@@ -1,0 +1,43 @@
+autoware_system_design_format: 0.4.0
+
+# node information
+name: OperationModeAvailabilityConverter.node
+
+description: Converts the command mode availability of the diagnostic graph into the operation mode availability flags.
+
+package:
+  name: autoware_diagnostic_graph_aggregator
+  provider: autoware
+
+launch:
+  plugin: autoware::diagnostic_graph_aggregator::ConverterNode
+  executable: converter_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: command_mode_availability
+    message_type: tier4_system_msgs/msg/CommandModeAvailability
+    description: Availability of each command mode id.
+    remap_target: ~/command_mode/availability
+
+publishers:
+  - name: operation_mode_availability
+    message_type: tier4_system_msgs/msg/OperationModeAvailability
+    description: Availability flags per operation mode, mapped by the command mode id parameters.
+    remap_target: ~/operation_mode/availability
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/converter.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: convert
+    trigger_conditions:
+      - on_input: command_mode_availability
+    outcomes:
+      - to_output: operation_mode_availability

--- a/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphConverter.node.yaml
+++ b/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphConverter.node.yaml
@@ -17,15 +17,15 @@ launch:
 subscribers:
   - name: diag_graph_struct
     message_type: tier4_system_msgs/msg/DiagGraphStruct
-    global: /diagnostics_graph/struct
+    remap_target: /diagnostics_graph/struct
   - name: diag_graph_status
     message_type: tier4_system_msgs/msg/DiagGraphStatus
-    global: /diagnostics_graph/status
+    remap_target: /diagnostics_graph/status
 
 publishers:
   - name: diagnostics_array
     message_type: diagnostic_msgs/msg/DiagnosticArray
-    global: /diagnostics_array
+    remap_target: /diagnostics_array
 
 # parameters
 param_files: []

--- a/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphDump.node.yaml
+++ b/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphDump.node.yaml
@@ -17,10 +17,10 @@ launch:
 subscribers:
   - name: diag_graph_struct
     message_type: tier4_system_msgs/msg/DiagGraphStruct
-    global: /diagnostics_graph/struct
+    remap_target: /diagnostics_graph/struct
   - name: diag_graph_status
     message_type: tier4_system_msgs/msg/DiagGraphStatus
-    global: /diagnostics_graph/status
+    remap_target: /diagnostics_graph/status
 
 publishers: []
 

--- a/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphLogging.node.yaml
+++ b/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphLogging.node.yaml
@@ -18,10 +18,10 @@ launch:
 subscribers:
   - name: diag_graph_struct
     message_type: tier4_system_msgs/msg/DiagGraphStruct
-    global: /diagnostics_graph/struct
+    remap_target: /diagnostics_graph/struct
   - name: diag_graph_status
     message_type: tier4_system_msgs/msg/DiagGraphStatus
-    global: /diagnostics_graph/status
+    remap_target: /diagnostics_graph/status
 
 publishers: []
 

--- a/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphLogging.node.yaml
+++ b/system/autoware_diagnostic_graph_utils/design/DiagnosticGraphLogging.node.yaml
@@ -28,7 +28,17 @@ publishers: []
 # parameters
 param_files: []
 
-param_values: []
+param_values:
+  - name: root_path
+    default: /autoware/modes/autonomous
+  - name: max_depth
+    default: 3
+  - name: show_rate
+    default: 1.0
+  - name: enable_terminal_log
+    default: false
+  - name: ignore_dependent_error
+    default: false
 
 # processes
 processes:

--- a/system/autoware_hazard_status_converter/design/HazardStatusConverter.node.yaml
+++ b/system/autoware_hazard_status_converter/design/HazardStatusConverter.node.yaml
@@ -18,10 +18,10 @@ launch:
 subscribers:
   - name: diag_graph_struct
     message_type: tier4_system_msgs/msg/DiagGraphStruct
-    global: /diagnostics_graph/struct
+    remap_target: /diagnostics_graph/struct
   - name: diag_graph_status
     message_type: tier4_system_msgs/msg/DiagGraphStatus
-    global: /diagnostics_graph/status
+    remap_target: /diagnostics_graph/status
   - name: emergency_holding
     message_type: tier4_system_msgs/msg/EmergencyHoldingState
     remap_target: ~/input/emergency_holding

--- a/system/autoware_processing_time_checker/design/ProcessingTimeChecker.node.yaml
+++ b/system/autoware_processing_time_checker/design/ProcessingTimeChecker.node.yaml
@@ -30,7 +30,9 @@ param_files:
   - name: param_file
     default: config/processing_time_checker.param.yaml
 
-param_values: []
+param_values:
+  - name: output_metrics
+    default: false
 
 # processes
 processes:


### PR DESCRIPTION
## Description

Split of #13298 — the `system` slice. Every port here is pinned to a fixed name with `global:`.

A port pinned with `global:` connects outside the design graph on a fixed topic: `link_manager` skips any connection whose target is a global input port, and the exporter emits no remap. With `remap_target:` the port takes part in the graph like any other, while the launcher still binds it to the official name.

Converted across:

- `autoware_diagnostic_graph_utils` — `DiagnosticGraphConverter`, `DiagnosticGraphDump`, `DiagnosticGraphLogging`: the `/diagnostics_graph/struct` and `/diagnostics_graph/status` inputs, and the converter's `/diagnostics_array` output.
- `autoware_hazard_status_converter` — the same two diagnostic graph inputs.
- `autoware_automatic_pose_initializer` — the `/localization/initialization_state` input and the `/localization/initialize` client.

`/diagnostics` itself stays `global:`.

### 4. Node designs the packages do not ship

`autoware_default_adapi_universe` builds fifteen AD API components with no design of their own, and `autoware_component_state_monitor` / `autoware_diagnostic_graph_aggregator` build three more: the state monitor that aggregates topic monitor diagnostics into per-component availability, the aggregator that turns `/diagnostics` into the diagnostic graph, and the converter that derives operation mode availability from it. A system that composes the AD API and the system component from design modules cannot reference any of them, so they are added here.

`DiagnosticGraphLogging` and `ProcessingTimeChecker` also declare the parameters their launchers pass, which have no package param file to come from.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it. autowarefoundation/autoware_launch#1976 instantiates all eighteen of these designs; without them its `AdapiNodes.module` and `System.module` cannot resolve.
- autowarefoundation/autoware_launch#1971 — the localization migration, whose `LocalizationUtil` connections depend on the `AutomaticPoseInitializer` change
- autowarefoundation/autoware_launch#1972 — the matching module connections

## How was this PR tested?

- `pre-commit run --files` on all five changed designs (Autoware System Design Format lint, prettier, yamllint) passes.
- The changes are byte-identical to the corresponding files on #13298, which was validated by an `autoware_sample_designs` deployment build across four modes; the connections that previously resolved to global input ports are now wired.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched. All topic and service names are unchanged — only the key that declares them.

## Interface changes

None.

## Effects on system behavior

None.


