### PR TITLE
fix(design): align the perception node designs with the packages they describe

### DIFF
--- a/perception/autoware_bevfusion/design/BEVFusion.node.yaml
+++ b/perception/autoware_bevfusion/design/BEVFusion.node.yaml
@@ -72,9 +72,9 @@ param_files:
   - name: common_param
     default: config/common_bevfusion.param.yaml
   - name: ml_package_param
-    default: ml_package_bevfusion_lidar.param.yaml
+    default: config/ml_package_bevfusion_lidar.param.yaml
   - name: class_remapper_param
-    default: detection_class_remapper.param.yaml
+    default: config/detection_class_remapper.param.yaml
 
 param_values:
   - name: use_compressed_images

--- a/perception/autoware_camera_streampetr/design/StreamPetr.node.yaml
+++ b/perception/autoware_camera_streampetr/design/StreamPetr.node.yaml
@@ -57,7 +57,7 @@ param_files:
   - name: node_param
     default: config/camera_streampetr.param.yaml
   - name: model_param
-    default: ml_package_camera_streampetr.param.yaml
+    default: config/ml_package_camera_streampetr.param.yaml
 
 param_values:
   - name: build_only

--- a/perception/autoware_detected_object_validation/design/ObjectLaneletFilter.node.yaml
+++ b/perception/autoware_detected_object_validation/design/ObjectLaneletFilter.node.yaml
@@ -8,7 +8,7 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::detected_object_validation::DetectedObjectLaneletFilterNode
+  plugin: autoware::detected_object_validation::lanelet_filter::DetectedObjectLaneletFilterNode
   executable: object_lanelet_filter_node
   node_output: screen
 

--- a/perception/autoware_detected_object_validation/design/TrackedObjectLaneletFilter.node.yaml
+++ b/perception/autoware_detected_object_validation/design/TrackedObjectLaneletFilter.node.yaml
@@ -9,7 +9,7 @@ package:
 
 launch:
   package: autoware_detected_object_validation
-  plugin: autoware::detected_object_validation::TrackedObjectLaneletFilterNode
+  plugin: autoware::detected_object_validation::lanelet_filter::TrackedObjectLaneletFilterNode
   executable: tracked_object_lanelet_filter_node
   node_output: screen
 

--- a/perception/autoware_elevation_map_loader/design/ElevationMapLoader.node.yaml
+++ b/perception/autoware_elevation_map_loader/design/ElevationMapLoader.node.yaml
@@ -25,7 +25,7 @@ subscribers:
     remap_target: input/pointcloud_map_metadata
   - name: map_hash
     message_type: tier4_external_api_msgs/msg/MapHash
-    global: /api/autoware/get/map/info/hash
+    remap_target: /api/autoware/get/map/info/hash
 
 publishers:
   - name: elevation_map

--- a/perception/autoware_lidar_apollo_instance_segmentation/design/LidarApolloInstanceSegmentation.node.yaml
+++ b/perception/autoware_lidar_apollo_instance_segmentation/design/LidarApolloInstanceSegmentation.node.yaml
@@ -9,7 +9,7 @@ package:
 
 launch:
   plugin: autoware::lidar_apollo_instance_segmentation::LidarInstanceSegmentationNode
-  executable: lidar_apollo_instance_segmentation_node
+  executable: autoware_lidar_apollo_instance_segmentation_node
   node_output: screen
 
 # interfaces

--- a/perception/autoware_lidar_frnet/design/LidarFRNet.node.yaml
+++ b/perception/autoware_lidar_frnet/design/LidarFRNet.node.yaml
@@ -37,11 +37,11 @@ publishers:
 # parameters
 param_files:
   - name: model_param
-    default: config/lidar_frnet.param.yaml
+    default: config/frnet.param.yaml
   - name: ml_package_param
-    default: ml_package_lidar_frnet.param.yaml
+    default: config/ml_package_frnet_ot128.param.yaml
   - name: diagnostics_param
-    default: config/diagnostics.param.yaml
+    default: config/diagnostics_frnet.param.yaml
 
 param_values:
   - name: build_only

--- a/perception/autoware_lidar_transfusion/design/LidarTransfusion.node.yaml
+++ b/perception/autoware_lidar_transfusion/design/LidarTransfusion.node.yaml
@@ -9,7 +9,7 @@ package:
 
 launch:
   plugin: autoware::lidar_transfusion::LidarTransfusionNode
-  executable: lidar_transfusion_node
+  executable: autoware_lidar_transfusion_node
   node_output: screen
 
 # interfaces


### PR DESCRIPTION
## Description

Split of #13298 — the `perception` slice. Three classes of fix.

### 1. Launch fields that name something the package does not build

Checked against `CMakeLists.txt` (`PLUGIN` / `EXECUTABLE` / `add_executable`) and `RCLCPP_COMPONENTS_REGISTER_NODE`.

| design | field | was | is |
| --- | --- | --- | --- |
| `ObjectLaneletFilter`, `TrackedObjectLaneletFilter` | plugin | missing `lanelet_filter::` namespace | qualified |
| `LidarApolloInstanceSegmentation` | executable | `lidar_apollo_instance_segmentation_node` | `autoware_lidar_apollo_instance_segmentation_node` |
| `LidarTransfusion` | executable | `lidar_transfusion_node` | `autoware_lidar_transfusion_node` |

### 2. Param file defaults that resolve to nothing

`BEVFusion` (`ml_package_bevfusion_lidar`, `detection_class_remapper`) and `StreamPetr` (`ml_package_camera_streampetr`) were missing the `config/` prefix. `LidarFRNet` named three files that do not exist — the real ones are `config/frnet.param.yaml`, `config/ml_package_frnet_ot128.param.yaml` and `config/diagnostics_frnet.param.yaml`.

### 3. A fixed-name interface declared as a remap target

`ElevationMapLoader` pins its `map_hash` input to `/api/autoware/get/map/info/hash` with `global:`. A port pinned with `global:` connects outside the design graph on a fixed topic: `link_manager` skips any connection whose target is a global input port, and the exporter emits no remap. With `remap_target:` the port takes part in the graph like any other, while the launcher still binds it to the official name.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it

## How was this PR tested?

- `pre-commit run --files` on all eight changed designs (Autoware System Design Format lint, prettier, yamllint) passes.
- Every launch field re-checked against the package `CMakeLists.txt` and the `RCLCPP_COMPONENTS_REGISTER_NODE` call site; every param file default now resolves to a file that exists in the package.
- The changes are byte-identical to the corresponding files on #13298, which was validated by an `autoware_sample_designs` deployment build.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched.

## Interface changes

None.

## Effects on system behavior

None.

