### PR TITLE
fix(design): align the control node designs with the packages they describe

### DIFF
--- a/control/autoware_control_command_gate/design/ControlCommandGate.node.yaml
+++ b/control/autoware_control_command_gate/design/ControlCommandGate.node.yaml
@@ -8,7 +8,7 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::control_command_gate::ControlCommandGateNode
+  plugin: autoware::control_command_gate::ControlCmdGate
   executable: control_command_gate_node
   node_output: screen
 

--- a/control/autoware_operation_mode_transition_manager/design/AutonomousModeTransitionFlag.node.yaml
+++ b/control/autoware_operation_mode_transition_manager/design/AutonomousModeTransitionFlag.node.yaml
@@ -25,10 +25,10 @@ subscribers:
 publishers:
   - name: transition_available
     message_type: tier4_system_msgs/msg/ModeChangeAvailable
-    global: /system/command_mode/transition/available
+    remap_target: /system/command_mode/transition/available
   - name: transition_completed
     message_type: tier4_system_msgs/msg/ModeChangeAvailable
-    global: /system/command_mode/transition/completed
+    remap_target: /system/command_mode/transition/completed
   - name: debug_info
     message_type: autoware_operation_mode_transition_manager/msg/OperationModeTransitionManagerDebug
     remap_target: ~/debug_info

--- a/control/autoware_operation_mode_transition_manager/design/OperationModeTransitionManager.node.yaml
+++ b/control/autoware_operation_mode_transition_manager/design/OperationModeTransitionManager.node.yaml
@@ -43,17 +43,26 @@ subscribers:
     remap_target: /control/external_cmd_selector/current_selector_mode
 
 publishers:
+  # system interfaces: node-side names are fixed
   - name: operation_mode
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
-  # shared with external operators; multiple publishers
+    remap_target: /system/operation_mode/state
+  # legacy interfaces: node-side names are fixed
   - name: engage
     message_type: autoware_vehicle_msgs/msg/Engage
-    global: /autoware/engage
     remap_target: /autoware/engage
   - name: gate_mode_cmd
     message_type: tier4_control_msgs/msg/GateMode
-    global: /control/gate_mode_cmd
     remap_target: /control/gate_mode_cmd
+
+servers:
+  # system interfaces: node-side names are fixed
+  - name: change_operation_mode
+    message_type: autoware_system_msgs/srv/ChangeOperationMode
+    remap_target: /system/operation_mode/change_operation_mode
+  - name: change_autoware_control
+    message_type: autoware_system_msgs/srv/ChangeAutowareControl
+    remap_target: /system/operation_mode/change_autoware_control
 
 clients:
   - name: control_mode_request

--- a/control/autoware_trajectory_follower_node/design/TrajectoryFollower.node.yaml
+++ b/control/autoware_trajectory_follower_node/design/TrajectoryFollower.node.yaml
@@ -30,13 +30,11 @@ publishers:
   - name: predicted_trajectory
     message_type: autoware_planning_msgs/msg/Trajectory
   - name: lateral_diagnostic
-    message_type: diagnostic_msgs/msg/DiagnosticStatus
+    message_type: autoware_internal_debug_msgs/msg/Float32MultiArrayStamped
   - name: slope_angle
-    message_type: std_msgs/msg/Float32Stamped
+    message_type: autoware_internal_debug_msgs/msg/Float32MultiArrayStamped
   - name: longitudinal_diagnostic
-    message_type: diagnostic_msgs/msg/DiagnosticStatus
-  - name: stop_reason
-    message_type: tier4_planning_msgs/msg/StopReasonArray
+    message_type: autoware_internal_debug_msgs/msg/Float32MultiArrayStamped
   - name: control_cmd
     message_type: autoware_control_msgs/msg/Control
 

--- a/control/autoware_vehicle_cmd_gate/design/VehicleCmdGate.node.yaml
+++ b/control/autoware_vehicle_cmd_gate/design/VehicleCmdGate.node.yaml
@@ -48,7 +48,6 @@ subscribers:
     remap_target: input/external_emergency_stop_heartbeat
   - name: gate_mode
     message_type: tier4_control_msgs/msg/GateMode
-    global: /control/gate_mode_cmd
     remap_target: input/gate_mode
   - name: emergency_control_cmd
     message_type: autoware_control_msgs/msg/Control
@@ -73,7 +72,6 @@ subscribers:
     remap_target: input/acceleration
   - name: engage
     message_type: autoware_vehicle_msgs/msg/Engage
-    global: /autoware/engage
     remap_target: input/engage
 
 publishers:


### PR DESCRIPTION
## Description

Split of #13298 — the `control` slice. The `CollisionDetector` part of that slice already landed as #13312; what remains is four designs.

### `ControlCommandGate` — plugin name

`autoware_control_command_gate` registers `autoware::control_command_gate::ControlCmdGate`, not `…::ControlCommandGateNode`.

### `AutonomousModeTransitionFlag` — fixed-name publishers

`transition_available` and `transition_completed` are pinned to `/system/command_mode/transition/{available,completed}` with `global:`. A port pinned with `global:` connects outside the design graph on a fixed topic: `link_manager` skips any connection whose target is a global input port, and the exporter emits no remap. With `remap_target:` the port takes part in the graph like any other, while the launcher still binds it to the official name.

### `TrajectoryFollower` — interface types

Checked against the installed message definitions and the `create_publisher` call sites.

| interface | was | is |
| --- | --- | --- |
| `slope_angle` | `std_msgs/msg/Float32Stamped` (no such type) | `autoware_internal_debug_msgs/msg/Float32MultiArrayStamped` |
| `lateral_diagnostic`, `longitudinal_diagnostic` | `diagnostic_msgs/msg/DiagnosticStatus` | `autoware_internal_debug_msgs/msg/Float32MultiArrayStamped` |

The `stop_reason` publisher is dropped; the node never creates it.

### `VehicleCmdGate` — gate mode and engage on the design graph

The `gate_mode` (`/control/gate_mode_cmd`) and `engage` (`/autoware/engage`) subscribers drop their `global:` pins and keep their `remap_target` declarations, so these inputs are connected through the design.

### `OperationModeTransitionManager` — system and legacy interfaces

The operation mode state publisher, the two operation mode change services and the legacy `engage` / `gate_mode_cmd` publishers are node-side fixed names. They are declared as remap targets so they sit on the design graph, matching the `VehicleCmdGate` side above.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it
- #13312 — the `CollisionDetector` part of this slice, already merged
- #13281 — introduced the `global:` pins on the VehicleCmdGate compatibility inputs that this PR converts to design-graph connections
- autowarefoundation/autoware_launch#1972 — the matching module connections. Paired; each needs the other.

## How was this PR tested?

- `pre-commit run --files` on all four changed designs (Autoware System Design Format lint, prettier, yamllint) passes.
- Launch fields re-checked against `CMakeLists.txt` and `RCLCPP_COMPONENTS_REGISTER_NODE`; interface types against the installed `.msg` definitions.
- The changes are byte-identical to the corresponding files on #13298, which was validated by an `autoware_sample_designs` deployment build across four modes.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched.

The `gate_mode`/`engage` inputs of `VehicleCmdGate` were declared `global:` in #13281 because of external publishers (internal API adaptor, joy controller, RViz panel); this PR moves them onto the design graph, so please check the multi-publisher expectation still holds for your systems.

## Interface changes

None. `TrajectoryFollower`'s debug publishers are corrected to the types the node already publishes, and `stop_reason` is removed from the design because the node does not create it — there is no node-side change.

## Effects on system behavior

None.


