### PR TITLE
fix(design): align the evaluator node designs with the packages they describe

### DIFF
--- a/evaluator/autoware_control_evaluator/design/ControlEvaluator.node.yaml
+++ b/evaluator/autoware_control_evaluator/design/ControlEvaluator.node.yaml
@@ -8,7 +8,7 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::control_evaluator::ControlEvaluatorNode
+  plugin: control_diagnostics::ControlEvaluatorNode
   executable: control_evaluator
   node_output: screen
 
@@ -32,26 +32,41 @@ subscribers:
     message_type: autoware_perception_msgs/msg/PredictedObjects
   - name: blind_spot
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/blind_spot
   - name: crosswalk
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/crosswalk
   - name: detection_area
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/detection_area
   - name: intersection
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/intersection
+  - name: merge_from_private
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/merge_from_private
+  - name: no_drivable_lane
+    message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/no_drivable_lane
   - name: no_stopping_area
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/no_stopping_area
   - name: stop_line
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/stop_line
   - name: traffic_light
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/traffic_light
   - name: virtual_traffic_light
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/virtual_traffic_light
   - name: walkway
     message_type: autoware_internal_planning_msgs/msg/PlanningFactorArray
+    remap_target: /planning/planning_factors/walkway
 
 publishers:
   - name: metrics
-    message_type: autoware_control_msgs/msg/ControlEvaluation
+    message_type: tier4_metric_msgs/msg/MetricArray
 
 # parameters
 param_files:

--- a/evaluator/autoware_evaluation_adapter/design/AutowareEngage.node.yaml
+++ b/evaluator/autoware_evaluation_adapter/design/AutowareEngage.node.yaml
@@ -6,25 +6,24 @@ package:
   provider: autoware
 launch:
   plugin: autoware::evaluation_adapter::AutowareEngage
-  executable: autoware_evaluation_adapter_node
   node_output: screen
 # interfaces
 subscribers:
   - name: operation_mode_state
     message_type: autoware_adapi_v1_msgs/msg/OperationModeState
-    global: /api/operation_mode/state
+    remap_target: /api/operation_mode/state
 publishers: []
 servers:
   - name: set_engage
     message_type: tier4_external_api_msgs/srv/Engage
-    global: /api/external/set/engage
+    remap_target: /api/external/set/engage
 clients:
   - name: change_to_stop
     message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
-    global: /api/operation_mode/change_to_stop
+    remap_target: /api/operation_mode/change_to_stop
   - name: change_to_autonomous
     message_type: autoware_adapi_v1_msgs/srv/ChangeOperationMode
-    global: /api/operation_mode/change_to_autonomous
+    remap_target: /api/operation_mode/change_to_autonomous
 # parameters
 param_files: []
 param_values: []

--- a/evaluator/autoware_evaluation_adapter/design/VelocityLimit.node.yaml
+++ b/evaluator/autoware_evaluation_adapter/design/VelocityLimit.node.yaml
@@ -6,21 +6,20 @@ package:
   provider: autoware
 launch:
   plugin: autoware::evaluation_adapter::VelocityLimit
-  executable: autoware_evaluation_adapter_node
   node_output: screen
 # interfaces
 subscribers:
   - name: current_max_velocity
     message_type: autoware_internal_planning_msgs/msg/VelocityLimit
-    global: /planning/scenario_planning/current_max_velocity
+    remap_target: /planning/scenario_planning/current_max_velocity
 publishers:
   - name: max_velocity_default
     message_type: autoware_internal_planning_msgs/msg/VelocityLimit
-    global: /planning/scenario_planning/max_velocity_default
+    remap_target: /planning/scenario_planning/max_velocity_default
 servers:
   - name: set_velocity_limit
     message_type: tier4_external_api_msgs/srv/SetVelocityLimit
-    global: /api/autoware/set/velocity_limit
+    remap_target: /api/autoware/set/velocity_limit
 # parameters
 param_files: []
 param_values: []

--- a/evaluator/autoware_perception_online_evaluator/design/PerceptionAnalyticsPublisher.node.yaml
+++ b/evaluator/autoware_perception_online_evaluator/design/PerceptionAnalyticsPublisher.node.yaml
@@ -14,10 +14,10 @@ subscribers:
     message_type: autoware_perception_msgs/msg/PredictedObjects
   - name: meas_to_tracked_latency
     message_type: autoware_internal_debug_msgs/msg/Float64Stamped
-    global: /perception/object_recognition/tracking/multi_object_tracker/debug/meas_to_tracked_object_ms
+    remap_target: /perception/object_recognition/tracking/multi_object_tracker/debug/meas_to_tracked_object_ms
   - name: prediction_latency
     message_type: autoware_internal_debug_msgs/msg/Float64Stamped
-    global: /perception/object_recognition/prediction/map_based_prediction/debug/processing_time_ms
+    remap_target: /perception/object_recognition/prediction/map_based_prediction/debug/processing_time_ms
 publishers:
   - name: perception_analytics
     message_type: tier4_metric_msgs/msg/MetricArray

--- a/evaluator/autoware_planning_evaluator/design/PlanningEvaluator.node.yaml
+++ b/evaluator/autoware_planning_evaluator/design/PlanningEvaluator.node.yaml
@@ -28,7 +28,7 @@ subscribers:
 
 publishers:
   - name: metrics
-    message_type: autoware_planning_msgs/msg/PlanningAnalysis
+    message_type: tier4_metric_msgs/msg/MetricArray
     remap_target: ~/metrics
 
 # parameters

--- a/evaluator/autoware_scenario_simulator_v2_adapter/design/MetricConverter.node.yaml
+++ b/evaluator/autoware_scenario_simulator_v2_adapter/design/MetricConverter.node.yaml
@@ -19,20 +19,20 @@ launch:
 subscribers:
   - name: planning_evaluator_metrics
     message_type: tier4_metric_msgs/msg/MetricArray
-    global: /planning/planning_evaluator/metrics
+    remap_target: /planning/planning_evaluator/metrics
   - name: control_evaluator_metrics
     message_type: tier4_metric_msgs/msg/MetricArray
-    global: /control/control_evaluator/metrics
+    remap_target: /control/control_evaluator/metrics
   - name: processing_time_checker_metrics
     message_type: tier4_metric_msgs/msg/MetricArray
-    global: /system/processing_time_checker/metrics
+    remap_target: /system/processing_time_checker/metrics
   - name: diagnostics
     message_type: diagnostic_msgs/msg/DiagnosticArray
     global: /diagnostics
 publishers:
   - name: overall_diagnostics
     message_type: tier4_simulation_msgs/msg/UserDefinedValue
-    global: /diagnostics/scenario_simulator_v2_adapter/overall_diagnostics
+    remap_target: /diagnostics/scenario_simulator_v2_adapter/overall_diagnostics
 # parameters
 param_files:
   - name: scenario_simulator_v2_adapter_param


### PR DESCRIPTION
## Description

Split of #13298 — the `evaluator` slice. Three classes of fix.

### 1. Fixed-name interfaces declared as remap targets

A port pinned with `global:` connects outside the design graph on a fixed topic: `link_manager` skips any connection whose target is a global input port, and the exporter emits no remap. With `remap_target:` the port takes part in the graph like any other, while the launcher still binds it to the official name.

Converted across `autoware_evaluation_adapter` (`AutowareEngage`, `VelocityLimit` — their operation mode, velocity limit and external API service ports), `autoware_perception_online_evaluator` (the two latency inputs) and `autoware_scenario_simulator_v2_adapter` (`MetricConverter`'s three metric inputs and its overall diagnostics output). `/diagnostics` stays `global:`.

### 2. Launch fields and interface types that do not match the package

| design | field | was | is |
| --- | --- | --- | --- |
| `ControlEvaluator` | plugin | `autoware::control_evaluator::ControlEvaluatorNode` | `control_diagnostics::ControlEvaluatorNode` |
| `ControlEvaluator` | `metrics` | `autoware_control_msgs/msg/ControlEvaluation` (no such type) | `tier4_metric_msgs/msg/MetricArray` |
| `PlanningEvaluator` | `metrics` | `autoware_planning_msgs/msg/PlanningAnalysis` (no such type) | `tier4_metric_msgs/msg/MetricArray` |

`AutowareEngage` and `VelocityLimit` are components registered with `RCLCPP_COMPONENTS_REGISTER_NODE` and build no executable of their own, so their `executable:` field is dropped.

### 3. `ControlEvaluator` planning factor inputs

The eleven planning factor subscribers are pinned to their `/planning/planning_factors/*` topics via `remap_target`; `merge_from_private` and `no_drivable_lane` were missing from the design entirely.

## Related links

**Parent Issue:**

- None

**Related:**

- #13298 — the umbrella PR this is split from
- autowarefoundation/autoware_launch#1976 — the launch counterpart; the reference system was built and run against this PR together with it
- autowarefoundation/autoware_launch#1972 — the matching module connections

## How was this PR tested?

- `pre-commit run --files` on all six changed designs (Autoware System Design Format lint, prettier, yamllint) passes.
- Launch fields re-checked against `CMakeLists.txt` and `RCLCPP_COMPONENTS_REGISTER_NODE`; interface types against the installed `.msg` definitions and the `create_publisher` / `create_subscription` call sites.
- The changes are byte-identical to the corresponding files on #13298, which was validated by an `autoware_sample_designs` deployment build across four modes.
- The `AutowareSample` reference system was built and run with these designs against autowarefoundation/autoware_launch#1976: `colcon build --packages-select autoware_sample_designs` succeeds with zero warnings and exports all four modes (Runtime, LoggingSimulation, PlanningSimulation, E2ESimulation), and planning simulation reaches autonomous mode.

## Notes for reviewers

Design metadata only; no launch file or node source is touched.

## Interface changes

None. The added `ControlEvaluator` subscribers are topics the node already subscribes to.

## Effects on system behavior

None.

