### PR TITLE
ci(clang-tidy-differential): remove deb packages that are built from source

### DIFF
--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -91,6 +91,26 @@ jobs:
         run: cp build_depends_stable.repos build_depends.repos
         shell: bash
 
+      - name: Remove released Debian packages of the source-built dependencies
+        if: ${{ steps.check-config-changed.outputs.config-changed == 'true' || steps.get-changed-files.outputs.changed-files != '' }}
+        run: |
+          ros_distro="${ROS_DISTRO:-${{ inputs.rosdistro }}}"
+          # Same step as in build-and-test-differential.yaml: the released packages install
+          # headers under /opt/ros/$ROS_DISTRO/include, which shadow the source-built ones.
+          # The clang-tidy action reuses the build cache from that job, so the workspace must
+          # match it. The action's own vcs import finds dependency_ws already populated.
+          mkdir -p dependency_ws
+          vcs import --recursive dependency_ws < build_depends.repos
+          for pkg_xml in $(find . -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            deb_name="ros-${ros_distro}-${pkg_name//_/-}"
+            if dpkg-query -W -f='${Status}' "$deb_name" 2>/dev/null | grep -q '^install ok installed$'; then
+              echo "Removing $deb_name"
+              sudo dpkg --remove --force-depends "$deb_name"
+            fi
+          done
+        shell: bash
+
       - name: Run clang-tidy
         if: ${{ steps.check-config-changed.outputs.config-changed == 'true' || steps.get-changed-files.outputs.changed-files != '' }}
         uses: autowarefoundation/autoware-github-actions/clang-tidy@v1


### PR DESCRIPTION
## Description

`clang-tidy-differential` fails with `clang-diagnostic-error` whenever a PR uses an API that exists only on `autoware_core` main (example: #13265, `autoware::point_types::PointCloudClassification`). ([failed CI](https://github.com/autowarefoundation/autoware_universe/actions/runs/34066373698/job/101578564050?pr=13265))

The CI image ships released `ros-<distro>-autoware-*` debs. Their headers under `/opt/ros/<distro>/include` are searched before the workspace `install/` tree. `build-and-test-differential` removes those debs before building (#13119), but `clang-tidy-differential` does not: it restores the build cache from that job and runs clang-tidy in a container where the stale headers are still installed, so clang resolves the released header instead of the source-built one.

This adds the same removal step to `clang-tidy-differential.yaml`, before the clang-tidy action runs.

## Related links

- #13265 (failing clang-tidy run: https://github.com/autowarefoundation/autoware_universe/actions/runs/34066373698/job/101578564050)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Compared the job logs of run 34066373698: the jazzy build job logs `Removing ros-jazzy-autoware-point-types` and builds `autoware_point_types` from `dependency_ws`; the clang-tidy job has no removal and fails on the same header.
- Tested in this CI

## Notes for reviewers

The step is a copy of the one in `build-and-test-differential.yaml`.

AI usage: investigation of the CI logs and the initial draft of this PR were done with Claude Code.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
