### PR TITLE
fix(trajectory_selector, trajectory_validator): sync changes to the

### DIFF
--- a/planning/autoware_trajectory_selector/design/TrajectorySelector.node.yaml
+++ b/planning/autoware_trajectory_selector/design/TrajectorySelector.node.yaml
@@ -11,6 +11,8 @@ launch:
 subscribers:
   - name: lanelet2_map
     message_type: autoware_map_msgs/msg/LaneletMapBin
+  - name: route
+    message_type: autoware_planning_msgs/msg/LaneletRoute
   - name: trajectories_generative
     message_type: autoware_internal_planning_msgs/msg/CandidateTrajectories
   - name: trajectories_backup

--- a/planning/autoware_trajectory_selector/include/autoware/trajectory_selector/trajectory_selector_node.hpp
+++ b/planning/autoware_trajectory_selector/include/autoware/trajectory_selector/trajectory_selector_node.hpp
@@ -30,6 +30,7 @@
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
@@ -42,6 +43,7 @@ using autoware_internal_planning_msgs::msg::CandidateTrajectories;
 using autoware_internal_planning_msgs::msg::CandidateTrajectory;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_planning_msgs::msg::LaneletRoute;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 
@@ -70,6 +72,12 @@ private:
    * @param msg Binary lanelet map message.
    */
   void map_callback(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg);
+
+  /**
+   * @brief Stores the received route for the validator context.
+   * @param msg Lanelet route message.
+   */
+  void route_callback(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletRoute) & msg);
 
   /**
    * @brief Forwards incoming candidate trajectories to the concatenator and trigger the
@@ -104,6 +112,7 @@ private:
   std::unique_ptr<trajectory_validator::TrajectoryValidatorWrapper> validator_ptr_;
   AUTOWARE_TIMER_PTR timer_;
   std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
+  LaneletRoute::ConstSharedPtr route_ptr_;
 
   // Polling Subscribers
   autoware::agnocast_wrapper::polling::PollingSubscriber<Odometry>::SharedPtr sub_odometry_ =
@@ -123,6 +132,7 @@ private:
 
   // Normal Subscribers
   AUTOWARE_SUBSCRIPTION_PTR(LaneletMapBin) sub_map_;
+  AUTOWARE_SUBSCRIPTION_PTR(LaneletRoute) sub_route_;
   AUTOWARE_SUBSCRIPTION_PTR(CandidateTrajectories) sub_trajectories_generative_;
   AUTOWARE_SUBSCRIPTION_PTR(CandidateTrajectories) sub_trajectories_backup_;
 

--- a/planning/autoware_trajectory_selector/launch/trajectory_selector.launch.xml
+++ b/planning/autoware_trajectory_selector/launch/trajectory_selector.launch.xml
@@ -9,6 +9,7 @@
   <arg name="input_objects" default="~/input/objects"/>
   <arg name="input_acceleration" default="~/input/acceleration"/>
   <arg name="input_traffic_signals" default="~/input/traffic_signals"/>
+  <arg name="input_route" default="~/input/route"/>
 
   <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
 
@@ -23,5 +24,6 @@
     <remap from="~/input/objects" to="$(var input_objects)"/>
     <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
     <remap from="~/input/traffic_signals" to="$(var input_traffic_signals)"/>
+    <remap from="~/input/route" to="$(var input_route)"/>
   </node>
 </launch>

--- a/planning/autoware_trajectory_selector/package.xml
+++ b/planning/autoware_trajectory_selector/package.xml
@@ -25,6 +25,7 @@
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
   <depend>autoware_trajectory_concatenator</depend>
   <depend>autoware_trajectory_validator</depend>
   <depend>autoware_utils_debug</depend>

--- a/planning/autoware_trajectory_selector/src/trajectory_selector_node.cpp
+++ b/planning/autoware_trajectory_selector/src/trajectory_selector_node.cpp
@@ -45,6 +45,10 @@ void TrajectorySelectorNode::subscribers()
     "~/input/lanelet2_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&TrajectorySelectorNode::map_callback, this, std::placeholders::_1));
 
+  sub_route_ = create_subscription<LaneletRoute>(
+    "~/input/route", rclcpp::QoS{1}.transient_local(),
+    std::bind(&TrajectorySelectorNode::route_callback, this, std::placeholders::_1));
+
   sub_trajectories_generative_ = create_subscription<CandidateTrajectories>(
     "~/input/trajectories_generative", 1,
     std::bind(&TrajectorySelectorNode::on_anchor_trajectories, this, std::placeholders::_1));
@@ -70,6 +74,12 @@ void TrajectorySelectorNode::map_callback(
 
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
+}
+
+void TrajectorySelectorNode::route_callback(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletRoute) & msg)
+{
+  route_ptr_ = std::make_shared<const LaneletRoute>(*msg);
 }
 
 void TrajectorySelectorNode::on_anchor_trajectories(
@@ -106,6 +116,13 @@ TrajectorySelectorNode::take_validator_data()
   }
 
   context.traffic_light_signals = sub_traffic_lights_->take_data();
+  if (!context.traffic_light_signals) {
+    // No traffic light input means no known signals, not an unavailable input.
+    context.traffic_light_signals =
+      std::make_shared<autoware_perception_msgs::msg::TrafficLightGroupArray>();
+  }
+
+  context.route = route_ptr_;
 
   context.lanelet_map = lanelet_map_ptr_;
   if (!context.lanelet_map) {
@@ -137,10 +154,10 @@ void TrajectorySelectorNode::concatenate_and_validate()
     return;
   }
 
-  auto validated_trajectories =
+  const auto validator_report =
     validator_ptr_->validate_trajectories(concatenated_trajectories, context_opt.value());
 
-  pub_trajectories_->publish(validated_trajectories);
+  pub_trajectories_->publish(validator_report.valid_trajectories);
 }
 
 void TrajectorySelectorNode::update_parameters()

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/trajectory_validator_report.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/trajectory_validator_report.hpp
@@ -18,6 +18,7 @@
 #include <autoware_trajectory_validator/msg/validation_report.hpp>
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
+#include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
 
 #include <algorithm>
 #include <string>
@@ -65,6 +66,7 @@ struct TrajectoryValidatorReport
   autoware_internal_planning_msgs::msg::CandidateTrajectories valid_trajectories;
   std::vector<EvaluationTable> evaluation_tables;
   std::vector<autoware_trajectory_validator::msg::ValidationReport> validation_reports;
+  autoware_internal_planning_msgs::msg::PlanningFactorArray planning_factors;
   size_t num_feasible_trajectories{0};
 
   std::unordered_map<std::string, double> processing_time_ms;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/crosswalk_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/crosswalk_filter.hpp
@@ -22,6 +22,7 @@
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 
+#include <autoware_internal_planning_msgs/msg/safety_factor_array.hpp>
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 
 #include <unordered_map>
@@ -30,6 +31,8 @@
 
 namespace autoware::trajectory_validator::plugin::traffic_rule
 {
+using autoware_internal_planning_msgs::msg::SafetyFactor;
+using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
@@ -146,7 +149,8 @@ private:
     const FilterContext & context, const TargetCrosswalks & target_crosswalks);
 
   bool is_obstructing_crosswalk(
-    const TrajectoryPoints & traj_points, const TargetCrosswalk & target_crosswalk) const;
+    const TrajectoryPoints & traj_points, const TargetCrosswalk & target_crosswalk,
+    SafetyFactorArray & safety_factors) const;
 
   void update_debug_data(
     const TrajectoryPoints & traj_points, const TargetCrosswalks & target_crosswalks,

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_wrapper.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_wrapper.hpp
@@ -21,6 +21,7 @@
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
 #include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_trajectory_validator/msg/metric_report.hpp>
 #include <autoware_trajectory_validator/msg/validation_report.hpp>
 #include <autoware_trajectory_validator/msg/validation_report_array.hpp>
@@ -111,6 +112,13 @@ private:
     const CandidateTrajectories & input_trajectories, const size_t num_feasible_trajectories);
 
   /**
+   * @brief Publishes the planning factors collected from all plugins this cycle.
+   * @param planning_factors Planning factors aggregated by the validator.
+   */
+  void publish_planning_factors(
+    const autoware_internal_planning_msgs::msg::PlanningFactorArray & planning_factors);
+
+  /**
    * @brief Publishes the validation report array.
    * @param reports Per-trajectory validation reports to publish.
    */
@@ -167,6 +175,9 @@ private:
   // Publishers
   std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
     pub_debug_;
+  std::unique_ptr<
+    autoware::planning_factor_interface::PlanningFactorInterfaceT<autoware::agnocast_wrapper::Node>>
+    planning_factor_interface_;
 
   // Internal state
   std::unique_ptr<

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_wrapper.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_wrapper.hpp
@@ -80,11 +80,12 @@ public:
     std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper);
 
   /**
-   * @brief Runs all plugins against the input trajectories and returns the feasible subset.
+   * @brief Runs all plugins against the input trajectories.
    * @param input_trajectories Candidate trajectories to validate.
    * @param context Current world state snapshot.
+   * @return Report holding the feasible subset and the per-trajectory validation reports.
    */
-  CandidateTrajectories validate_trajectories(
+  TrajectoryValidatorReport validate_trajectories(
     const CandidateTrajectories & input_trajectories, const ValidatorContext & context);
 
 private:

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -23,6 +23,7 @@
 #include <tl_expected/expected.hpp>
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
+#include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -37,6 +38,7 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using VehicleInfo = autoware::vehicle_info_utils::VehicleInfo;
 using autoware_internal_planning_msgs::msg::CandidateTrajectory;
+using autoware_internal_planning_msgs::msg::PlanningFactorArray;
 using autoware_trajectory_validator::msg::MetricReport;
 using autoware_trajectory_validator::msg::RiskLevel;
 
@@ -45,6 +47,7 @@ struct ValidationResult
 {
   bool is_feasible{true};
   std::vector<MetricReport> metrics{};
+  PlanningFactorArray planning_factors{};
 };
 
 /** @brief Base class for trajectory validator plugins. */

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -32,6 +32,7 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_traffic_light_compliance_checker</depend>
   <depend>autoware_traffic_light_utils</depend>

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -69,6 +69,9 @@ TrajectoryValidatorReport TrajectoryValidator::process(
           evaluation.reason = "Found failed metrics";
         }
         combined_metrics.insert(combined_metrics.end(), val.metrics.begin(), val.metrics.end());
+        report.planning_factors.factors.insert(
+          report.planning_factors.factors.end(), val.planning_factors.factors.begin(),
+          val.planning_factors.factors.end());
       }
 
       report.processing_time_ms[evaluation.plugin_name] += stop_watch.toc(evaluation.plugin_name);

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/crosswalk_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/crosswalk_filter.cpp
@@ -25,6 +25,9 @@
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 
+#include <autoware_internal_planning_msgs/msg/control_point.hpp>
+#include <autoware_internal_planning_msgs/msg/planning_factor.hpp>
+
 #include <boost/geometry.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
 
@@ -241,9 +244,10 @@ CrosswalkFilter::result_t CrosswalkFilter::is_feasible(
   update_target_objects(context, target_crosswalks);
 
   std::unordered_set<lanelet::Id> obstructing_crosswalk_ids;
+  SafetyFactorArray safety_factors;
   const bool feasible =
     std::none_of(target_crosswalks.begin(), target_crosswalks.end(), [&](const auto & cw) {
-      if (!is_obstructing_crosswalk(candidate_trajectory.points, cw)) return false;
+      if (!is_obstructing_crosswalk(candidate_trajectory.points, cw, safety_factors)) return false;
       obstructing_crosswalk_ids.insert(cw.crosswalk_info.crosswalk->id());
       return true;
     });
@@ -262,7 +266,25 @@ CrosswalkFilter::result_t CrosswalkFilter::is_feasible(
       .metric_value(0.0)
       .risk(risk_level));
 
-  return ValidationResult{feasible, std::move(metrics)};
+  PlanningFactorArray planning_factors;
+  if (!feasible) {
+    const auto control_point =
+      autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::ControlPoint>()
+        .pose(context.odometry->pose.pose)
+        .velocity(0.0)
+        .shift_length(0.0)
+        .distance(0.0);
+    planning_factors.factors.push_back(
+      autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::PlanningFactor>()
+        .module(get_name())
+        .is_driving_forward(true)
+        .control_points({control_point})
+        .behavior(autoware_internal_planning_msgs::msg::PlanningFactor::STOP)
+        .detail("crosswalk_obstruction")
+        .safety_factors(safety_factors));
+  }
+
+  return ValidationResult{feasible, std::move(metrics), std::move(planning_factors)};
 }
 
 std::vector<TargetCrosswalk> CrosswalkFilter::get_target_crosswalks(
@@ -434,7 +456,8 @@ void CrosswalkFilter::update_target_objects(
 }
 
 bool CrosswalkFilter::is_obstructing_crosswalk(
-  const TrajectoryPoints & traj_points, const TargetCrosswalk & target_crosswalk) const
+  const TrajectoryPoints & traj_points, const TargetCrosswalk & target_crosswalk,
+  SafetyFactorArray & safety_factors) const
 {
   if (!target_crosswalk.is_crossing) return false;
 
@@ -467,6 +490,14 @@ bool CrosswalkFilter::is_obstructing_crosswalk(
   }();
 
   if (required_waiting_time < 1e-3) return false;
+
+  SafetyFactor safety_factor;
+  safety_factor.type = SafetyFactor::OBJECT;
+  safety_factor.object_id = min_duration_obj.object.object_id;
+  safety_factor.points.push_back(
+    min_duration_obj.object.kinematics.initial_pose_with_covariance.pose.position);
+  safety_factor.is_safe = false;
+  safety_factors.factors.push_back(safety_factor);
 
   if (!params_.use_trajectory_time) return true;
 

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_wrapper.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_wrapper.cpp
@@ -70,6 +70,9 @@ TrajectoryValidatorWrapper::TrajectoryValidatorWrapper(
   });
   publishers();
 
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterfaceT<
+      autoware::agnocast_wrapper::Node>>(&node, interface_name_);
   validator_ptr_ = std::make_unique<TrajectoryValidator>(plugins_);
   diagnostics_interface_ptr_ = std::make_unique<
     autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>(
@@ -161,6 +164,7 @@ TrajectoryValidatorReport TrajectoryValidatorWrapper::validate_trajectories(
   update_diagnostic(input_trajectories, report.num_feasible_trajectories);
 
   publish_validation_reports(report.validation_reports);
+  publish_planning_factors(report.planning_factors);
 
   // Wire up the debug publishers using the opaque report data
   publish_debug(report.evaluation_tables, report.processing_time_ms, context.odometry->pose.pose);
@@ -186,6 +190,29 @@ void TrajectoryValidatorWrapper::update_diagnostic(
   }
 
   diagnostics_interface_ptr_->publish(node_ptr_->get_clock()->now());
+}
+
+void TrajectoryValidatorWrapper::publish_planning_factors(
+  const autoware_internal_planning_msgs::msg::PlanningFactorArray & planning_factors)
+{
+  for (const auto & factor : planning_factors.factors) {
+    if (factor.control_points.empty()) continue;
+
+    const auto & start = factor.control_points.front();
+    if (factor.control_points.size() == 1) {
+      planning_factor_interface_->add(
+        start.distance, start.pose, factor.behavior, factor.safety_factors,
+        factor.is_driving_forward, start.velocity, start.shift_length, factor.detail);
+      continue;
+    }
+
+    const auto & end = factor.control_points.back();
+    planning_factor_interface_->add(
+      start.distance, end.distance, start.pose, end.pose, factor.behavior, factor.safety_factors,
+      factor.is_driving_forward, start.velocity, end.velocity, start.shift_length, end.shift_length,
+      factor.detail);
+  }
+  planning_factor_interface_->publish();
 }
 
 void TrajectoryValidatorWrapper::publish_validation_reports(

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_wrapper.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_wrapper.cpp
@@ -133,7 +133,7 @@ void TrajectoryValidatorWrapper::publishers()
       node_ptr_, "~/debug");
 }
 
-CandidateTrajectories TrajectoryValidatorWrapper::validate_trajectories(
+TrajectoryValidatorReport TrajectoryValidatorWrapper::validate_trajectories(
   const autoware_internal_planning_msgs::msg::CandidateTrajectories & input_trajectories,
   const ValidatorContext & context)
 {
@@ -165,7 +165,7 @@ CandidateTrajectories TrajectoryValidatorWrapper::validate_trajectories(
   // Wire up the debug publishers using the opaque report data
   publish_debug(report.evaluation_tables, report.processing_time_ms, context.odometry->pose.pose);
 
-  return report.valid_trajectories;
+  return report;
 }
 
 void TrajectoryValidatorWrapper::update_diagnostic(


### PR DESCRIPTION
## Description

Ports the trajectory selector and validator improvements from the TIER IV `feat/v0.64/e2e` branch that do not depend on TIER IV-only filters or packages.

**Route reaches the validator filters.** The crosswalk and traffic light filters need the current route, but the selector never provided it, so both filters rejected every trajectory whenever they were enabled. The selector now subscribes to the route and passes it on.

**Missing traffic light input no longer rejects trajectories.** On maps without traffic lights, or before the first signal message arrives, the traffic light filter treated the absent input as an error. An absent input is now treated as "no known signals".

**Validation results carry risk levels to the caller.** The validator now hands the selector the full validation report, including the per-trajectory risk level, instead of only the surviving trajectories. Published topics are unchanged. This prepares for a follow-up PR where the boundary departure filter reports a low caution risk for trajectories running close to an uncrossable boundary.

**Filters publish planning factors.** Filters can attach planning factors to their result, and the validator publishes them on `/planning/planning_factors/trajectory_validator`. The crosswalk filter reports a STOP factor naming the obstructing pedestrian when it rejects a trajectory. This makes rejections visible in RViz and to downstream consumers.

Not included: the ranker and adapter integration into the selector node from the TIER IV branch. Upstream keeps `autoware_trajectory_ranker` and `autoware_trajectory_adapter` as standalone nodes, and merging them into the selector is an architecture change to be discussed separately.

## Related links

**Parent Issue:**

- None

**Source PRs (TIER IV `feat/v0.64/e2e`):**

- https://github.com/tier4/autoware_universe/pull/3208 — route in validator context, validation report exposure
- https://github.com/tier4/autoware_universe/pull/3251 — empty traffic light message by default
- https://github.com/tier4/autoware_universe/pull/3118 — planning factor publishing
- https://github.com/tier4/autoware_universe/pull/3209 — crosswalk safety factor

## How was this PR tested?

Built with `-DBUILD_TESTING=ON` and ran the package tests:

- `autoware_trajectory_validator`: 7/7 passed
- `autoware_trajectory_selector`: 5/5 passed

## Notes for reviewers

The route is optional in the selector. Filters that need it return their own error, so a missing route disables those filters only, instead of blocking validation of all trajectories.

## Interface changes

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name                                         | Message Type                                     | Description                                   |
|:------------|:-----------|:---------------------------------------------------|:-------------------------------------------------|:----------------------------------------------|
| Added       | Sub        | `~/input/route`                                    | `autoware_planning_msgs/msg/LaneletRoute`        | Route forwarded to validator filters          |
| Added       | Pub        | `/planning/planning_factors/trajectory_validator`  | `autoware_internal_planning_msgs/msg/PlanningFactorArray` | Reasons for trajectory rejection     |

## Effects on system behavior

Crosswalk and traffic light filters now work when enabled; previously they rejected every trajectory. Trajectories are no longer rejected on maps without traffic light input. Rejections by the crosswalk filter are visible as planning factors.