### PR TITLE
feat(autoware_tensorrt_common): add getIOTensorNames

### DIFF
--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -26,6 +26,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -67,6 +68,8 @@ public:
    * parameter.
    * @param[in] profiler Per-layer profiler.
    * @param[in] plugin_paths Paths for TensorRT plugins.
+   * @throw std::runtime_error If TensorRT cannot be initialized, which includes failing to parse
+   * the ONNX model at `trt_config.onnx_path`.
    */
   TrtCommon(
     const TrtCommonConfig & trt_config,
@@ -114,6 +117,18 @@ public:
    * @return Number of IO tensors.
    */
   [[nodiscard]] int32_t getNbIOTensors() const;
+
+  /**
+   * @brief Get the names of all IO tensors from TensorRT engine with fallback from TensorRT
+   * network.
+   *
+   * Valid immediately after construction. Valid to call before `setup()`.
+   *
+   * @throw std::runtime_error If TensorRT counts a tensor it cannot name, which it should never
+   * do.
+   * @return Names of every IO tensor.
+   */
+  [[nodiscard]] std::unordered_set<std::string> getIOTensorNames() const;
 
   /**
    * @brief Get tensor shape by index from TensorRT engine with fallback from TensorRT network.

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -28,8 +28,10 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -233,6 +235,23 @@ int32_t TrtCommon::getNbIOTensors() const
     return engine_->getNbIOTensors();
   }
   return network_->getNbInputs() + network_->getNbOutputs();
+}
+
+std::unordered_set<std::string> TrtCommon::getIOTensorNames() const
+{
+  const auto num_tensors = getNbIOTensors();
+  std::unordered_set<std::string> names;
+  names.reserve(static_cast<std::size_t>(num_tensors));
+  for (int32_t index = 0; index < num_tensors; ++index) {
+    const auto * name = getIOTensorName(index);
+    if (name == nullptr) {
+      throw std::runtime_error(
+        "TensorRT reports " + std::to_string(num_tensors) + " IO tensors but cannot name index " +
+        std::to_string(index) + ".");
+    }
+    names.emplace(name);
+  }
+  return names;
 }
 
 nvinfer1::Dims TrtCommon::getTensorShape(const int32_t index) const


### PR DESCRIPTION
## Description

Callers that need to know which tensors a model declares had to enumerate `getNbIOTensors()` /
`getIOTensorName()` themselves, or ask `getTensorIOMode()` one name at a time. The second is a
trap: TensorRT logs an error for every name the engine does not have, so probing a contract
against a narrower model fills the log with errors that report nothing wrong.

`getIOTensorNames()` enumerates once and returns the set, and its documentation says why it is the
right way to ask. Like the accessors it wraps, it reads the parsed network before `setup()` and
the engine afterwards.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

Built `autoware_tensorrt_common` and, since the header changed, its consumers: `autoware_ptv3`,
`autoware_lidar_transfusion`, `autoware_tensorrt_yolox`, `autoware_lidar_centerpoint` and
`autoware_lidar_frnet` — 40 packages, no errors. Exercised end to end by #13290, which replaces
its own copy of this enumeration with the accessor.

## Notes for reviewers

Additive; no existing behaviour changes.

## Interface changes

None.

## Effects on system behavior

None.
