### PR TITLE
feat(autoware_diffusion_planner): remap unsupported objects to pedestrian

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -25,6 +25,7 @@
         start_time_s: 2.0
     planning_frequency_hz: 10.0
     ignore_neighbors: false
+    remap_unsupported_objects_to_pedestrian: false
     traffic_light_group_msg_timeout_seconds: 0.2
     batch_size: 1
     temperature: [0.0]

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
@@ -154,12 +154,15 @@ private:
 struct AgentData
 {
   // Legacy buffering: push unconditionally, fill new agents with copies, erase disappeared agents.
-  void update_histories(const TrackedObjects & objects);
+  void update_histories(
+    const TrackedObjects & objects, const bool remap_unsupported_objects_to_pedestrian = false);
 
   // Resampled buffering: dedup on advancing header stamp, reset on a backward time jump, grow
   // histories without repeat-fill, and retain absent agents until their newest observation ages
   // out of the history window.
-  void update_histories(const TrackedObjects & objects, const HistoryResamplingParams & params);
+  void update_histories(
+    const TrackedObjects & objects, const HistoryResamplingParams & params,
+    const bool remap_unsupported_objects_to_pedestrian = false);
 
   // Transform histories, trim to max_num_agent, and return the processed vector.
   std::vector<AgentHistory> transformed_and_trimmed_histories(

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -160,6 +160,7 @@ struct DiffusionPlannerParams
   bool build_only;
   double planning_frequency_hz;
   bool ignore_neighbors;
+  bool remap_unsupported_objects_to_pedestrian;
   double traffic_light_group_msg_timeout_seconds;
   int batch_size;
   std::vector<double> temperature_list;

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -113,6 +113,11 @@
           "default": false,
           "description": "Ignore neighbor agents"
         },
+        "remap_unsupported_objects_to_pedestrian": {
+          "type": "boolean",
+          "default": false,
+          "description": "Treat UNKNOWN and HAZARD tracked objects as PEDESTRIAN, the most conservative supported class, so the planner reacts to them instead of dropping them. Non-BOX shapes are replaced with a 0.5 m bounding box. ANIMAL, OVER_DRIVABLE and UNDER_DRIVABLE remain ignored."
+        },
         "traffic_light_group_msg_timeout_seconds": {
           "type": "number",
           "default": 0.2,

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -21,7 +21,11 @@
 #include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/utils/utils.hpp"
 
+#include <rclcpp/clock.hpp>
+#include <rclcpp/logging.hpp>
+
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_utils_math/normalization.hpp>
 
 #include <algorithm>
@@ -92,6 +96,38 @@ std::vector<AgentHistory> transform_sort_trim(
       histories.begin() + static_cast<std::ptrdiff_t>(max_num_agent), histories.end());
   }
   return histories;
+}
+
+// HAZARD objects are not supported by the model, so remap them to PEDESTRIAN
+// to make the planner consider them.
+TrackedObject remap_hazard_to_pedestrian(const TrackedObject & object)
+{
+  const bool is_hazard = autoware::object_recognition_utils::getHighestProbLabel(
+                           object.classification) == ObjectClassification::HAZARD;
+  if (!is_hazard) {
+    return object;
+  }
+
+  TrackedObject remapped = object;
+  for (auto & classification : remapped.classification) {
+    if (classification.label == ObjectClassification::HAZARD) {
+      classification.label = ObjectClassification::PEDESTRIAN;
+    }
+  }
+
+  if (remapped.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    static rclcpp::Clock clock{RCL_ROS_TIME};
+    RCLCPP_WARN_THROTTLE(
+      rclcpp::get_logger("diffusion_planner"), clock, constants::LOG_THROTTLE_INTERVAL_MS,
+      "HAZARD object %s has a non-BOX shape (type=%u). Replacing it with a 0.5 m bounding box.",
+      autoware_utils_uuid::to_hex_string(remapped.object_id).c_str(), remapped.shape.type);
+    remapped.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+    remapped.shape.footprint.points.clear();
+    remapped.shape.dimensions.x = 0.5;
+    remapped.shape.dimensions.y = 0.5;
+    remapped.shape.dimensions.z = 0.5;
+  }
+  return remapped;
 }
 
 }  // namespace
@@ -174,7 +210,8 @@ void AgentData::update_histories(const TrackedObjects & objects)
 {
   const rclcpp::Time objects_timestamp(objects.header.stamp);
   std::vector<std::string> found_ids;
-  for (const TrackedObject & object : objects.objects) {
+  for (const TrackedObject & input_object : objects.objects) {
+    const TrackedObject object = remap_hazard_to_pedestrian(input_object);
     if (get_model_label(object) == AgentLabel::IGNORE) {
       continue;
     }
@@ -239,7 +276,8 @@ void AgentData::update_histories(
   last_processed_stamp_ = objects_timestamp;
 
   latest_ids_.clear();
-  for (const TrackedObject & object : objects.objects) {
+  for (const TrackedObject & input_object : objects.objects) {
+    const TrackedObject object = remap_hazard_to_pedestrian(input_object);
     if (get_model_label(object) == AgentLabel::IGNORE) {
       continue;
     }

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -21,12 +21,12 @@
 #include "autoware/diffusion_planner/dimensions.hpp"
 #include "autoware/diffusion_planner/utils/utils.hpp"
 
+#include <autoware/object_recognition_utils/object_recognition_utils.hpp>
+#include <autoware_utils_math/normalization.hpp>
 #include <rclcpp/clock.hpp>
 #include <rclcpp/logging.hpp>
 
-#include <autoware/object_recognition_utils/object_recognition_utils.hpp>
 #include <autoware_perception_msgs/msg/shape.hpp>
-#include <autoware_utils_math/normalization.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -74,6 +74,59 @@ AgentLabel get_model_label(const TrackedObject & object)
   }
 }
 
+// UNKNOWN and HAZARD are not classes the model was trained on, so get_model_label() maps them to
+// IGNORE and they are dropped. They can still obstruct driving. ANIMAL, OVER_DRIVABLE and
+// UNDER_DRIVABLE are deliberately excluded: they are either not obstacles or not drivable-space
+// hazards the planner should brake for.
+bool is_unsupported_obstacle_label(const uint8_t label)
+{
+  return label == autoware_perception_msgs::msg::ObjectClassification::UNKNOWN ||
+         label == autoware_perception_msgs::msg::ObjectClassification::HAZARD;
+}
+
+// Rewrite unsupported obstacles to PEDESTRIAN, the most conservative supported class, so they
+// survive the IGNORE and POLYGON filters below and reach the model.
+TrackedObject remap_unsupported_to_pedestrian(const TrackedObject & object)
+{
+  // An empty classification also yields UNKNOWN from getHighestProbLabel(), but such an object
+  // carries no label to rewrite, so leave it alone rather than silently promoting it.
+  if (object.classification.empty()) {
+    return object;
+  }
+
+  const uint8_t highest_prob_label =
+    autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+  if (!is_unsupported_obstacle_label(highest_prob_label)) {
+    return object;
+  }
+
+  TrackedObject remapped = object;
+  for (auto & classification : remapped.classification) {
+    if (is_unsupported_obstacle_label(classification.label)) {
+      classification.label = autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN;
+    }
+  }
+
+  // Two reasons to replace a non-BOX shape: the POLYGON filter below would otherwise drop the
+  // object we just decided to keep, and a POLYGON carries its extent in `footprint` while the
+  // model reads dimensions.x/y as length/width, which would feed it garbage extents.
+  if (remapped.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    static rclcpp::Clock clock{RCL_ROS_TIME};
+    RCLCPP_WARN_THROTTLE(
+      rclcpp::get_logger("diffusion_planner"), clock, constants::LOG_THROTTLE_INTERVAL_MS,
+      "Unsupported-class object %s (label=%u) has a non-BOX shape (type=%u). Replacing it with a "
+      "0.5 m bounding box.",
+      autoware_utils_uuid::to_hex_string(remapped.object_id).c_str(), highest_prob_label,
+      remapped.shape.type);
+    remapped.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+    remapped.shape.footprint.points.clear();
+    remapped.shape.dimensions.x = 0.5;
+    remapped.shape.dimensions.y = 0.5;
+    remapped.shape.dimensions.z = 0.5;
+  }
+  return remapped;
+}
+
 // Transform every history to the target frame, sort by distance to the frame origin (nearest
 // first), and trim to at most max_num_agent entries.
 std::vector<AgentHistory> transform_sort_trim(
@@ -96,38 +149,6 @@ std::vector<AgentHistory> transform_sort_trim(
       histories.begin() + static_cast<std::ptrdiff_t>(max_num_agent), histories.end());
   }
   return histories;
-}
-
-// HAZARD objects are not supported by the model, so remap them to PEDESTRIAN
-// to make the planner consider them.
-TrackedObject remap_hazard_to_pedestrian(const TrackedObject & object)
-{
-  const bool is_hazard = autoware::object_recognition_utils::getHighestProbLabel(
-                           object.classification) == ObjectClassification::HAZARD;
-  if (!is_hazard) {
-    return object;
-  }
-
-  TrackedObject remapped = object;
-  for (auto & classification : remapped.classification) {
-    if (classification.label == ObjectClassification::HAZARD) {
-      classification.label = ObjectClassification::PEDESTRIAN;
-    }
-  }
-
-  if (remapped.shape.type != autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    static rclcpp::Clock clock{RCL_ROS_TIME};
-    RCLCPP_WARN_THROTTLE(
-      rclcpp::get_logger("diffusion_planner"), clock, constants::LOG_THROTTLE_INTERVAL_MS,
-      "HAZARD object %s has a non-BOX shape (type=%u). Replacing it with a 0.5 m bounding box.",
-      autoware_utils_uuid::to_hex_string(remapped.object_id).c_str(), remapped.shape.type);
-    remapped.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
-    remapped.shape.footprint.points.clear();
-    remapped.shape.dimensions.x = 0.5;
-    remapped.shape.dimensions.y = 0.5;
-    remapped.shape.dimensions.z = 0.5;
-  }
-  return remapped;
 }
 
 }  // namespace
@@ -206,12 +227,17 @@ void AgentHistory::update(const TrackedObject & object, const rclcpp::Time & tim
   push_back(state);
 }
 
-void AgentData::update_histories(const TrackedObjects & objects)
+void AgentData::update_histories(
+  const TrackedObjects & objects, const bool remap_unsupported_objects_to_pedestrian)
 {
   const rclcpp::Time objects_timestamp(objects.header.stamp);
   std::vector<std::string> found_ids;
   for (const TrackedObject & input_object : objects.objects) {
-    const TrackedObject object = remap_hazard_to_pedestrian(input_object);
+    // Remap before the filters on purpose: the rewritten object is PEDESTRIAN with a BOX shape by
+    // then, so it survives both the IGNORE and the POLYGON guard.
+    const TrackedObject object = remap_unsupported_objects_to_pedestrian
+                                   ? remap_unsupported_to_pedestrian(input_object)
+                                   : input_object;
     if (get_model_label(object) == AgentLabel::IGNORE) {
       continue;
     }
@@ -250,7 +276,8 @@ std::vector<AgentHistory> AgentData::transformed_and_trimmed_histories(
 }
 
 void AgentData::update_histories(
-  const TrackedObjects & objects, [[maybe_unused]] const HistoryResamplingParams & params)
+  const TrackedObjects & objects, [[maybe_unused]] const HistoryResamplingParams & params,
+  const bool remap_unsupported_objects_to_pedestrian)
 {
   const rclcpp::Time objects_timestamp(objects.header.stamp);
 
@@ -277,7 +304,10 @@ void AgentData::update_histories(
 
   latest_ids_.clear();
   for (const TrackedObject & input_object : objects.objects) {
-    const TrackedObject object = remap_hazard_to_pedestrian(input_object);
+    // Same remap as the legacy overload; see the comment there.
+    const TrackedObject object = remap_unsupported_objects_to_pedestrian
+                                   ? remap_unsupported_to_pedestrian(input_object)
+                                   : input_object;
     if (get_model_label(object) == AgentLabel::IGNORE) {
       continue;
     }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -377,11 +377,14 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   // frame time); otherwise the legacy buffered histories are used directly.
   std::vector<AgentHistory> processed_neighbor_histories;
   if (params_.object_motion_resampling.enable) {
-    agent_data_.update_histories(*effective_objects, params_.object_motion_resampling);
+    agent_data_.update_histories(
+      *effective_objects, params_.object_motion_resampling,
+      params_.remap_unsupported_objects_to_pedestrian);
     processed_neighbor_histories = agent_data_.resampled_transformed_and_trimmed_histories(
       frame_time, map_to_ego_transform, NEIGHBOR_SHAPE[1], params_.object_motion_resampling);
   } else {
-    agent_data_.update_histories(*effective_objects);
+    agent_data_.update_histories(
+      *effective_objects, params_.remap_unsupported_objects_to_pedestrian);
     processed_neighbor_histories =
       agent_data_.transformed_and_trimmed_histories(map_to_ego_transform, NEIGHBOR_SHAPE[1]);
   }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -193,6 +193,8 @@ void DiffusionPlanner::set_up_params()
   params_.build_only = this->declare_parameter<bool>("build_only", false);
   params_.planning_frequency_hz = this->declare_parameter<double>("planning_frequency_hz", 10.0);
   params_.ignore_neighbors = this->declare_parameter<bool>("ignore_neighbors", false);
+  params_.remap_unsupported_objects_to_pedestrian =
+    this->declare_parameter<bool>("remap_unsupported_objects_to_pedestrian", false);
   params_.traffic_light_group_msg_timeout_seconds =
     this->declare_parameter<double>("traffic_light_group_msg_timeout_seconds", 0.2);
   params_.batch_size = this->declare_parameter<int>("batch_size", 1);
@@ -327,6 +329,9 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<std::string>(parameters, "model.precision", temp_params.trt_precision);
     update_param<bool>(parameters, "model.use_cuda_graph", temp_params.use_cuda_graph);
     update_param<bool>(parameters, "ignore_neighbors", temp_params.ignore_neighbors);
+    update_param<bool>(
+      parameters, "remap_unsupported_objects_to_pedestrian",
+      temp_params.remap_unsupported_objects_to_pedestrian);
     update_param<double>(
       parameters, "traffic_light_group_msg_timeout_seconds",
       temp_params.traffic_light_group_msg_timeout_seconds);

--- a/planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp
+++ b/planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp
@@ -65,4 +65,70 @@ protected:
   TrackedObject tracked_object_;
 };
 
+TEST_F(AgentEdgeCaseTest, HazardObjectIsRemappedToPedestrian)
+{
+  tracked_object_.classification.front().label =
+    autoware_perception_msgs::msg::ObjectClassification::HAZARD;
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  ASSERT_EQ(histories.size(), 1U);
+  const auto & state = histories.front().get_latest_state();
+  EXPECT_EQ(state.label, AgentLabel::PEDESTRIAN);
+  EXPECT_EQ(
+    state.original_info.classification.front().label,
+    autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
+  // BOX shape is kept as is
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 5.0);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 2.0);
+}
+
+TEST_F(AgentEdgeCaseTest, HazardObjectWithNonBoxShapeGetsDefaultBox)
+{
+  tracked_object_.classification.front().label =
+    autoware_perception_msgs::msg::ObjectClassification::HAZARD;
+  tracked_object_.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  // The polygon hazard object is not skipped because its shape is replaced with a bounding box
+  ASSERT_EQ(histories.size(), 1U);
+  const auto & state = histories.front().get_latest_state();
+  EXPECT_EQ(state.label, AgentLabel::PEDESTRIAN);
+  EXPECT_EQ(state.original_info.shape.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 0.5);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 0.5);
+  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.z, 0.5);
+}
+
+TEST_F(AgentEdgeCaseTest, NonHazardPolygonObjectIsStillSkipped)
+{
+  tracked_object_.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+
+  TrackedObjects objects;
+  objects.header.stamp.sec = 100;
+  objects.objects.push_back(tracked_object_);
+
+  AgentData agent_data;
+  agent_data.update_histories(objects);
+  const auto histories =
+    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+
+  EXPECT_TRUE(histories.empty());
+}
+
 }  // namespace autoware::diffusion_planner::test

--- a/planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp
+++ b/planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp
@@ -63,72 +63,111 @@ protected:
   }
 
   TrackedObject tracked_object_;
+
+  // Feed the single fixture object through AgentData and return the surviving histories.
+  std::vector<AgentHistory> run(const bool remap)
+  {
+    TrackedObjects objects;
+    objects.header.stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
+    objects.objects.push_back(tracked_object_);
+
+    AgentData agent_data;
+    agent_data.update_histories(objects, remap);
+    return agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+  }
+
+  void set_label(const uint8_t label)
+  {
+    tracked_object_.classification.clear();
+    autoware_perception_msgs::msg::ObjectClassification classification;
+    classification.label = label;
+    classification.probability = 0.9;
+    tracked_object_.classification.push_back(classification);
+  }
 };
 
-TEST_F(AgentEdgeCaseTest, HazardObjectIsRemappedToPedestrian)
+TEST_F(AgentEdgeCaseTest, UnknownObjectIsRemappedToPedestrian)
 {
-  tracked_object_.classification.front().label =
-    autoware_perception_msgs::msg::ObjectClassification::HAZARD;
+  set_label(autoware_perception_msgs::msg::ObjectClassification::UNKNOWN);
 
-  TrackedObjects objects;
-  objects.header.stamp.sec = 100;
-  objects.objects.push_back(tracked_object_);
+  const auto histories = run(true);
 
-  AgentData agent_data;
-  agent_data.update_histories(objects);
-  const auto histories =
-    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
-
-  ASSERT_EQ(histories.size(), 1U);
+  ASSERT_EQ(histories.size(), 1u);
   const auto & state = histories.front().get_latest_state();
   EXPECT_EQ(state.label, AgentLabel::PEDESTRIAN);
   EXPECT_EQ(
     state.original_info.classification.front().label,
     autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
-  // BOX shape is kept as is
+
+  const auto array = state.as_array();
+  EXPECT_FLOAT_EQ(array[8], 0.0F);   // VEHICLE
+  EXPECT_FLOAT_EQ(array[9], 1.0F);   // PEDESTRIAN
+  EXPECT_FLOAT_EQ(array[10], 0.0F);  // BICYCLE
+
+  // A BOX shape must keep its real extents.
   EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 5.0);
   EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 2.0);
 }
 
-TEST_F(AgentEdgeCaseTest, HazardObjectWithNonBoxShapeGetsDefaultBox)
+TEST_F(AgentEdgeCaseTest, HazardObjectIsRemappedToPedestrian)
 {
-  tracked_object_.classification.front().label =
-    autoware_perception_msgs::msg::ObjectClassification::HAZARD;
-  tracked_object_.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+  set_label(autoware_perception_msgs::msg::ObjectClassification::HAZARD);
 
-  TrackedObjects objects;
-  objects.header.stamp.sec = 100;
-  objects.objects.push_back(tracked_object_);
+  const auto histories = run(true);
 
-  AgentData agent_data;
-  agent_data.update_histories(objects);
-  const auto histories =
-    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
-
-  // The polygon hazard object is not skipped because its shape is replaced with a bounding box
-  ASSERT_EQ(histories.size(), 1U);
+  ASSERT_EQ(histories.size(), 1u);
   const auto & state = histories.front().get_latest_state();
   EXPECT_EQ(state.label, AgentLabel::PEDESTRIAN);
-  EXPECT_EQ(state.original_info.shape.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
-  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.x, 0.5);
-  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.y, 0.5);
-  EXPECT_DOUBLE_EQ(state.original_info.shape.dimensions.z, 0.5);
+  EXPECT_EQ(
+    state.original_info.classification.front().label,
+    autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
 }
 
-TEST_F(AgentEdgeCaseTest, NonHazardPolygonObjectIsStillSkipped)
+TEST_F(AgentEdgeCaseTest, UnknownPolygonObjectGetsDefaultBox)
 {
+  set_label(autoware_perception_msgs::msg::ObjectClassification::UNKNOWN);
   tracked_object_.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
 
-  TrackedObjects objects;
-  objects.header.stamp.sec = 100;
-  objects.objects.push_back(tracked_object_);
+  const auto histories = run(true);
 
-  AgentData agent_data;
-  agent_data.update_histories(objects);
-  const auto histories =
-    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), 10);
+  // Not dropped by the POLYGON filter, because the remap replaced the shape first.
+  ASSERT_EQ(histories.size(), 1u);
+  const auto & shape = histories.front().get_latest_state().original_info.shape;
+  EXPECT_EQ(shape.type, autoware_perception_msgs::msg::Shape::BOUNDING_BOX);
+  EXPECT_DOUBLE_EQ(shape.dimensions.x, 0.5);
+  EXPECT_DOUBLE_EQ(shape.dimensions.y, 0.5);
+  EXPECT_TRUE(shape.footprint.points.empty());
+}
 
-  EXPECT_TRUE(histories.empty());
+TEST_F(AgentEdgeCaseTest, UnsupportedObjectsAreIgnoredWhenRemapDisabled)
+{
+  for (const uint8_t label :
+       {autoware_perception_msgs::msg::ObjectClassification::UNKNOWN,
+        autoware_perception_msgs::msg::ObjectClassification::HAZARD}) {
+    set_label(label);
+
+    const auto histories = run(false);
+
+    // get_model_label() maps both to AgentLabel::IGNORE, so they are dropped entirely.
+    EXPECT_TRUE(histories.empty()) << "label " << static_cast<int>(label) << " was not ignored";
+  }
+}
+
+TEST_F(AgentEdgeCaseTest, SupportedPolygonObjectIsStillSkipped)
+{
+  // Stays CAR, so the remap must not touch it and the POLYGON filter must still drop it.
+  tracked_object_.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+
+  EXPECT_TRUE(run(true).empty());
+}
+
+TEST_F(AgentEdgeCaseTest, EmptyClassificationObjectIsStillIgnored)
+{
+  // getHighestProbLabel() returns UNKNOWN for an empty vector; there is no label to rewrite, so the
+  // object must stay ignored rather than being silently promoted to PEDESTRIAN.
+  tracked_object_.classification.clear();
+
+  EXPECT_TRUE(run(true).empty());
 }
 
 }  // namespace autoware::diffusion_planner::test

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/unknown_pose.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/unknown_pose.cpp
@@ -46,6 +46,8 @@
 
 #include <rviz_common/display_context.hpp>
 
+#include <geometry_msgs/msg/point32.hpp>
+
 #include <algorithm>
 #include <random>
 #include <string>
@@ -121,6 +123,21 @@ SimulatedObject UnknownInitialPoseTool::createObjectMsg() const
   object.shape.dimensions.x = length;
   object.shape.dimensions.y = width;
   object.shape.dimensions.z = 2.0;
+
+  // A POLYGON shape is defined by its footprint, not by `dimensions`. Leaving the footprint empty
+  // yields a zero-area object, which the tracker can never confirm, so the dummy object would never
+  // be published on the tracking topic. Emit the rectangle implied by length/width instead.
+  const auto add_footprint_point = [&object](const double x, const double y) {
+    geometry_msgs::msg::Point32 point;
+    point.x = static_cast<float>(x);
+    point.y = static_cast<float>(y);
+    point.z = 0.0F;
+    object.shape.footprint.points.push_back(point);
+  };
+  add_footprint_point(length / 2.0, width / 2.0);
+  add_footprint_point(-length / 2.0, width / 2.0);
+  add_footprint_point(-length / 2.0, -width / 2.0);
+  add_footprint_point(length / 2.0, -width / 2.0);
 
   // initial state
   object.initial_state.pose_covariance.pose.position.z = position_z_->getFloat();


### PR DESCRIPTION
## Description

`get_model_label()` maps `UNKNOWN` and `HAZARD` tracked objects to `AgentLabel::IGNORE`, so they
are dropped before they reach the model (see #12900). Those objects can still obstruct driving.

This PR adds a `remap_unsupported_objects_to_pedestrian` parameter (`bool`, default `false`). When
enabled, `AgentData::update_histories()` rewrites such objects to `PEDESTRIAN` — the most
conservative supported class — before the `IGNORE` and `POLYGON` filters run, so they survive both
and reach the model. Both `update_histories()` overloads (legacy and resampled) take the flag, and
it is registered in `on_parameter()` so it can be toggled at runtime.

Scope of the remapping:

- Only `UNKNOWN` and `HAZARD` are remapped. `ANIMAL`, `OVER_DRIVABLE` and `UNDER_DRIVABLE` stay
  ignored — they are either not obstacles or not drivable-space hazards the planner should brake for.
- An object with an empty `classification` is left alone rather than promoted. `getHighestProbLabel()`
  also returns `UNKNOWN` for it, but there is no label to rewrite.
- A non-`BOUNDING_BOX` shape is replaced with a 0.5 m box, with a throttled warning. A `POLYGON`
  carries its extent in `footprint` while the model reads `dimensions.x/y` as length/width, so
  passing one through would feed the model meaningless extents — and the `POLYGON` guard would drop
  the object the remap just decided to keep.

Note: this PR also carries a one-hunk fix to `tier4_dummy_object_rviz_plugin`. Dummy `UNKNOWN`
objects were published with a `POLYGON` shape and an empty `footprint`, i.e. zero area, which the
tracker never confirms — so they never appeared on the tracking topic. It now emits the rectangle
implied by the tool's length/width, which is what makes this code path reachable in the planning
simulator. Happy to split it into its own PR if reviewers prefer.

## How was this PR tested?

- [x] Unit tests: new `UNKNOWN` / `HAZARD` cases in
      `planning/autoware_diffusion_planner/test/agent_edge_case_test.cpp`
- [x] planning simulator: place a dummy `UNKNOWN` object in the ego lane, confirm the planner
      ignores it with the parameter `false` and reacts to it with the parameter `true`

## Notes for reviewers

The remap happens before the filters on purpose — after them, the object is already gone. See the
comments in `remap_unsupported_to_pedestrian()`.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `remap_unsupported_objects_to_pedestrian` | `bool` | `false` | Treat `UNKNOWN` and `HAZARD` tracked objects as `PEDESTRIAN`, the most conservative supported class, so the planner reacts to them instead of dropping them. Non-`BOX` shapes are replaced with a 0.5 m bounding box. `ANIMAL`, `OVER_DRIVABLE` and `UNDER_DRIVABLE` remain ignored. |

## Effects on system behavior

None by default: the parameter is `false`, which preserves the current behavior exactly. When
enabled, `UNKNOWN` and `HAZARD` objects are fed to the model as pedestrians, so the planner brakes
for and steers around obstacles it previously dropped — at the cost of reacting to perception noise
that shows up as `UNKNOWN`.
