### PR TITLE
feat(autoware_trajectory): replace find_first_interval to optimize search

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_bidirectional_traffic_module/src/bidirectional_lanelets.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_bidirectional_traffic_module/src/bidirectional_lanelets.cpp
@@ -190,7 +190,7 @@ ConnectedBidirectionalLanelets::get_overlap_interval(
     lane_ids_set.insert(lanelet.id());
   }
 
-  auto interval = experimental::trajectory::find_intervals(
+  auto interval_opt = experimental::trajectory::find_first_interval(
     trajectory,
     [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) -> bool {
       for (const auto & lane_id : point.lane_ids) {
@@ -198,8 +198,8 @@ ConnectedBidirectionalLanelets::get_overlap_interval(
       }
       return false;
     });
-  if (interval.empty()) return std::nullopt;
-  return interval.front();
+  if (!interval_opt.has_value()) return std::nullopt;
+  return interval_opt.value();
 }
 
 Eigen::Vector2d calc_pose_direction(const geometry_msgs::msg::Pose & pose)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/experimental/time_to_collision.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/experimental/time_to_collision.cpp
@@ -69,16 +69,16 @@ std::vector<FuturePose> calculate_future_profile(
     return {};
   }
 
-  const auto intervals_on_objective_lane = autoware::experimental::trajectory::find_intervals(
+  const auto intervals_on_objective_lane = autoware::experimental::trajectory::find_first_interval(
     path, [lane_id](const PathPointWithLaneId & p) {
       return std::find(p.lane_ids.begin(), p.lane_ids.end(), lane_id) != p.lane_ids.end();
     });
-  if (intervals_on_objective_lane.empty()) {
+  if (!intervals_on_objective_lane.has_value()) {
     return {};
   }
 
   auto reference_path =
-    autoware::experimental::trajectory::crop(path, 0, intervals_on_objective_lane.front().end);
+    autoware::experimental::trajectory::crop(path, 0, intervals_on_objective_lane.value().end);
   reference_path.longitudinal_velocity_mps().range(0, *current_s).set(current_velocity);
 
   PathWithLaneId reference_path_msg;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/experimental/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/experimental/util.cpp
@@ -305,15 +305,15 @@ std::optional<StopLinePositions> generate_stop_points(
     intersection_lanelet.leftBound().front().basicPoint2d(),
     intersection_lanelet.rightBound().front().basicPoint2d()};
 
-  const auto lane_id_intervals =
-    autoware::experimental::trajectory::find_intervals(path, [&](const PathPointWithLaneId & p) {
+  const auto lane_id_intervals = autoware::experimental::trajectory::find_first_interval(
+    path, [&](const PathPointWithLaneId & p) {
       return std::find(p.lane_ids.begin(), p.lane_ids.end(), intersection_lanelet.id()) !=
              p.lane_ids.end();
     });
-  if (lane_id_intervals.empty()) {
+  if (!lane_id_intervals.has_value()) {
     return std::nullopt;
   }
-  const auto [start_lane, end] = lane_id_intervals.front();
+  const auto [start_lane, end] = lane_id_intervals.value();
   const auto start = std::max(0., start_lane - ego_length);
 
   for (const auto & s : path.get_underlying_bases()) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/utils.cpp
@@ -132,17 +132,17 @@ std::optional<Polygon2d> generate_ego_no_stopping_area_lane_polygon(
   }
 
   const auto no_stopping_area = no_stopping_area_reg_elem.noStoppingAreas().front();
-  const auto ego_area_intervals = experimental::trajectory::find_intervals(
+  const auto ego_area_interval = experimental::trajectory::find_first_interval(
     path, [&](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & p) {
       const auto & pos = p.point.pose.position;
       return bg::covered_by(
         Point2d{pos.x, pos.y}, lanelet::utils::to2D(no_stopping_area).basicPolygon());
     });
-  if (ego_area_intervals.empty()) {
+  if (!ego_area_interval.has_value()) {
     return std::nullopt;
   }
 
-  const auto [ego_area_start_s, ego_area_end_s] = ego_area_intervals.front();
+  const auto [ego_area_start_s, ego_area_end_s] = ego_area_interval.value();
   if (ego_area_start_s - *ego_s > max_polygon_length) {
     return std::nullopt;
   }


### PR DESCRIPTION
## Description
:warning: This PR must be merged after [autoware_core #1441](https://github.com/autowarefoundation/autoware_core/pull/1441) and #13237 .
[autoware_core #1441](https://github.com/autowarefoundation/autoware_core/pull/1441) add `find_first_interval` in `autoware_trajectory`.

This PR replaces the usage in autoware_universe.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
