### PR TITLE
ci: add ENABLE_AGNOCAST=1 differential build job

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -16,6 +16,11 @@ on:
         default: humble
         required: false
         type: string
+      enable-agnocast:
+        description: True if ENABLE_AGNOCAST should be set to "1".
+        type: boolean
+        default: false
+        required: false
       run-condition:
         default: true
         required: false
@@ -134,11 +139,13 @@ jobs:
       - name: Build
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
+        env:
+          ENABLE_AGNOCAST: ${{ inputs.enable-agnocast && '1' || '' }}
         with:
           rosdistro: ${{ inputs.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
-          cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
+          cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}${{ inputs.enable-agnocast && '-agnocast' || '' }}
           build-pre-command: ${{ inputs.build-pre-command }}
           # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
           underlay-workspace: /opt/autoware
@@ -150,6 +157,8 @@ jobs:
         id: test
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-test@v1
+        env:
+          ENABLE_AGNOCAST: ${{ inputs.enable-agnocast && '1' || '' }}
         with:
           rosdistro: ${{ inputs.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}

--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -65,6 +65,19 @@ jobs:
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  build-and-test-differential-agnocast:
+    if: ${{ always() }}
+    needs:
+      - require-label
+    uses: ./.github/workflows/build-and-test-differential.yaml
+    with:
+      rosdistro: jazzy
+      container: ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy
+      enable-agnocast: true
+      run-condition: ${{ needs.require-label.outputs.result == 'true' && github.event.pull_request.base.ref == 'main' }}
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
   build-and-test-packages-above-differential:
     if: ${{ always() }}
     needs:

--- a/build_depends_stable.repos
+++ b/build_depends_stable.repos
@@ -40,7 +40,7 @@ repositories:
   middleware/external/agnocast:
     type: git
     url: https://github.com/tier4/agnocast.git
-    version: backport-jazzy-support-v2.1.2
+    version: 2.4.0
   universe/external/bevdet_vendor:
     type: git
     url: https://github.com/autowarefoundation/bevdet_vendor.git


### PR DESCRIPTION
## Description

62 Universe packages depend on `autoware_agnocast_wrapper`, but no CI job builds them with `ENABLE_AGNOCAST=1`, so code that only compiles in the default build can be merged. This adds a differential job mirroring `build-and-test-diff-jazzy-agnocast` in autoware_core.

- `build-and-test-differential.yaml`: new `enable-agnocast` input, exported as `ENABLE_AGNOCAST` to the build and test steps and appended to `cache-key-element`.
- `build-test-tidy-pr.yaml`: new `build-and-test-differential-agnocast` job (jazzy, `universe-dependencies-jazzy`).
- `build_depends_stable.repos`: bump `middleware/external/agnocast` to `2.4.0`, the minimum the wrapper requires (`find_package(agnocastlib 2.4.0 REQUIRED)`). No effect on the existing jobs, where the conditional `agnocastlib` dependency is not selected.

## Related links

**Parent Issue:**

- <https://github.com/autowarefoundation/autoware/issues/5968>

## How was this PR tested?

## Notes for reviewers

- Restricted to PRs against `main`, where `build_depends_nightly.repos` builds Core from source. On the release branches Core comes pre-built without Agnocast from the Docker image, so its wrapper headers would have no backend to compile against.
- jazzy only, matching autoware_core's differential workflow.

## Interface changes

None.

## Effects on system behavior

None.
