### PR TITLE
feat(diffusion_planner): apply agnocast_wrapper::Node

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -262,14 +262,13 @@ private:
     sub_tracked_objects_ =
       autoware::agnocast_wrapper::polling::create_polling_subscriber<TrackedObjects>(
         this, "~/input/tracked_objects");
-  // The newest message is enough: each TrafficLightGroupArray is a full snapshot of the arbitrated
-  // signals, and the traffic light map keeps the newest stamp per group.
   autoware::agnocast_wrapper::polling::PollingSubscriber<
     autoware_perception_msgs::msg::TrafficLightGroupArray,
-    autoware::agnocast_wrapper::polling::polling_policy::Newest>::SharedPtr sub_traffic_signals_ =
+    autoware::agnocast_wrapper::polling::polling_policy::All>::SharedPtr sub_traffic_signals_ =
     autoware::agnocast_wrapper::polling::create_polling_subscriber<
       autoware_perception_msgs::msg::TrafficLightGroupArray,
-      autoware::agnocast_wrapper::polling::polling_policy::Newest>(this, "~/input/traffic_signals");
+      autoware::agnocast_wrapper::polling::polling_policy::All>(
+      this, "~/input/traffic_signals", rclcpp::QoS{10});
   autoware::agnocast_wrapper::polling::PollingSubscriber<TurnIndicatorsReport>::SharedPtr
     sub_turn_indicators_ =
       autoware::agnocast_wrapper::polling::create_polling_subscriber<TurnIndicatorsReport>(

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -18,18 +18,17 @@
 #include "autoware/diffusion_planner/diffusion_planner_core.hpp"
 #include "autoware/diffusion_planner/utils/planning_factor_utils.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
-#include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/ros/update_param.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <autoware_utils_diagnostics/diagnostics_interface.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp/subscription.hpp>
-#include <rclcpp/timer.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
@@ -60,7 +59,8 @@ using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 using HADMapBin = autoware_map_msgs::msg::LaneletMapBin;
 using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_internal_planning_msgs::msg::PlanningFactor;
-using autoware_utils_diagnostics::DiagnosticsInterface;
+using DiagnosticsInterface =
+  autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>;
 using geometry_msgs::msg::Pose;
 using rcl_interfaces::msg::SetParametersResult;
 using std_srvs::srv::SetBool;
@@ -117,7 +117,7 @@ struct DiffusionPlannerPlanningFactorParams
  * - generator_uuid_: Unique identifier for the planner instance.
  * - vehicle_info_: Vehicle-specific parameters.
  */
-class DiffusionPlanner : public rclcpp::Node
+class DiffusionPlanner : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit DiffusionPlanner(const rclcpp::NodeOptions & options);
@@ -148,7 +148,7 @@ private:
    * @brief Callback for receiving and processing map data.
    * @param map_msg The received map message.
    */
-  void on_map(const HADMapBin::ConstSharedPtr map_msg);
+  void on_map(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(HADMapBin) & map_msg);
 
   /**
    * @brief Publish visualization markers for debugging.
@@ -200,72 +200,86 @@ private:
    * @brief Enable or disable start guidance.
    */
   void on_set_start_guidance_enabled(
-    const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response);
+    const AUTOWARE_SERVER_REQUEST_PTR(SetBool) & request,
+    const AUTOWARE_SERVER_RESPONSE_PTR(SetBool) & response);
 
   /**
    * @brief Enable or disable stop guidance.
    */
   void on_set_stop_guidance_enabled(
-    const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response);
+    const AUTOWARE_SERVER_REQUEST_PTR(SetBool) & request,
+    const AUTOWARE_SERVER_RESPONSE_PTR(SetBool) & response);
 
   /**
    * @brief Enable or disable centerline guidance.
    */
   void on_set_centerline_guidance_enabled(
-    const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response);
+    const AUTOWARE_SERVER_REQUEST_PTR(SetBool) & request,
+    const AUTOWARE_SERVER_RESPONSE_PTR(SetBool) & response);
 
   // Core logic instance
   std::unique_ptr<DiffusionPlannerCore> core_;
 
   // Node parameters
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
   DiffusionPlannerParams params_;
   DiffusionPlannerDebugParams debug_params_;
 
   // Node elements
-  rclcpp::TimerBase::SharedPtr timer_;
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
-    debug_processing_time_detail_pub_;
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    debug_processing_time_pub_;
-  rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_{nullptr};
-  rclcpp::Publisher<CandidateTrajectories>::SharedPtr pub_trajectories_{nullptr};
-  rclcpp::Publisher<PredictedObjects>::SharedPtr pub_objects_{nullptr};
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_lane_marker_{nullptr};
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_linestring_marker_{nullptr};
-  rclcpp::Publisher<MarkerArray>::SharedPtr pub_route_marker_{nullptr};
-  rclcpp::Publisher<TurnIndicatorsCommand>::SharedPtr pub_turn_indicators_{nullptr};
-  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroup>::SharedPtr
-    pub_traffic_signal_{nullptr};
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_snapped_pose_{nullptr};
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
-    pub_snap_interpolation_time_{nullptr};
-  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pub_inference_time_{nullptr};
-  rclcpp::Publisher<std_msgs::msg::Float32MultiArray>::SharedPtr pub_denoising_steps_{nullptr};
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr
-    pub_guidance_status_{nullptr};
-  rclcpp::Service<SetBool>::SharedPtr set_start_guidance_enabled_service_{nullptr};
-  rclcpp::Service<SetBool>::SharedPtr set_stop_guidance_enabled_service_{nullptr};
-  rclcpp::Service<SetBool>::SharedPtr set_centerline_guidance_enabled_service_{nullptr};
+  AUTOWARE_TIMER_PTR timer_;
+  AUTOWARE_PUBLISHER_PTR(autoware_utils::ProcessingTimeDetail) debug_processing_time_detail_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped)
+  debug_processing_time_pub_;
+  AUTOWARE_PUBLISHER_PTR(Trajectory) pub_trajectory_;
+  AUTOWARE_PUBLISHER_PTR(CandidateTrajectories) pub_trajectories_;
+  AUTOWARE_PUBLISHER_PTR(PredictedObjects) pub_objects_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) pub_lane_marker_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) pub_linestring_marker_;
+  AUTOWARE_PUBLISHER_PTR(MarkerArray) pub_route_marker_;
+  AUTOWARE_PUBLISHER_PTR(TurnIndicatorsCommand) pub_turn_indicators_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrafficLightGroup)
+  pub_traffic_signal_;
+  AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::PoseStamped) pub_snapped_pose_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::Float64Stamped)
+  pub_snap_interpolation_time_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Float64) pub_inference_time_;
+  AUTOWARE_PUBLISHER_PTR(std_msgs::msg::Float32MultiArray) pub_denoising_steps_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::StringStamped)
+  pub_guidance_status_;
+  AUTOWARE_SERVICE_PTR(SetBool) set_start_guidance_enabled_service_;
+  AUTOWARE_SERVICE_PTR(SetBool) set_stop_guidance_enabled_service_;
+  AUTOWARE_SERVICE_PTR(SetBool) set_centerline_guidance_enabled_service_;
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
-  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
-    this, "~/input/odometry"};
-  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
-    sub_current_acceleration_{this, "~/input/acceleration"};
-  autoware_utils::InterProcessPollingSubscriber<TrackedObjects> sub_tracked_objects_{
-    this, "~/input/tracked_objects"};
-  autoware_utils::InterProcessPollingSubscriber<
-    autoware_perception_msgs::msg::TrafficLightGroupArray, autoware_utils::polling_policy::All>
-    sub_traffic_signals_{this, "~/input/traffic_signals", rclcpp::QoS{10}};
-  autoware_utils::InterProcessPollingSubscriber<TurnIndicatorsReport> sub_turn_indicators_{
-    this, "~/input/turn_indicators"};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletRoute, autoware_utils::polling_policy::Newest>
-    route_subscriber_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
-  autoware_utils::InterProcessPollingSubscriber<
-    LaneletMapBin, autoware_utils::polling_policy::Newest>
-    vector_map_subscriber_{this, "~/input/vector_map", rclcpp::QoS{1}.transient_local()};
-  rclcpp::Subscription<HADMapBin>::SharedPtr sub_map_;
+  autoware::agnocast_wrapper::polling::PollingSubscriber<Odometry>::SharedPtr
+    sub_current_odometry_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<Odometry>(
+        this, "~/input/odometry");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<AccelWithCovarianceStamped>::SharedPtr
+    sub_current_acceleration_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<AccelWithCovarianceStamped>(
+        this, "~/input/acceleration");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<TrackedObjects>::SharedPtr
+    sub_tracked_objects_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<TrackedObjects>(
+        this, "~/input/tracked_objects");
+  // The newest message is enough: each TrafficLightGroupArray is a full snapshot of the arbitrated
+  // signals, and the traffic light map keeps the newest stamp per group.
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    autoware_perception_msgs::msg::TrafficLightGroupArray,
+    autoware::agnocast_wrapper::polling::polling_policy::Newest>::SharedPtr sub_traffic_signals_ =
+    autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      autoware_perception_msgs::msg::TrafficLightGroupArray,
+      autoware::agnocast_wrapper::polling::polling_policy::Newest>(this, "~/input/traffic_signals");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<TurnIndicatorsReport>::SharedPtr
+    sub_turn_indicators_ =
+      autoware::agnocast_wrapper::polling::create_polling_subscriber<TurnIndicatorsReport>(
+        this, "~/input/turn_indicators");
+  autoware::agnocast_wrapper::polling::PollingSubscriber<
+    LaneletRoute, autoware::agnocast_wrapper::polling::polling_policy::Newest>::SharedPtr
+    route_subscriber_ = autoware::agnocast_wrapper::polling::create_polling_subscriber<
+      LaneletRoute, autoware::agnocast_wrapper::polling::polling_policy::Newest>(
+      this, "~/input/route", rclcpp::QoS{1}.transient_local());
+  AUTOWARE_SUBSCRIPTION_PTR(HADMapBin) sub_map_;
   UUID generator_uuid_;
   VehicleInfo vehicle_info_;
 
@@ -274,7 +288,8 @@ private:
 
   std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
-  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+  std::unique_ptr<
+    autoware::planning_factor_interface::PlanningFactorInterfaceT<autoware::agnocast_wrapper::Node>>
     planning_factor_interface_;
   DiffusionPlannerPlanningFactorParams planning_factor_params_;
 };

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -580,11 +580,7 @@ void DiffusionPlanner::on_timer()
   auto ego_acceleration = sub_current_acceleration_->take_data();
   auto temp_route_ptr = route_subscriber_->take_data();
   auto turn_indicators_ptr = sub_turn_indicators_->take_data();
-  std::vector<std::shared_ptr<const autoware_perception_msgs::msg::TrafficLightGroupArray>>
-    traffic_signals;
-  if (auto traffic_signals_msg = sub_traffic_signals_->take_data()) {
-    traffic_signals.push_back(std::move(traffic_signals_msg));
-  }
+  auto traffic_signals = sub_traffic_signals_->take_data();
 
   // Prepare frame context using core
   const std::optional<FrameContext> frame_context = core_->create_frame_context(

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::diffusion_planner
@@ -70,7 +71,8 @@ std::string compute_file_hash_hex(const std::string & path)
 }  // namespace
 
 DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
-: Node("diffusion_planner", options), generator_uuid_(autoware_utils_uuid::generate_uuid())
+: autoware::agnocast_wrapper::Node("diffusion_planner", options),
+  generator_uuid_(autoware_utils_uuid::generate_uuid())
 {
   // Initialize the node
   pub_trajectory_ = this->create_publisher<Trajectory>("~/output/trajectory", 1);
@@ -132,8 +134,8 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
       std::placeholders::_2));
 
   planning_factor_interface_ =
-    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
-      this, "diffusion_planner");
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterfaceT<
+      autoware::agnocast_wrapper::Node>>(this, "diffusion_planner");
 
   diagnostics_inference_ = std::make_unique<DiagnosticsInterface>(this, "inference_status");
   try {
@@ -152,7 +154,7 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     }
   }
 
-  timer_ = rclcpp::create_timer(
+  timer_ = autoware::agnocast_wrapper::create_timer(
     this, get_clock(), rclcpp::Rate(params_.planning_frequency_hz).period(),
     std::bind(&DiffusionPlanner::on_timer, this));
 
@@ -448,7 +450,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
 }
 
 void DiffusionPlanner::on_set_start_guidance_enabled(
-  const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response)
+  const AUTOWARE_SERVER_REQUEST_PTR(SetBool) & request,
+  const AUTOWARE_SERVER_RESPONSE_PTR(SetBool) & response)
 {
   core_->set_start_guidance_enabled(request->data);
 
@@ -457,7 +460,8 @@ void DiffusionPlanner::on_set_start_guidance_enabled(
 }
 
 void DiffusionPlanner::on_set_stop_guidance_enabled(
-  const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response)
+  const AUTOWARE_SERVER_REQUEST_PTR(SetBool) & request,
+  const AUTOWARE_SERVER_RESPONSE_PTR(SetBool) & response)
 {
   core_->set_stop_guidance_enabled(request->data);
 
@@ -466,7 +470,8 @@ void DiffusionPlanner::on_set_stop_guidance_enabled(
 }
 
 void DiffusionPlanner::on_set_centerline_guidance_enabled(
-  const SetBool::Request::SharedPtr request, const SetBool::Response::SharedPtr response)
+  const AUTOWARE_SERVER_REQUEST_PTR(SetBool) & request,
+  const AUTOWARE_SERVER_RESPONSE_PTR(SetBool) & response)
 {
   core_->set_centerline_guidance_enabled(request->data);
 
@@ -490,23 +495,23 @@ void DiffusionPlanner::publish_snapped_pose(
   }
 
   const Eigen::Matrix4d & snapped_pose = frame_context.snapped_pose.value();
-  geometry_msgs::msg::PoseStamped pose_msg;
-  pose_msg.header.stamp = timestamp;
-  pose_msg.header.frame_id = "map";
-  pose_msg.pose.position.x = snapped_pose(0, 3);
-  pose_msg.pose.position.y = snapped_pose(1, 3);
-  pose_msg.pose.position.z = snapped_pose(2, 3);
+  auto pose_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_snapped_pose_);
+  pose_msg->header.stamp = timestamp;
+  pose_msg->header.frame_id = "map";
+  pose_msg->pose.position.x = snapped_pose(0, 3);
+  pose_msg->pose.position.y = snapped_pose(1, 3);
+  pose_msg->pose.position.z = snapped_pose(2, 3);
   const Eigen::Quaterniond q(snapped_pose.block<3, 3>(0, 0));
-  pose_msg.pose.orientation.x = q.x();
-  pose_msg.pose.orientation.y = q.y();
-  pose_msg.pose.orientation.z = q.z();
-  pose_msg.pose.orientation.w = q.w();
-  pub_snapped_pose_->publish(pose_msg);
+  pose_msg->pose.orientation.x = q.x();
+  pose_msg->pose.orientation.y = q.y();
+  pose_msg->pose.orientation.z = q.z();
+  pose_msg->pose.orientation.w = q.w();
+  pub_snapped_pose_->publish(std::move(pose_msg));
 
-  autoware_internal_debug_msgs::msg::Float64Stamped interpolation_time_msg;
-  interpolation_time_msg.stamp = timestamp;
-  interpolation_time_msg.data = frame_context.snapped_interpolation_time_s.value();
-  pub_snap_interpolation_time_->publish(interpolation_time_msg);
+  auto interpolation_time_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_snap_interpolation_time_);
+  interpolation_time_msg->stamp = timestamp;
+  interpolation_time_msg->data = frame_context.snapped_interpolation_time_s.value();
+  pub_snap_interpolation_time_->publish(std::move(interpolation_time_msg));
 }
 
 void DiffusionPlanner::publish_debug_markers(
@@ -570,12 +575,16 @@ void DiffusionPlanner::on_timer()
   }
 
   // Take data from subscribers
-  auto objects = sub_tracked_objects_.take_data();
-  auto ego_kinematic_state = sub_current_odometry_.take_data();
-  auto ego_acceleration = sub_current_acceleration_.take_data();
-  auto traffic_signals = sub_traffic_signals_.take_data();
-  auto temp_route_ptr = route_subscriber_.take_data();
-  auto turn_indicators_ptr = sub_turn_indicators_.take_data();
+  auto objects = sub_tracked_objects_->take_data();
+  auto ego_kinematic_state = sub_current_odometry_->take_data();
+  auto ego_acceleration = sub_current_acceleration_->take_data();
+  auto temp_route_ptr = route_subscriber_->take_data();
+  auto turn_indicators_ptr = sub_turn_indicators_->take_data();
+  std::vector<std::shared_ptr<const autoware_perception_msgs::msg::TrafficLightGroupArray>>
+    traffic_signals;
+  if (auto traffic_signals_msg = sub_traffic_signals_->take_data()) {
+    traffic_signals.push_back(std::move(traffic_signals_msg));
+  }
 
   // Prepare frame context using core
   const std::optional<FrameContext> frame_context = core_->create_frame_context(
@@ -650,9 +659,9 @@ void DiffusionPlanner::on_timer()
     return;
   }
 
-  std_msgs::msg::Float64 inference_time_msg;
-  inference_time_msg.data = inference_result->inference_time_ms;
-  pub_inference_time_->publish(inference_time_msg);
+  auto inference_time_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_inference_time_);
+  inference_time_msg->data = inference_result->inference_time_ms;
+  pub_inference_time_->publish(std::move(inference_time_msg));
 
   PlannerOutput planner_output;
   try {
@@ -680,10 +689,10 @@ void DiffusionPlanner::on_timer()
 
   // Publish diagnostics
   diagnostics_inference_->publish(frame_time);
-  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
-  processing_time_msg.stamp = get_clock()->now();
-  processing_time_msg.data = stop_watch_ptr_->toc("processing_time", true);
-  debug_processing_time_pub_->publish(processing_time_msg);
+  auto processing_time_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(debug_processing_time_pub_);
+  processing_time_msg->stamp = get_clock()->now();
+  processing_time_msg->data = stop_watch_ptr_->toc("processing_time", true);
+  debug_processing_time_pub_->publish(std::move(processing_time_msg));
 }
 
 void DiffusionPlanner::publish_guidance_status(
@@ -693,9 +702,6 @@ void DiffusionPlanner::publish_guidance_status(
   if (guidance_triggered.empty()) {
     return;
   }
-
-  autoware_internal_debug_msgs::msg::StringStamped msg;
-  msg.stamp = timestamp;
 
   std::vector<std::string> batch_entries;
   size_t batch_size = 0;
@@ -721,9 +727,10 @@ void DiffusionPlanner::publish_guidance_status(
     }
     result += batch_entries[i];
   }
-  msg.data = result;
-
-  pub_guidance_status_->publish(msg);
+  auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_guidance_status_);
+  msg->stamp = timestamp;
+  msg->data = result;
+  pub_guidance_status_->publish(std::move(msg));
 }
 
 void DiffusionPlanner::publish_planning_factor(const Trajectory & trajectory)
@@ -750,7 +757,7 @@ void DiffusionPlanner::publish_planning_factor(const Trajectory & trajectory)
   planning_factor_interface_->publish();
 }
 
-void DiffusionPlanner::on_map(const HADMapBin::ConstSharedPtr map_msg)
+void DiffusionPlanner::on_map(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(HADMapBin) & map_msg)
 {
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*map_msg);
   core_->set_map(lanelet_map_ptr_);


### PR DESCRIPTION
## Description

Applies `autoware::agnocast_wrapper::Node` to `autoware_diffusion_planner`: publishers, subscriptions, services, the timer and the polling subscribers now go through the wrapper, so the node runs on either backend (`ENABLE_AGNOCAST=0`/`=1`). The CMake side was already prepared via `autoware_agnocast_wrapper_register_node`.

`~/input/traffic_signals` keeps `polling_policy::All` with `QoS(10)`, as before the migration. The wrapper's polling API gained that policy in autowarefoundation/autoware_core#1443, which this PR depends on.

Also drops `vector_map_subscriber_`, an unused polling subscriber on `~/input/vector_map` (the map is consumed through the `sub_map_` callback).

## Related links

None.

## How was this PR tested?

- Built and unit-tested with `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`: 110 gtest cases pass in both builds.
- Ran the node standalone in both modes (`SingleThreadedExecutor` / `CallbackIsolatedAgnocastExecutor` with the Agnocast heaphook) and confirmed it starts, brings up its endpoints and drives the timer at the configured rate.
- Ran the logging simulator with `planning_setting:=diffusion_planner` (`ENABLE_AGNOCAST=0`, sample-map-rosbag, route set, traffic signals injected at 5 messages per 100 ms because the bag carries no camera data). One `take_data()` returned 5 messages on 982 planning cycles, and `candidate_trajectories` held its rate with and without the injection.
- The end-to-end comparison of the published trajectory between the two modes in a simulator is still open. Kept as a draft until then.

## Notes for reviewers

- Debug messages assembled in the node are now built directly in the loaned message (`ALLOCATE_OUTPUT_MESSAGE_UNIQUE`). Messages produced by `DiffusionPlannerCore` keep the const-ref `publish()` overload: the core builds them on the heap, so the copy the overload makes is what places the payload in shared memory.
- Depends on autowarefoundation/autoware_core#1443 (`polling_policy::All` in the wrapper's polling subscriber). This PR does not build until that one is merged.

## Interface changes

None.

## Effects on system behavior

None.

