### PR TITLE
fix(planning): fix ENABLE_AGNOCAST=1 build and startup of trajectory_selector

### DIFF
--- a/planning/autoware_trajectory_ranker/CMakeLists.txt
+++ b/planning/autoware_trajectory_ranker/CMakeLists.txt
@@ -21,6 +21,7 @@ ament_auto_add_library(${trajectory_ranker_lib_target} SHARED
   src/evaluation.cpp
   src/utils.cpp
 )
+autoware_agnocast_wrapper_setup(${trajectory_ranker_lib_target})
 
 target_link_libraries(${trajectory_ranker_lib_target}
   ${PROJECT_NAME}_param

--- a/planning/autoware_trajectory_selector/src/trajectory_selector_node.cpp
+++ b/planning/autoware_trajectory_selector/src/trajectory_selector_node.cpp
@@ -83,9 +83,11 @@ void TrajectorySelectorNode::map_callback(
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
+  if (!msg) return;
+
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
-  if (msg != nullptr) route_handler_ptr_->setMap(*msg);
+  route_handler_ptr_->setMap(*msg);
 }
 
 void TrajectorySelectorNode::route_callback(
@@ -93,8 +95,10 @@ void TrajectorySelectorNode::route_callback(
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
+  if (!msg) return;
+
   route_ptr_ = std::make_shared<const LaneletRoute>(*msg);
-  if (msg != nullptr) route_handler_ptr_->setRoute(*msg);
+  route_handler_ptr_->setRoute(*msg);
 }
 
 void TrajectorySelectorNode::on_anchor_trajectories(


### PR DESCRIPTION
## Description

`ENABLE_AGNOCAST=1` builds of `autoware_trajectory_selector` have been broken since #13353, and even with the build fixed the node fails to start.
The `ENABLE_AGNOCAST=1` configuration is not covered by CI in this repository, so none of these problems was caught before the merge.
This PR fixes all three.

### 1. `autoware_trajectory_selector`: comparing a message pointer with `nullptr`

#13353 added two `if (msg != nullptr)` guards in `map_callback()` and `route_callback()`.
The parameter type is `AUTOWARE_MESSAGE_CONST_SHARED_PTR(T)`, which is `std::shared_ptr<const T>` with `ENABLE_AGNOCAST=0` but `autoware::agnocast_wrapper::message_ptr<const T, Shared>` with `ENABLE_AGNOCAST=1`.
`message_ptr` intentionally defines no comparison operators and only an `explicit operator bool()`, so the comparison does not compile:

```
error: no match for 'operator!=' (operand types are
  'const autoware::agnocast_wrapper::message_ptr<const autoware_map_msgs::msg::LaneletMapBin_<...>,
   autoware::agnocast_wrapper::OwnershipType::Shared>' and 'std::nullptr_t')
```

The guards are now written as `if (!msg) return;` at the top of each callback, which compiles in both configurations.
They were also moved before the first dereference: in the original code `from_autoware_map_msgs(*msg)` and `std::make_shared<const LaneletRoute>(*msg)` ran before the check, so the guards could never protect anything.

### 2. `autoware_trajectory_ranker`: missing `autoware_agnocast_wrapper_setup()`

#13353 turned the two ranker nodes into a library and removed both `autoware_agnocast_wrapper_register_node()` calls.
That macro calls `autoware_agnocast_wrapper_setup()` internally, so it was the only thing defining `USE_AGNOCAST_ENABLED` for this package, and no replacement was added.
Meanwhile the public headers of this package (`evaluation.hpp`, `metrics_interface.hpp`, `trajectory_ranker_wrapper.hpp`) started to include `<autoware/agnocast_wrapper/node.hpp>` and hold `agnocast_wrapper::Node *`.

`autoware/agnocast_wrapper/node.hpp` defines two different classes under the same name depending on that macro, so the ranker library was compiled against the non-Agnocast `Node` while `autoware_trajectory_selector` passes the Agnocast one.
Both mangle identically, so this links cleanly and only breaks at run time.
With `ENABLE_AGNOCAST=1` the node fails to start:

```
[ERROR] [autoware_trajectory_selector_node]: Failed to load node class:
  NodeTopics::create_publisher is not supported in agnocast. Use agnocast::create_publisher instead.
```

Adding `autoware_agnocast_wrapper_setup()` to the library target fixes it.
The macro is `PUBLIC`, so it also reaches `${PROJECT_NAME}_plugins` and the tests, which link that target.
This mirrors what `autoware_trajectory_validator` already does.

### 3. `autoware_trajectory_adapter`: missing `autoware_agnocast_wrapper_setup()`

This is the same problem as section 2, in a different package.
#13355 turned the standalone adapter node into a library and removed `autoware_agnocast_wrapper_register_node()`, leaving nothing to define `USE_AGNOCAST_ENABLED` for this package.
`trajectory_adapter_wrapper.cpp` includes `<autoware/agnocast_wrapper/node.hpp>` and calls `node_ptr_->get_logger()` and `node_ptr_->create_publisher<>()`, so the library is compiled against the non-Agnocast `Node` while `autoware_trajectory_selector` passes the Agnocast one.

`TrajectorySelectorNode` constructs its wrappers in the order concatenator, validator, ranker, adapter.
With only section 2 fixed, startup gets past the ranker and then fails in the adapter constructor with the same `NodeTopics::create_publisher` error.
`autoware_trajectory_validator` is unaffected because #12920 already added the call there.
`autoware_trajectory_concatenator` needs no change because its wrapper is header-only and is expanded in the caller's translation unit.

## Related links

- #13353 (the change sections 1 and 2 come from)
- #13355 (the change section 3 comes from)
- #12920 (the `agnocast_wrapper::Node` application to `autoware_trajectory_selector`)

## How was this PR tested?

All of the following was done with `ENABLE_AGNOCAST=1`, on a branch merged with current `main`.

- **Build**: `autoware_trajectory_concatenator`, `autoware_trajectory_validator`, `autoware_trajectory_ranker`, `autoware_trajectory_adapter` and `autoware_trajectory_selector` build from a clean `build/` and `install/`.
- **Startup**: `autoware_trajectory_selector_node` starts as a standalone node and reaches steady state. Its fallback timer keeps firing (`No concatenated trajectories received yet`, expected with no inputs), the six ranker metric plugins are loaded, and it shuts down cleanly on SIGINT.
- **Cause confirmed by comparison**: with either `autoware_agnocast_wrapper_setup()` line removed and everything else unchanged, the same run fails with the `NodeTopics::create_publisher` error above, in the ranker and in the adapter respectively. Fixing only one of them just moves the failure to the next wrapper in the construction order.

The `ENABLE_AGNOCAST=0` build is left to CI.

## Interface changes

None.

## Effects on system behavior

None for `ENABLE_AGNOCAST=0`.
For `ENABLE_AGNOCAST=1`, `autoware_trajectory_selector` builds and starts again.