### PR TITLE
fix(run_out): handles -NaN collision time

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/CMakeLists.txt
@@ -9,4 +9,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   DIRECTORY src
 )
 
+if(BUILD_TESTING)
+  ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
+    test/test_collisions.cpp
+  )
+  target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
+endif()
+
 ament_auto_package(INSTALL_TO_SHARE config)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collision.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collision.hpp
@@ -117,7 +117,7 @@ void calculate_overlapping_collision(
 /// @param[in] params The parameters for collision calculation.
 /// @return A vector of collisions.
 std::vector<Collision> calculate_interval_collisions(
-  std::vector<TimeOverlapIntervalPair> intervals, const Parameters & params);
+  const std::vector<TimeOverlapIntervalPair> & intervals, const Parameters & params);
 
 /// @brief Calculates collisions between the ego vehicle's trajectory footprint and a predicted
 /// object's footprint.

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collisions.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "collision.hpp"
 #include "parameters.hpp"
 #include "types.hpp"
 
@@ -42,7 +43,6 @@
 
 namespace autoware::motion_velocity_planner::run_out
 {
-
 namespace
 {
 bool is_same_direction(const TimeOverlapInterval & ego, const Parameters & params)
@@ -117,7 +117,7 @@ FootprintIntersection calculate_footprint_intersection(
 std::pair<autoware_planning_msgs::msg::TrajectoryPoint, double>
 calculate_closest_interpolated_point_and_arc_length(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
-  const universe_utils::Point2d & p, const double longitudinal_offset = 0.0)
+  const universe_utils::Point2d & p, const double longitudinal_offset)
 {
   autoware_planning_msgs::msg::TrajectoryPoint trajectory_point;
   geometry_msgs::msg::Point pt;
@@ -227,17 +227,6 @@ std::vector<FootprintIntersection> calculate_intersections(
   }
   return intersections;
 }
-
-struct TimeOverlapIntervalPair
-{
-  TimeOverlapInterval ego;
-  TimeOverlapInterval object;
-
-  TimeOverlapIntervalPair(TimeOverlapInterval e, TimeOverlapInterval o)
-  : ego(std::move(e)), object(std::move(o))
-  {
-  }
-};
 
 void create_overlap(
   std::vector<TimeOverlapIntervalPair> & overlap_intervals,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collisions.cpp
@@ -325,25 +325,42 @@ void calculate_overlapping_collision(
          << "]/ego_vel[" << ego.first_intersection.ego_vel << "]";
       c.explanation = ss.str();
     }
-  } else if (is_opposite_direction(ego, params)) {
-    // predict time when collision would occur by finding time when arc lengths are equal
-    const auto overlap_length =
-      ego.last_intersection.arc_length - ego.first_intersection.arc_length;
-    const auto ego_overlap_duration =
-      ego.last_intersection.ego_time - ego.first_intersection.ego_time;
-    const auto object_overlap_duration =
-      object.last_intersection.object_time - object.first_intersection.object_time;
-    const auto ego_vel = overlap_length / ego_overlap_duration;
-    const auto obj_vel = overlap_length / object_overlap_duration;
-    const auto lon_buffer = std::min(overlap_length, 4.0);
-    const auto collision_time_within_overlap = (overlap_length - lon_buffer) / (ego_vel + obj_vel);
-    // TODO(Maxime): we need to correctly account for the agents' longitudinal offsets
-    c.ego_collision_time += collision_time_within_overlap;
+    return;
+  }
+
+  // keeping original behavior
+  if (!is_opposite_direction(ego, params)) {
+    return;
+  }
+
+  // predict time when collision would occur by finding time when arc lengths are equal
+  const auto overlap_length = ego.last_intersection.arc_length - ego.first_intersection.arc_length;
+  const auto ego_overlap_duration =
+    ego.last_intersection.ego_time - ego.first_intersection.ego_time;
+  const auto object_overlap_duration =
+    object.last_intersection.object_time - object.first_intersection.object_time;
+
+  // degenerate (point-like) overlap: no length or no duration to estimate velocities from
+  if (
+    std::abs(overlap_length) < 1e-3 || std::abs(ego_overlap_duration) < 1e-3 ||
+    std::abs(object_overlap_duration) < 1e-3) {
     std::stringstream ss;
     ss << std::setprecision(2) << "coll_t = ego_enter_time[" << ego.first_intersection.ego_time
-       << "]+coll_t_within_overlap[" << collision_time_within_overlap << "]";
+       << "]";
     c.explanation = ss.str();
+    return;  // keep the ego enter time set above; the code below would divide by zero -> NaN
   }
+
+  const auto ego_vel = overlap_length / ego_overlap_duration;
+  const auto obj_vel = overlap_length / object_overlap_duration;
+  const auto lon_buffer = std::min(overlap_length, 4.0);
+  const auto collision_time_within_overlap = (overlap_length - lon_buffer) / (ego_vel + obj_vel);
+  // TODO(Maxime): we need to correctly account for the agents' longitudinal offsets
+  c.ego_collision_time += collision_time_within_overlap;
+  std::stringstream ss;
+  ss << std::setprecision(2) << "coll_t = ego_enter_time[" << ego.first_intersection.ego_time
+     << "]+coll_t_within_overlap[" << collision_time_within_overlap << "]";
+  c.explanation = ss.str();
 }
 
 Collision calculate_collision(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/test/test_collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/test/test_collisions.cpp
@@ -1,0 +1,163 @@
+// Copyright 2026 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/collision.hpp"
+#include "../src/parameters.hpp"
+#include "../src/types.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+namespace autoware::motion_velocity_planner::run_out
+{
+namespace
+{
+Parameters make_params()
+{
+  Parameters params;
+  params.collision_time_margin = 1.0;
+  params.collision_same_direction_angle_threshold = 0.785;      // [rad] 45 degrees
+  params.collision_opposite_direction_angle_threshold = 0.785;  // [rad] 45 degrees
+  params.ignore_collision_conditions.if_ego_arrives_first.enable = false;
+  params.ignore_collision_conditions.if_ego_arrives_first.margin.ego_enter_times = {0.0, 10.0};
+  params.ignore_collision_conditions.if_ego_arrives_first.margin.time_margins = {0.0, 0.0};
+  params.ignore_collision_conditions.if_ego_arrives_first.max_overlap_duration = 0.0;
+  params.ignore_collision_conditions.if_ego_arrives_first_and_cannot_stop.enable = false;
+  params.ignore_collision_conditions.if_ego_arrives_first_and_cannot_stop
+    .calculated_stop_time_limit = 0.0;
+  return params;
+}
+
+/// @brief intersection of an object moving in the opposite direction of ego
+FootprintIntersection make_intersection(
+  const double ego_time, const double object_time, const double arc_length,
+  const IntersectionPosition position = front_left)
+{
+  FootprintIntersection fi;
+  fi.ego_time = ego_time;
+  fi.object_time = object_time;
+  fi.arc_length = arc_length;
+  fi.position = position;
+  fi.yaw_diff = M_PI;  // ego and the object move in opposite directions
+  fi.ego_vel = 5.0;
+  fi.vel_diff = 10.0;
+  return fi;
+}
+}  // namespace
+
+TEST(TestCollisions, degenerate_overlap_gives_finite_collision_time)
+{
+  const auto params = make_params();
+  const auto intersection = make_intersection(11.1, 12.0, 33.0);
+  const TimeOverlapInterval ego(11.1, 11.1, intersection, intersection);
+  const TimeOverlapInterval object(12.0, 12.0, intersection, intersection);
+  Collision c(ego, object);
+
+  calculate_overlapping_collision(c, ego, object, params);
+
+  EXPECT_EQ(c.type, collision);
+  EXPECT_TRUE(std::isfinite(c.ego_collision_time)) << "collision time = " << c.ego_collision_time;
+  EXPECT_DOUBLE_EQ(c.ego_collision_time, 11.1);
+}
+
+TEST(TestCollisions, zero_overlap_length_gives_finite_collision_time)
+{
+  const auto params = make_params();
+  const TimeOverlapInterval ego(
+    11.0, 12.0, make_intersection(11.0, 10.0, 30.0), make_intersection(12.0, 12.0, 30.0));
+  const TimeOverlapInterval object(
+    10.0, 12.0, make_intersection(11.0, 10.0, 30.0), make_intersection(12.0, 12.0, 30.0));
+  Collision c(ego, object);
+
+  calculate_overlapping_collision(c, ego, object, params);
+
+  EXPECT_EQ(c.type, collision);
+  EXPECT_TRUE(std::isfinite(c.ego_collision_time)) << "collision time = " << c.ego_collision_time;
+  EXPECT_DOUBLE_EQ(c.ego_collision_time, 11.0);
+}
+
+TEST(TestCollisions, zero_ego_duration_gives_finite_collision_time)
+{
+  const auto params = make_params();
+  const TimeOverlapInterval ego(
+    11.0, 11.0, make_intersection(11.0, 10.0, 30.0), make_intersection(11.0, 12.0, 40.0));
+  const TimeOverlapInterval object(
+    10.0, 12.0, make_intersection(11.0, 10.0, 30.0), make_intersection(11.0, 12.0, 40.0));
+  Collision c(ego, object);
+
+  calculate_overlapping_collision(c, ego, object, params);
+
+  EXPECT_EQ(c.type, collision);
+  EXPECT_TRUE(std::isfinite(c.ego_collision_time)) << "collision time = " << c.ego_collision_time;
+  EXPECT_DOUBLE_EQ(c.ego_collision_time, 11.0);
+}
+
+TEST(TestCollisions, zero_object_duration_gives_finite_collision_time)
+{
+  const auto params = make_params();
+  const TimeOverlapInterval ego(
+    11.0, 12.0, make_intersection(11.0, 10.0, 30.0), make_intersection(12.0, 10.0, 40.0));
+  const TimeOverlapInterval object(
+    10.0, 10.0, make_intersection(11.0, 10.0, 30.0), make_intersection(12.0, 10.0, 40.0));
+  Collision c(ego, object);
+
+  calculate_overlapping_collision(c, ego, object, params);
+
+  EXPECT_EQ(c.type, collision);
+  EXPECT_TRUE(std::isfinite(c.ego_collision_time)) << "collision time = " << c.ego_collision_time;
+  EXPECT_DOUBLE_EQ(c.ego_collision_time, 11.0);
+}
+
+TEST(TestCollisions, regular_opposite_direction_overlap_is_unchanged)
+{
+  const auto params = make_params();
+  // ego covers the 10m overlap in 1s, the object covers it in 2s
+  const TimeOverlapInterval ego(
+    11.0, 12.0, make_intersection(11.0, 10.0, 30.0), make_intersection(12.0, 12.0, 40.0));
+  const TimeOverlapInterval object(
+    10.0, 12.0, make_intersection(11.0, 10.0, 30.0), make_intersection(12.0, 12.0, 40.0));
+  Collision c(ego, object);
+
+  calculate_overlapping_collision(c, ego, object, params);
+
+  EXPECT_EQ(c.type, collision);
+  // lon_buffer = min(10, 4) = 4, ego_vel = 10, obj_vel = 5 -> 11.0 + (10 - 4) / 15 = 11.4
+  EXPECT_DOUBLE_EQ(c.ego_collision_time, 11.4);
+}
+
+TEST(TestCollisions, unclosed_trailing_overlap_gives_finite_collision_time)
+{
+  const auto params = make_params();
+  std::vector<FootprintIntersection> intersections;
+  // the object enters and exits the rear part of the footprint, closing a first overlap
+  intersections.push_back(make_intersection(9.0, 0.5, 20.0, rear_left));
+  intersections.push_back(make_intersection(10.0, 5.0, 25.0, rear_right));
+  // this one opens a new overlap and the intersection list ends
+  intersections.push_back(make_intersection(11.1, 12.0, 33.0, front_left));
+
+  const auto intervals = calculate_overlap_intervals(intersections);
+
+  ASSERT_EQ(intervals.size(), 2UL);
+  const auto & degenerate = intervals[1];
+  EXPECT_DOUBLE_EQ(degenerate.ego.from, degenerate.ego.to);
+
+  const auto c = calculate_collision(degenerate.ego, degenerate.object, params);
+
+  EXPECT_EQ(c.type, collision);
+  EXPECT_TRUE(std::isfinite(c.ego_collision_time)) << "collision time = " << c.ego_collision_time;
+  EXPECT_DOUBLE_EQ(c.ego_collision_time, 11.1);
+}
+}  // namespace autoware::motion_velocity_planner::run_out


### PR DESCRIPTION
## Description

`calculate_overlapping_collision` estimated the collision time inside an opposite-direction overlap by dividing the overlap length by the ego and object traversal durations:

```cpp
const auto ego_vel = overlap_length / ego_overlap_duration;
const auto obj_vel = overlap_length / object_overlap_duration;
const auto collision_time_within_overlap = (overlap_length - lon_buffer) / (ego_vel + obj_vel);
```

When the overlap is degenerate, zero length, or zero ego/object duration, this evaluates to `0.0 / 0.0` and yields `NaN`/`-nan`. The `NaN` propagates into `Collision::ego_collision_time` and finally into the inserted stop point, producing an invalid stop point.

A degenerate overlap is reachable in practice: `calculate_overlap_intervals` closes a trailing overlap that was opened by the last footprint intersection with `from == to`, so both ego and object intervals collapse to a single instant.

## Related links

**Parent Issue:**

- T4DEV-58829

## How was this PR tested?

Each degenerate case asserts `std::isfinite(c.ego_collision_time)` and that the collision time equals the ego enter time.

```bash
colcon test --event-handlers console_cohesion+ \
  --packages-select autoware_motion_velocity_run_out_module
```

## Notes for reviewers

None

## Interface changes

None.

## Effects on system behavior

Opposite-direction collisions whose overlap interval is degenerate no longer produce a `NaN` collision time, so the run out module no longer inserts an invalid stop point in that case. The collision time falls back to the ego enter time, which is conservative. All non-degenerate cases are numerically identical to before.