### PR TITLE
fix(trajectory_validator): port fixes to trajectory validator

### DIFF
--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -90,6 +90,13 @@ if(BUILD_TESTING)
     autoware_trajectory_validator_plugins
   )
 
+  ament_add_gtest(test_risk_utils
+    test/detail/test_risk_utils.cpp
+  )
+  target_link_libraries(test_risk_utils
+    ${trajectory_validator_lib_target}
+  )
+
 endif()
 
 autoware_ament_auto_package(

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/risk_utils.hpp
@@ -1,0 +1,58 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__RISK_UTILS_HPP_
+#define AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__RISK_UTILS_HPP_
+
+#include "autoware_trajectory_validator/msg/metric_report.hpp"
+#include "autoware_trajectory_validator/msg/risk_level.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace autoware::trajectory_validator
+{
+using autoware_trajectory_validator::msg::MetricReport;
+using autoware_trajectory_validator::msg::RiskLevel;
+using RiskLevelType = RiskLevel::_level_type;
+
+/**
+ * @brief Returns the worst risk level from a vector of RiskLevel messages.
+ * @param risks A vector of RiskLevel messages.
+ * @return The worst risk level.
+ */
+inline RiskLevelType worst_risk_level(const std::vector<RiskLevel> & risks)
+{
+  RiskLevelType worst = RiskLevel::SAFE;
+  for (const auto & risk : risks) {
+    worst = std::max(worst, risk.level);
+  }
+  return worst;
+}
+
+/**
+ * @brief Returns the worst risk level from a vector of MetricReport messages.
+ * @param metrics A vector of MetricReport messages.
+ * @return The worst risk level.
+ */
+inline RiskLevelType worst_risk_level(const std::vector<MetricReport> & metrics)
+{
+  RiskLevelType worst = RiskLevel::SAFE;
+  for (const auto & metric : metrics) {
+    worst = std::max(worst, metric.risk.level);
+  }
+  return worst;
+}
+}  // namespace autoware::trajectory_validator
+#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__DETAIL__RISK_UTILS_HPP_

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -104,15 +104,14 @@ TrajectoryValidatorReport TrajectoryValidator::process(
       report.num_feasible_trajectories++;
     }
 
-    // remove metrics from inactive plugins so that they dont affect final trajectory risk level
-    combined_metrics.erase(
-      std::remove_if(
-        combined_metrics.begin(), combined_metrics.end(),
-        [&](const auto & metric) { return active_filter_names.count(metric.validator_name) == 0; }),
-      combined_metrics.end());
+    // only consider metrics from active filters for final trajectory risk level
+    std::vector<autoware_trajectory_validator::msg::MetricReport> active_metrics;
+    std::copy_if(
+      combined_metrics.begin(), combined_metrics.end(), std::back_inserter(active_metrics),
+      [&](const auto & metric) { return active_filter_names.count(metric.validator_name) > 0; });
 
     RiskLevel risk_level;
-    risk_level.level = worst_risk_level(combined_metrics);
+    risk_level.level = worst_risk_level(active_metrics);
     report.validation_reports.push_back(
       autoware_trajectory_validator::build<autoware_trajectory_validator::msg::ValidationReport>()
         .trajectory_stamp(candidate_trajectory.header.stamp)

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/trajectory_validator/detail/trajectory_validator.hpp"
 
+#include "autoware/trajectory_validator/detail/risk_utils.hpp"
+
 #include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 
@@ -61,21 +63,32 @@ TrajectoryValidatorReport TrajectoryValidator::process(
       stop_watch.tic(evaluation.plugin_name);
       const auto res = plugin->is_feasible(candidate_trajectory, context);
 
+      RiskLevel risk_level;
       if (!res) {
         evaluation.is_feasible = false;
         evaluation.reason = res.error();
+        // NOTE: If the plugin fails unexpectedly, treat it as a DANGER risk level.
+        risk_level.level = RiskLevel::DANGER;
       } else {
         const auto & val = res.value();
         evaluation.is_feasible = val.is_feasible;
         if (!val.is_feasible) {
           evaluation.reason = "Found failed metrics";
         }
+        risk_level.level = worst_risk_level(val.metrics);
         combined_metrics.insert(combined_metrics.end(), val.metrics.begin(), val.metrics.end());
         report.planning_factors.factors.insert(
           report.planning_factors.factors.end(), val.planning_factors.factors.begin(),
           val.planning_factors.factors.end());
       }
 
+      combined_metrics.push_back(
+        autoware_trajectory_validator::build<autoware_trajectory_validator::msg::MetricReport>()
+          .validator_name(plugin->get_name())
+          .validator_category(plugin->category())
+          .metric_name("trajectory_feasibility")
+          .metric_value(evaluation.is_feasible ? 1.0 : 0.0)
+          .risk(risk_level));
       report.processing_time_ms[evaluation.plugin_name] += stop_watch.toc(evaluation.plugin_name);
 
       table.plugin_evaluations.push_back(evaluation);
@@ -87,8 +100,7 @@ TrajectoryValidatorReport TrajectoryValidator::process(
       report.valid_trajectories.candidate_trajectories.push_back(candidate_trajectory);
     }
 
-    const bool all_feasible = table.all_feasible();
-    if (all_feasible) {
+    if (table.all_feasible()) {
       report.num_feasible_trajectories++;
     }
 
@@ -100,7 +112,7 @@ TrajectoryValidatorReport TrajectoryValidator::process(
       combined_metrics.end());
 
     RiskLevel risk_level;
-    risk_level.level = all_feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
+    risk_level.level = worst_risk_level(combined_metrics);
     report.validation_reports.push_back(
       autoware_trajectory_validator::build<autoware_trajectory_validator::msg::ValidationReport>()
         .trajectory_stamp(candidate_trajectory.header.stamp)

--- a/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
@@ -140,7 +140,7 @@ MetricReport VehicleConstraintFilter::check_speed(const TrajectoryPoints & traj_
   const auto [max_observed, is_ok] = is_speed_ok(traj_points, params_.max_speed);
 
   RiskLevel risk_level;
-  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::HIGH_CAUTION;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
@@ -154,7 +154,7 @@ MetricReport VehicleConstraintFilter::check_acceleration(const TrajectoryPoints 
   const auto [max_observed, is_ok] = is_acceleration_ok(traj_points, params_.max_acceleration);
 
   RiskLevel risk_level;
-  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::HIGH_CAUTION;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
@@ -168,7 +168,7 @@ MetricReport VehicleConstraintFilter::check_deceleration(const TrajectoryPoints 
   const auto [max_observed, is_ok] = is_deceleration_ok(traj_points, params_.max_deceleration);
 
   RiskLevel risk_level;
-  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::HIGH_CAUTION;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
@@ -184,7 +184,7 @@ MetricReport VehicleConstraintFilter::check_steering_angle(
     is_steering_angle_ok(traj_points, *vehicle_info_ptr_, params_.max_steering_angle);
 
   RiskLevel risk_level;
-  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::HIGH_CAUTION;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
@@ -200,7 +200,7 @@ MetricReport VehicleConstraintFilter::check_steering_rate(
     is_steering_rate_ok(traj_points, *vehicle_info_ptr_, params_.max_steering_rate);
 
   RiskLevel risk_level;
-  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::HIGH_CAUTION;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())

--- a/planning/autoware_trajectory_validator/test/detail/test_risk_utils.cpp
+++ b/planning/autoware_trajectory_validator/test/detail/test_risk_utils.cpp
@@ -1,0 +1,85 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_validator/detail/risk_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace autoware::trajectory_validator
+{
+namespace
+{
+
+RiskLevel make_risk(const RiskLevelType level)
+{
+  RiskLevel risk;
+  risk.level = level;
+  return risk;
+}
+
+MetricReport make_metric(const RiskLevelType level)
+{
+  MetricReport metric;
+  metric.risk = make_risk(level);
+  return metric;
+}
+
+TEST(RiskUtilsTest, RiskLevelArrayReturnsSafeForEmptyInput)
+{
+  EXPECT_EQ(worst_risk_level(std::vector<RiskLevel>{}), RiskLevel::SAFE);
+}
+
+TEST(RiskUtilsTest, RiskLevelArrayReturnsWorstRisk)
+{
+  const std::vector<RiskLevel> risks{
+    make_risk(RiskLevel::SAFE), make_risk(RiskLevel::HIGH_CAUTION),
+    make_risk(RiskLevel::LOW_CAUTION)};
+
+  EXPECT_EQ(worst_risk_level(risks), RiskLevel::HIGH_CAUTION);
+}
+
+TEST(RiskUtilsTest, RiskLevelArrayTreatsFatalAsWorst)
+{
+  const std::vector<RiskLevel> risks{
+    make_risk(RiskLevel::DANGER), make_risk(RiskLevel::FATAL), make_risk(RiskLevel::HIGH_CAUTION)};
+
+  EXPECT_EQ(worst_risk_level(risks), RiskLevel::FATAL);
+}
+
+TEST(RiskUtilsTest, MetricReportArrayReturnsSafeForEmptyInput)
+{
+  EXPECT_EQ(worst_risk_level(std::vector<MetricReport>{}), RiskLevel::SAFE);
+}
+
+TEST(RiskUtilsTest, MetricReportArrayReturnsWorstRisk)
+{
+  const std::vector<MetricReport> metrics{
+    make_metric(RiskLevel::LOW_CAUTION), make_metric(RiskLevel::DANGER),
+    make_metric(RiskLevel::HIGH_CAUTION)};
+
+  EXPECT_EQ(worst_risk_level(metrics), RiskLevel::DANGER);
+}
+
+TEST(RiskUtilsTest, MetricReportArrayTreatsFatalAsWorst)
+{
+  const std::vector<MetricReport> metrics{
+    make_metric(RiskLevel::SAFE), make_metric(RiskLevel::DANGER), make_metric(RiskLevel::FATAL)};
+
+  EXPECT_EQ(worst_risk_level(metrics), RiskLevel::FATAL);
+}
+
+}  // namespace
+}  // namespace autoware::trajectory_validator


### PR DESCRIPTION
## Description
This is a cherry-pick PR to port fixes made `trajectory_validator` from private TIER IV fork:
- https://github.com/tier4/autoware_universe/pull/3188
- https://github.com/tier4/autoware_universe/pull/3279

The PR introduces a new assessment utility for risk level evaluation, updates how risk levels are determined and reported throughout the trajectory validation process, and adds corresponding tests. The main focus is on improving the accuracy and granularity of risk assessment in the trajectory validator, especially by refining the logic for aggregating and reporting risk levels from multiple metrics.

### Changes
- Added new header file `assessment.hpp` that provides utility function `worst_risk_level()`
- Updated `trajectory_validator.cpp` to use the `worst_risk_level()` for determining the overall risk level per plugin/candidate_traj
- Changed the risk level assigned by all `vehicle_constraint_filter` from `DANGER` to `HIGH_CAUTION`
- Refactored validator to keep shadow mode filter metrics in final validation report

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- successful build
- pass unit tests