### PR TITLE
feat(autoware_default_adapi_universe): run the core API nodes standalone under agnocast

### DIFF
--- a/system/autoware_default_adapi_universe/launch/default_adapi.launch.py
+++ b/system/autoware_default_adapi_universe/launch/default_adapi.launch.py
@@ -27,14 +27,18 @@ from launch_ros.descriptions import ComposableNode
 from launch_ros.parameter_descriptions import ParameterFile
 from launch_ros.substitutions import FindPackageShare
 
+CORE = "autoware_default_adapi"
 UNIVERSE = "autoware_default_adapi_universe"
 
-# Nodes derived from autoware::agnocast_wrapper::Node, as (node name, class name, executable).
-# Composed like any other node under ENABLE_AGNOCAST=0, where that base is backed by rclcpp;
-# run as their own process under =1, where they need an AgnocastOnly executor that a shared
+# Nodes derived from autoware::agnocast_wrapper::Node, as (package, node name, class name,
+# executable). Composed like any other node under ENABLE_AGNOCAST=0, where that base is backed by
+# rclcpp; run as their own process under =1, where they need an AgnocastOnly executor that a shared
 # component container cannot provide.
 AGNOCAST_WRAPPER_NODES = [
-    ("diagnostics", "DiagnosticsNode", "diagnostics_node"),
+    (CORE, "interface", "InterfaceNode", "interface_node"),
+    (CORE, "localization", "LocalizationNode", "localization_node"),
+    (CORE, "routing", "RoutingNode", "routing_node"),
+    (UNIVERSE, "diagnostics", "DiagnosticsNode", "diagnostics_node"),
 ]
 
 
@@ -91,9 +95,6 @@ def launch_setup(context, *args, **kwargs):
     use_agnocast = context.perform_substitution(LaunchConfiguration("use_agnocast")) == "1"
 
     components = [
-        create_api_node("autoware_default_adapi", "interface", "InterfaceNode"),
-        create_api_node("autoware_default_adapi", "localization", "LocalizationNode"),
-        create_api_node("autoware_default_adapi", "routing", "RoutingNode"),
         create_api_node("autoware_default_adapi_universe", "autoware_state", "AutowareStateNode"),
         create_api_node("autoware_default_adapi_universe", "fail_safe", "FailSafeNode"),
         create_api_node("autoware_default_adapi_universe", "heartbeat", "HeartbeatNode"),
@@ -111,11 +112,11 @@ def launch_setup(context, *args, **kwargs):
         create_api_node("autoware_default_adapi_universe", "vehicle_door", "VehicleDoorNode"),
     ]
     nodes = []
-    for node_name, class_name, executable in AGNOCAST_WRAPPER_NODES:
+    for package_name, node_name, class_name, executable in AGNOCAST_WRAPPER_NODES:
         if use_agnocast:
-            nodes.append(create_standalone_api_node(UNIVERSE, node_name, executable))
+            nodes.append(create_standalone_api_node(package_name, node_name, executable))
         else:
-            components.append(create_api_node(UNIVERSE, node_name, class_name))
+            components.append(create_api_node(package_name, node_name, class_name))
 
     container = ComposableNodeContainer(
         namespace="adapi",


### PR DESCRIPTION
## Description

`InterfaceNode`, `LocalizationNode` and `RoutingNode` come from `autoware_default_adapi` in autoware_core, and autowarefoundation/autoware_core#1438 moves them to `autoware::agnocast_wrapper::Node`. Under `ENABLE_AGNOCAST=1` that base needs an `AgnocastOnly` executor, which the shared `/adapi/container` cannot provide, so this launch file has to start them as their own processes there.

The three are moved into `AGNOCAST_WRAPPER_NODES`, the list `DiagnosticsNode` already uses for this. Its entries now carry the package name, because these three live in `autoware_default_adapi` rather than in this package; the helper functions already took one.

Under `ENABLE_AGNOCAST=0` nothing changes: the loop composes them into `/adapi/container` as before.

## Related links

**Parent Issue:**

- None.

Pairs with autowarefoundation/autoware_core#1438, which this one should land before: until it merges, `=1` cannot start these three, because the core package registers them with `rclcpp_components_register_nodes` and the executables named here do not exist yet. Merging in the other order is worse, since the container would then load nodes that need an executor and heaphook it cannot give them.

## How was this PR tested?

Ran the logging simulator at `=1` with autowarefoundation/autoware_core#1438. The three start as their own processes, `ros2 node list_agnocast` reports them and `diagnostics` as Agnocast enabled, and the other thirteen API nodes stay in `/adapi/container`. The API surface they own was exercised from plain ROS 2 clients, so the bridge is crossed each time: `/api/interface/version` returns `1.9.1`, `/api/localization/initialization_state` reaches `INITIALIZED`, and an RViz goal moves `/api/routing/state` to `SET` and fills `/api/routing/route`.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None under `ENABLE_AGNOCAST=0`.

Under `=1` the three nodes run as separate processes instead of inside `/adapi/container`, with the heaphook preloaded on those processes alone.
