### PR TITLE
feat(autoware_tensorrt_plugins): support INT8 precision in ImplicitGemmPlugin

### DIFF
--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -109,6 +109,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     src/multi_scale_deform_attn_ops/ms_deform_attn_kernel.cu
     src/rotate_ops/rotate_kernel.cu
     src/select_and_pad_ops/select_and_pad_kernel.cu
+    src/quantize_ops/quantize_features.cu
   )
 
   add_library(${PROJECT_NAME} SHARED

--- a/perception/autoware_tensorrt_plugins/include/autoware/quantize_ops/quantize_features.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/quantize_ops/quantize_features.hpp
@@ -1,0 +1,48 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__QUANTIZE_OPS__QUANTIZE_FEATURES_HPP_
+#define AUTOWARE__QUANTIZE_OPS__QUANTIZE_FEATURES_HPP_
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+// INT8 quantization helpers for the ImplicitGemm plugin's INT8 (precision==1) path.
+
+/// Quantize FP16 features to INT8: out = round(in / scale) clamped to [-128, 127].
+void launch_quantize_features(
+  const __half * input, std::int8_t * output, float scale, std::int64_t total_elements,
+  cudaStream_t stream);
+
+/// Quantize FP16 weights to INT8 per output channel using ``w_scales[c]``.
+void launch_quantize_weights_per_channel(
+  const __half * input, std::int8_t * output, const float * w_scales, std::int64_t c_out,
+  std::int64_t elements_per_channel, cudaStream_t stream);
+
+/// Recover per-channel weight scales from the export-side channel_scale:
+/// w_scale[c] = channel_scale[c] * output_scale / input_scale.
+void launch_compute_w_scales(
+  const float * channel_scale, float * w_scales, float output_scale, float input_scale,
+  std::int64_t c_out, cudaStream_t stream);
+
+/// Fold the output dequant into per-channel scale/bias for the s8s8f16 epilogue (which never
+/// multiplies ``alpha``): gemm_channel_scale[c] = channel_scale[c] * output_scale,
+/// gemm_bias[c] = bias_scaled[c] * output_scale. The GEMM is then called with output_scale = 1.
+void launch_fuse_output_scale_into_gemm_scale_bias(
+  const float * channel_scale, const float * bias_scaled, float output_scale,
+  float * gemm_channel_scale_out, float * gemm_bias_out, std::int64_t c_out, cudaStream_t stream);
+
+#endif  // AUTOWARE__QUANTIZE_OPS__QUANTIZE_FEATURES_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -18,12 +18,14 @@
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
 #include <cuda_runtime.h>
-#include <spconvlib/spconv/csrc/sparse/convops/gemmops/GemmTunerSimple.h>  // cSpell:ignore spconvlib
+#include <spconvlib/cumm/conv/main/ConvMainUnitTest.h>  // cSpell:ignore spconvlib cumm
+#include <spconvlib/spconv/csrc/sparse/convops/gemmops/GemmTunerSimple.h>
 #include <spconvlib/spconv/csrc/sparse/convops/spops/ConvGemmOps.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -47,7 +49,19 @@ struct ImplicitGemmParameters
   /// tv::gemm::Activation as integer:
   /// kNone=0, kReLU=1, kSigmoid=2, kLeakyReLU=3.
   std::int32_t act_type{static_cast<std::int32_t>(tv::gemm::Activation::kNone)};
+
+  /// Precision mode: 0 = floating point (FP16/FP32), 1 = INT8.
+  /// In INT8 mode the node carries two extra FP32 inputs (channel_scale, bias_scaled),
+  /// FP16 features/weights are quantized to INT8 inside enqueue, and the GEMM is run with
+  /// per-output-channel scales (see sparse_int8_onnx_transform.py / Path B).
+  std::int32_t precision{0};
+  /// INT8 only: input_amax / 127, used to quantize the FP16 features to INT8.
+  float input_scale{1.0F};
 };
+
+/// Precision values for ImplicitGemmParameters::precision.
+constexpr std::int32_t kIMPLICIT_GEMM_PRECISION_FP{0};
+constexpr std::int32_t kIMPLICIT_GEMM_PRECISION_INT8{1};
 
 class ImplicitGemmPlugin : public IPluginV3,
                            public IPluginV3OneCore,
@@ -58,7 +72,7 @@ public:
   using ConvTunerSimple = spconvlib::spconv::csrc::sparse::convops::spops::ConvTuner;
   ImplicitGemmPlugin(const std::string & name, ImplicitGemmParameters const & params);
 
-  ~ImplicitGemmPlugin() override = default;
+  ~ImplicitGemmPlugin() override;
 
   // IPluginV3 Methods
 
@@ -120,12 +134,33 @@ private:
   static constexpr std::int32_t INOUT_PAIR_FWD_INDEX{2};
   static constexpr std::int32_t INOUT_PAIR_MASK_FWD_SPLITS_INDEX{3};
   static constexpr std::int32_t INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX{4};
+  /// FP path (precision==0): optional per-channel bias at input index 5 (num_inputs == 6).
   static constexpr std::int32_t INOUT_OPTIONAL_BIAS_INDEX{5};
+  /// INT8 path (precision==1): 7 inputs total — FP32 per-output-channel scale and bias.
+  static constexpr std::int32_t INOUT_CHANNEL_SCALE_INDEX{5};
+  static constexpr std::int32_t INOUT_BIAS_SCALED_INDEX{6};
+
+  static constexpr std::int32_t NUM_INPUTS_INT8{7};
 
   static constexpr std::int32_t NUM_PLUGIN_INPUTS_NO_BIAS{5};
   static constexpr std::int32_t NUM_PLUGIN_INPUTS_BIAS{6};
 
   void initFieldsToSerialize();
+
+  bool is_int8() const noexcept { return params_.precision == kIMPLICIT_GEMM_PRECISION_INT8; }
+
+  // INT8 path helpers (no-ops / unused in FP path).
+  std::int32_t enqueueInt8(
+    PluginTensorDesc const * input_desc, void const * const * inputs, void * const * outputs,
+    void * workspace, cudaStream_t stream) noexcept;
+  /// Allocate the persistent INT8 weight/scale/bias cache for a (constant) filter shape.
+  /// Called from ``configurePlugin`` (build) and ``onShapeChange`` (runtime) so the cudaMalloc
+  /// happens outside CUDA graph capture; the quantization kernels that fill it run on the first
+  /// enqueue (filter device data is only available there). Idempotent for an unchanged shape.
+  std::int32_t allocateConstantCache(
+    std::int64_t c_out, std::int64_t k1, std::int64_t k2, std::int64_t k3,
+    std::int64_t c_in) noexcept;
+  void releaseConstantCache() noexcept;
 
   std::string layer_name_;
   ImplicitGemmParameters params_;
@@ -137,9 +172,26 @@ private:
 
   std::unique_ptr<ConvTunerSimple> tuner_fp32_ptr_{};
   std::unique_ptr<ConvTunerSimple> tuner_fp16_ptr_{};
+  std::unique_ptr<ConvTunerSimple> tuner_int8_ptr_{};
 
   // Pre-allocated CPU mask tensor to avoid heap allocation during CUDA graph capture.
   tv::Tensor mask_tensor_;
+
+  // ── INT8 persistent constant cache (precision==1 only) ──────────────────────────────────
+  // Filters / scales / bias are graph constants, so we quantize them once and reuse the device
+  // buffers across enqueues. Buffers are cudaMalloc'd in configurePlugin and filled lazily on the
+  // first enqueue (filter device data is only available there).
+  std::mutex cache_mutex_{};
+  bool cache_allocated_{false};
+  bool cache_filled_{false};
+  std::int64_t cached_c_out_{0};
+  std::int64_t cached_k1_{0};
+  std::int64_t cached_k2_{0};
+  std::int64_t cached_k3_{0};
+  std::int64_t cached_c_in_{0};
+  std::int8_t * cached_weight_int8_ptr_{nullptr};
+  float * cached_w_scales_ptr_{nullptr};
+  float * cached_gemm_bias_ptr_{nullptr};
 };
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -380,13 +380,16 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
   using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
 
+  // Dispatch before the FP input-count check: the INT8 node carries seven inputs, so
+  // asserting the FP counts first aborts every INT8 engine on its first inference.
+  if (is_int8()) {
+    PLUGIN_ASSERT(num_plugin_inputs_ == NUM_INPUTS_INT8);
+    return enqueueInt8(input_desc, inputs, outputs, workspace, stream);
+  }
+
   PLUGIN_ASSERT(
     num_plugin_inputs_ == NUM_PLUGIN_INPUTS_NO_BIAS ||
     num_plugin_inputs_ == NUM_PLUGIN_INPUTS_BIAS);
-
-  if (is_int8()) {
-    return enqueueInt8(input_desc, inputs, outputs, workspace, stream);
-  }
 
   std::int64_t num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
   std::int64_t num_in_features = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -14,10 +14,12 @@
 
 #include "autoware/tensorrt_plugins/implicit_gemm_plugin.hpp"
 
+#include "autoware/quantize_ops/quantize_features.hpp"
 #include "autoware/tensorrt_plugins/plugin_utils.hpp"
 
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
+#include <cuda_fp16.h>
 #include <spconvlib/spconv/csrc/sparse/all/SpconvOps.h>  // cSpell:ignore spconvlib
 #include <spconvlib/spconv/csrc/sparse/alloc/StaticAllocator.h>
 #include <spconvlib/spconv/csrc/sparse/convops/SimpleExternalSpconvMatmul.h>
@@ -26,10 +28,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -80,10 +84,18 @@ ImplicitGemmPlugin::ImplicitGemmPlugin(
   tuner_fp16_ptr_ =
     std::make_unique<ConvTunerSimple>(ConvMain::get_all_conv_algo_desp());  // cSpell:ignore desp
   tuner_fp32_ptr_ = std::make_unique<ConvTunerSimple>(ConvMain::get_all_conv_algo_desp());
+  if (is_int8()) {
+    tuner_int8_ptr_ = std::make_unique<ConvTunerSimple>(ConvMain::get_all_conv_algo_desp());
+  }
 
   // Pre-allocate CPU mask tensor to avoid heap allocation during CUDA graph capture.
   mask_tensor_ = tv::zeros({1}, tv::uint32, -1);
   mask_tensor_.data_ptr<uint32_t>()[0] = 0xffffffff;
+}
+
+ImplicitGemmPlugin::~ImplicitGemmPlugin()
+{
+  releaseConstantCache();
 }
 
 void ImplicitGemmPlugin::initFieldsToSerialize()
@@ -149,7 +161,41 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   DynamicPluginTensorDesc const * in, std::int32_t num_inputs, DynamicPluginTensorDesc const * out,
   std::int32_t num_outputs) noexcept
 {
-  // Validate input arguments.
+  PLUGIN_ASSERT(in != nullptr);
+  PLUGIN_ASSERT(out != nullptr);
+  PLUGIN_ASSERT(num_outputs == 1);
+
+  if (is_int8()) {
+    // INT8 path: 7 inputs (features FP16, filters FP16, 3 INT32 index tensors,
+    // channel_scale FP32, bias_scaled FP32). Output is FP16.
+    PLUGIN_ASSERT(num_inputs == NUM_INPUTS_INT8);
+    num_plugin_inputs_ = num_inputs;
+
+    PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.dims.nbDims == 2);
+    PLUGIN_ASSERT(in[INOUT_FILTERS_INDEX].desc.dims.nbDims == 5);
+    PLUGIN_ASSERT(in[INOUT_PAIR_FWD_INDEX].desc.dims.nbDims == 2);
+    PLUGIN_ASSERT(in[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].desc.dims.nbDims == 2);
+    PLUGIN_ASSERT(in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.dims.nbDims == 1);
+    PLUGIN_ASSERT(in[INOUT_CHANNEL_SCALE_INDEX].desc.dims.nbDims == 1);
+    PLUGIN_ASSERT(in[INOUT_BIAS_SCALED_INDEX].desc.dims.nbDims == 1);
+    PLUGIN_ASSERT(out[0].desc.dims.nbDims == 2);
+    PLUGIN_ASSERT(
+      in[INOUT_FILTERS_INDEX].desc.dims.d[4] == in[INOUT_IN_FEATURES_INDEX].desc.dims.d[1]);
+    PLUGIN_ASSERT(
+      in[INOUT_CHANNEL_SCALE_INDEX].desc.dims.d[0] == in[INOUT_FILTERS_INDEX].desc.dims.d[0]);
+    PLUGIN_ASSERT(
+      in[INOUT_BIAS_SCALED_INDEX].desc.dims.d[0] == in[INOUT_FILTERS_INDEX].desc.dims.d[0]);
+    PLUGIN_ASSERT(params_.act_type >= 0 && params_.act_type <= 3);
+
+    // Pre-allocate the persistent INT8 weight/scale/bias cache here (constant filter shape is
+    // known from descriptors) so no cudaMalloc happens inside enqueue / CUDA graph capture.
+    return allocateConstantCache(
+      in[INOUT_FILTERS_INDEX].desc.dims.d[0], in[INOUT_FILTERS_INDEX].desc.dims.d[1],
+      in[INOUT_FILTERS_INDEX].desc.dims.d[2], in[INOUT_FILTERS_INDEX].desc.dims.d[3],
+      in[INOUT_IN_FEATURES_INDEX].desc.dims.d[1]);
+  }
+
+  // FP path.
   // 5 inputs: standard implicit GEMM path without fused bias.
   // 6 inputs: implicit GEMM path with optional per-channel bias.
   // TODO(vividf): should use PLUGIN_VALIDATE_AND_RETURN instead of PLUGIN_ASSERT for input
@@ -201,10 +247,46 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
   std::int32_t num_outputs) noexcept
 {
   PLUGIN_ASSERT(in_out != nullptr);
+  PLUGIN_ASSERT(num_outputs == 1);
+
+  if (is_int8()) {
+    PLUGIN_ASSERT(num_inputs == NUM_INPUTS_INT8);
+    std::int32_t const n_slots_int8 = num_inputs + num_outputs;
+    PLUGIN_ASSERT(pos >= 0 && pos < n_slots_int8);
+
+    bool supported_int8 = in_out[pos].desc.format == nvinfer1::TensorFormat::kLINEAR;
+    switch (pos) {
+      // Features: FP16 only (quantized to INT8 inside enqueue).
+      case INOUT_IN_FEATURES_INDEX:
+        supported_int8 &= in_out[pos].desc.type == nvinfer1::DataType::kHALF;
+        break;
+      // Filters and output share the features (FP16) type.
+      case INOUT_FILTERS_INDEX:
+        supported_int8 &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
+        break;
+      // Index tensors: INT32.
+      case INOUT_PAIR_FWD_INDEX:
+      case INOUT_PAIR_MASK_FWD_SPLITS_INDEX:
+      case INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX:
+        supported_int8 &= in_out[pos].desc.type == nvinfer1::DataType::kINT32;
+        break;
+      // Per-output-channel scale / bias: FP32.
+      case INOUT_CHANNEL_SCALE_INDEX:
+      case INOUT_BIAS_SCALED_INDEX:
+        supported_int8 &= in_out[pos].desc.type == nvinfer1::DataType::kFLOAT;
+        break;
+      default:  // output
+        supported_int8 &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
+        break;
+    }
+    return supported_int8;
+  }
+
   PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
   // in_out is the combined [inputs..., outputs...] tensor array; n_slots = num_inputs +
   // num_outputs.
+
   std::int32_t const n_slots = num_inputs + num_outputs;
   PLUGIN_ASSERT(pos >= 0 && pos < n_slots);
 
@@ -257,9 +339,12 @@ std::int32_t ImplicitGemmPlugin::getOutputDataTypes(
 {
   PLUGIN_ASSERT(output_types != nullptr);
   PLUGIN_ASSERT(input_types != nullptr);
-  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
+  PLUGIN_ASSERT(
+    num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS ||
+    num_inputs == NUM_INPUTS_INT8);
   PLUGIN_ASSERT(num_outputs == 1);
 
+  // FP path: output dtype follows the features. INT8 path: features are FP16, output FP16.
   output_types[0] = input_types[INOUT_IN_FEATURES_INDEX];
 
   return 0;
@@ -273,13 +358,16 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
 {
   PLUGIN_ASSERT(inputs != nullptr);
   PLUGIN_ASSERT(outputs != nullptr);
-  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
+  PLUGIN_ASSERT(
+    num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS ||
+    num_inputs == NUM_INPUTS_INT8);
   PLUGIN_ASSERT(num_outputs == 1);
   PLUGIN_ASSERT(inputs[0].nbDims == 2);
 
+  // num_act_out from pair_mask_fwd (index 3, dim 0); C_out from filters (index 1, dim 0).
   outputs[0].nbDims = 2;
-  outputs[0].d[0] = inputs[3].d[0];
-  outputs[0].d[1] = inputs[1].d[0];
+  outputs[0].d[0] = inputs[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].d[0];
+  outputs[0].d[1] = inputs[INOUT_FILTERS_INDEX].d[0];
 
   return 0;
 }
@@ -295,6 +383,10 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   PLUGIN_ASSERT(
     num_plugin_inputs_ == NUM_PLUGIN_INPUTS_NO_BIAS ||
     num_plugin_inputs_ == NUM_PLUGIN_INPUTS_BIAS);
+
+  if (is_int8()) {
+    return enqueueInt8(input_desc, inputs, outputs, workspace, stream);
+  }
 
   std::int64_t num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
   std::int64_t num_in_features = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];
@@ -386,8 +478,19 @@ std::int32_t ImplicitGemmPlugin::onShapeChange(
   [[maybe_unused]] PluginTensorDesc const * in, std::int32_t num_inputs,
   [[maybe_unused]] PluginTensorDesc const * out, [[maybe_unused]] std::int32_t num_outputs) noexcept
 {
-  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
+  PLUGIN_ASSERT(
+    num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS ||
+    num_inputs == NUM_INPUTS_INT8);
   num_plugin_inputs_ = num_inputs;
+
+  // Runtime path: configurePlugin (build-only) is not called here, so (re)allocate the INT8 cache
+  // now that concrete shapes are known and we are outside any CUDA graph capture.
+  if (is_int8() && in != nullptr && num_inputs == NUM_INPUTS_INT8) {
+    return allocateConstantCache(
+      in[INOUT_FILTERS_INDEX].dims.d[0], in[INOUT_FILTERS_INDEX].dims.d[1],
+      in[INOUT_FILTERS_INDEX].dims.d[2], in[INOUT_FILTERS_INDEX].dims.d[3],
+      in[INOUT_IN_FEATURES_INDEX].dims.d[1]);
+  }
   return 0;
 }
 
@@ -407,6 +510,221 @@ std::size_t ImplicitGemmPlugin::getWorkspaceSize(
   [[maybe_unused]] DynamicPluginTensorDesc const * outputs,
   [[maybe_unused]] std::int32_t num_outputs) const noexcept
 {
+  if (is_int8()) {
+    // Scratch for the quantized INT8 features only (weights/scales/bias live in the persistent
+    // cache). Sized to the max number of active input voxels * C_in, aligned to 256 bytes.
+    auto align = [](std::int64_t x) -> std::int64_t { return (x + 255) & ~255LL; };
+    std::int64_t const max_n = inputs[INOUT_IN_FEATURES_INDEX].max.d[0];
+    std::int64_t const c_in = inputs[INOUT_IN_FEATURES_INDEX].max.d[1];
+    return static_cast<std::size_t>(align(max_n * c_in));
+  }
+  return 0;
+}
+
+// ─── INT8 path ─────────────────────────────────────────────────────────────────────────────
+
+void ImplicitGemmPlugin::releaseConstantCache() noexcept
+{
+  if (cached_weight_int8_ptr_ != nullptr) {
+    cudaFree(cached_weight_int8_ptr_);
+    cached_weight_int8_ptr_ = nullptr;
+  }
+  if (cached_w_scales_ptr_ != nullptr) {
+    cudaFree(cached_w_scales_ptr_);
+    cached_w_scales_ptr_ = nullptr;
+  }
+  if (cached_gemm_bias_ptr_ != nullptr) {
+    cudaFree(cached_gemm_bias_ptr_);
+    cached_gemm_bias_ptr_ = nullptr;
+  }
+  cache_allocated_ = false;
+  cache_filled_ = false;
+  cached_c_out_ = 0;
+  cached_k1_ = 0;
+  cached_k2_ = 0;
+  cached_k3_ = 0;
+  cached_c_in_ = 0;
+}
+
+std::int32_t ImplicitGemmPlugin::allocateConstantCache(
+  std::int64_t c_out, std::int64_t k1, std::int64_t k2, std::int64_t k3, std::int64_t c_in) noexcept
+{
+  std::int64_t const k_vol = k1 * k2 * k3;
+  std::int64_t const weight_bytes =
+    c_out * k_vol * c_in * static_cast<std::int64_t>(sizeof(std::int8_t));
+  std::int64_t const c_out_float_bytes = c_out * static_cast<std::int64_t>(sizeof(float));
+
+  if (weight_bytes <= 0 || c_out_float_bytes <= 0) {
+    std::fprintf(
+      stderr, "[ImplicitGemm INT8] %s: invalid filter shape for cache allocation\n",
+      layer_name_.c_str());
+    return -1;
+  }
+
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+
+  // Re-allocate only if the (constant) filter shape changed.
+  bool const same_shape = cache_allocated_ && cached_c_out_ == c_out && cached_c_in_ == c_in &&
+                          cached_k1_ == k1 && cached_k2_ == k2 && cached_k3_ == k3;
+  if (same_shape) {
+    return 0;
+  }
+
+  releaseConstantCache();
+
+  cudaError_t st = cudaMalloc(
+    reinterpret_cast<void **>(&cached_weight_int8_ptr_), static_cast<std::size_t>(weight_bytes));
+  if (st == cudaSuccess) {
+    st = cudaMalloc(
+      reinterpret_cast<void **>(&cached_w_scales_ptr_),
+      static_cast<std::size_t>(c_out_float_bytes));
+  }
+  if (st == cudaSuccess) {
+    st = cudaMalloc(
+      reinterpret_cast<void **>(&cached_gemm_bias_ptr_),
+      static_cast<std::size_t>(c_out_float_bytes));
+  }
+  if (st != cudaSuccess) {
+    std::fprintf(
+      stderr, "[ImplicitGemm INT8] %s: cudaMalloc(weight cache) failed: %s\n", layer_name_.c_str(),
+      cudaGetErrorString(st));
+    releaseConstantCache();
+    return -1;
+  }
+
+  cache_allocated_ = true;
+  cache_filled_ = false;
+  cached_c_out_ = c_out;
+  cached_k1_ = k1;
+  cached_k2_ = k2;
+  cached_k3_ = k3;
+  cached_c_in_ = c_in;
+  return 0;
+}
+
+std::int32_t ImplicitGemmPlugin::enqueueInt8(
+  PluginTensorDesc const * input_desc, void const * const * inputs, void * const * outputs,
+  void * workspace, cudaStream_t stream) noexcept
+{
+  using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
+  using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
+
+  std::int64_t const num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
+  std::int64_t const c_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];
+  std::int64_t const c_out = input_desc[INOUT_FILTERS_INDEX].dims.d[0];
+  std::int64_t const k1 = input_desc[INOUT_FILTERS_INDEX].dims.d[1];
+  std::int64_t const k2 = input_desc[INOUT_FILTERS_INDEX].dims.d[2];
+  std::int64_t const k3 = input_desc[INOUT_FILTERS_INDEX].dims.d[3];
+  std::int64_t const k_vol = k1 * k2 * k3;
+  std::int64_t const num_act_out = input_desc[INOUT_PAIR_FWD_INDEX].dims.d[1];
+
+  auto * feat_int8_ptr = reinterpret_cast<std::int8_t *>(workspace);
+
+  // 1) Quantize FP16 features → INT8 into the workspace scratch.
+  launch_quantize_features(
+    reinterpret_cast<const __half *>(inputs[INOUT_IN_FEATURES_INDEX]), feat_int8_ptr,
+    params_.input_scale, num_act_in * c_in, stream);
+
+  // 2) Fill the persistent weight/scale/bias cache once (filter device data only available here).
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    // Fallback allocation: normally done in configurePlugin/onShapeChange (outside CUDA graph
+    // capture). Only reached if neither ran for this shape.
+    if (!cache_allocated_) {
+      // Allocate inline (rare path). Compute sizes from the current descriptors.
+      std::int64_t const weight_bytes =
+        c_out * k_vol * c_in * static_cast<std::int64_t>(sizeof(std::int8_t));
+      std::int64_t const c_out_float_bytes = c_out * static_cast<std::int64_t>(sizeof(float));
+      cudaError_t st = cudaMalloc(
+        reinterpret_cast<void **>(&cached_weight_int8_ptr_),
+        static_cast<std::size_t>(weight_bytes));
+      if (st == cudaSuccess) {
+        st = cudaMalloc(
+          reinterpret_cast<void **>(&cached_w_scales_ptr_),
+          static_cast<std::size_t>(c_out_float_bytes));
+      }
+      if (st == cudaSuccess) {
+        st = cudaMalloc(
+          reinterpret_cast<void **>(&cached_gemm_bias_ptr_),
+          static_cast<std::size_t>(c_out_float_bytes));
+      }
+      if (st != cudaSuccess) {
+        std::fprintf(
+          stderr, "[ImplicitGemm INT8] %s: inline cudaMalloc(weight cache) failed: %s\n",
+          layer_name_.c_str(), cudaGetErrorString(st));
+        releaseConstantCache();
+        return -1;
+      }
+      cache_allocated_ = true;
+      cache_filled_ = false;
+      cached_c_out_ = c_out;
+      cached_k1_ = k1;
+      cached_k2_ = k2;
+      cached_k3_ = k3;
+      cached_c_in_ = c_in;
+    }
+    if (!cache_filled_) {
+      launch_compute_w_scales(
+        reinterpret_cast<const float *>(inputs[INOUT_CHANNEL_SCALE_INDEX]), cached_w_scales_ptr_,
+        params_.output_scale, params_.input_scale, c_out, stream);
+      launch_quantize_weights_per_channel(
+        reinterpret_cast<const __half *>(inputs[INOUT_FILTERS_INDEX]), cached_weight_int8_ptr_,
+        cached_w_scales_ptr_, c_out, k_vol * c_in, stream);
+      // s8s8f16 epilogue does not multiply alpha: fold output_scale into scale/bias and pass
+      // output_scale = 1 to the GEMM (w_scales buffer is overwritten with gemm_channel_scale).
+      launch_fuse_output_scale_into_gemm_scale_bias(
+        reinterpret_cast<const float *>(inputs[INOUT_CHANNEL_SCALE_INDEX]),
+        reinterpret_cast<const float *>(inputs[INOUT_BIAS_SCALED_INDEX]), params_.output_scale,
+        cached_w_scales_ptr_, cached_gemm_bias_ptr_, c_out, stream);
+      cudaError_t st = cudaGetLastError();
+      if (st != cudaSuccess) {
+        std::fprintf(
+          stderr, "[ImplicitGemm INT8] %s: weight-cache kernel launch failed: %s\n",
+          layer_name_.c_str(), cudaGetErrorString(st));
+        return -1;
+      }
+      cache_filled_ = true;
+    }
+  }
+
+  // 3) Build tv::Tensors and run the INT8 implicit GEMM (FP16 output).
+  tv::Tensor features_tv = tv::from_blob(feat_int8_ptr, {num_act_in, c_in}, tv::int8, 0);
+  tv::Tensor weights_tv =
+    tv::from_blob(cached_weight_int8_ptr_, {c_out, k1, k2, k3, c_in}, tv::int8, 0);
+  tv::Tensor pair_fwd = tv::from_blob(
+    inputs[INOUT_PAIR_FWD_INDEX],
+    {input_desc[INOUT_PAIR_FWD_INDEX].dims.d[0], input_desc[INOUT_PAIR_FWD_INDEX].dims.d[1]},
+    tv::int32, 0);
+  tv::Tensor pair_mask_fwd = tv::from_blob(
+    inputs[INOUT_PAIR_MASK_FWD_SPLITS_INDEX],
+    {1, input_desc[INOUT_PAIR_MASK_FWD_SPLITS_INDEX].dims.d[0]}, tv::int32, 0);
+  tv::Tensor mask_argsort_fwd = tv::from_blob(
+    inputs[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX],
+    {1, input_desc[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].dims.d[0]}, tv::int32, 0);
+  tv::Tensor out_features = tv::from_blob(outputs[0], {num_act_out, c_out}, tv::float16, 0);
+
+  tv::Tensor channel_scale_tv = tv::from_blob(cached_w_scales_ptr_, {c_out}, tv::float32, 0);
+  tv::Tensor bias_scaled_tv = tv::from_blob(cached_gemm_bias_ptr_, {c_out}, tv::float32, 0);
+
+  std::vector<tv::Tensor> pair_mask_splits{pair_mask_fwd};
+  std::vector<tv::Tensor> mask_argsort_splits{mask_argsort_fwd};
+
+  std::unordered_map<std::string, tv::Tensor> tensor_dict{
+    {SPCONV_ALLOC_FEATURES, features_tv},
+    {SPCONV_ALLOC_FILTERS, weights_tv},
+    {SPCONV_ALLOC_OUT_FEATURES, out_features}};
+  StaticAllocator alloc(tensor_dict);
+
+  ConvGemmOps::implicit_gemm(
+    alloc, *tuner_int8_ptr_, features_tv, weights_tv, pair_fwd, pair_mask_splits,
+    mask_argsort_splits, static_cast<int>(num_act_out), mask_tensor_, arch_,
+    /*is_train=*/false, /*is_subm=*/static_cast<bool>(params_.is_subm),
+    reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false),
+    /*auto_fp32_accum=*/true, /*fp32_accum=*/false, /*bias=*/bias_scaled_tv, params_.act_alpha,
+    params_.act_beta, activation_from_int(params_.act_type), /*use_tf32=*/false,
+    /*output_scale=*/1.0f, /*scale=*/channel_scale_tv, /*output_add=*/tv::Tensor(),
+    /*output_add_scale=*/0.0f, /*output_dtype=*/static_cast<int>(tv::float16));
+
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -42,6 +42,9 @@ ImplicitGemmPluginCreator::ImplicitGemmPluginCreator()
   plugin_attributes_.emplace_back("output_add_scale", nullptr, PluginFieldType::kFLOAT32, 1);
   plugin_attributes_.emplace_back("output_scale", nullptr, PluginFieldType::kFLOAT32, 1);
   plugin_attributes_.emplace_back("act_type", nullptr, PluginFieldType::kINT32, 1);
+  // INT8 (precision==1) attributes. Absent on FP nodes (default precision=0).
+  plugin_attributes_.emplace_back("precision", nullptr, PluginFieldType::kINT32, 1);
+  plugin_attributes_.emplace_back("input_scale", nullptr, PluginFieldType::kFLOAT32, 1);
 
   fc_.nbFields = plugin_attributes_.size();
   fc_.fields = plugin_attributes_.data();
@@ -87,6 +90,15 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
         parameters.act_type = static_cast<std::int32_t const *>(fields[i].data)[0];
         PLUGIN_VALIDATE(parameters.act_type >= 0 && parameters.act_type <= 3);
+      } else if (attr_name == "precision") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+        parameters.precision = static_cast<std::int32_t const *>(fields[i].data)[0];
+        PLUGIN_VALIDATE(
+          parameters.precision == kIMPLICIT_GEMM_PRECISION_FP ||
+          parameters.precision == kIMPLICIT_GEMM_PRECISION_INT8);
+      } else if (attr_name == "input_scale") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.input_scale = static_cast<float const *>(fields[i].data)[0];
       }
     }
   };
@@ -107,7 +119,8 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
          << " act_alpha=" << parameters.act_alpha << " act_beta=" << parameters.act_beta
          << " is_subm=" << parameters.is_subm << " is_train=" << parameters.is_train
          << " output_add_scale=" << parameters.output_add_scale
-         << " output_scale=" << parameters.output_scale << " act_type=" << parameters.act_type;
+         << " output_scale=" << parameters.output_scale << " act_type=" << parameters.act_type
+         << " precision=" << parameters.precision << " input_scale=" << parameters.input_scale;
       logDebug(ss.str().c_str());
 
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), parameters}};

--- a/perception/autoware_tensorrt_plugins/src/quantize_ops/quantize_features.cu
+++ b/perception/autoware_tensorrt_plugins/src/quantize_ops/quantize_features.cu
@@ -1,0 +1,109 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/quantize_ops/quantize_features.hpp"
+
+namespace
+{
+constexpr int kBlockSize = 256;
+}  // namespace
+
+__global__ void quantize_features_kernel(
+  const __half * __restrict__ input, std::int8_t * __restrict__ output, float inv_scale,
+  std::int64_t total_elements)
+{
+  std::int64_t idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < total_elements) {
+    float val = __half2float(input[idx]) * inv_scale;
+    val = fminf(fmaxf(roundf(val), -128.0f), 127.0f);
+    output[idx] = static_cast<std::int8_t>(val);
+  }
+}
+
+__global__ void quantize_weights_per_channel_kernel(
+  const __half * __restrict__ input, std::int8_t * __restrict__ output,
+  const float * __restrict__ w_scales, std::int64_t c_out, std::int64_t elements_per_channel)
+{
+  std::int64_t idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  std::int64_t total = c_out * elements_per_channel;
+  if (idx < total) {
+    std::int64_t c = idx / elements_per_channel;
+    float inv_scale = 1.0f / w_scales[c];
+    float val = __half2float(input[idx]) * inv_scale;
+    val = fminf(fmaxf(roundf(val), -128.0f), 127.0f);
+    output[idx] = static_cast<std::int8_t>(val);
+  }
+}
+
+__global__ void compute_w_scales_kernel(
+  const float * __restrict__ channel_scale, float * __restrict__ w_scales, float output_scale,
+  float input_scale, std::int64_t c_out)
+{
+  std::int64_t idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < c_out) {
+    // channel_scale[c] = (input_scale * w_scale[c]) / output_scale
+    // => w_scale[c] = channel_scale[c] * output_scale / input_scale
+    w_scales[idx] = channel_scale[idx] * output_scale / input_scale;
+  }
+}
+
+__global__ void fuse_output_scale_into_gemm_scale_bias_kernel(
+  const float * __restrict__ channel_scale, const float * __restrict__ bias_scaled,
+  float output_scale, float * __restrict__ gemm_channel_scale_out,
+  float * __restrict__ gemm_bias_out, std::int64_t c_out)
+{
+  std::int64_t idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < c_out) {
+    gemm_channel_scale_out[idx] = channel_scale[idx] * output_scale;
+    gemm_bias_out[idx] = bias_scaled[idx] * output_scale;
+  }
+}
+
+void launch_quantize_features(
+  const __half * input, std::int8_t * output, float scale, std::int64_t total_elements,
+  cudaStream_t stream)
+{
+  float inv_scale = 1.0f / scale;
+  int grid = static_cast<int>((total_elements + kBlockSize - 1) / kBlockSize);
+  quantize_features_kernel<<<grid, kBlockSize, 0, stream>>>(
+    input, output, inv_scale, total_elements);
+}
+
+void launch_quantize_weights_per_channel(
+  const __half * input, std::int8_t * output, const float * w_scales, std::int64_t c_out,
+  std::int64_t elements_per_channel, cudaStream_t stream)
+{
+  std::int64_t total = c_out * elements_per_channel;
+  int grid = static_cast<int>((total + kBlockSize - 1) / kBlockSize);
+  quantize_weights_per_channel_kernel<<<grid, kBlockSize, 0, stream>>>(
+    input, output, w_scales, c_out, elements_per_channel);
+}
+
+void launch_compute_w_scales(
+  const float * channel_scale, float * w_scales, float output_scale, float input_scale,
+  std::int64_t c_out, cudaStream_t stream)
+{
+  int grid = static_cast<int>((c_out + kBlockSize - 1) / kBlockSize);
+  compute_w_scales_kernel<<<grid, kBlockSize, 0, stream>>>(
+    channel_scale, w_scales, output_scale, input_scale, c_out);
+}
+
+void launch_fuse_output_scale_into_gemm_scale_bias(
+  const float * channel_scale, const float * bias_scaled, float output_scale,
+  float * gemm_channel_scale_out, float * gemm_bias_out, std::int64_t c_out, cudaStream_t stream)
+{
+  int grid = static_cast<int>((c_out + kBlockSize - 1) / kBlockSize);
+  fuse_output_scale_into_gemm_scale_bias_kernel<<<grid, kBlockSize, 0, stream>>>(
+    channel_scale, bias_scaled, output_scale, gemm_channel_scale_out, gemm_bias_out, c_out);
+}


### PR DESCRIPTION
## Description

An INT8 path for `ImplicitGemmPlugin`, selected by two new plugin attributes so that every engine built so far is bit-for-bit unaffected:

| attribute | meaning |
| --- | --- |
| `precision` | `0` = floating point (default), `1` = INT8 |
| `input_scale` | INT8 only: `input_amax / 127`, used to quantize the FP16 features |

An INT8 node takes **7 inputs instead of 5 or 6**: the usual features, filters and three index tensors, plus per-output-channel `channel_scale` and `bias_scaled` (both FP32) at indices 5 and 6.

Features, filters and the output stay **FP16 at the graph boundary** — the quantization happens inside the plugin, so the ONNX graph carries **no Q/DQ pair** for the node. That is why the precision lives in an attribute rather than in the graph: TensorRT cannot fuse `QuantizeLinear`/`DequantizeLinear` into a custom plugin node, so a Q/DQ-based INT8 sparse convolution would only add two elementwise kernels around an unchanged FP16 GEMM.

`enqueueInt8()` quantizes the features into the plugin workspace on every call and runs the `s8s8f16` GEMM with per-output-channel scales. Weights, weight scales and bias are graph constants, so they are quantized once into a persistent device cache and reused across enqueues; the cache is allocated in `configurePlugin()` (build) and `onShapeChange()` (runtime) so the `cudaMalloc` stays outside CUDA-graph capture, and filled lazily on the first enqueue, where the filter device data first exists. Because the `s8s8f16` epilogue never multiplies `alpha`, the output dequantization is folded into the per-channel scale and bias up front and the GEMM is called with `output_scale = 1`.

The floating-point path, including the fused bias/activation from #12658, is unchanged.

The second commit is the one bug this shook out: `enqueue()` asserted the floating-point input count (5 or 6) *before* dispatching to `enqueueInt8()`, so every INT8 node — which has seven inputs — aborted the process on its first inference, even though `configurePlugin()`, `supportsFormatCombination()`, `getOutputShapes()` and `onShapeChange()` already branched on `precision` and the engine therefore built fine.

### Who produces these attributes

TIER IV's `autoware-ml` quantization framework, which is already the exporter for the sparse graphs `autoware_bevfusion` and `autoware_ptv3` consume. Its export pass rewrites the plugin node instead of inserting Q/DQ. One node of a PTv3 encoder export, verbatim:

```text
FP16 (today)     /enc/enc0/block0/cpe/cpe.0/ImplicitGemm
  inputs : [features, weight, pair_fwd, pair_mask, mask_argsort]
  attrs  : act_type=0, is_subm=1, output_scale=1.0, …

INT8 (this PR)   /enc/enc0/block0/cpe/cpe.0/ImplicitGemm
  inputs : [features, weight, pair_fwd, pair_mask, mask_argsort,
            enc_enc0_block0_cpe_0_channel_scale, enc_enc0_block0_cpe_0_bias_scaled]
  attrs  : act_type=0, is_subm=1, output_scale=1.0,
           precision=1, input_scale=0.046849, …
```

An INT8 graph built against a plugin *without* this change is rejected at engine build (unknown attributes), which is the failure mode if exporter and plugin get out of step.

### What it buys, and where it does not

Measured through the `autoware-ml` deploy chain on an internal LiDAR dataset (122 m range, 0.12 m voxels), TensorRT 10.8, RTX PRO 6000 Blackwell, with a `libautoware_tensorrt_plugins.so` built from this branch.

**PTv3 semantic segmentation, 300 frames — worth it.** Its 12 `cpe` convolutions are `SubMConv3d(C, C, k=3)` with C up to 512, i.e. 27·C² MACs per active voxel:

| recipe | mIoU | encoder | seg head | graphs |
| --- | ---: | ---: | ---: | ---: |
| INT8 Linear only | 0.7794 | 5.599 ms | 1.471 ms | 7.070 ms |
| **+ sparse INT8 (12/12 convs)** | **0.7787** | 5.113 ms | 1.423 ms | **6.536 ms (−7.6%)** |

**BEVFusion-L, 100 frames — measured, and not worth enabling.** The sparse tower gets 0.054 ms faster (below the 0.03 ms standard error of the mean) for −1.2% mAP, and quantizing all 21 layers is *slower* than FP16 (4.137 vs 4.015 ms). Its tower is 16–128 channels wide, and the INT8 GEMM only wins once the channel count is wide enough — measured per layer, 0.65–0.88× at C ≤ 32 against 1.25–1.75× at C ≥ 128.

So this path is what makes a wide sparse tower's INT8 viable; it is offered as a capability, not as a change of any shipped configuration.

## Related links

**Parent Issue:**

- None.

Predecessors this builds on: #12658 (fused bias/activation in `ImplicitGemmPlugin`), #12734, #12378.

## How was this PR tested?

- **Compiles**: built with the plugin's own CMake path (CUDA 12.9, `sm_120`), including the new `quantize_ops` translation unit, from this branch rebased onto `main`.
- **Runs**: exercised end to end by the `autoware-ml` deploy chain for both sparse models — PTQ calibration → ONNX carrying `precision=1` → engine build → evaluation over 300 (PTv3) and 100 (BEVFusion) frames, plus per-block keep-list sweeps (leave-one-out and only-one over 12 blocks) which repeatedly build and run INT8 engines with different subsets of nodes quantized.
- **Floating-point path**: unchanged and re-measured in the same sessions; the FP16 baselines in the table above come from engines built with this plugin.
- **Not run on a vehicle.** No node configuration in this repository selects an INT8 sparse engine, so nothing in the default pipeline exercises the new path.

## Notes for reviewers

- The precision is an attribute rather than graph-level Q/DQ because TensorRT will not fuse Q/DQ into a plugin node; see the Description.
- The weight/bias quantization cache is deliberately allocated in `configurePlugin()` / `onShapeChange()` and filled on first `enqueue()`: allocation must stay out of CUDA-graph capture, but the filter device pointer is only valid at enqueue time.
- `output_scale` stays `1` for INT8 nodes; the dequantization is folded into `channel_scale` / `bias_scaled` by the exporter because the `s8s8f16` epilogue ignores `alpha`.
- The two commits are kept separate on purpose: the second is a run-time-only bug (the engine built fine, the process aborted on first inference), and reads more clearly as its own fix.

## Interface changes

No ROS topics or parameters change. The change is to the plugin's ONNX-facing contract, and it is additive:

| Change type | Name | Type | Default | Description |
|:---|:---|:---|:---|:---|
| Added | `precision` | `int32` attribute | `0` (floating point) | `1` selects the INT8 path |
| Added | `input_scale` | `float32` attribute | — (required only when `precision=1`) | `input_amax / 127` |
| Added | input 5 `channel_scale` | `float32[C_out]` | — (INT8 only) | per-output-channel weight scale, output dequant folded in |
| Added | input 6 `bias_scaled` | `float32[C_out]` | — (INT8 only) | bias pre-divided by the output scale |

A graph that sets neither attribute is parsed and executed exactly as before.

## Effects on system behavior

None by default: `precision` defaults to `0`, so existing engines and existing exports keep the floating-point path, byte for byte. Behaviour changes only for a graph that explicitly sets `precision=1`, and no configuration in this repository does.
