### PR TITLE
feat(autoware_bevfusion): precompute the down-sampling rulebooks outside the sparse engine

### DIFF
--- a/perception/autoware_bevfusion/CMakeLists.txt
+++ b/perception/autoware_bevfusion/CMakeLists.txt
@@ -77,6 +77,8 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
   # Find Eigen3
   find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
+  find_package(nlohmann_json REQUIRED)
+
   add_definitions("-DTV_CUDA")
 
   # cSpell:ignore expt
@@ -101,6 +103,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     lib/postprocess/circle_nms_kernel.cu
     lib/postprocess/postprocess_kernel.cu
     lib/preprocess/preprocess_kernel.cu
+    lib/preprocess/sparse_rulebook_precompute.cu
     lib/camera/camera_preprocess_kernel.cu
   )
 
@@ -135,6 +138,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     ${CUBLAS_LIBRARIES}
     ${CUDA_curand_LIBRARY}
     ${PROJECT_NAME}_cuda_lib
+    nlohmann_json::nlohmann_json
   )
 
   # To suppress unknown-pragmas error. The root-cause is CUB library in CUDA 11.6.

--- a/perception/autoware_bevfusion/config/ml_package_bevfusion_lidar.param.yaml
+++ b/perception/autoware_bevfusion/config/ml_package_bevfusion_lidar.param.yaml
@@ -9,6 +9,12 @@
     max_points_per_voxel: 10
     use_intensity: false
 
+    # Set true ONLY with a sparse engine exported with the 4 down-sample
+    # GetIndicePairsImplicitGemm nodes removed (trainStation/DDS removal). The runtime then
+    # precomputes those rulebooks from the voxel coords and binds them. See
+    # BEVFusion_spconv_DDS_optimization.md.
+    sparse_remove_trainstation: false
+
     d_bound: [1.0, 166.2, 1.4]
     x_bound: [-122.4, 122.4, 0.68]
     y_bound: [-122.4, 122.4, 0.68]

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_config.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_config.hpp
@@ -247,6 +247,21 @@ public:
 
   ///// RUNTIME DIMENSIONS /////
   std::array<std::int64_t, 3> voxels_num_{};
+
+  ///// SPARSE trainStation/DDS REMOVAL /////
+  // When true, the sparse engine was exported with the 4 down-sample GetIndicePairsImplicitGemm
+  // nodes removed (their rulebooks exposed as graph inputs). The runtime then precomputes those
+  // rulebooks from the voxel coordinates and binds them before inference. Plain member (set by the
+  // node from a ROS param) to avoid extending the large positional constructor.
+  // See BEVFusion_spconv_DDS_optimization.md (Slice 2b).
+  bool sparse_remove_trainstation_{false};
+  // Upper bound on active out-voxels per down-sample stage; must match the plugin's
+  // out_indices_num_limit_ and the TensorRT profile max for the rulebook inputs.
+  std::int64_t sparse_out_indices_num_limit_{256000};
+  // Fallback for sparse engines exported before the ONNX carried "rulebook_coors_permutation":
+  // true if `coors` is [z,y,x] and those exports were built on [x,y,z] (the AWML contract).
+  // Ignored when the ONNX records its column order.
+  bool sparse_coors_is_zyx_{true};
 };
 
 }  // namespace autoware::bevfusion

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
@@ -19,6 +19,7 @@
 #include "autoware/bevfusion/postprocess/postprocess_kernel.hpp"
 #include "autoware/bevfusion/preprocess/pointcloud_densification.hpp"
 #include "autoware/bevfusion/preprocess/preprocess_kernel.hpp"
+#include "autoware/bevfusion/preprocess/sparse_rulebook_precompute.hpp"
 #include "autoware/bevfusion/preprocess/voxel_generator.hpp"
 #include "autoware/bevfusion/utils.hpp"
 #include "autoware/bevfusion/visibility_control.hpp"
@@ -36,6 +37,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -136,6 +138,15 @@ protected:
 
   void setSensorFusionTensorAddresses();
 
+  // trainStation/DDS removal: declare the 16 rulebook graph inputs, bind their stable device
+  // buffers, and set their per-stage runtime shapes. No-ops unless
+  // config_.sparse_remove_trainstation_ is set. See sparse_rulebook_precompute.hpp.
+  void addSparseRulebookNetworkIO(std::vector<autoware::tensorrt_common::NetworkIO> & network_io);
+  void addSparseRulebookProfileDims(
+    std::vector<autoware::tensorrt_common::ProfileDims> & profile_dims);
+  void bindSparseRulebookAddresses();
+  void setSparseRulebookInputShapes();
+
   bool inference();
 
   bool postProcess(std::vector<Box3D> & det_boxes3d);
@@ -147,6 +158,9 @@ protected:
     nullptr};
   std::unique_ptr<PreprocessCuda> pre_ptr_{nullptr};
   std::unique_ptr<PostprocessCuda> post_ptr_{nullptr};
+  std::unique_ptr<SparseRulebookPrecompute> sparse_rulebook_ptr_{nullptr};
+  // Column order the precomputed rulebooks are built on (see RulebookMetadata).
+  std::array<int, 3> rulebook_coors_permutation_{0, 1, 2};
   cudaStream_t stream_{nullptr};
 
   BEVFusionConfig config_;

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/preprocess/sparse_rulebook_precompute.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/preprocess/sparse_rulebook_precompute.hpp
@@ -1,0 +1,137 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BEVFUSION__PREPROCESS__SPARSE_RULEBOOK_PRECOMPUTE_HPP_
+#define AUTOWARE__BEVFUSION__PREPROCESS__SPARSE_RULEBOOK_PRECOMPUTE_HPP_
+
+// Runtime precompute of the BEVFusion sparse-encoder down-sample rulebooks for the
+// trainStation/DDS-stripped engine (see AWML deploy flag ``spconv_remove_trainstation`` and
+// BEVFusion_spconv_DDS_optimization.md, Slice 2/2b).
+//
+// The optimized sparse ONNX has its 4 down-sample ``GetIndicePairsImplicitGemm`` nodes removed and
+// their outputs exposed as graph inputs. Those rulebooks depend only on voxel geometry, so they are
+// computed here from the voxel coordinates and bound to the engine before ``enqueueV3`` — removing
+// the in-graph ``DeviceToShapeHostCopy`` syncs that produced the ``[trainStationN]`` segments.
+//
+// This mirrors, per down-sample stage, the non-subm path of the GetIndicePairsImplicitGemm plugin
+// (autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp::enqueue) and the
+// validated Python reference (AWML deployment/.../pipelines/sparse_rulebook_precompute.py).
+
+#include <autoware/cuda_utils/cuda_unique_ptr.hpp>
+
+#include <cuda_runtime.h>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace autoware::bevfusion
+{
+
+using autoware::cuda_utils::CudaUniquePtr;
+
+// One stride>1 (down-sampling) sparse convolution whose rulebook is precomputed.
+struct SparseDownsampleStage
+{
+  // ONNX graph-input base name (e.g. ``rulebook/l1``); the 4 bound tensors are
+  // ``<onnx_base>/{out_indices,pair_fwd,pair_mask,mask_argsort}`` — matches
+  // export/sparse_trainstation_transform.py:rulebook_input_name().
+  std::string onnx_base;
+  std::vector<int> ksize;          // e.g. {3,3,3} ; conv_out {1,1,3}
+  std::vector<int> stride;         // e.g. {2,2,2} ; conv_out {1,1,2}
+  std::vector<int> padding;        // per-stage
+  std::vector<int> dilation;       // {1,1,1}
+  std::vector<int> spatial_shape;  // input spatial shape of this stage (x,y,z); 1440->720->360->180
+  int kernel_volume{0};            // prod(ksize); filled by ctor if 0
+};
+
+// What the runtime needs to regenerate the graph's precomputed rulebooks, as the exporter recorded
+// it in the ONNX metadata_props ("rulebook_stages" + "rulebook_coors_permutation").
+struct RulebookMetadata
+{
+  std::vector<SparseDownsampleStage> stages;
+  // For each spconv spatial coordinate column, the graph `coors` spatial column it is read from —
+  // the convolutions were exported on coordinates in this order, so the rulebooks must be built on
+  // it too. Absent in older exports; the caller then falls back to the legacy contract.
+  std::optional<std::array<int, 3>> coors_permutation;
+};
+
+class SparseRulebookPrecompute
+{
+public:
+  // out_indices_num_limit must equal the plugin's upper bound (256000) used for the TRT profile
+  // max.
+  SparseRulebookPrecompute(
+    int out_indices_num_limit, std::vector<SparseDownsampleStage> stages, cudaStream_t stream);
+
+  // Compute all stage rulebooks from input voxel coordinates.
+  //   coors_d      : device buffer of voxel coords, row-major [num_in, coors_cols].
+  //   num_in       : number of input voxels.
+  //   coors_cols   : 3 (graph-input spatial coords, no batch) or 4 (already [batch, ...] in the
+  //                  convolutions' column order; copied verbatim).
+  //   coors_permutation : for each spconv spatial column, the `coors` column it is read from
+  //                  (RulebookMetadata::coors_permutation). {2,1,0} turns [z,y,x] into [x,y,z];
+  //                  {1,2,0} turns it into [y,x,z].
+  // After this returns, stageCount(i) and the device pointers below are valid for binding.
+  void compute(
+    const std::int32_t * coors_d, int num_in, int coors_cols,
+    const std::array<int, 3> & coors_permutation);
+
+  int numStages() const { return static_cast<int>(stages_.size()); }
+  const SparseDownsampleStage & stage(int i) const { return stages_[i]; }
+  int stageCount(int i) const { return stage_counts_[i]; }  // active out-voxels of stage i
+
+  // Device pointers to the (stable, upper-bound-sized) rulebook buffers, valid after compute().
+  std::int32_t * outIndices(int i) const { return out_indices_d_[i].get(); }    // [count, 4]
+  std::int32_t * pairFwd(int i) const { return pair_fwd_d_[i].get(); }          // [KV, count]
+  std::int32_t * pairMask(int i) const { return pair_mask_d_[i].get(); }        // [count, 1]
+  std::int32_t * maskArgsort(int i) const { return mask_argsort_d_[i].get(); }  // [count]
+
+private:
+  void allocateStageBuffers();
+  // Run one down-sample stage's rulebook generation (mirrors the plugin non-subm enqueue).
+  // Returns num_act_out for the stage; out_indices for the next stage's input.
+  int computeStage(int i, const std::int32_t * coords_in_d, int num_in);
+
+  int out_indices_num_limit_;
+  std::vector<SparseDownsampleStage> stages_;
+  cudaStream_t stream_;
+
+  std::vector<int> stage_counts_;
+
+  // Per-stage output (engine-input) buffers, capacity out_indices_num_limit_. spconv writes each
+  // tensor densely (stride = num_act_out, not N); only the first stageCount(i) entries along the
+  // dynamic dim are bound, which is exactly the dense prefix the engine reads.
+  std::vector<CudaUniquePtr<std::int32_t[]>> out_indices_d_;   // [n,4] in [N,4]
+  std::vector<CudaUniquePtr<std::int32_t[]>> pair_fwd_d_;      // [KV,n] in [KV,N]
+  std::vector<CudaUniquePtr<std::int32_t[]>> pair_mask_d_;     // [n,1] in [N] (mask_count==1)
+  std::vector<CudaUniquePtr<std::int32_t[]>> mask_argsort_d_;  // [n] in [N]
+
+  // Scratch: [batch,x,y,z] int32 coords fed to spconv (max num voxels).
+  CudaUniquePtr<std::int32_t[]> coords_xyzb_d_{nullptr};
+  // spconv index-generation workspace + indices_kernel_num + thrust temp (per the plugin layout).
+  CudaUniquePtr<std::uint8_t[]> spconv_workspace_d_{nullptr};
+  std::size_t spconv_workspace_size_{0};
+  // Frame-invariant worst-case theoretical max active-output (max over stages at the N upper
+  // bound). computeStage() carves the workspace with this constant instead of a per-frame value, so
+  // the workspace layout / offsets do not vary frame to frame (num_in <= N => this always bounds
+  // the per-frame need). Avoids a per-frame get_handcrafted_max_act_out() call.
+  int max_act_out_theory_worst_{0};
+};
+
+}  // namespace autoware::bevfusion
+
+#endif  // AUTOWARE__BEVFUSION__PREPROCESS__SPARSE_RULEBOOK_PRECOMPUTE_HPP_

--- a/perception/autoware_bevfusion/lib/bevfusion_trt.cpp
+++ b/perception/autoware_bevfusion/lib/bevfusion_trt.cpp
@@ -23,20 +23,169 @@
 #include <autoware/cuda_utils/cuda_utils.hpp>
 #include <autoware/point_types/memory.hpp>
 #include <autoware_utils_math/constants.hpp>
+#include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
+#include <fstream>
+#include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace autoware::bevfusion
 {
+
+namespace
+{
+// Minimal protobuf field scanner: reads a varint from the stream.
+// Returns false on EOF or read error.
+bool read_varint(std::ifstream & f, std::uint64_t & out)
+{
+  out = 0;
+  int shift = 0;
+  std::uint8_t b;
+  do {
+    if (shift >= 64) {
+      return false;  // overlong varint (corrupt input) — avoid shift-overflow UB
+    }
+    if (!f.read(reinterpret_cast<char *>(&b), 1)) {
+      return false;
+    }
+    out |= static_cast<std::uint64_t>(b & 0x7FU) << shift;
+    shift += 7;
+  } while (b & 0x80U);
+  return true;
+}
+
+// Load the precomputed-rulebook contract from the ONNX metadata_props the exporter embedded:
+// "rulebook_stages" (the down-sample stages' geometry, JSON) and "rulebook_coors_permutation"
+// (the coordinate column order the graph was exported with, JSON [3]).
+//
+// Parses only the top-level protobuf fields of ModelProto, skipping the large graph field
+// (field 7) via seekg — total I/O is a few KB regardless of model size.
+// Returns empty stages if the path is empty, the file is missing, or the key is absent.
+RulebookMetadata load_rulebook_metadata(const std::string & onnx_path)
+{
+  RulebookMetadata metadata;
+  if (onnx_path.empty()) {
+    return metadata;
+  }
+  std::ifstream f(onnx_path, std::ios::binary);
+  if (!f.is_open()) {
+    return metadata;
+  }
+
+  // ONNX ModelProto (protobuf3) top-level field numbers:
+  //   1  ir_version       (varint)
+  //   7  graph            (length-delimited, large — skip via seekg)
+  //   8  opset_import     (length-delimited, repeated)
+  //   14 metadata_props   (length-delimited, repeated StringStringEntryProto)
+  //      └── 1 key (string), 2 value (string)
+  constexpr int kFieldMetadataProps = 14;
+  constexpr std::uint32_t kWireVarint = 0;
+  constexpr std::uint32_t kWireLenDelim = 2;
+  constexpr std::string_view kStagesKey = "rulebook_stages";
+  constexpr std::string_view kPermutationKey = "rulebook_coors_permutation";
+
+  std::map<std::string, std::string> props;
+  while (f.good()) {
+    std::uint64_t tag_u64;
+    if (!read_varint(f, tag_u64)) {
+      break;
+    }
+    const int field_num = static_cast<int>(tag_u64 >> 3U);
+    const std::uint32_t wire_type = static_cast<std::uint32_t>(tag_u64 & 0x7ULL);
+
+    if (wire_type == kWireVarint) {
+      std::uint64_t dummy;
+      if (!read_varint(f, dummy)) {
+        break;
+      }
+    } else if (wire_type == kWireLenDelim) {
+      std::uint64_t length;
+      if (!read_varint(f, length)) {
+        break;
+      }
+      if (field_num != kFieldMetadataProps) {
+        // Skip non-metadata fields (including the large graph) with a single seek.
+        f.seekg(static_cast<std::streamoff>(length), std::ios::cur);
+        continue;
+      }
+      // Parse StringStringEntryProto: field 1 = key, field 2 = value.
+      std::string key, value;
+      const std::streampos entry_start = f.tellg();
+      const std::streampos entry_end = entry_start + static_cast<std::streamoff>(length);
+      while (f.tellg() < entry_end) {
+        std::uint64_t sub_tag;
+        if (!read_varint(f, sub_tag)) {
+          break;
+        }
+        const int sub_field = static_cast<int>(sub_tag >> 3U);
+        const std::uint32_t sub_wire = static_cast<std::uint32_t>(sub_tag & 0x7ULL);
+        if (sub_wire != kWireLenDelim) {
+          break;
+        }
+        std::uint64_t sub_len;
+        if (!read_varint(f, sub_len)) {
+          break;
+        }
+        std::string buf(sub_len, '\0');
+        if (!f.read(buf.data(), static_cast<std::streamsize>(sub_len))) {
+          break;
+        }
+        if (sub_field == 1) {
+          key = std::move(buf);
+        } else if (sub_field == 2) {
+          value = std::move(buf);
+        }
+      }
+      f.seekg(entry_end);  // ensure we're at the correct position after the entry
+      props.emplace(std::move(key), std::move(value));
+    } else {
+      break;  // unexpected wire type — stop parsing
+    }
+  }
+
+  const auto stages_it = props.find(std::string(kStagesKey));
+  if (stages_it == props.end()) {
+    return metadata;
+  }
+  // A key that is present but not the expected JSON is surfaced rather than reported as
+  // "metadata absent, re-export".
+  try {
+    for (const auto & entry : nlohmann::json::parse(stages_it->second)) {
+      SparseDownsampleStage s;
+      s.onnx_base = entry.at("onnx_base").get<std::string>();
+      s.ksize = entry.at("ksize").get<std::vector<int>>();
+      s.stride = entry.at("stride").get<std::vector<int>>();
+      s.padding = entry.at("padding").get<std::vector<int>>();
+      s.dilation = entry.at("dilation").get<std::vector<int>>();
+      s.spatial_shape = entry.at("spatial_shape").get<std::vector<int>>();
+      metadata.stages.push_back(std::move(s));
+    }
+    const auto permutation_it = props.find(std::string(kPermutationKey));
+    if (permutation_it != props.end()) {
+      const auto columns = nlohmann::json::parse(permutation_it->second).get<std::vector<int>>();
+      if (columns.size() != 3) {
+        throw std::runtime_error("expected 3 entries in rulebook_coors_permutation");
+      }
+      metadata.coors_permutation = std::array<int, 3>{columns[0], columns[1], columns[2]};
+    }
+  } catch (const std::exception & e) {
+    throw std::runtime_error(
+      std::string("ONNX rulebook metadata is present but could not be parsed: ") + e.what());
+  }
+  return metadata;
+}
+}  // namespace
 
 BEVFusionTRT::BEVFusionTRT(
   const TrtBEVFusionConfig & trt_config, const DensificationParam & densification_param,
@@ -51,6 +200,28 @@ BEVFusionTRT::BEVFusionTRT(
   stop_watch_ptr_->tic("processing/inner");
 
   initPtr();
+
+  // trainStation/DDS removal: owns the stable rulebook buffers bound as engine inputs.
+  // Reads the stage geometry and the coordinate column order from the metadata_props the
+  // exporter embedded in the ONNX.
+  if (config_.sparse_remove_trainstation_) {
+    const std::string onnx_path = trt_config.common.onnx_path.string();
+    auto metadata = load_rulebook_metadata(onnx_path);
+    if (metadata.stages.empty()) {
+      throw std::runtime_error(
+        "sparse_remove_trainstation is enabled but the ONNX at '" + onnx_path +
+        "' has no 'rulebook_stages' metadata. Re-export the model with the down-sample "
+        "rulebooks precomputed (autoware-ml BEVFusion sparse stage / AWML "
+        "spconv_remove_trainstation=True).");
+    }
+    // Exports that predate the recorded column order were built on [x, y, z] coordinates, from
+    // a [z, y, x] graph input when sparse_coors_is_zyx is set.
+    rulebook_coors_permutation_ = metadata.coors_permutation.value_or(
+      config_.sparse_coors_is_zyx_ ? std::array<int, 3>{2, 1, 0} : std::array<int, 3>{0, 1, 2});
+    sparse_rulebook_ptr_ = std::make_unique<SparseRulebookPrecompute>(
+      static_cast<int>(config_.sparse_out_indices_num_limit_), std::move(metadata.stages), stream_);
+  }
+
   initTrt(trt_config);
 }
 
@@ -132,6 +303,9 @@ void BEVFusionTRT::initTrt(const TrtBEVFusionConfig & trt_config)
   // Camera branch (only for fusion mode)
   addCameraNetworkIO(network_io);
 
+  // trainStation/DDS removal: precomputed rulebook graph inputs (no-op unless enabled)
+  addSparseRulebookNetworkIO(network_io);
+
   // Outputs
   network_io.emplace_back(
     "bbox_pred", nvinfer1::Dims{2, {config_.num_box_values_, config_.num_proposals_}});
@@ -162,6 +336,9 @@ void BEVFusionTRT::initTrt(const TrtBEVFusionConfig & trt_config)
   // Camera branch (only for fusion mode)
   addCameraProfileDims(profile_dims);
 
+  // trainStation/DDS removal: profiles for the rulebook inputs (no-op unless enabled)
+  addSparseRulebookProfileDims(profile_dims);
+
   auto network_io_ptr =
     std::make_unique<std::vector<autoware::tensorrt_common::NetworkIO>>(network_io);
   auto profile_dims_ptr =
@@ -180,6 +357,9 @@ void BEVFusionTRT::initTrt(const TrtBEVFusionConfig & trt_config)
   network_trt_ptr_->setTensorAddress("coors", voxel_coords_d_.get());
 
   setSensorFusionTensorAddresses();
+
+  // trainStation/DDS removal: bind the stable rulebook buffers (no-op unless enabled)
+  bindSparseRulebookAddresses();
 
   network_trt_ptr_->setTensorAddress("label_pred", label_pred_output_d_.get());
   network_trt_ptr_->setTensorAddress("bbox_pred", bbox_pred_output_d_.get());
@@ -347,6 +527,89 @@ void BEVFusionTRT::setSensorFusionTensorAddresses()
   network_trt_ptr_->setTensorAddress("kept", kept_d_.get());
   network_trt_ptr_->setTensorAddress("ranks", ranks_d_.get());
   network_trt_ptr_->setTensorAddress("indices", indices_d_.get());
+}
+
+void BEVFusionTRT::addSparseRulebookNetworkIO(
+  std::vector<autoware::tensorrt_common::NetworkIO> & network_io)
+{
+  if (!sparse_rulebook_ptr_) {
+    return;
+  }
+  for (int i = 0; i < sparse_rulebook_ptr_->numStages(); ++i) {
+    const auto & s = sparse_rulebook_ptr_->stage(i);
+    const std::int64_t kv = s.kernel_volume;
+    network_io.emplace_back(
+      s.onnx_base + "/out_indices", nvinfer1::Dims{2, {-1, 4}});                      // out_indices
+    network_io.emplace_back(s.onnx_base + "/pair_fwd", nvinfer1::Dims{2, {kv, -1}});  // pair_fwd
+    network_io.emplace_back(s.onnx_base + "/pair_mask", nvinfer1::Dims{2, {-1, 1}});  // pair_mask
+    network_io.emplace_back(
+      s.onnx_base + "/mask_argsort", nvinfer1::Dims{1, {-1}});  // mask_argsort
+  }
+}
+
+void BEVFusionTRT::addSparseRulebookProfileDims(
+  std::vector<autoware::tensorrt_common::ProfileDims> & profile_dims)
+{
+  if (!sparse_rulebook_ptr_) {
+    return;
+  }
+  const std::int64_t n_min = 1;
+  const std::int64_t n_opt = config_.voxels_num_[1];
+  const std::int64_t n_max = config_.sparse_out_indices_num_limit_;
+  for (int i = 0; i < sparse_rulebook_ptr_->numStages(); ++i) {
+    const auto & s = sparse_rulebook_ptr_->stage(i);
+    const std::int64_t kv = s.kernel_volume;
+    profile_dims.emplace_back(
+      s.onnx_base + "/out_indices", nvinfer1::Dims{2, {n_min, 4}}, nvinfer1::Dims{2, {n_opt, 4}},
+      nvinfer1::Dims{2, {n_max, 4}});
+    profile_dims.emplace_back(
+      s.onnx_base + "/pair_fwd", nvinfer1::Dims{2, {kv, n_min}}, nvinfer1::Dims{2, {kv, n_opt}},
+      nvinfer1::Dims{2, {kv, n_max}});
+    profile_dims.emplace_back(
+      s.onnx_base + "/pair_mask", nvinfer1::Dims{2, {n_min, 1}}, nvinfer1::Dims{2, {n_opt, 1}},
+      nvinfer1::Dims{2, {n_max, 1}});
+    profile_dims.emplace_back(
+      s.onnx_base + "/mask_argsort", nvinfer1::Dims{1, {n_min}}, nvinfer1::Dims{1, {n_opt}},
+      nvinfer1::Dims{1, {n_max}});
+  }
+}
+
+void BEVFusionTRT::bindSparseRulebookAddresses()
+{
+  if (!sparse_rulebook_ptr_) {
+    return;
+  }
+  for (int i = 0; i < sparse_rulebook_ptr_->numStages(); ++i) {
+    const auto & s = sparse_rulebook_ptr_->stage(i);
+    network_trt_ptr_->setTensorAddress(
+      (s.onnx_base + "/out_indices").c_str(), sparse_rulebook_ptr_->outIndices(i));
+    network_trt_ptr_->setTensorAddress(
+      (s.onnx_base + "/pair_fwd").c_str(), sparse_rulebook_ptr_->pairFwd(i));
+    network_trt_ptr_->setTensorAddress(
+      (s.onnx_base + "/pair_mask").c_str(), sparse_rulebook_ptr_->pairMask(i));
+    network_trt_ptr_->setTensorAddress(
+      (s.onnx_base + "/mask_argsort").c_str(), sparse_rulebook_ptr_->maskArgsort(i));
+  }
+}
+
+void BEVFusionTRT::setSparseRulebookInputShapes()
+{
+  if (!sparse_rulebook_ptr_) {
+    return;
+  }
+  for (int i = 0; i < sparse_rulebook_ptr_->numStages(); ++i) {
+    const auto & s = sparse_rulebook_ptr_->stage(i);
+    const std::int64_t n = sparse_rulebook_ptr_->stageCount(i);
+    const std::int64_t kv = s.kernel_volume;
+    network_trt_ptr_->setInputShape(
+      (s.onnx_base + "/out_indices").c_str(), nvinfer1::Dims{2, {n, 4}});
+    network_trt_ptr_->setInputShape(
+      (s.onnx_base + "/pair_fwd").c_str(), nvinfer1::Dims{2, {kv, n}});
+    network_trt_ptr_->setInputShape(
+      (s.onnx_base + "/pair_mask").c_str(), nvinfer1::Dims{2, {n, 1}});
+    network_trt_ptr_->setInputShape(
+      (s.onnx_base + "/mask_argsort").c_str(), nvinfer1::Dims{1, {n}});
+  }
 }
 
 bool BEVFusionTRT::detect(
@@ -589,6 +852,9 @@ void BEVFusionTRT::configureTensorRTInputs(std::int64_t num_voxels, std::size_t 
   network_trt_ptr_->setInputShape(
     "coors", nvinfer1::Dims{2, {num_voxels, BEVFusionConfig::kNum3DCoords}});
 
+  // trainStation/DDS removal: set the rulebook input shapes from the precomputed per-stage counts.
+  setSparseRulebookInputShapes();
+
   if (!config_.sensor_fusion_) {
     return;
   }
@@ -672,6 +938,14 @@ bool BEVFusionTRT::preProcess(
     processPointCloudVoxelization(num_points, is_num_voxels_within_range);
   if (num_voxels < 0) {
     return false;
+  }
+
+  // trainStation/DDS removal: precompute the 4 down-sample rulebooks from the voxel coords on the
+  // GPU (one host sync per stage for its active-voxel count), so the engine has no in-graph DDS.
+  if (sparse_rulebook_ptr_) {
+    sparse_rulebook_ptr_->compute(
+      voxel_coords_d_.get(), static_cast<int>(num_voxels), BEVFusionConfig::kNum3DCoords,
+      rulebook_coors_permutation_);
   }
 
   configureTensorRTInputs(num_voxels, num_points);

--- a/perception/autoware_bevfusion/lib/preprocess/sparse_rulebook_precompute.cu
+++ b/perception/autoware_bevfusion/lib/preprocess/sparse_rulebook_precompute.cu
@@ -1,0 +1,285 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/bevfusion/preprocess/sparse_rulebook_precompute.hpp"
+
+#include <autoware/cuda_utils/cuda_check_error.hpp>
+
+// spconv (same headers the GetIndicePairsImplicitGemm plugin uses). cSpell:ignore spconvlib
+#include <spconvlib/spconv/csrc/sparse/all/SpconvOps.h>
+#include <spconvlib/spconv/csrc/sparse/alloc/StaticAllocator.h>
+
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+namespace autoware::bevfusion
+{
+
+namespace
+{
+using SpconvOps = spconvlib::spconv::csrc::sparse::all::SpconvOps;
+using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
+
+// kMaskImplicitGemm (matches the exported GetIndicePairsImplicitGemm ``algo`` attribute = 1).
+constexpr int kAlgo = 1;
+// mask_count: 1 for kMaskImplicitGemm (split-mask would be 2). pair_mask / mask_argsort are [1, N].
+constexpr int kMaskCount = 1;
+// do_sort: pair-mask argsort. Validated equivalent with sort on; output numerics are independent of
+// the argsort ordering (it only schedules the masked gemm). Kept on to match the Python reference.
+constexpr bool kDoSort = true;
+constexpr std::size_t kThrustTempBytes = 8U * 1024U * 1024U;
+
+// coors_d[num_in, cols] -> out[num_in, 4] = [batch=0, s0, s1, s2] with s_j = src[perm_j]: the
+// graph's `coors` spatial columns reordered into the column order the convolutions were exported
+// with. cols == 4 : input is already [batch, ...] in that order and is copied verbatim.
+__global__ void buildBatchedCoordsKernel(
+  const std::int32_t * __restrict__ in, std::int32_t * __restrict__ out, int num_in, int cols,
+  int perm0, int perm1, int perm2)
+{
+  const int r = blockIdx.x * blockDim.x + threadIdx.x;
+  if (r >= num_in) {
+    return;
+  }
+  const std::int32_t * src = in + static_cast<std::int64_t>(r) * cols;
+  std::int32_t * dst = out + static_cast<std::int64_t>(r) * 4;
+  if (cols == 4) {
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
+    return;
+  }
+  // cols == 3
+  dst[0] = 0;  // batch
+  dst[1] = src[perm0];
+  dst[2] = src[perm1];
+  dst[3] = src[perm2];
+}
+
+bool useInt64HashK(
+  const std::vector<int> & spatial, const std::vector<int> & ksize, const std::vector<int> & stride,
+  const std::vector<int> & padding, const std::vector<int> & dilation)
+{
+  auto out_dims = SpconvOps::get_conv_output_size(spatial, ksize, stride, padding, dilation);
+  std::int64_t vol = std::accumulate(
+    out_dims.begin(), out_dims.end(), static_cast<std::int64_t>(1),
+    std::multiplies<std::int64_t>());
+  return vol >= static_cast<std::int64_t>(std::numeric_limits<int>::max());
+}
+}  // namespace
+
+SparseRulebookPrecompute::SparseRulebookPrecompute(
+  int out_indices_num_limit, std::vector<SparseDownsampleStage> stages, cudaStream_t stream)
+: out_indices_num_limit_(out_indices_num_limit), stages_(std::move(stages)), stream_(stream)
+{
+  for (auto & s : stages_) {
+    if (s.kernel_volume == 0) {
+      s.kernel_volume = std::accumulate(s.ksize.begin(), s.ksize.end(), 1, std::multiplies<int>());
+    }
+  }
+  stage_counts_.assign(stages_.size(), 0);
+  allocateStageBuffers();
+}
+
+void SparseRulebookPrecompute::allocateStageBuffers()
+{
+  const int N = out_indices_num_limit_;
+
+  int max_kv = 0;
+  bool any_int64_hash = false;
+  // Worst-case max_act_out_in_theory over all stages at the maximum input count (N). Each runtime
+  // stage uses num_in <= N, so this bounds the largest workspace any stage can carve. Stored as a
+  // member and reused by computeStage() every frame so the workspace layout/offsets are frame-
+  // invariant (no per-frame get_handcrafted_max_act_out()).
+  max_act_out_theory_worst_ = 0;
+  for (const auto & s : stages_) {
+    max_act_out_theory_worst_ = std::max(
+      max_act_out_theory_worst_,
+      SpconvOps::get_handcrafted_max_act_out(
+        static_cast<std::size_t>(N), s.ksize, s.stride, s.padding, s.dilation));
+  }
+  const int max_act_out_theory = max_act_out_theory_worst_;
+  for (const auto & s : stages_) {
+    max_kv = std::max(max_kv, s.kernel_volume);
+    any_int64_hash =
+      any_int64_hash || useInt64HashK(s.spatial_shape, s.ksize, s.stride, s.padding, s.dilation);
+
+    out_indices_d_.emplace_back(
+      autoware::cuda_utils::make_unique<std::int32_t[]>(static_cast<std::size_t>(N) * 4));
+    pair_fwd_d_.emplace_back(
+      autoware::cuda_utils::make_unique<std::int32_t[]>(
+        static_cast<std::size_t>(s.kernel_volume) * N));
+    pair_mask_d_.emplace_back(
+      autoware::cuda_utils::make_unique<std::int32_t[]>(static_cast<std::size_t>(kMaskCount) * N));
+    mask_argsort_d_.emplace_back(
+      autoware::cuda_utils::make_unique<std::int32_t[]>(static_cast<std::size_t>(kMaskCount) * N));
+  }
+
+  coords_xyzb_d_ =
+    autoware::cuda_utils::make_unique<std::int32_t[]>(static_cast<std::size_t>(N) * 4);
+
+  // Workspace layout mirrors get_indices_pairs_implicit_gemm_plugin.cpp (non-subm):
+  //   [ spconv index-gen workspace ]
+  //   [ indices_kernel_num : KV int32 ]
+  //   [ pair_bwd           : KV * N int32 ]
+  //   [ pair_mask_bwd      : mask_count * N int32 ]
+  //   [ mask_argsort_bwd   : mask_count * N int32 ]
+  //   [ thrust_tmp         : kThrustTempBytes ]
+  // Sized for the largest stage (max kernel_volume) and reused across stages.
+  const bool use_direct_table = true;  // non-subm
+  std::size_t spconv_ws = static_cast<std::size_t>(SpconvOps::get_indice_gen_workspace_size(
+    max_kv, N, N, max_act_out_theory, /*is_subm=*/false, any_int64_hash, use_direct_table));
+  std::size_t sz = spconv_ws;
+  sz += static_cast<std::size_t>(max_kv) * sizeof(std::int32_t);          // indices_kernel_num
+  sz += static_cast<std::size_t>(max_kv) * N * sizeof(std::int32_t);      // pair_bwd
+  sz += static_cast<std::size_t>(kMaskCount) * N * sizeof(std::int32_t);  // pair_mask_bwd
+  sz += static_cast<std::size_t>(kMaskCount) * N * sizeof(std::int32_t);  // mask_argsort_bwd
+  sz += kThrustTempBytes;
+
+  spconv_workspace_size_ = sz;
+  spconv_workspace_d_ = autoware::cuda_utils::make_unique<std::uint8_t[]>(sz);
+}
+
+int SparseRulebookPrecompute::computeStage(int i, const std::int32_t * coords_in_d, int num_in)
+{
+  const SparseDownsampleStage & s = stages_[i];
+  const int N = out_indices_num_limit_;
+  const int kv = s.kernel_volume;
+
+  std::vector<int> ksize = s.ksize, stride = s.stride, padding = s.padding, dilation = s.dilation;
+  std::vector<int> input_dims = s.spatial_shape;
+  const bool use_direct_table = true;
+  const bool use_int64_hash_k = useInt64HashK(s.spatial_shape, ksize, stride, padding, dilation);
+
+  // max_act_out_in_theory sizes the internal indice_pairs_uniq buffer (~max_act_out_in_theory
+  // * 1.1). Using N here (as the earliest code did) under-allocates for the large down-sample
+  // stages and trips the StaticAllocator "tensor size too small" assert. The plugin derives it from
+  // the per-call input count; we instead reuse the frame-invariant worst case (max over stages at
+  // the N upper bound, computed once in allocateStageBuffers). Since num_in <= N and
+  // get_handcrafted_max_act_out is non-decreasing in the input count, this always bounds the
+  // per-frame need, while keeping the workspace carving/offsets identical every frame (no per-frame
+  // get_handcrafted_max_act_out()).
+  const int max_act_out_theory = max_act_out_theory_worst_;
+
+  // Carve the workspace exactly like the plugin.
+  std::uint8_t * ws = spconv_workspace_d_.get();
+  std::size_t spconv_ws_size = static_cast<std::size_t>(SpconvOps::get_indice_gen_workspace_size(
+    kv, N, N, max_act_out_theory, /*is_subm=*/false, use_int64_hash_k, use_direct_table));
+
+  auto ws_tensors = SpconvOps::get_indice_gen_tensors_from_workspace(
+    ws, kv, N, N, max_act_out_theory, /*is_subm=*/false, use_int64_hash_k, use_direct_table);
+
+  std::uint8_t * indice_num_ptr = ws + spconv_ws_size;
+  tv::Tensor indices_kernel_num = tv::from_blob(indice_num_ptr, {kv}, tv::int32, 0);
+  CHECK_CUDA_ERROR(cudaMemsetAsync(
+    indice_num_ptr, 0, static_cast<std::size_t>(kv) * sizeof(std::int32_t), stream_));
+
+  std::uint8_t * extra = indice_num_ptr + static_cast<std::size_t>(kv) * sizeof(std::int32_t);
+  tv::Tensor pair_bwd = tv::from_blob(extra, {kv, N}, tv::int32, 0);
+  extra += static_cast<std::size_t>(kv) * N * sizeof(std::int32_t);
+  tv::Tensor pair_mask_bwd = tv::from_blob(extra, {kMaskCount, N}, tv::int32, 0);
+  extra += static_cast<std::size_t>(kMaskCount) * N * sizeof(std::int32_t);
+  tv::Tensor mask_argsort_bwd = tv::from_blob(extra, {kMaskCount, N}, tv::int32, 0);
+  extra += static_cast<std::size_t>(kMaskCount) * N * sizeof(std::int32_t);
+  tv::Tensor thrust_tmp =
+    tv::from_blob(extra, {static_cast<std::int64_t>(kThrustTempBytes)}, tv::uint8, 0);
+
+  // Outputs go to our stable per-stage buffers (= the engine input tensors). spconv writes each
+  // forward tensor densely into the first num_act_out columns (stride num_act_out, not N), so the
+  // engine binds the matching dense [.., n] prefix directly — no repacking needed.
+  tv::Tensor out_indices = tv::from_blob(out_indices_d_[i].get(), {N, 4}, tv::int32, 0);
+  tv::Tensor pair_fwd = tv::from_blob(pair_fwd_d_[i].get(), {kv, N}, tv::int32, 0);
+  tv::Tensor pair_mask_fwd = tv::from_blob(pair_mask_d_[i].get(), {kMaskCount, N}, tv::int32, 0);
+  tv::Tensor mask_argsort_fwd =
+    tv::from_blob(mask_argsort_d_[i].get(), {kMaskCount, N}, tv::int32, 0);
+
+  tv::Tensor input_indices =
+    tv::from_blob(const_cast<std::int32_t *>(coords_in_d), {num_in, 4}, tv::int32, 0);
+
+  ws_tensors.emplace(SPCONV_ALLOC_PAIR_FWD, pair_fwd);
+  ws_tensors.emplace(SPCONV_ALLOC_PAIR_BWD, pair_bwd);
+  ws_tensors.emplace(SPCONV_ALLOC_PAIR_MASK, pair_mask_fwd);
+  ws_tensors.emplace(SPCONV_ALLOC_PAIR_MASK_BWD, pair_mask_bwd);
+  ws_tensors.emplace(SPCONV_ALLOC_MASK_ARG_SORT, mask_argsort_fwd);
+  ws_tensors.emplace(SPCONV_ALLOC_MASK_ARG_SORT_BWD, mask_argsort_bwd);
+  ws_tensors.emplace(SPCONV_ALLOC_OUT_INDICES, out_indices);
+  ws_tensors.emplace(SPCONV_ALLOC_INDICE_NUM_PER_LOC, indices_kernel_num);  // cSpell:ignore INDICE
+
+  StaticAllocator alloc(ws_tensors);
+  alloc.thrust_tmp_tensor_ = thrust_tmp;
+
+  // cSpell:ignore indice
+  auto pair_res = SpconvOps::get_indice_pairs_implicit_gemm(
+    alloc, input_indices, /*batch_size=*/1, input_dims, kAlgo, ksize, stride, padding, dilation,
+    {0, 0, 0}, /*subm=*/false, /*transpose=*/false, /*is_train=*/false,
+    reinterpret_cast<std::uintptr_t>(stream_), N, tv::CUDAKernelTimer(false), use_direct_table,
+    kDoSort);
+
+  // num_act_out (host int; spconv performs the single D2H here).
+  return std::get<1>(pair_res);
+}
+
+void SparseRulebookPrecompute::compute(
+  const std::int32_t * coors_d, int num_in, int coors_cols,
+  const std::array<int, 3> & coors_permutation)
+{
+  if (num_in <= 0 || num_in > out_indices_num_limit_) {
+    throw std::runtime_error(
+      "SparseRulebookPrecompute: num_in (" + std::to_string(num_in) + ") out of (0, " +
+      std::to_string(out_indices_num_limit_) + "]");
+  }
+  if (coors_cols != 3 && coors_cols != 4) {
+    throw std::runtime_error(
+      "SparseRulebookPrecompute: coors_cols must be 3 (spatial coords) or 4 ([batch, ...])");
+  }
+  for (const int column : coors_permutation) {
+    if (column < 0 || column >= 3) {
+      throw std::runtime_error(
+        "SparseRulebookPrecompute: coors_permutation entries must index the 3 spatial columns");
+    }
+  }
+
+  // Build [batch, *spatial] int32 coords in the convolutions' column order for the first stage.
+  const int block = 256;
+  const int grid = (num_in + block - 1) / block;
+  buildBatchedCoordsKernel<<<grid, block, 0, stream_>>>(
+    coors_d, coords_xyzb_d_.get(), num_in, coors_cols, coors_permutation[0], coors_permutation[1],
+    coors_permutation[2]);
+  CHECK_CUDA_ERROR(cudaGetLastError());
+
+  // Cascade: each down-sample's out_indices feed the next (submanifold layers in between do not
+  // change coordinates, so they are not part of this cascade — they stay in the TRT graph).
+  const std::int32_t * cur_coords = coords_xyzb_d_.get();
+  int cur_num = num_in;
+  for (int i = 0; i < static_cast<int>(stages_.size()); ++i) {
+    const int n_out = computeStage(i, cur_coords, cur_num);
+    // n_out feeds the next stage and is bound as the engine input shape, so it must stay within
+    // the buffer / TRT-profile bound. spconv caps it at out_indices_num_limit_; guard anyway.
+    if (n_out <= 0 || n_out > out_indices_num_limit_) {
+      throw std::runtime_error(
+        "SparseRulebookPrecompute: stage " + std::to_string(i) + " produced " +
+        std::to_string(n_out) + " active voxels (expected within (0, " +
+        std::to_string(out_indices_num_limit_) + "])");
+    }
+    stage_counts_[i] = n_out;
+    cur_coords = out_indices_d_[i].get();  // [n_out, 4]
+    cur_num = n_out;
+  }
+}
+
+}  // namespace autoware::bevfusion

--- a/perception/autoware_bevfusion/package.xml
+++ b/perception/autoware_bevfusion/package.xml
@@ -9,6 +9,7 @@
   <maintainer email="kotaro.uetake@tier4.jp">Kotaro Uetake</maintainer>
   <maintainer email="masato.saeki@tier4.jp">Masato Saeki</maintainer>
   <maintainer email="kokseang.tan@tier4.jp">Kok Seang Tan</maintainer>
+  <maintainer email="yihsiang.fang@tier4.jp">Yi-Hsiang Fang</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
@@ -28,6 +29,7 @@
   <depend>cuda_blackboard</depend>
   <depend>image_transport</depend>
   <depend>launch_ros</depend>
+  <depend>nlohmann-json-dev</depend>
   <depend>pcl_ros</depend>
   <depend>perception_utils</depend>
   <depend>rclcpp</depend>

--- a/perception/autoware_bevfusion/schema/ml_package_bevfusion.schema.json
+++ b/perception/autoware_bevfusion/schema/ml_package_bevfusion.schema.json
@@ -173,6 +173,11 @@
           "type": "boolean",
           "description": "Whether to use intensity feature in point cloud processing.",
           "default": true
+        },
+        "sparse_remove_trainstation": {
+          "type": "boolean",
+          "description": "Enable only with a sparse engine exported with the 4 down-sample GetIndicePairsImplicitGemm nodes removed (trainStation/DDS removal). The runtime precomputes those rulebooks from the voxel coordinates and binds them as graph inputs.",
+          "default": false
         }
       },
       "required": [

--- a/perception/autoware_bevfusion/src/bevfusion_node.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node.cpp
@@ -183,6 +183,11 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
 
   sensor_fusion_ = config.sensor_fusion_;
 
+  // trainStation/DDS removal: enable when the sparse engine was exported with the 4 down-sample
+  // GetIndicePairsImplicitGemm nodes removed (rulebooks precomputed + bound at runtime).
+  config.sparse_remove_trainstation_ =
+    this->declare_parameter<bool>("sparse_remove_trainstation", false, descriptor);
+
   use_compressed_images_ =
     this->declare_parameter<bool>("use_compressed_images", false, descriptor);
   const auto run_image_undistortion =


### PR DESCRIPTION
## Description

A sparse convolution runs in two steps: `GetIndicePairsImplicitGemm` builds the *rulebook* (which input voxel feeds which output voxel, per kernel offset), then `ImplicitGemm` does the arithmetic. For a submanifold layer the output voxel set equals the input set, so the rulebook's shape is known before it runs. For a **down-sampling** layer the output voxel set is new and its size is only known once the kernel has run — a data-dependent shape. TensorRT handles that by copying the size back to the host and waiting for it before it can schedule what follows: the `[trainStation1..6]` regions in the engine's layer list, measured at **0.83 ms of pure stall per frame — 23% of this model's sparse engine** — for its four down-sampling layers.

The rulebook chain is a pure function of the voxel coordinates: nothing in it depends on features, weights or precision. So `SparseRulebookPrecompute` rebuilds the four rulebooks from the frame's voxel coordinates before the engine runs and binds them as 16 graph inputs (`rulebook/<indice_key>/{out_indices, pair_fwd, pair_mask, mask_argsort}`). A graph exported that way carries no `GetIndicePairsImplicitGemm` node for those layers, and therefore no data-dependent shape. The submanifold layers keep generating their own rulebooks: they have no dynamic shape to remove, and moving them would only relocate the work.

The geometry to rebuild from travels **inside the ONNX**. The loader reads `metadata_props` for

- `rulebook_stages` — per-stage kernel geometry and input spatial shape, and
- `rulebook_coors_permutation` — for each convolution spatial column, the `coors` column it is read from,

so the runtime does not hard-code the coordinate order the model was exported with. That second key matters more than it looks: a rulebook built on the wrong column order is a perfectly valid rulebook *for a transposed BEV grid*, so the engine runs and the detections are quietly wrong. Exports that predate the key fall back to the previous `sparse_coors_is_zyx` behaviour.

**Opt-in, default off.** The new `sparse_remove_trainstation` parameter (default `false`) gates the whole path; every entry point returns early while the precompute object is not constructed, so a node that does not set it behaves byte for byte as today. Enabling it against an engine whose ONNX has no rulebook metadata fails at construction with a message telling the operator to re-export, rather than silently binding nothing.

### Exported ONNX, before → after

The matching exporter change (TIER IV's `autoware-ml`, BEVFusion sparse stage; AWML's `spconv_remove_trainstation=True` does the same) produces:

| | before | after |
| --- | ---: | ---: |
| nodes | 160 | 156 |
| `GetIndicePairsImplicitGemm` | 8 | **4** (only the submanifold ones) |
| graph inputs | 3 | **19** |
| `metadata_props` | — | `+rulebook_stages`, `+rulebook_coors_permutation` |

```text
rulebook/spconv1/out_indices   INT32[spconv1_num, 4]
rulebook/spconv1/pair_fwd      INT32[27, spconv1_num]
rulebook/spconv1/pair_mask     INT32[spconv1_num, 1]
rulebook/spconv1/mask_argsort  INT32[spconv1_num]
rulebook/spconv2/…             (the same four, per stage: spconv1, spconv2, spconv3, conv_out)
```

### What it buys (engine-side, measured through the exporter's evaluation chain)

100 frames, TensorRT 10.8, RTX PRO 6000 Blackwell, an internal LiDAR dataset (120 m range, 0.17 m voxels):

| | sparse engine | dense | graphs | mAP |
| --- | ---: | ---: | ---: | ---: |
| FP16 | 4.015 ms | 1.776 | 5.791 | 0.4512 |
| **FP16 + precomputed rulebooks** | **2.211 ms** | 1.739 | **3.949** | 0.4513 |

Inside the engine (`IProfiler`, same engines):

| | pair_gen (submanifold) | pair_gen (down-sampling) | `[trainStation]` | GEMM | rest | total |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| FP16 | 0.546 | 0.550 | **0.831 (6 regions)** | 1.510 | 0.248 | 3.686 |
| FP16 + rulebook | 0.507 | **0** | **0 (0 regions)** | 1.498 | 0.228 | 2.234 |

The engine loses 1.80 ms (−45%), more than the 1.38 ms the profiled numbers predicted: a profiler serializes the enqueue path, so it only sees the synchronization itself, and once the stall is gone TensorRT can also pipeline the kernels that followed it. GEMM, submanifold pair generation and everything else are unchanged — what disappears is exactly the down-sampling pair generation plus the stall. mAP is unchanged (0.4512 → 0.4513).

**The work moves rather than vanishing**, and this PR is the side where it is cheap: on the exporter's Python evaluation chain the precompute costs 1.7 ms of wall clock (only 0.64 ms of it GPU kernels, the rest Python, synchronizations and the allocator), which cancels the engine's gain; here it is those kernels plus four host reads, so the expected net is ≈ −1.1 ms/frame on the sparse stage. **That last number is an expectation, not a measurement** — see below.

## Related links

**Parent Issue:**

- None.

Builds on #12658 (fused bias/activation in `ImplicitGemmPlugin`) and the sparse-encoder export path already used by this node.

Independent of #13369 (INT8 precision in `ImplicitGemmPlugin`), which is in flight for the same sparse stack: the two touch different packages and either can land first. The rulebook precompute is precision-agnostic — it was measured with both FP16 and INT8 sparse engines and removes the same 1.80 ms in each.

## How was this PR tested?

- **Compiles** against current `main`: `nvcc -std=c++17 -arch=sm_120 -DTV_CUDA` on the new `sparse_rulebook_precompute.cu` (the package already builds against `spconvlib` in `preprocess_kernel.cu`, so the only new dependency is `nlohmann_json`, declared in `package.xml` and `CMakeLists.txt`); `cpplint` and `clang-format` clean.
- **The contract it implements** was validated on the exporter side: the same 16 inputs and the same two metadata keys, with an engine-inspector comparison showing 135 → 125 layers and 6 → 0 `[trainStation]` regions, and `max abs diff = 0.0088` (FP16 level) against the unmodified graph on identical inputs. The engine numbers above come from that chain.
- **Not run on a vehicle**, and no shipped configuration sets `sparse_remove_trainstation`, so the default path is what CI and the vehicle exercise today. The on-device figure to watch when it is enabled is `debug/processing_time/preprocess_ms` against `inference_ms`.

## Notes for reviewers

- The parameter is deliberately opt-in rather than auto-detected from the ONNX metadata: enabling it changes which tensors the engine expects, so engine and parameter have to be rolled out together, and a mismatch should be loud.
- `rulebook_coors_permutation` is the subtle part. Please read `load_rulebook_metadata()` and the fallback for exports that predate the key — that fallback is what keeps existing engines working.
- `SparseRulebookPrecompute` owns stable device buffers sized by `sparse_out_indices_num_limit`, so the addresses can be bound once and only the per-stage shapes change per frame.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:---|:---|:---|:---|:---|
| Added | `sparse_remove_trainstation` | `bool` | `false` | Enable only with a sparse engine exported with the four down-sampling `GetIndicePairsImplicitGemm` nodes removed; the runtime precomputes those rulebooks and binds them as graph inputs. |

No topic changes. The engine's input set changes only when the parameter is enabled, and then it is determined by the ONNX the operator supplies.

## Effects on system behavior

None by default: `sparse_remove_trainstation` defaults to `false` and every code path added here is behind it. With it enabled and a matching engine, the sparse stage's latency drops (see the table) and outputs are equivalent at FP16 rounding level; with it enabled and a non-matching engine, construction fails with an explicit re-export message instead of running with unbound inputs.
