### PR TITLE
fix(autoware_carla_interface): publish the ego pose at base_link instead of the vehicle center

### DIFF
--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -698,6 +698,9 @@ class carla_ros2_interface(object):
             origin_x=origin_x,
             origin_y=origin_y,
         )
+        location = carla.Location(x=self.sensor_loader.wheelbase / 2.0)
+        carla_pose_transform.transform(location)
+        carla_pose_transform.location = location
 
         # RViz's 2D Pose Estimate only carries x/y/yaw (z is always 0), so the
         # map-frame z is meaningless here. When spawn_point_ground_snap is
@@ -724,6 +727,13 @@ class carla_ros2_interface(object):
             else:
                 self.logger.warning("Cannot set initial pose: ego vehicle not available")
 
+    def _ego_base_link_transform(self):
+        """Return the ego transform at base_link (rear axle), wheelbase/2 behind the actor origin."""
+        transform = self.ego_actor.get_transform()
+        location = carla.Location(x=-self.sensor_loader.wheelbase / 2.0)
+        transform.transform(location)
+        return carla.Transform(location, transform.rotation)
+
     def pose(self):
         """Transform odometry data to Pose and publish with covariance (thread-safe)."""
         if self.checkFrequency("pose"):
@@ -749,7 +759,7 @@ class carla_ros2_interface(object):
         with self._state_lock:
             if not self.ego_actor:
                 return
-            ego_transform = self.ego_actor.get_transform()
+            ego_transform = self._ego_base_link_transform()
 
         origin_x, origin_y = self._current_map_origin()
         pose_carla.position = carla_location_to_ros_point(
@@ -1348,7 +1358,7 @@ class carla_ros2_interface(object):
         with self._state_lock:
             if not self.ego_actor:
                 return
-            ego_transform = self.ego_actor.get_transform()
+            ego_transform = self._ego_base_link_transform()
             ego_vel = self.ego_actor.get_velocity()
             ego_ang_vel = self.ego_actor.get_angular_velocity()
 


### PR DESCRIPTION
## Description

`SensorKitLoader` places every sensor `wheelbase / 2` behind its `base_link` calibration (it subtracts `wheelbase / 2` from x before spawning), so in this bridge `base_link` is the rear axle and the CARLA actor origin is the vehicle center, `wheelbase / 2` ahead of it. The GNSS pose, the ground truth localization (`publish_ground_truth_localization`) and the RViz initial pose still used the actor origin as `base_link`, which put the ego 1.425 m (with the default wheelbase) ahead of its sensors and of every other actor.

This applies the same wheelbase offset in those three places, using the value the sensor loader already reads from the sensor mapping (`vehicle_config.wheelbase`, default 2.85 m), so the published poses stay consistent with the sensor placement.

## Related links

**Parent Issue:**

- None.

**Related:**

- The `carla_sensor_kit` calibration is authored the same way (`x_base = x_car_center + 1.425 (WB=2.850 m)`): https://github.com/autowarefoundation/autoware_launch/blob/main/sensor_kit/carla_sensor_kit_launch/carla_sensor_kit_description/config/sensor_kit_calibration.yaml
- #13321 provided the surrounding vehicles used as the reference in the test below.

## How was this PR tested?

`colcon build --packages-select autoware_carla_interface --symlink-install` and pre-commit pass.

Run against a live CARLA 0.9.16 server on Town01 with `planning_simulator.launch.xml` and this bridge, localization replaced by the package's `carla_state_publisher` (GNSS pose to `/localization/kinematic_state`, no NDT), and the ground truth objects of #13321 as the reference. Compared with the rear axle that CARLA reports through the wheel physics, `base_link` moved from 1.40 m ahead of it to 0.03 m behind it (mostly the default wheelbase against the Prius's 2.82 m). A vehicle placed right beside the ego is drawn beside it in RViz after the change and 1.4 m behind it before; driving to a goal 200 m away behaved the same. A video is attached.

## Notes for reviewers

The offset reuses the sensor loader's wheelbase on purpose: the `carla_sensor_kit` calibration is authored against WB = 2.85 m, so the poses have to use the same number as the sensors; `vehicle_info.wheel_base` (2.79 m for `sample_vehicle`) and the CARLA physics wheelbase differ from it.

The RViz initial pose is converted the other way, so a 2D Pose Estimate now puts `base_link` on the clicked point. `spawn_point` still places the actor origin, and the twist is still the actor origin's velocity.

## Interface changes

None.

## Effects on system behavior

With `publish_ground_truth_localization` (the E2E planning setup) the ego localization moves from the vehicle center to the rear axle, 1.425 m backward with the default wheelbase; a setup that compensated for the old offset elsewhere, for example in its goal or spawn positions, will see that compensation become an error. `spawn_point` keeps placing the actor origin, so `base_link` now starts `wheelbase / 2` behind the given coordinates.

With NDT localization the estimated pose does not change: the GNSS pose only seeds the initialization, and a 2D Pose Estimate now lands `base_link` on the clicked point instead of 1.4 m behind it. Any consumer that takes the GNSS pose as `base_link` gets the corrected pose, for example the package's `carla_state_publisher` (not started by the shipped launch files) or external tools that read `/sensing/gnss/pose_with_covariance`.

## AI assistance

I used Claude Opus 5 / Fable 5 to check, modify, and review the code.
I have personally reviewed the entire content of this PR.

https://github.com/user-attachments/assets/f78d5165-ce6f-47ab-891d-fea1b072847f