### PR TITLE
feat(crosswalk_filter): port crosswalk filter improvements

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -24,11 +24,15 @@
       lat_detection_margin: 1.0 # [m] lateral extrusion length from crosswalk edge
       object_clear_time_th: 0.3 # [s] duration threshold to clear target object when no longer seen
       overshoot_tolerance: 0.1  # [m] maximum overshoot distance allowed to consider the trajectory feasible
-      nominal_deceleration: 1.0 # [m/s^2] nominal deceleration to calculate the stop distance used as trajectory length limit
-      nominal_jerk: 1.0 # [m/s^3] nominal jerk to calculate the stop distance used as trajectory length limit
       stop_duration: 3.0 # [s] minimum duration of the stop to consider the trajectory feasible
       arrived_distance_threshold: 5.0 # [m] threshold to check if the ego vehicle has arrived at crosswalk stop line
       use_trajectory_time: false # [bool] whether to use the embedded trajectory time to evaluate the stop duration
+      stopping_params:
+        nominal_decel: 1.0 # [m/s^2] nominal deceleration to calculate the stop distance used as trajectory length limit
+        nominal_jerk: 1.0 # [m/s^3] nominal jerk to calculate the stop distance used as trajectory length limit
+        decel_limit: 2.0 # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
+        jerk_limit: 2.0 # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
+        delay_response_time: 0.5 # [s] delay response time used to estimate the minimum ego stopping distance
 
     traffic_light:
       deceleration_limit: 2.8  # [m/s^2] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/crosswalk_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/crosswalk_filter.hpp
@@ -25,6 +25,7 @@
 #include <autoware_internal_planning_msgs/msg/safety_factor_array.hpp>
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 
+#include <array>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -57,14 +58,18 @@ struct TargetCrosswalk
   CrosswalkOnTrajectory crosswalk_info;
   lanelet::BasicPolygon2d crosswalk_polygon;
   lanelet::BasicPolygons2d detection_areas;
+  /// Sidewalk-side entry edges (left↔right at each end of the crosswalk lanelet).
+  std::array<lanelet::BasicSegment2d, 2> entry_edges;
   bool is_crossing{false};
 
   TargetCrosswalk(
     const CrosswalkOnTrajectory & crosswalk_info, const lanelet::BasicPolygon2d & crosswalk_polygon,
-    const lanelet::BasicPolygons2d & detection_areas, const bool is_crossing)
+    const lanelet::BasicPolygons2d & detection_areas,
+    const std::array<lanelet::BasicSegment2d, 2> & entry_edges, const bool is_crossing)
   : crosswalk_info(crosswalk_info),
     crosswalk_polygon(crosswalk_polygon),
     detection_areas(detection_areas),
+    entry_edges(entry_edges),
     is_crossing(is_crossing)
   {
   }

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/crosswalk_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/crosswalk_filter.hpp
@@ -147,6 +147,14 @@ private:
   std::unordered_map<lanelet::Id, TargetObjects> crosswalk_objects_map_;
   std::unordered_set<ObjectClassification::_label_type> object_types_;
 
+  struct StoppingDistance
+  {
+    std::optional<double> nominal;
+    std::optional<double> minimum;
+  } stopping_distance_;
+
+  std::optional<rclcpp::Time> last_frame_time_;
+
   TargetCrosswalks get_target_crosswalks(
     const TrajectoryPoints & traj_points, const FilterContext & context);
 
@@ -156,6 +164,8 @@ private:
   bool is_obstructing_crosswalk(
     const TrajectoryPoints & traj_points, const TargetCrosswalk & target_crosswalk,
     SafetyFactorArray & safety_factors) const;
+
+  RiskLevel::_level_type get_risk_level(const double arc_length_to_stop_line) const;
 
   void update_debug_data(
     const TrajectoryPoints & traj_points, const TargetCrosswalks & target_crosswalks,

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -69,16 +69,6 @@ validator:
       default_value: 0.1
       description: maximum overshoot distance allowed to consider the trajectory feasible (m)
       read_only: false
-    nominal_deceleration:
-      type: double
-      default_value: 1.0
-      description: nominal deceleration to calculate the stop distance used as trajectory length limit (m/s^2)
-      read_only: false
-    nominal_jerk:
-      type: double
-      default_value: 1.0
-      description: nominal jerk to calculate the stop distance used as trajectory length limit (m/s^3)
-      read_only: false
     stop_duration:
       type: double
       default_value: 3.0
@@ -94,6 +84,32 @@ validator:
       default_value: false
       description: whether to use the embedded trajectory time to evaluate the stop duration
       read_only: false
+    stopping_params:
+      nominal_decel:
+        type: double
+        default_value: 1.0
+        description: nominal deceleration to calculate the stop distance used as trajectory length limit (m/s^2)
+        read_only: false
+      nominal_jerk:
+        type: double
+        default_value: 1.0
+        description: nominal jerk to calculate the stop distance used as trajectory length limit (m/s^3)
+        read_only: false
+      decel_limit:
+        type: double
+        default_value: 2.0
+        description: deceleration limit to calculate the stop distance used as trajectory length limit (m/s^2)
+        read_only: false
+      jerk_limit:
+        type: double
+        default_value: 2.0
+        description: jerk limit to calculate the stop distance used as trajectory length limit (m/s^3)
+        read_only: false
+      delay_response_time:
+        type: double
+        default_value: 0.5
+        description: delay response time used to estimate the minimum ego stopping distance (s)
+        read_only: false
 
   traffic_light:
     deceleration_limit:

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -94,18 +94,6 @@
               "default": 0.1,
               "minimum": 0.0
             },
-            "nominal_deceleration": {
-              "type": "number",
-              "description": "Nominal deceleration to calculate the stop distance used as trajectory length limit [m/s²].",
-              "default": 1.0,
-              "minimum": 0.0
-            },
-            "nominal_jerk": {
-              "type": "number",
-              "description": "Nominal jerk to calculate the stop distance used as trajectory length limit [m/s³].",
-              "default": 1.0,
-              "minimum": 0.0
-            },
             "stop_duration": {
               "type": "number",
               "description": "Minimum duration of the stop to consider the trajectory feasible [s].",
@@ -122,6 +110,39 @@
               "type": "boolean",
               "description": "Whether to use the embedded trajectory time to evaluate the stop duration.",
               "default": false
+            },
+            "stopping_params": {
+              "type": "object",
+              "properties": {
+                "nominal_decel": {
+                  "type": "number",
+                  "description": "Nominal deceleration to calculate the stop distance used as trajectory length limit [m/s²].",
+                  "default": 1.0
+                },
+                "nominal_jerk": {
+                  "type": "number",
+                  "description": "Nominal jerk to calculate the stop distance used as trajectory length limit [m/s³].",
+                  "default": 1.0
+                },
+                "decel_limit": {
+                  "type": "number",
+                  "description": "Deceleration limit to calculate the stop distance used as trajectory length limit [m/s²].",
+                  "default": 2.0
+                },
+                "jerk_limit": {
+                  "type": "number",
+                  "description": "Jerk limit to calculate the stop distance used as trajectory length limit [m/s³].",
+                  "default": 2.0
+                },
+                "delay_response_time": {
+                  "type": "number",
+                  "description": "Delay response time used to estimate the minimum ego stopping distance [s].",
+                  "default": 0.5,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
             }
           },
           "required": [],

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/crosswalk_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/crosswalk_filter.cpp
@@ -33,8 +33,10 @@
 
 #include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_core/geometry/Polygon.h>
+#include <tf2/utils.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <functional>
 #include <limits>
@@ -47,7 +49,9 @@
 
 namespace
 {
+using autoware::trajectory_validator::plugin::traffic_rule::TargetCrosswalk;
 using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
 using autoware_utils_geometry::Line2d;
 
 ObjectClassification::_label_type to_classification_label(const std::string & label_str)
@@ -200,6 +204,97 @@ std::vector<CrosswalkOnTrajectory> filter_crosswalks_intersecting_trajectory(
   }
 
   return crosswalks_on_trajectory;
+}
+
+lanelet::BasicPoint2d closest_point_on_segment(
+  const lanelet::BasicPoint2d & point, const lanelet::BasicSegment2d & segment)
+{
+  const auto & p1 = segment.first;
+  const auto & p2 = segment.second;
+  const auto dir = p2 - p1;
+  const double length_sq = dir.squaredNorm();
+  if (length_sq < 1e-12) {
+    return p1;
+  }
+  const double t = std::clamp((point - p1).dot(dir) / length_sq, 0.0, 1.0);
+  return p1 + t * dir;
+}
+
+/// @brief Sidewalk-side entry edges of the crosswalk (left↔right at each end of the lanelet).
+std::array<lanelet::BasicSegment2d, 2> get_crosswalk_entry_edges(
+  const lanelet::CrosswalkConstPtr & crosswalk)
+{
+  const auto & crosswalk_lanelet = crosswalk->crosswalkLanelet();
+  const auto left = crosswalk_lanelet.leftBound2d();
+  const auto right = crosswalk_lanelet.rightBound2d();
+  return {
+    lanelet::BasicSegment2d{left.front().basicPoint2d(), right.front().basicPoint2d()},
+    lanelet::BasicSegment2d{left.back().basicPoint2d(), right.back().basicPoint2d()}};
+}
+
+/// @brief Closest point on either stored crosswalk entry edge to @p point.
+lanelet::BasicPoint2d closest_point_on_crosswalk_entries(
+  const lanelet::BasicPoint2d & point, const std::array<lanelet::BasicSegment2d, 2> & entry_edges)
+{
+  auto closest = closest_point_on_segment(point, entry_edges.front());
+  double min_dist_sq = (closest - point).squaredNorm();
+  for (size_t i = 1; i < entry_edges.size(); ++i) {
+    const auto candidate = closest_point_on_segment(point, entry_edges[i]);
+    const double dist_sq = (candidate - point).squaredNorm();
+    if (dist_sq < min_dist_sq) {
+      min_dist_sq = dist_sq;
+      closest = candidate;
+    }
+  }
+  return closest;
+}
+
+bool is_target_object(const PredictedObject & obj, const TargetCrosswalk & cw)
+{
+  // check if the object is inside the detection areas
+  auto is_inside_detection_areas = [&]() {
+    const auto & obj_position = obj.kinematics.initial_pose_with_covariance.pose.position;
+    lanelet::BasicPoint2d obj_point(obj_position.x, obj_position.y);
+    return std::any_of(
+      cw.detection_areas.begin(), cw.detection_areas.end(),
+      [&](const auto & area) { return lanelet::geometry::distance2d(area, obj_point) < 1e-3; });
+  }();
+  if (!is_inside_detection_areas) return false;
+
+  // check if the object has a high confidence path through the crosswalk
+  static constexpr double confidence_threshold = 0.5;
+  auto has_high_confidence_path = std::any_of(
+    obj.kinematics.predicted_paths.begin(), obj.kinematics.predicted_paths.end(),
+    [&](const auto & path) { return path.confidence >= confidence_threshold; });
+
+  if (has_high_confidence_path) {
+    for (const auto & path : obj.kinematics.predicted_paths) {
+      if (path.confidence < confidence_threshold) continue;
+      for (const auto & p : path.path) {
+        const auto p_point = lanelet::BasicPoint2d(p.position.x, p.position.y);
+        if (!boost::geometry::disjoint(cw.crosswalk_polygon, p_point)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // static objects are always target objects
+  const auto obj_speed = obj.kinematics.initial_twist_with_covariance.twist.linear.x;
+  if (std::abs(obj_speed) < 0.1) return true;
+
+  // check if the object is moving toward the crosswalk
+  const auto & pose = obj.kinematics.initial_pose_with_covariance.pose;
+  const auto & twist = obj.kinematics.initial_twist_with_covariance.twist.linear;
+  const lanelet::BasicPoint2d obj_pos(pose.position.x, pose.position.y);
+
+  const Eigen::Rotation2Dd obj_rot(tf2::getYaw(pose.orientation));
+  const auto obj_vel_vector = obj_rot * Eigen::Vector2d(twist.x, twist.y);
+
+  const auto closest_entry_point = closest_point_on_crosswalk_entries(obj_pos, cw.entry_edges);
+  const auto to_entry = closest_entry_point - obj_pos;
+  return obj_vel_vector.dot(to_entry) > 0.0;
 }
 
 }  // namespace
@@ -358,7 +453,7 @@ std::vector<TargetCrosswalk> CrosswalkFilter::get_target_crosswalks(
     target_crosswalks.emplace_back(
       cw, crosswalk_polygon,
       get_detection_areas(cw.crosswalk, params_.lon_detection_margin, params_.lat_detection_margin),
-      is_crossing);
+      get_crosswalk_entry_edges(cw.crosswalk), is_crossing);
   }
 
   return target_crosswalks;
@@ -435,20 +530,10 @@ void CrosswalkFilter::update_target_objects(
       cw_objects.end());
   };
 
-  auto is_inside_detection_areas =
-    [&](const PredictedObject & obj, const lanelet::BasicPolygons2d & detection_areas) {
-      const auto obj_position = obj.kinematics.initial_pose_with_covariance.pose.position;
-      lanelet::BasicPoint2d obj_point(obj_position.x, obj_position.y);
-      return std::any_of(detection_areas.begin(), detection_areas.end(), [&](const auto & area) {
-        return lanelet::geometry::distance2d(area, obj_point) < 1e-3;
-      });
-    };
-
   for (const auto & cw : target_crosswalks) {
-    auto detection_areas = cw.detection_areas;
     bool is_ego_stopped_at_cw = is_stopped_at_crosswalk(cw);
     for (const auto & object : objects) {
-      if (!is_inside_detection_areas(object, detection_areas)) continue;
+      if (!is_target_object(object, cw)) continue;
       update_object(object, cw.crosswalk_info.crosswalk->id(), is_ego_stopped_at_cw);
     }
     clear_old_objects(cw.crosswalk_info.crosswalk->id());

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/crosswalk_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/crosswalk_filter.cpp
@@ -331,6 +331,26 @@ CrosswalkFilter::result_t CrosswalkFilter::is_feasible(
     return tl::make_unexpected("Route is not available in the context.");
   }
 
+  const auto current_time = rclcpp::Time(context.odometry->header.stamp);
+  if (!last_frame_time_ || *last_frame_time_ != current_time) {
+    stopping_distance_ = StoppingDistance{};
+    last_frame_time_ = current_time;
+  }
+
+  if (!stopping_distance_.nominal) {
+    stopping_distance_.nominal = autoware::motion_utils::calculate_stop_distance(
+      context.odometry->twist.twist.linear.x, context.acceleration->accel.accel.linear.x,
+      params_.stopping_params.nominal_decel, params_.stopping_params.nominal_jerk,
+      params_.stopping_params.delay_response_time);
+  }
+
+  if (!stopping_distance_.minimum) {
+    stopping_distance_.minimum = autoware::motion_utils::calculate_stop_distance(
+      context.odometry->twist.twist.linear.x, context.acceleration->accel.accel.linear.x,
+      params_.stopping_params.decel_limit, params_.stopping_params.jerk_limit,
+      params_.stopping_params.delay_response_time);
+  }
+
   const auto target_crosswalks = get_target_crosswalks(candidate_trajectory.points, context);
 
   std::vector<MetricReport> metrics;
@@ -340,10 +360,12 @@ CrosswalkFilter::result_t CrosswalkFilter::is_feasible(
 
   std::unordered_set<lanelet::Id> obstructing_crosswalk_ids;
   SafetyFactorArray safety_factors;
+  double arc_length_to_stop_line = std::numeric_limits<double>::max();
   const bool feasible =
     std::none_of(target_crosswalks.begin(), target_crosswalks.end(), [&](const auto & cw) {
       if (!is_obstructing_crosswalk(candidate_trajectory.points, cw, safety_factors)) return false;
       obstructing_crosswalk_ids.insert(cw.crosswalk_info.crosswalk->id());
+      arc_length_to_stop_line = cw.crosswalk_info.arc_length_to_stop_line_m;
       return true;
     });
 
@@ -352,7 +374,7 @@ CrosswalkFilter::result_t CrosswalkFilter::is_feasible(
     context.odometry->header.stamp, context.odometry->pose.pose.position.z);
 
   RiskLevel risk_level;
-  risk_level.level = feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
+  risk_level.level = feasible ? RiskLevel::SAFE : get_risk_level(arc_length_to_stop_line);
   metrics.push_back(
     autoware_trajectory_validator::build<MetricReport>()
       .validator_name(get_name())
@@ -382,6 +404,31 @@ CrosswalkFilter::result_t CrosswalkFilter::is_feasible(
   return ValidationResult{feasible, std::move(metrics), std::move(planning_factors)};
 }
 
+RiskLevel::_level_type CrosswalkFilter::get_risk_level(const double arc_length_to_stop_line) const
+{
+  const auto ego_front_to_stop_line =
+    arc_length_to_stop_line - vehicle_info_ptr_->max_longitudinal_offset_m;
+
+  if (ego_front_to_stop_line <= params_.arrived_distance_threshold) {
+    return RiskLevel::DANGER;
+  }
+
+  static constexpr double tolerance = 0.1;
+  if (
+    stopping_distance_.nominal &&
+    ego_front_to_stop_line > (*stopping_distance_.nominal - tolerance)) {
+    return RiskLevel::LOW_CAUTION;
+  }
+
+  if (
+    stopping_distance_.minimum &&
+    ego_front_to_stop_line > (*stopping_distance_.minimum - tolerance)) {
+    return RiskLevel::HIGH_CAUTION;
+  }
+
+  return RiskLevel::DANGER;
+}
+
 std::vector<TargetCrosswalk> CrosswalkFilter::get_target_crosswalks(
   const TrajectoryPoints & traj_points, const FilterContext & context)
 {
@@ -394,15 +441,10 @@ std::vector<TargetCrosswalk> CrosswalkFilter::get_target_crosswalks(
 
   if (crosswalks_on_route.empty()) return target_crosswalks;
 
-  const double current_vel = context.odometry->twist.twist.linear.x;
-  const double current_acc = context.acceleration->accel.accel.linear.x;
-  const auto decel_limit = 1.0;
-  const auto jerk_limit = 1.0;
-
-  auto stop_distance = autoware::motion_utils::calculate_stop_distance(
-    current_vel, current_acc, decel_limit, jerk_limit);
-  const auto lookahead_distance_m = stop_distance
-                                      ? *stop_distance + params_.arrived_distance_threshold
+  const auto front_offset_m =
+    vehicle_info_ptr_->max_longitudinal_offset_m + params_.arrived_distance_threshold;
+  const auto lookahead_distance_m = stopping_distance_.nominal
+                                      ? *stopping_distance_.nominal + front_offset_m
                                       : std::numeric_limits<double>::max();
 
   lanelet::BasicLineString2d trajectory_ls;

--- a/planning/autoware_trajectory_validator/test/plugins/test_crosswalk_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_crosswalk_filter.cpp
@@ -16,11 +16,13 @@
 
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/crosswalk.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/predicted_path.hpp>
 #include <autoware_perception_msgs/msg/shape.hpp>
 
 #include <gtest/gtest.h>
@@ -30,8 +32,10 @@
 #include <lanelet2_core/primitives/Polygon.h>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 using autoware::trajectory_validator::FilterContext;
@@ -39,13 +43,19 @@ using autoware::trajectory_validator::plugin::traffic_rule::CrosswalkFilter;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::PredictedPath;
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_utils_geometry::create_quaternion_from_yaw;
 
 namespace
 {
 constexpr double k_stop_line_x = 10.0;
 constexpr double k_far_stop_line_x = 150.0;
 constexpr double k_stop_duration = 1.0;
+// South sidewalk detection end-cap (see create_and_set_map_with_crosswalk).
+constexpr double k_south_detection_y = -7.0;
+// Object-frame forward speed used for toward/away gates.
+constexpr float k_object_speed = 1.0f;
 }  // namespace
 
 class CrosswalkFilterTest : public ::testing::Test
@@ -173,13 +183,15 @@ protected:
     context_.route = route;
   }
 
-  static PredictedObject make_pedestrian(const double x, const double y)
+  static PredictedObject make_pedestrian(
+    const double x, const double y, const double yaw = 0.0, const float twist_x = 0.0f)
   {
     PredictedObject obj;
     obj.object_id = autoware_utils_uuid::generate_uuid();
     obj.kinematics.initial_pose_with_covariance.pose.position.x = x;
     obj.kinematics.initial_pose_with_covariance.pose.position.y = y;
-    obj.kinematics.initial_pose_with_covariance.pose.orientation.w = 1.0;
+    obj.kinematics.initial_pose_with_covariance.pose.orientation = create_quaternion_from_yaw(yaw);
+    obj.kinematics.initial_twist_with_covariance.twist.linear.x = twist_x;
     obj.shape.type = autoware_perception_msgs::msg::Shape::CYLINDER;
     obj.shape.dimensions.x = 0.5;
     obj.shape.dimensions.y = 0.5;
@@ -189,6 +201,22 @@ protected:
     obj.classification.front().probability = 1.0f;
     obj.existence_probability = 1.0f;
     return obj;
+  }
+
+  static PredictedPath make_predicted_path(
+    const std::vector<std::pair<double, double>> & xy_points, const float confidence)
+  {
+    PredictedPath path;
+    path.confidence = confidence;
+    path.time_step = rclcpp::Duration::from_seconds(0.1);
+    for (const auto & [x, y] : xy_points) {
+      geometry_msgs::msg::Pose pose;
+      pose.position.x = x;
+      pose.position.y = y;
+      pose.orientation.w = 1.0;
+      path.path.push_back(pose);
+    }
+    return path;
   }
 
   void set_pedestrians(const std::vector<PredictedObject> & pedestrians)
@@ -351,4 +379,100 @@ TEST_F(CrosswalkFilterTest, NewTargetObjectExtendsStopDuration)
   set_pedestrians({first_object, second_object});
   expect_feasibility(
     traj, true, "should become feasible after waiting stop_duration for the newer object");
+}
+
+TEST_F(CrosswalkFilterTest, MovingAwayWithoutPredictedPathIsIgnored)
+{
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_odometry(5.0f, node_->now());
+
+  // South detection area: facing -Y (away from the crosswalk entry).
+  set_pedestrians({make_pedestrian(k_stop_line_x, k_south_detection_y, -M_PI_2, k_object_speed)});
+
+  expect_feasibility(
+    create_trajectory(0.0, 80.0, 5.0f), true,
+    "object moving away from the crosswalk with no predicted path should not be a target");
+}
+
+TEST_F(CrosswalkFilterTest, MovingTowardWithoutPredictedPathIsTarget)
+{
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_odometry(5.0f, node_->now());
+
+  // South detection area: facing +Y (toward the crosswalk entry).
+  set_pedestrians({make_pedestrian(k_stop_line_x, k_south_detection_y, M_PI_2, k_object_speed)});
+
+  expect_feasibility(
+    create_trajectory(0.0, 80.0, 5.0f), false,
+    "object moving toward the crosswalk with no predicted path should be a target");
+}
+
+TEST_F(CrosswalkFilterTest, HighConfidencePathThroughCrosswalkIsTarget)
+{
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_odometry(5.0f, node_->now());
+
+  // Velocity points away, but a high-confidence path crosses the crosswalk polygon.
+  auto obj = make_pedestrian(k_stop_line_x, k_south_detection_y, -M_PI_2, k_object_speed);
+  obj.kinematics.predicted_paths.push_back(make_predicted_path(
+    {{k_stop_line_x, k_south_detection_y}, {k_stop_line_x, 0.0}, {k_stop_line_x, 3.0}}, 0.9f));
+  set_pedestrians({obj});
+
+  expect_feasibility(
+    create_trajectory(0.0, 80.0, 5.0f), false,
+    "high-confidence predicted path through the crosswalk should keep the object as a target");
+}
+
+TEST_F(CrosswalkFilterTest, HighConfidencePathAwayFromCrosswalkIsIgnored)
+{
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_odometry(5.0f, node_->now());
+
+  // Still inside the detection area, but the predicted path never enters the crosswalk.
+  auto obj = make_pedestrian(k_stop_line_x, k_south_detection_y, M_PI_2, k_object_speed);
+  obj.kinematics.predicted_paths.push_back(make_predicted_path(
+    {{k_stop_line_x, k_south_detection_y}, {k_stop_line_x, -9.0}, {k_stop_line_x, -12.0}}, 0.9f));
+  set_pedestrians({obj});
+
+  expect_feasibility(
+    create_trajectory(0.0, 80.0, 5.0f), true,
+    "high-confidence predicted path that misses the crosswalk should not be a target");
+}
+
+TEST_F(CrosswalkFilterTest, LowConfidencePathsFallBackToVelocityGate)
+{
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_odometry(5.0f, node_->now());
+
+  // Path would go through the crosswalk, but confidence is below the gate threshold.
+  auto away_obj = make_pedestrian(k_stop_line_x, k_south_detection_y, -M_PI_2, k_object_speed);
+  away_obj.kinematics.predicted_paths.push_back(
+    make_predicted_path({{k_stop_line_x, k_south_detection_y}, {k_stop_line_x, 0.0}}, 0.2f));
+  set_pedestrians({away_obj});
+
+  expect_feasibility(
+    create_trajectory(0.0, 80.0, 5.0f), true,
+    "low-confidence paths should fall back to velocity; moving away is ignored");
+
+  auto toward_obj = make_pedestrian(k_stop_line_x, k_south_detection_y, M_PI_2, k_object_speed);
+  toward_obj.kinematics.predicted_paths.push_back(
+    make_predicted_path({{k_stop_line_x, k_south_detection_y}, {k_stop_line_x, 0.0}}, 0.2f));
+  set_pedestrians({toward_obj});
+
+  expect_feasibility(
+    create_trajectory(0.0, 80.0, 5.0f), false,
+    "low-confidence paths should fall back to velocity; moving toward is a target");
+}
+
+TEST_F(CrosswalkFilterTest, StoppedObjectInDetectionAreaIsTarget)
+{
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_odometry(5.0f, node_->now());
+
+  // Explicitly stopped; no predicted paths.
+  set_pedestrians({make_pedestrian(k_stop_line_x, k_south_detection_y, 0.0, 0.0f)});
+
+  expect_feasibility(
+    create_trajectory(0.0, 80.0, 5.0f), false,
+    "stopped object in the detection area should remain a target");
 }

--- a/planning/autoware_trajectory_validator/test/plugins/test_crosswalk_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_crosswalk_filter.cpp
@@ -14,8 +14,10 @@
 
 #include "autoware/trajectory_validator/filters/traffic_rule/crosswalk_filter.hpp"
 
+#include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/crosswalk.hpp>
+#include <autoware_trajectory_validator/msg/risk_level.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 
@@ -34,6 +36,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -45,6 +48,7 @@ using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::PredictedPath;
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_trajectory_validator::msg::RiskLevel;
 using autoware_utils_geometry::create_quaternion_from_yaw;
 
 namespace
@@ -52,10 +56,34 @@ namespace
 constexpr double k_stop_line_x = 10.0;
 constexpr double k_far_stop_line_x = 150.0;
 constexpr double k_stop_duration = 1.0;
+constexpr double k_arrived_distance_threshold = 5.0;
+constexpr double k_nominal_decel = 1.0;
+constexpr double k_nominal_jerk = 1.0;
+constexpr double k_decel_limit = 2.0;
+constexpr double k_jerk_limit = 2.0;
+constexpr double k_delay_response_time = 0.5;
 // South sidewalk detection end-cap (see create_and_set_map_with_crosswalk).
 constexpr double k_south_detection_y = -7.0;
 // Object-frame forward speed used for toward/away gates.
 constexpr float k_object_speed = 1.0f;
+
+struct StopDistances
+{
+  double nominal{};
+  double minimum{};
+};
+
+std::optional<StopDistances> calc_stop_distances(const double velocity)
+{
+  const auto nominal = autoware::motion_utils::calculate_stop_distance(
+    velocity, 0.0, k_nominal_decel, k_nominal_jerk, k_delay_response_time);
+  const auto minimum = autoware::motion_utils::calculate_stop_distance(
+    velocity, 0.0, k_decel_limit, k_jerk_limit, k_delay_response_time);
+  if (!nominal || !minimum) {
+    return std::nullopt;
+  }
+  return StopDistances{*nominal, *minimum};
+}
 }  // namespace
 
 class CrosswalkFilterTest : public ::testing::Test
@@ -80,10 +108,13 @@ protected:
     params.crosswalk.object_clear_time_th = 0.3;
     params.crosswalk.distance_hysteresis_th = 0.3;
     params.crosswalk.overshoot_tolerance = 0.0;
-    params.crosswalk.nominal_deceleration = 1.0;
-    params.crosswalk.nominal_jerk = 1.0;
     params.crosswalk.stop_duration = k_stop_duration;
-    params.crosswalk.arrived_distance_threshold = 5.0;
+    params.crosswalk.arrived_distance_threshold = k_arrived_distance_threshold;
+    params.crosswalk.stopping_params.nominal_decel = k_nominal_decel;
+    params.crosswalk.stopping_params.nominal_jerk = k_nominal_jerk;
+    params.crosswalk.stopping_params.decel_limit = k_decel_limit;
+    params.crosswalk.stopping_params.jerk_limit = k_jerk_limit;
+    params.crosswalk.stopping_params.delay_response_time = k_delay_response_time;
     filter_->update_parameters(params);
 
     context_.route = std::make_shared<autoware_planning_msgs::msg::LaneletRoute>();
@@ -267,6 +298,31 @@ protected:
     ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error: "
                                  << (res.has_value() ? "" : res.error()) << " " << message;
     EXPECT_EQ(res->is_feasible, expected_feasible) << message;
+  }
+
+  void set_vehicle_front_offset(const double front_offset_m)
+  {
+    autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+    vehicle_info.max_longitudinal_offset_m = front_offset_m;
+    filter_->set_vehicle_info(vehicle_info);
+  }
+
+  void expect_obstruction_risk(
+    const std::vector<TrajectoryPoint> & points, const uint8_t expected_risk_level,
+    const bool expected_feasible, const std::string & message = "")
+  {
+    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_trajectory;
+    candidate_trajectory.points = points;
+    const auto res = filter_->is_feasible(candidate_trajectory, context_);
+    ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error: "
+                                 << (res.has_value() ? "" : res.error()) << " " << message;
+    EXPECT_EQ(res->is_feasible, expected_feasible) << message;
+
+    const auto it = std::find_if(res->metrics.begin(), res->metrics.end(), [](const auto & metric) {
+      return metric.metric_name == "check_crosswalk_obstruction";
+    });
+    ASSERT_NE(it, res->metrics.end()) << "expected check_crosswalk_obstruction metric. " << message;
+    EXPECT_EQ(it->risk.level, expected_risk_level) << message;
   }
 
   std::shared_ptr<CrosswalkFilter> filter_;
@@ -475,4 +531,118 @@ TEST_F(CrosswalkFilterTest, StoppedObjectInDetectionAreaIsTarget)
   expect_feasibility(
     create_trajectory(0.0, 80.0, 5.0f), false,
     "stopped object in the detection area should remain a target");
+}
+
+TEST_F(CrosswalkFilterTest, RiskLevelSafeWhenNoTargetObjects)
+{
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_odometry(5.0f, node_->now());
+  clear_objects();
+
+  expect_obstruction_risk(
+    create_trajectory(0.0, 80.0, 5.0f), RiskLevel::SAFE, true,
+    "intersecting crosswalk without waiting VRUs should report SAFE");
+}
+
+TEST_F(CrosswalkFilterTest, RiskLevelDangerWhenWithinArrivedDistance)
+{
+  // Ego front is within arrived_distance_threshold of the stop line.
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_odometry(5.0f, node_->now());
+  set_pedestrian_at(k_stop_line_x, -7.0);
+
+  const double ego_x = k_stop_line_x - k_arrived_distance_threshold;
+  expect_obstruction_risk(
+    create_trajectory(ego_x, 80.0, 5.0f), RiskLevel::DANGER, false,
+    "obstruction inside arrived distance should report DANGER");
+}
+
+TEST_F(CrosswalkFilterTest, RiskLevelDangerWhenEgoStoppedNearCrosswalk)
+{
+  create_and_set_map_with_crosswalk(k_stop_line_x);
+  set_pedestrian_at(k_stop_line_x, -7.0);
+  set_odometry(0.0f, node_->now());
+
+  expect_obstruction_risk(
+    create_trajectory(8.0, 80.0, 5.0f), RiskLevel::DANGER, false,
+    "stopped near the stop line with a waiting VRU should report DANGER");
+}
+
+TEST_F(CrosswalkFilterTest, RiskLevelDangerWhenCannotStopWithMinimumBraking)
+{
+  constexpr float ego_velocity = 5.0f;
+  const auto stop_distances = calc_stop_distances(ego_velocity);
+  ASSERT_TRUE(stop_distances.has_value());
+  ASSERT_GT(stop_distances->minimum, k_arrived_distance_threshold);
+
+  // Place the stop line between arrived_distance and minimum stopping distance.
+  const double stop_line_x = 0.5 * (k_arrived_distance_threshold + stop_distances->minimum);
+  create_and_set_map_with_crosswalk(stop_line_x);
+  set_odometry(ego_velocity, node_->now());
+  set_pedestrian_at(stop_line_x, -7.0);
+
+  expect_obstruction_risk(
+    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::DANGER, false,
+    "obstruction closer than minimum stop distance should report DANGER");
+}
+
+TEST_F(CrosswalkFilterTest, RiskLevelHighCautionWhenOnlyHardBrakingCanStop)
+{
+  constexpr float ego_velocity = 5.0f;
+  const auto stop_distances = calc_stop_distances(ego_velocity);
+  ASSERT_TRUE(stop_distances.has_value());
+  ASSERT_GT(stop_distances->nominal, stop_distances->minimum);
+
+  // Place the stop line between minimum and nominal stopping distances.
+  const double stop_line_x = 0.5 * (stop_distances->minimum + stop_distances->nominal);
+  create_and_set_map_with_crosswalk(stop_line_x);
+  set_odometry(ego_velocity, node_->now());
+  set_pedestrian_at(stop_line_x, -7.0);
+
+  expect_obstruction_risk(
+    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::HIGH_CAUTION, false,
+    "obstruction beyond minimum but within nominal stop distance should report HIGH_CAUTION");
+}
+
+TEST_F(CrosswalkFilterTest, RiskLevelLowCautionWhenNominalBrakingCanStop)
+{
+  constexpr float ego_velocity = 5.0f;
+  const auto stop_distances = calc_stop_distances(ego_velocity);
+  ASSERT_TRUE(stop_distances.has_value());
+
+  // Still inside lookahead (nominal + arrived), but beyond nominal stopping distance.
+  const double stop_line_x = stop_distances->nominal + 1.0;
+  ASSERT_LT(stop_line_x, stop_distances->nominal + k_arrived_distance_threshold);
+  create_and_set_map_with_crosswalk(stop_line_x);
+  set_odometry(ego_velocity, node_->now());
+  set_pedestrian_at(stop_line_x, -7.0);
+
+  expect_obstruction_risk(
+    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::LOW_CAUTION, false,
+    "obstruction beyond nominal stop distance should report LOW_CAUTION");
+}
+
+TEST_F(CrosswalkFilterTest, RiskLevelAccountsForVehicleFrontOffset)
+{
+  constexpr float ego_velocity = 5.0f;
+  constexpr double front_offset_m = 4.0;
+  const auto stop_distances = calc_stop_distances(ego_velocity);
+  ASSERT_TRUE(stop_distances.has_value());
+
+  // Without front offset this distance would be LOW_CAUTION; subtracting the bumper offset
+  // moves it into the HIGH_CAUTION band.
+  const double stop_line_x = stop_distances->nominal + 1.0;
+  const double ego_front_to_stop_line = stop_line_x - front_offset_m;
+  ASSERT_GT(ego_front_to_stop_line, k_arrived_distance_threshold);
+  ASSERT_GT(ego_front_to_stop_line, stop_distances->minimum);
+  ASSERT_LE(ego_front_to_stop_line, stop_distances->nominal);
+
+  set_vehicle_front_offset(front_offset_m);
+  create_and_set_map_with_crosswalk(stop_line_x);
+  set_odometry(ego_velocity, node_->now());
+  set_pedestrian_at(stop_line_x, -7.0);
+
+  expect_obstruction_risk(
+    create_trajectory(0.0, 80.0, ego_velocity), RiskLevel::HIGH_CAUTION, false,
+    "risk should use ego-front-to-stop-line distance, not raw arc length");
 }


### PR DESCRIPTION
## Description
This a cherry-pick PR to sync changes from private TIER IV fork:
- https://github.com/tier4/autoware_universe/pull/3318
- https://github.com/tier4/autoware_universe/pull/3319

The PR improves target object filtering by considering predicted paths, and objects motion in addition to existing conditions. An object is considered as target object when it shows crossing intent:
  - Object is within detection area, AND
  - A high-confidence predicted path intersects the crosswalk polygon, or
  - Object is stopped or moving towards crosswalk

Additionally, the PR introduces a distance based risk_level assignment based on the ego’s remaining distance to the stop line, measured against nominal and minimum stopping distances:

| Condition | Risk |
|---|---|
| Feasible (no obstruction) | `SAFE` |
| `distance` <= `arrived_distance_threshold` | `DANGER` |
| `distance` >= `nominal_stopping_distance` | `LOW_CAUTION` |
| `nominal_stopping_distance` >= `distance` > `minimum_stopping_distance` | `HIGH_CAUTION` |
| `distance` <= `minimum_stopping_distance` | `DANGER` |

### Changes

**Target object filtering:**
- `crosswalk_filter.hpp`
  - Add `entry_edges` (`std::array<lanelet::BasicSegment2d, 2>`) to `TargetCrosswalk` struct.
- `crosswalk_filter.cpp`
  - Add helpers to compute / query crosswalk entry edges (`get_crosswalk_entry_edges`, `closest_point_on_segment`, `closest_point_on_crosswalk_entries`).
  - Add `is_target_object()` with intent gates:
    1. inside detection area
    2. high-confidence predicted path through crosswalk polygon (if available)
    3. otherwise stopped → keep; moving → keep only if velocity points toward nearest entry edge
  - Use `is_target_object()` in `update_target_objects()` instead of detection-area-only filtering.
- `test_crosswalk_filter.cpp`
  - Extend pedestrian helpers with yaw / twist / predicted paths.
  - Add tests for velocity toward/away, path-through / path-away, low-confidence fallback, and stopped objects.

**Risk level assignment:**
- Add stopping kinematics parameters to crosswalk_filter params:
  - `nominal_decel` / `nominal_jerk`
  - `decel_limit` / `jerk_limit`
  - `delay_response_time`
- Update config, parameter struct, and schema
- Add function `get_risk_level(arc_length_to_stop_line)` to check risk_level conditions
- Cache nominal/minimum stopping distances per odometry stamp across candidate trajectories in the same frame
- Add unit tests to cover risk level assignment logic

## How was this PR tested?
- `colcon build  --packages-select autoware_trajectory_validator --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release`
- `colcon test --packages-select autoware_trajectory_validator`
- PSIM:

[cw_filter_risk.webm](https://github.com/user-attachments/assets/dbb99a5a-3078-448f-a632-54330f35bee7)