### PR TITLE
feat(obstacle_stop): port obstacle stop improvements

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -44,6 +44,7 @@
       nominal_stopping_decel: 1.0 # [m/s^2]
       maximum_stopping_decel: 4.0 # [m/s^2]
       stopping_jerk: 3.0 # [m/s^3]
+      delay_response_time: 0.5 #[s]
       on_time_buffer: 0.5 # [s]
       off_time_buffer: 0.7 # [s]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
@@ -82,8 +83,7 @@
           bicycle: 3.0
           pedestrian: 5.0
         ego_decel: 2.0           # [m/s^2]
-        reaction_time: 0.4       # [s]
-        safety_margin: 3.0       # [m]
+        safety_margin: 1.5       # [m]
         lookahead_horizon: 1.5   # [s]
 
     surround_obstacle_stop:

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -46,21 +46,30 @@
       stopping_jerk: 3.0 # [m/s^3]
       on_time_buffer: 0.5 # [s]
       off_time_buffer: 0.7 # [s]
-      lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       objects:
         target_objects:
           bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"]
           polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"]
+          pointcloud: ["structure", "vegetation"]
         stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
         safety_buffer: 0.1       # safety buffer to expand object shape [m]
-
-      pointcloud:
-        target_types: ["structure", "vegetation"]
-        height_buffer: 0.5  # height buffer to add above ego height [m]
-        min_height: 0.2  # minimum height of pointcloud [m]
+        pointcloud_height_buffer: 0.5
+        pointcloud_min_height: 0.2
+        lateral_margin:
+          car: 0.2
+          truck: 0.2
+          bus: 0.2
+          trailer: 0.2
+          motorcycle: 0.2
+          bicycle: 0.2
+          pedestrian: 0.2
+          hazard: 0.2
+          structure: 0.2
+          vegetation: 0.2
+          unknown: 0.2
 
       rss_params:
         enable: true

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -141,6 +141,10 @@ minimum_rule_based_planner:
       type: double
       default_value: 3.0
       description: stopping jerk [m/s^3]
+    delay_response_time:
+      type: double
+      default_value: 0.5
+      description: delay response time used to estimate the minimum ego stopping distance [s]
     on_time_buffer:
       type: double
       default_value: 0.5
@@ -333,15 +337,9 @@ minimum_rule_based_planner:
         description: deceleration for ego vehicle used in RSS calculation [m/s^2]
         validation:
           bounds<>: [0.0, 10.0]
-      reaction_time:
-        type: double
-        default_value: 0.4
-        description: reaction time used in RSS calculation [s]
-        validation:
-          bounds<>: [0.0, 10.0]
       safety_margin:
         type: double
-        default_value: 3.0
+        default_value: 1.5
         description: safety margin used in RSS calculation [m]
         validation:
           bounds<>: [0.0, 10.0]

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -149,10 +149,6 @@ minimum_rule_based_planner:
       type: double
       default_value: 1.0
       description: time buffer after obstacle stop [s]
-    lateral_margin:
-      type: double
-      default_value: 0.2
-      description: lateral margin for obstacle stop [m]
     arrived_distance_threshold:
       type: double
       default_value: 0.5
@@ -172,6 +168,11 @@ minimum_rule_based_planner:
           default_value: [car, truck, bus, trailer, pedestrian, hazard, unknown]
           description: types of polygon shaped objects to consider for obstacle stop
           read_only: false
+        pointcloud:
+          type: string_array
+          default_value: [structure, vegetation]
+          description: types of pointcloud to consider for obstacle stop
+          read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.3
@@ -188,24 +189,96 @@ minimum_rule_based_planner:
         description: safety buffer to expand object shape [m]
         validation:
           bounds<>: [0.0, 10.0]
-    pointcloud:
-      target_types:
-        type: string_array
-        default_value: [structure, vegetation]
-        description: pointcloud types to consider for obstacle stop
-        read_only: false
-      height_buffer:
+      pointcloud_height_buffer:
         type: double
         default_value: 0.5
-        description: height buffer to add above ego height [m]
+        description: height buffer to add above ego height for pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
-      min_height:
+      pointcloud_min_height:
         type: double
         default_value: 0.2
         description: minimum height of pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
+      lateral_margin:
+        car:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for car objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        truck:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for truck objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        bus:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for bus objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        trailer:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for trailer objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        motorcycle:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for motorcycle objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        bicycle:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for bicycle objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        pedestrian:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for pedestrian objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        hazard:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for hazard objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        structure:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for structure pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        vegetation:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for vegetation pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        unknown:
+          type: double
+          default_value: 0.2
+          description: Lateral margin on top of ego width for unknown objects and unclassified pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
     rss_params:
       enable:
         type: bool

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -93,7 +93,8 @@ bool ObstacleStop::is_obstacle_detected(
   debug_data_.trajectory_shape = build_trajectory_footprint_index(
     traj_points, data.odometry_ptr->pose.pose, context_->vehicle_info,
     data.odometry_ptr->twist.twist.linear.x, data.acceleration_ptr->accel.accel.linear.x,
-    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin);
+    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
+    params_.delay_response_time);
   const auto collision_point_pcd = check_pointcloud(traj_points, data);
   update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
   const auto collision_point_objects = check_predicted_objects(traj_points, data);
@@ -161,7 +162,7 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const Modifier
     nearest_collision_point_->arc_length - stop_margin,
     debug_data_.trajectory_shape.trajectory_length, data.odometry_ptr->twist.twist.linear.x,
     data.acceleration_ptr->accel.accel.linear.x, params_.maximum_stopping_decel,
-    params_.stopping_jerk);
+    params_.stopping_jerk, params_.delay_response_time);
 
   if (
     target_stop_point_arc_length < params_.arrived_distance_threshold ||
@@ -203,7 +204,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   auto collision_point = get_nearest_object_collision(
     debug_data_.target_objects, traj_points, context_->vehicle_info, object_decel_map_,
-    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.ego_decel, params_.delay_response_time, params_.stop_margin,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
     params_.rss_params.lookahead_horizon, params_.rss_params.enable);
 
@@ -480,6 +481,8 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     add_text_marker(
       ss.str(), obj.object.kinematics.initial_pose_with_covariance.pose,
       ns + "/target_objects_text", id, white);
+    if (!obj.is_safe)
+      add_polygon_marker(obj.ego_footprint, ns + "/overlapping_ego_footprint", id, magenta);
     id++;
   }
 

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -19,6 +19,7 @@
 #include <autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <algorithm>
@@ -34,10 +35,13 @@ namespace autoware::minimum_rule_based_planner::plugin
 using autoware::trajectory_processor::utils::clamp_stop_point_arc_length;
 using autoware::trajectory_processor::utils::insert_stop_point;
 using autoware::trajectory_processor::utils::replace_trajectory_with_stop_point;
+using autoware::trajectory_processor::utils::obstacle_stop::build_trajectory_footprint_index;
 using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_object_collision;
 using autoware::trajectory_processor::utils::obstacle_stop::get_nearest_pcd_collision;
-using autoware::trajectory_processor::utils::obstacle_stop::get_trajectory_shape;
+using autoware::trajectory_processor::utils::obstacle_stop::LateralMarginMap;
+using autoware::trajectory_processor::utils::obstacle_stop::ObjectType;
 using autoware::trajectory_processor::utils::obstacle_stop::PointCloud;
+using autoware::trajectory_processor::utils::obstacle_stop::TargetObject;
 
 void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
 {
@@ -49,7 +53,7 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
 
   pointcloud_filter_ =
     std::make_unique<trajectory_processor::utils::obstacle_stop::PointCloudFilter>(
-      params_.pointcloud.target_types);
+      params_.objects.target_objects.pointcloud);
 
   object_filter_ = std::make_unique<trajectory_processor::utils::obstacle_stop::ObjectFilter>(
     params_.objects.target_objects.bbox, params_.objects.target_objects.polygon,
@@ -63,6 +67,7 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
     get_node_ptr()->create_publisher<StringStamped>("~/obstacle_stop/debug/text", 1);
 
   update_object_decel_map();
+  update_lateral_margin_map();
 }
 
 void ObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data)
@@ -71,7 +76,7 @@ void ObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data
 
   const auto detected = is_obstacle_detected(traj_points, data);
   publish_debug_string(!detected);
-  publish_debug_data("obstacle_stop", data);
+  publish_debug_data("obstacle_stop");
 
   if (!detected) return;
   if (!nearest_collision_point_) return;
@@ -84,11 +89,10 @@ bool ObstacleStop::is_obstacle_detected(
 {
   debug_data_ = DebugData();
   safety_factors_ = SafetyFactorArray{};
-  debug_data_.trajectory_shape = get_trajectory_shape(
+  debug_data_.trajectory_shape = build_trajectory_footprint_index(
     traj_points, data.odometry_ptr->pose.pose, context_->vehicle_info,
     data.odometry_ptr->twist.twist.linear.x, data.acceleration_ptr->accel.accel.linear.x,
-    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
-    params_.lateral_margin);
+    params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin);
   const auto collision_point_pcd = check_pointcloud(traj_points, data);
   update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
   const auto collision_point_objects = check_predicted_objects(traj_points, data);
@@ -144,8 +148,7 @@ bool ObstacleStop::is_obstacle_detected(
              : nearest_objects_collision_point.value();
   });
 
-  debug_data_.active_collision_point =
-    nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
+  debug_data_.ego_z = data.odometry_ptr->pose.pose.position.z;
 
   return nearest_collision_point_ != std::nullopt;
 }
@@ -183,26 +186,40 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   if (!data.predicted_objects_ptr || data.predicted_objects_ptr->objects.empty())
     return std::nullopt;
-  auto predicted_objects = *data.predicted_objects_ptr;
+  debug_data_.filtered_objects = *data.predicted_objects_ptr;
 
-  object_filter_->filter_objects(predicted_objects);
+  object_filter_->filter_objects(debug_data_.filtered_objects);
+
+  debug_data_.target_objects.clear();
+  debug_data_.target_objects.reserve(debug_data_.filtered_objects.objects.size());
+  for (const auto & object : debug_data_.filtered_objects.objects) {
+    debug_data_.target_objects.emplace_back(object);
+  }
+
   object_filter_->filter_by_target_area(
-    predicted_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape.polygon,
-    debug_data_.target_polygons);
+    debug_data_.target_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
+    lateral_margin_map_);
 
-  autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
-    traj_points, context_->vehicle_info, predicted_objects, object_decel_map_,
+    debug_data_.target_objects, traj_points, context_->vehicle_info, object_decel_map_,
     params_.rss_params.ego_decel, params_.rss_params.reaction_time,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
+    params_.rss_params.lookahead_horizon, params_.rss_params.enable);
 
-  if (collision_point) debug_data_.colliding_object = colliding_object;
+  if (collision_point) {
+    auto it = std::find_if(
+      debug_data_.target_objects.begin(), debug_data_.target_objects.end(),
+      [&](const TargetObject & object) { return !object.is_safe; });
+    if (it != debug_data_.target_objects.end()) {
+      debug_data_.colliding_object = it->object;
+    }
+  }
+
   return collision_point;
 }
 
 std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
-  const TrajectoryPoints & traj_points, const ModifierData & data)
+  [[maybe_unused]] const TrajectoryPoints & traj_points, const ModifierData & data)
 {
   if (!params_.use_pointcloud) return std::nullopt;
 
@@ -215,22 +232,6 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
   pcl::fromROSMsg(*pointcloud, *filtered_pointcloud);
 
   {
-    const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
-    const auto rel_min_corner = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.min_corner().to_3d(), data.odometry_ptr->pose.pose);
-    const auto rel_max_corner = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.max_corner().to_3d(), data.odometry_ptr->pose.pose);
-    constexpr double buffer = 1.0;
-    const auto [min_x, max_x] = std::minmax(rel_min_corner.x(), rel_max_corner.x());
-    const auto [min_y, max_y] = std::minmax(rel_min_corner.y(), rel_max_corner.y());
-    const auto min_z = params_.pointcloud.min_height;
-    const auto max_z = context_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
-    pointcloud_filter_->filter_pointcloud(
-      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
-      max_z);
-  }
-
-  {
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
       transform_stamped = context_->tf_buffer.lookupTransform(
@@ -238,6 +239,7 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
         rclcpp::Duration::from_seconds(0.1));
     } catch (tf2::TransformException & e) {
       RCLCPP_WARN(get_node_ptr()->get_logger(), "no transform found for pointcloud: %s", e.what());
+      return std::nullopt;
     }
 
     Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.transform).cast<float>();
@@ -247,6 +249,20 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       p.y = q.y();
       p.z = q.z();
     }
+  }
+
+  {
+    const auto & bbox = debug_data_.trajectory_shape.bounding_box;
+    constexpr double buffer = 1.0;
+    const auto [min_x, max_x] = std::minmax(bbox.min_corner().x(), bbox.max_corner().x());
+    const auto [min_y, max_y] = std::minmax(bbox.min_corner().y(), bbox.max_corner().y());
+    const auto ego_z = data.odometry_ptr->pose.pose.position.z;
+    const auto min_z = ego_z + params_.objects.pointcloud_min_height;
+    const auto max_z =
+      ego_z + context_->vehicle_info.vehicle_height_m + params_.objects.pointcloud_height_buffer;
+    pointcloud_filter_->filter_pointcloud(
+      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
+      max_z);
   }
 
   {
@@ -263,7 +279,8 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
   }
 
   return get_nearest_pcd_collision(
-    traj_points, debug_data_.trajectory_shape, filtered_pointcloud, debug_data_.target_pcd_points);
+    debug_data_.trajectory_shape, filtered_pointcloud, lateral_margin_map_,
+    debug_data_.target_pcd_points);
 }
 
 void ObstacleStop::update_collision_points_buffer(
@@ -338,7 +355,7 @@ std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point(
 
   auto minimum_arc_length = std::numeric_limits<double>::max();
   for (const auto & cp : collision_points_buffer) {
-    if (cp.is_active > minimum_arc_length || !cp.is_active) continue;
+    if (cp.arc_length >= minimum_arc_length || !cp.is_active) continue;
     nearest_collision_point = cp;
     minimum_arc_length = cp.arc_length;
   }
@@ -355,7 +372,7 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
   ss << "OBSTACLE STOP (Backup Planner):" << "\n";
   ss << "\t\t" << "SAFE: " << is_safe << "\n";
   ss << "\t\t" << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
-     << debug_data_.target_polygons.size() << "\n";
+     << debug_data_.target_objects.size() << "\n";
   ss << "\t\t" << "POINTCLOUD: " << filtered_pcd_size << " --> "
      << debug_data_.target_pcd_points.size() << "\n";
   if (nearest_collision_point_) {
@@ -369,33 +386,62 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
   pub_debug_text_->publish(string_stamp);
 }
 
-void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData & data) const
+void ObstacleStop::publish_debug_data(const std::string & ns) const
 {
   if (debug_data_.filtered_points) pub_filtered_pointcloud_->publish(*debug_data_.filtered_points);
 
   MarkerArray marker_array;
-  const auto ego_z = data.odometry_ptr->pose.pose.position.z;
+  const auto ego_z = debug_data_.ego_z;
   const auto white = autoware_utils::create_marker_color(1.0, 1.0, 1.0, 1.0);
   const auto yellow = autoware_utils::create_marker_color(1.0, 1.0, 0.0, 1.0);
   const auto magenta = autoware_utils::create_marker_color(1.0, 0.0, 1.0, 1.0);
 
-  auto add_point_marker = [&](
-                            const geometry_msgs::msg::Point & point, const std::string & marker_ns,
-                            const int id, const std_msgs::msg::ColorRGBA & color,
-                            const double scale = 0.1) {
+  auto add_line_list_marker = [&](
+                                const std::vector<geometry_msgs::msg::Point> & segments,
+                                const std::string & ns, const int id,
+                                const std_msgs::msg::ColorRGBA & color) {
     Marker marker = autoware_utils::create_default_marker(
-      "map", get_clock()->now(), marker_ns, id, Marker::SPHERE,
-      autoware_utils::create_marker_scale(scale, scale, scale), color);
+      "map", get_clock()->now(), ns, id, Marker::LINE_LIST,
+      autoware_utils::create_marker_scale(0.1, 0.1, 0.1), color);
     marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.pose.position = point;
+    marker.points = segments;
     marker_array.markers.push_back(marker);
   };
 
+  int id = 0;
+  {
+    using autoware_utils_geometry::calc_offset_pose;
+    const auto & shape = debug_data_.trajectory_shape;
+    const auto half_width = shape.ego_half_width;
+    const auto front_offset = std::abs(shape.ego_front_offset);
+    const auto back_offset = std::abs(shape.ego_back_offset);
+    std::vector<geometry_msgs::msg::Point> segments;
+    auto dist = 0.0;
+    for (const auto & footprint : shape.footprints) {
+      if (footprint.arc_length - dist < 1.0) continue;
+      dist = footprint.arc_length;
+      auto front_left = calc_offset_pose(footprint.pose, front_offset, -half_width, 0.0).position;
+      auto front_right = calc_offset_pose(footprint.pose, front_offset, half_width, 0.0).position;
+      auto rear_right = calc_offset_pose(footprint.pose, -back_offset, half_width, 0.0).position;
+      auto rear_left = calc_offset_pose(footprint.pose, -back_offset, -half_width, 0.0).position;
+      segments.emplace_back(rear_left);
+      segments.emplace_back(front_left);
+      segments.emplace_back(front_left);
+      segments.emplace_back(front_right);
+      segments.emplace_back(front_right);
+      segments.emplace_back(rear_right);
+      segments.emplace_back(rear_right);
+      segments.emplace_back(rear_left);
+    }
+    add_line_list_marker(segments, ns + "/traj_polygon", id, yellow);
+    id++;
+  }
+
   auto add_polygon_marker = [&](
-                              const Polygon2d & polygon, const std::string & marker_ns,
-                              const int id, const std_msgs::msg::ColorRGBA & color) {
+                              const Polygon2d & polygon, const std::string & ns, const int id,
+                              const std_msgs::msg::ColorRGBA & color) {
     Marker marker = autoware_utils::create_default_marker(
-      "map", get_clock()->now(), marker_ns, id, Marker::LINE_STRIP,
+      "map", get_clock()->now(), ns, id, Marker::LINE_STRIP,
       autoware_utils::create_marker_scale(0.1, 0.1, 0.1), color);
     marker.lifetime = rclcpp::Duration::from_seconds(0.2);
 
@@ -408,11 +454,19 @@ void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData
     marker_array.markers.push_back(marker);
   };
 
-  int id = 0;
-  for (const auto & traj_polygon : debug_data_.trajectory_shape.polygon) {
-    add_polygon_marker(traj_polygon, ns + "/traj_polygon", id, yellow);
-    id++;
-  }
+  auto add_text_marker = [&](
+                           const std::string & text, const geometry_msgs::msg::Pose & pose,
+                           const std::string & ns, const int id,
+                           const std_msgs::msg::ColorRGBA & color, const double scale = 0.4) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), ns, id, Marker::TEXT_VIEW_FACING,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose = pose;
+    marker.pose.position.z += 1.0;
+    marker.text = text;
+    marker_array.markers.push_back(marker);
+  };
 
   {
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
@@ -425,10 +479,31 @@ void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData
     id++;
   }
 
-  for (const auto & target_polygon : debug_data_.target_polygons) {
+  for (const auto & obj : debug_data_.target_objects) {
+    const auto & target_polygon = obj.polygon;
     add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(2);
+    ss << "safe: " << (obj.is_safe ? "true" : "false") << "\n";
+    ss << "rss_safe_dist: " << obj.safe_distance << " m" << "\n";
+    ss << "dist_from_ego: " << obj.distance_from_ego << " m";
+    add_text_marker(
+      ss.str(), obj.object.kinematics.initial_pose_with_covariance.pose,
+      ns + "/target_objects_text", id, white);
     id++;
   }
+
+  auto add_point_marker = [&](
+                            const geometry_msgs::msg::Point & point, const std::string & ns,
+                            const int id, const std_msgs::msg::ColorRGBA & color,
+                            const double scale = 0.1) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), ns, id, Marker::SPHERE,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose.position = point;
+    marker_array.markers.push_back(marker);
+  };
 
   for (const auto & target_pcd_point : debug_data_.target_pcd_points) {
     add_point_marker(target_pcd_point, ns + "/target_pcd", id, magenta, 0.25);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -23,6 +23,7 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <limits>
 #include <memory>
@@ -159,7 +160,7 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const Modifier
   const auto target_stop_point_arc_length = clamp_stop_point_arc_length(
     nearest_collision_point_->arc_length - stop_margin,
     debug_data_.trajectory_shape.trajectory_length, data.odometry_ptr->twist.twist.linear.x,
-    data.acceleration_ptr->accel.accel.linear.x, params_.nominal_stopping_decel,
+    data.acceleration_ptr->accel.accel.linear.x, params_.maximum_stopping_decel,
     params_.stopping_jerk);
 
   if (
@@ -291,60 +292,49 @@ void ObstacleStop::update_collision_points_buffer(
 
   const auto now = get_clock()->now();
 
-  std::optional<double> closest_distance_diff = std::nullopt;
+  // prune obsolete collision points
   collision_points_buffer.erase(
     std::remove_if(
       collision_points_buffer.begin(), collision_points_buffer.end(),
       [&](CollisionPoint & cp) {
-        if (cp.is_active && (now - cp.start_time).seconds() > params_.off_time_buffer) return true;
-
-        if (!collision_point && !cp.is_active) return true;
-
-        cp.arc_length = motion_utils::calcSignedArcLength(traj_points, 0LU, cp.point);
-        const auto distance_diff = collision_point ? collision_point->arc_length - cp.arc_length
-                                                   : std::numeric_limits<double>::max();
-        const bool is_close = abs(distance_diff) < close_distance_threshold;
-
-        if (!cp.is_active && !is_close) return true;
-
-        if (!cp.is_active && (now - cp.start_time).seconds() > params_.on_time_buffer) {
-          cp.is_active = true;
-          cp.start_time = now;
-        }
-
-        if (
-          is_close &&
-          (!closest_distance_diff || abs(distance_diff) < abs(*closest_distance_diff))) {
-          closest_distance_diff = distance_diff;
-        }
-
-        return false;
+        if (cp.is_active) return (now - cp.last_seen).seconds() > params_.off_time_buffer;
+        return !collision_point;
       }),
     collision_points_buffer.end());
 
   if (!collision_point) return;
 
+  // find nearest tracked collision
+  auto nearest_collision_point_it = collision_points_buffer.end();
+  auto nearest_distance_diff = std::numeric_limits<double>::max();
+  for (auto it = collision_points_buffer.begin(); it != collision_points_buffer.end(); ++it) {
+    const auto estimated_shift = std::abs(it->obstacle_lon_vel) * (now - it->last_seen).seconds();
+    it->arc_length = motion_utils::calcSignedArcLength(traj_points, 0LU, it->point);
+    const auto expected_arc_length = it->arc_length + estimated_shift;
+    const auto distance_diff = collision_point->arc_length - expected_arc_length;
+    if (
+      std::abs(distance_diff) > close_distance_threshold ||
+      std::abs(distance_diff) > std::abs(nearest_distance_diff))
+      continue;
+    nearest_collision_point_it = it;
+    nearest_distance_diff = distance_diff;
+  }
+
   constexpr double eps = 1e-3;
-  if (collision_points_buffer.empty() || !closest_distance_diff) {
-    collision_points_buffer.emplace_back(*collision_point, now, params_.on_time_buffer < eps);
+  if (nearest_collision_point_it == collision_points_buffer.end()) {
+    collision_points_buffer.emplace_back(*collision_point, now, now, params_.on_time_buffer < eps);
     return;
   }
 
-  auto nearest_collision_point_it = std::find_if(
-    collision_points_buffer.begin(), collision_points_buffer.end(), [&](const CollisionPoint & cp) {
-      return abs(cp.arc_length - collision_point->arc_length) < abs(*closest_distance_diff) + eps;
-    });
-
-  if (nearest_collision_point_it == collision_points_buffer.end()) return;
-
-  if (*closest_distance_diff < 0.0) {
-    nearest_collision_point_it->point = collision_point->point;
-    nearest_collision_point_it->arc_length = collision_point->arc_length;
+  if ((now - nearest_collision_point_it->first_seen).seconds() > params_.on_time_buffer) {
+    nearest_collision_point_it->is_active = true;
   }
 
-  if (nearest_collision_point_it->is_active) {
-    nearest_collision_point_it->start_time = now;
-  }
+  nearest_collision_point_it->last_seen = now;
+  nearest_collision_point_it->obstacle_lon_vel = collision_point->obstacle_lon_vel;
+  nearest_collision_point_it->is_dynamic = collision_point->is_dynamic;
+  nearest_collision_point_it->point = collision_point->point;
+  nearest_collision_point_it->arc_length = collision_point->arc_length;
 }
 
 std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point(

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -18,7 +18,6 @@
 #include "autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp"
 #include "plugin_interface.hpp"
 
-#include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
@@ -26,6 +25,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::minimum_rule_based_planner::plugin
@@ -34,10 +34,10 @@ using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_internal_planning_msgs::msg::SafetyFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_planning_msgs::msg::TrajectoryPoint;
-using autoware_utils_geometry::MultiPolygon2d;
 using autoware_utils_geometry::Polygon2d;
 using trajectory_processor::utils::obstacle_stop::CollisionPoint;
 using trajectory_processor::utils::obstacle_stop::DebugData;
+using trajectory_processor::utils::obstacle_stop::LateralMarginMap;
 using trajectory_processor::utils::obstacle_stop::ObjectDecelMap;
 using trajectory_processor::utils::obstacle_stop::ObjectType;
 using visualization_msgs::msg::Marker;
@@ -61,14 +61,11 @@ public:
       object_filter_->set_params(
         p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
         p.max_lateral_velocity_th, p.safety_buffer);
-    }
-
-    {
-      const auto & p = params_.pointcloud;
-      pointcloud_filter_->set_params(p.target_types);
+      pointcloud_filter_->set_params(p.target_objects.pointcloud);
     }
 
     update_object_decel_map();
+    update_lateral_margin_map();
   }
   const MinimumRuleBasedPlannerParams::ObstacleStop & get_params() const { return params_; }
 
@@ -97,6 +94,7 @@ private:
   std::unique_ptr<trajectory_processor::utils::obstacle_stop::ObjectFilter> object_filter_;
 
   ObjectDecelMap object_decel_map_;
+  LateralMarginMap lateral_margin_map_;
 
   AUTOWARE_PUBLISHER_PTR(MarkerArray) debug_viz_pub_;
   AUTOWARE_PUBLISHER_PTR(PointCloud2) pub_filtered_pointcloud_;
@@ -113,6 +111,23 @@ private:
       {ObjectType::MOTORCYCLE, p.object_decel.motorcycle},
       {ObjectType::BICYCLE, p.object_decel.bicycle},
       {ObjectType::PEDESTRIAN, p.object_decel.pedestrian}};
+  }
+
+  void update_lateral_margin_map()
+  {
+    const auto & p = params_.objects.lateral_margin;
+    lateral_margin_map_ = {
+      {ObjectType::CAR, p.car},
+      {ObjectType::TRUCK, p.truck},
+      {ObjectType::BUS, p.bus},
+      {ObjectType::TRAILER, p.trailer},
+      {ObjectType::MOTORCYCLE, p.motorcycle},
+      {ObjectType::BICYCLE, p.bicycle},
+      {ObjectType::PEDESTRIAN, p.pedestrian},
+      {ObjectType::HAZARD, p.hazard},
+      {ObjectType::STRUCTURE, p.structure},
+      {ObjectType::VEGETATION, p.vegetation},
+      {ObjectType::UNKNOWN, p.unknown}};
   }
 
   bool is_obstacle_detected(const TrajectoryPoints & traj_points, const ModifierData & data);
@@ -132,7 +147,7 @@ private:
   void set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data);
 
   void publish_debug_string(bool is_safe) const;
-  void publish_debug_data(const std::string & ns, const ModifierData & data) const;
+  void publish_debug_data(const std::string & ns) const;
 };
 
 }  // namespace autoware::minimum_rule_based_planner::plugin

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -213,6 +213,12 @@
               "default": 3.0,
               "minimum": 0.0
             },
+            "delay_response_time": {
+              "type": "number",
+              "description": "Delay response time [s]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
             "on_time_buffer": {
               "type": "number",
               "description": "On time buffer [s]",
@@ -456,16 +462,10 @@
                   "default": 4.0,
                   "minimum": 0.0
                 },
-                "reaction_time": {
-                  "type": "number",
-                  "description": "Reaction time used in RSS calculation [s]",
-                  "default": 0.2,
-                  "minimum": 0.0
-                },
                 "safety_margin": {
                   "type": "number",
                   "description": "Safety margin used in RSS calculation [m]",
-                  "default": 2.0,
+                  "default": 1.5,
                   "minimum": 0.0
                 },
                 "lookahead_horizon": {

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -225,12 +225,6 @@
               "default": 1.0,
               "minimum": 0.0
             },
-            "lateral_margin": {
-              "type": "number",
-              "description": "Lateral margin [m]",
-              "default": 0.5,
-              "minimum": 0.0
-            },
             "arrived_distance_threshold": {
               "type": "number",
               "description": "Threshold to check if the ego vehicle has arrived at the stop point [m]",
@@ -276,6 +270,14 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "pointcloud": {
+                      "type": "array",
+                      "description": "Types of pointcloud to consider for obstacle stop",
+                      "default": ["structure", "vegetation"],
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [],
@@ -300,33 +302,92 @@
                   "default": 0.0,
                   "minimum": 0.0,
                   "maximum": 10.0
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            },
-            "pointcloud": {
-              "type": "object",
-              "properties": {
-                "target_types": {
-                  "type": "array",
-                  "description": "Pointcloud types to consider for obstacle stop",
-                  "default": ["structure", "vegetation"],
-                  "items": {
-                    "type": "string"
-                  }
                 },
-                "height_buffer": {
+                "pointcloud_height_buffer": {
                   "type": "number",
-                  "description": "Height buffer to add above ego height [m]",
+                  "description": "Height buffer to add above ego height for pointcloud [m]",
                   "default": 0.5,
                   "minimum": 0.0
                 },
-                "min_height": {
+                "pointcloud_min_height": {
                   "type": "number",
                   "description": "Minimum height of pointcloud [m]",
                   "default": 0.2,
                   "minimum": 0.0
+                },
+                "lateral_margin": {
+                  "type": "object",
+                  "description": "Lateral margin on top of ego width from trajectory, per object or pointcloud class [m]",
+                  "properties": {
+                    "car": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for car objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "truck": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for truck objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "bus": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for bus objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "trailer": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for trailer objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "motorcycle": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for motorcycle objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "bicycle": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for bicycle objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "pedestrian": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for pedestrian objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "hazard": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for hazard objects [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "structure": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for structure pointcloud [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "vegetation": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for vegetation pointcloud [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    },
+                    "unknown": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for unknown objects and unclassified pointcloud [m]",
+                      "default": 0.2,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -46,6 +46,7 @@
       nominal_deceleration: 1.0 # [m/s^2]
       maximum_deceleration: 4.0 # [m/s^2]
       jerk_limit: 3.0 # [m/s^3]
+      delay_response_time: 0.5 # [s] delay response time used to estimate the minimum ego stopping distance
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
     # Obstacle Stop Plugin Parameters
@@ -101,8 +102,7 @@
           pedestrian: 5.0
           animal: 5.0
         ego_decel: 2.0 # [m/s^2]
-        reaction_time: 0.4 # [s]
-        safety_margin: 3.0 # [m]
+        safety_margin: 1.5 # [m]
         lookahead_horizon: 1.5 # [s]
 
     # Surround Obstacle Stop Plugin Parameters

--- a/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
+++ b/planning/autoware_trajectory_processor/config/trajectory_processor.param.yaml
@@ -56,7 +56,6 @@
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
       minimum_stop_margin: 3.0 # [m]
-      lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
 
       obstacle_tracking:
@@ -71,14 +70,24 @@
         target_objects:
           bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"]
           polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"]
+          pointcloud: ["structure", "vegetation"]
         stopped_velocity_th: 0.3 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
         safety_buffer: 0.1 # [m] safety buffer to expand object shape
-
-      pointcloud:
-        target_types: ["structure", "vegetation"]
-        height_buffer: 0.5  # height buffer to add above ego height [m]
-        min_height: 0.2  # minimum height of pointcloud [m]
+        pointcloud_height_buffer: 0.2
+        pointcloud_min_height: 0.2
+        lateral_margin:
+          car: 0.1
+          truck: 0.1
+          bus: 0.1
+          trailer: 0.1
+          motorcycle: 0.1
+          bicycle: 0.1
+          pedestrian: 0.1
+          hazard: 0.1
+          structure: 0.1
+          vegetation: 0.1
+          unknown: 0.0
 
       rss_params:
         enable: true

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -16,7 +16,6 @@
 #define AUTOWARE__TRAJECTORY_PROCESSOR__TRAJECTORY_MODIFIER_PLUGINS__OBSTACLE_STOP_HPP_
 
 #include "autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp"
-#include "autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp"
 #include "autoware/trajectory_processor/trajectory_processor_plugin_base.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -42,7 +41,6 @@ using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_internal_planning_msgs::msg::SafetyFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_perception_msgs::msg::PredictedObjects;
-using autoware_utils_geometry::MultiPolygon2d;
 using autoware_utils_geometry::Polygon2d;
 using sensor_msgs::msg::PointCloud2;
 using utils::obstacle_stop::CollisionPoint;
@@ -65,7 +63,7 @@ public:
 
   const ModifierParams::ObstacleStop & get_params() const { return params_; }
 
-  void publish_debug_data([[maybe_unused]] const std::string & ns) const override;
+  void publish_debug_data(const std::string & ns) const override;
 
 protected:
   void on_initialize(const TrajectoryProcessorParams & params) override;
@@ -87,8 +85,8 @@ private:
   SafetyFactorArray safety_factors_;
 
   std::unordered_map<utils::obstacle_stop::ObjectType, double> object_decel_map_;
+  utils::obstacle_stop::LateralMarginMap lateral_margin_map_;
 
-  MarkerArray marker_array_;
   PublisherHandle<visualization_msgs::msg::MarkerArray> debug_viz_pub_;
   PublisherHandle<PointCloud2> pub_filtered_pointcloud_;
   PublisherHandle<StringStamped> pub_debug_text_;

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -235,6 +235,7 @@ struct TargetObject
 {
   PredictedObject object;
   Polygon2d polygon;
+  Polygon2d ego_footprint;
   bool is_safe{false};
   double distance_from_ego{0.0};
   double safe_distance{0.0};
@@ -248,7 +249,6 @@ struct DebugData
   PointCloud2::SharedPtr filtered_points;
   PredictedObjects filtered_objects;
   TargetObjects target_objects;
-  MultiPolygon2d target_polygons;
   TrajectoryShape trajectory_shape;
   std::vector<geometry_msgs::msg::Point> target_pcd_points;
   std::optional<PredictedObject> colliding_object;
@@ -274,25 +274,30 @@ void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points)
 TrajectoryShape build_trajectory_footprint_index(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
-  const double ego_accel, const double decel, const double jerk, const double stop_margin);
+  const double ego_accel, const double decel, const double jerk, const double stop_margin,
+  const double time_delay = 0.0);
+
+using QueryResult = std::pair<size_t, Polygon2d>;
 
 /**
- * @brief Find ego footprints whose expanded OBB contains the given point.
+ * @brief Find the nearest ego footprint whose expanded OBB contains the given point.
  * @details Coarse R-tree AABB query (inflated by `lat_margin`), then a precise vehicle-frame
  * OBB test: x in [-ego_back_offset, ego_front_offset], |y| <= ego_half_width + lat_margin.
- * @return Footprint indices sorted by increasing arc_length.
+ * @return Overlapping footprint index and Ego OBB (including `lat_margin`) transformed into the
+ * nearest hit pose frame, or nullopt if none contain the point.
  */
-std::vector<size_t> query_overlapping_footprints(
+std::optional<QueryResult> query_overlapping_footprint(
   const TrajectoryShape & shape, const Point2d & point, const double lat_margin);
 
 /**
- * @brief Find ego footprints that intersect the given object polygon.
+ * @brief Find the nearest ego footprint that intersects the given object polygon.
  * @details Coarse R-tree AABB query (inflated by `lat_margin`), then
  * `autoware_utils_geometry::sat::intersects` in the footprint frame. The ego OBB (including
  * `lat_margin`) is built once per query; each candidate only inverse-transforms the object.
- * @return Footprint indices sorted by increasing arc_length.
+ * @return Overlapping footprint index and Ego OBB (including `lat_margin`) transformed into the
+ * nearest hit pose frame, or nullopt if none intersect.
  */
-std::vector<size_t> query_overlapping_footprints(
+std::optional<QueryResult> query_overlapping_footprint(
   const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin);
 
 /**
@@ -328,20 +333,20 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
  * the safe-distance model.
  * @param ego_decel Magnitude of ego deceleration [m/s^2] for the ego stopping term.
  * @param reaction_time system reaction time [s] to respond to detected collision.
- * @param safety_margin Extra longitudinal buffer [m] added to the computed safe distance.
+ * @param min_safe_distance Lower limit on the required gap while the object is moving [m].
+ * @param rss_safety_buffer Buffer added inside the RSS safe-distance formula [m].
  * @param stopped_vel_th Objects with longitudinal speed along the path below this [m/s] are
  * considered static.
  * @param lookahead_horizon Maximum `time_from_start` along the trajectory [s] to propagate objects
  * and ego states.
- * @param[out] colliding_object Object with the smallest arc-length collision among unsafe cases.
  * @return Collision geometry and arc length, or nullopt if inputs are invalid or objects are safe
  */
 std::optional<CollisionPoint> get_nearest_object_collision(
   TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
-  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  const bool use_rss_check = true);
+  const double min_safe_distance, const double rss_safety_buffer, const double stopped_vel_th,
+  const double lookahead_horizon, const bool use_rss_check = true);
 
 /// Filters predicted objects by semantic type, speed, and spatial relationship to the trajectory.
 struct ObjectFilter
@@ -399,7 +404,7 @@ struct ObjectFilter
    * @brief Keep only objects that intersect ego footprints, dropping those leaving laterally.
    * @details Objects with no overlapping footprint (expanded by `lat_margin`) are removed. Moving
    * objects judged to be exiting the corridor (using lateral velocity and a short prediction
-   * horizon) are also removed. Polygons of retained objects are accumulated in `target_polygons`.
+   * horizon) are also removed.
    * @param[in,out] objects Predicted objects to filter in place.
    * @param trajectory_points Reference path for time and geometry queries.
    * @param trajectory_shape Ego footprint index used for overlap queries.

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -157,9 +157,11 @@ struct CollisionPoint
 {
   geometry_msgs::msg::Point point;
   double arc_length;
-  rclcpp::Time start_time;
+  double obstacle_lon_vel;
   bool is_active{false};
   bool is_dynamic{false};
+  rclcpp::Time first_seen;
+  rclcpp::Time last_seen;
 
   /**
    * @brief Construct a collision sample from a point and its arc length along the reference path.
@@ -168,24 +170,29 @@ struct CollisionPoint
    * @param is_dynamic Whether this collision is dynamic.
    */
   CollisionPoint(
-    const geometry_msgs::msg::Point & point, const double arc_length, const bool is_dynamic = false)
-  : point(point), arc_length(arc_length), is_dynamic(is_dynamic)
+    const geometry_msgs::msg::Point & point, const double arc_length, const double obstacle_lon_vel,
+    const bool is_dynamic = false)
+  : point(point), arc_length(arc_length), obstacle_lon_vel(obstacle_lon_vel), is_dynamic(is_dynamic)
   {
   }
 
   /**
    * @brief Copy a collision point and attach timing / activation state (e.g. for hysteresis).
    * @param collision_point Source geometry and arc length.
-   * @param start_time Time associated with this collision state.
+   * @param first_seen Time associated with first detection of this collision state.
+   * @param last_seen Time associated with last detection of this collision state.
    * @param active Whether this collision is currently considered active.
    */
   CollisionPoint(
-    const CollisionPoint & collision_point, const rclcpp::Time & start_time, const bool active)
+    const CollisionPoint & collision_point, const rclcpp::Time & first_seen,
+    const rclcpp::Time & last_seen, const bool active)
   : point(collision_point.point),
     arc_length(collision_point.arc_length),
-    start_time(start_time),
+    obstacle_lon_vel(collision_point.obstacle_lon_vel),
     is_active(active),
-    is_dynamic(collision_point.is_dynamic)
+    is_dynamic(collision_point.is_dynamic),
+    first_seen(first_seen),
+    last_seen(last_seen)
   {
   }
 };

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -25,8 +25,10 @@
 #include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
+#include <boost/geometry/index/rtree.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_hash.hpp>
@@ -35,11 +37,13 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace autoware::trajectory_processor::utils::obstacle_stop
@@ -55,6 +59,8 @@ using autoware_perception_msgs::msg::Shape;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using autoware_utils_geometry::MultiPolygon2d;
+using autoware_utils_geometry::Point2d;
+using autoware_utils_geometry::Polygon2d;
 
 enum class ObjectType : uint8_t {
   UNKNOWN = 0,
@@ -117,6 +123,36 @@ inline static const std::unordered_map<PointCloudClassification, ObjectType>
     {PointCloudClassification::NOISE, ObjectType::NOISE},
     {PointCloudClassification::INVALID, ObjectType::UNKNOWN}};
 
+using ObjectDecelMap = std::unordered_map<ObjectType, double>;
+using LateralMarginMap = std::unordered_map<ObjectType, double>;
+
+inline ObjectType to_object_type(const PredictedObject & object)
+{
+  const auto label =
+    object.classification.empty()
+      ? ObjectClassification::UNKNOWN
+      : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+  const auto it = classification_to_object_type.find(label);
+  return it != classification_to_object_type.end() ? it->second : ObjectType::UNKNOWN;
+}
+
+inline ObjectType to_object_type(const PointCloudClassification classification)
+{
+  const auto it = pcd_class_to_object_type.find(classification);
+  return it != pcd_class_to_object_type.end() ? it->second : ObjectType::UNKNOWN;
+}
+
+inline double get_lateral_margin(const LateralMarginMap & map, const ObjectType type)
+{
+  if (const auto it = map.find(type); it != map.end()) {
+    return it->second;
+  }
+  if (const auto it = map.find(ObjectType::UNKNOWN); it != map.end()) {
+    return it->second;
+  }
+  return 0.0;
+}
+
 struct CollisionPoint
 {
   geometry_msgs::msg::Point point;
@@ -161,24 +197,53 @@ struct ObjectState
   geometry_msgs::msg::Point nearest_point;
 };
 
+/// Ego vehicle footprint sampled along the detection trajectory.
+/// Queried as an OBB using TrajectoryShape extents plus a class-specific lateral margin.
+struct EgoFootprint
+{
+  geometry_msgs::msg::Pose pose;
+  size_t traj_index{0};    ///< nearest original trajectory index
+  double arc_length{0.0};  ///< arc length from trajectory start to this pose (baselink)
+};
+
+using FootprintNode = std::pair<autoware_utils_geometry::Box2d, size_t>;
+using FootprintRtree =
+  boost::geometry::index::rtree<FootprintNode, boost::geometry::index::rstar<16>>;
+
 struct TrajectoryShape
 {
-  MultiPolygon2d polygon;
   autoware_utils_geometry::Box2d bounding_box;
-  double trajectory_length;
-  double forward_traj_length;
+  double trajectory_length{0.0};
+  double forward_traj_length{0.0};
+  std::vector<EgoFootprint> footprints;
+  FootprintRtree rtree;
+  double ego_half_width{0.0};
+  double ego_front_offset{0.0};  ///< vehicle_info.max_longitudinal_offset_m
+  double ego_back_offset{0.0};   ///< -vehicle_info.min_longitudinal_offset_m
 
   [[nodiscard]] double ego_arc_length() const { return trajectory_length - forward_traj_length; }
 };
+
+struct TargetObject
+{
+  PredictedObject object;
+  Polygon2d polygon;
+  bool is_safe{false};
+  double distance_from_ego{0.0};
+  double safe_distance{0.0};
+
+  explicit TargetObject(const PredictedObject & object) : object(object) {}
+};
+using TargetObjects = std::vector<TargetObject>;
 
 struct DebugData
 {
   PointCloud2::SharedPtr filtered_points;
   PredictedObjects filtered_objects;
+  TargetObjects target_objects;
   MultiPolygon2d target_polygons;
   TrajectoryShape trajectory_shape;
   std::vector<geometry_msgs::msg::Point> target_pcd_points;
-  geometry_msgs::msg::Point active_collision_point;
   std::optional<PredictedObject> colliding_object;
   double ego_z = 0.0;  // cached for marker placement during publish_debug_data
 };
@@ -191,46 +256,53 @@ struct DebugData
 void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points);
 
 /**
- * @brief Build a 2D swept footprint of the ego vehicle along the portion of the path used for
- * obstacle detection.
- * @details The detection length combines stopping-distance logic (speed, deceleration, jerk,
- * margins) with the path ahead of the ego. The polygon is the union of vehicle footprints
- * sampled along that segment; the returned bounding box encloses that multi-polygon.
- * @param trajectory_points Full reference trajectory.
- * @param ego_pose Current ego pose on the trajectory.
- * @param vehicle_info Vehicle geometry for the footprint polygon.
- * @param ego_vel Current longitudinal speed [m/s].
- * @param ego_accel Current longitudinal acceleration [m/s^2].
- * @param decel Magnitude of comfortable deceleration used for stopping distance [m/s^2].
- * @param jerk Longitudinal jerk limit used for stopping distance [m/s^3].
- * @param stop_margin Extra longitudinal margin added to the detection range [m].
- * @param lateral_margin Lateral expansion of the footprint [m].
- * @param longitudinal_margin Longitudinal expansion of the footprint [m].
- * @return Swept shape, its axis-aligned bounding box, total trajectory length, and forward arc
- * length from the ego.
+ * @brief Build an R-tree of ego footprints along the obstacle-detection portion of the trajectory.
+ * @details Detection length combines stopping-distance logic with the path ahead of the ego.
+ * Footprints are sampled with a minimum spacing of 0.1 m and interpolated to a maximum spacing of
+ * 1.0 m. Each entry stores the pose, nearest original trajectory index, and arc length from the
+ * trajectory start. Vehicle extents are stored without extra lateral margin; class-specific
+ * expansion is applied at query time.
+ * @return TrajectoryShape with footprints, rtree, bounding box, lengths, and ego extents populated.
  */
-TrajectoryShape get_trajectory_shape(
+TrajectoryShape build_trajectory_footprint_index(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
-  const double ego_accel, const double decel, const double jerk, const double stop_margin,
-  const double lateral_margin = 0.0, const double longitudinal_margin = 0.0);
+  const double ego_accel, const double decel, const double jerk, const double stop_margin);
 
 /**
- * @brief Find the closest point-cloud obstacle inside the trajectory swept area.
- * @details Points inside `trajectory_shape.polygon` are considered; the collision is the one with
- * minimum arc length along `trajectory_points`. All inlier points are appended to
- * `target_pcd_points` for visualization or debugging.
- * @param trajectory_points Reference path for arc-length queries.
- * @param trajectory_shape Swept ego region from get_trajectory_shape().
+ * @brief Find ego footprints whose expanded OBB contains the given point.
+ * @details Coarse R-tree AABB query (inflated by `lat_margin`), then a precise vehicle-frame
+ * OBB test: x in [-ego_back_offset, ego_front_offset], |y| <= ego_half_width + lat_margin.
+ * @return Footprint indices sorted by increasing arc_length.
+ */
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Point2d & point, const double lat_margin);
+
+/**
+ * @brief Find ego footprints that intersect the given object polygon.
+ * @details Coarse R-tree AABB query (inflated by `lat_margin`), then
+ * `autoware_utils_geometry::sat::intersects` in the footprint frame. The ego OBB (including
+ * `lat_margin`) is built once per query; each candidate only inverse-transforms the object.
+ * @return Footprint indices sorted by increasing arc_length.
+ */
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin);
+
+/**
+ * @brief Find the closest point-cloud obstacle that overlaps an ego footprint.
+ * @details Each point is queried against `trajectory_shape.rtree` with the lateral margin for its
+ * class. The collision is the inlier with minimum arc length (footprint arc length plus
+ * longitudinal offset in the vehicle frame). All inlier points are appended to `target_pcd_points`.
+ * @param trajectory_shape Ego footprint index from build_trajectory_footprint_index().
  * @param pointcloud Input points in the same frame as the trajectory.
- * @param[out] target_pcd_points Points that fell inside the trajectory polygon.
+ * @param lateral_margin_map Per-class lateral expansion of the ego footprint [m].
+ * @param[out] target_pcd_points Points that overlapped at least one footprint.
  * @return Nearest collision by arc length, or nullopt if the cloud is empty or none intersect.
  */
 std::optional<CollisionPoint> get_nearest_pcd_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
-
-using ObjectDecelMap = std::unordered_map<ObjectType, double>;
+  const TrajectoryShape & trajectory_shape, const PointCloud::Ptr & pointcloud,
+  const LateralMarginMap & lateral_margin_map,
+  std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
 /**
  * @brief Find the nearest predicted object that is not longitudinally safe relative to the ego
@@ -258,11 +330,10 @@ using ObjectDecelMap = std::unordered_map<ObjectType, double>;
  * @return Collision geometry and arc length, or nullopt if inputs are invalid or objects are safe
  */
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points,
+  TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
-  const double ego_decel, const double reaction_time, const double safety_margin,
-  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object,
+  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
+  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   const bool use_rss_check = true);
 
 /// Filters predicted objects by semantic type, speed, and spatial relationship to the trajectory.
@@ -318,19 +389,20 @@ struct ObjectFilter
   }
 
   /**
-   * @brief Keep only objects that intersect the target region, dropping those leaving laterally.
-   * @details Objects disjoint from `target_area` are removed. Moving objects that are judged to be
-   * exiting the corridor (using lateral velocity and a short prediction horizon) are also removed.
-   * Polygons of retained objects are accumulated in `target_polygons`.
+   * @brief Keep only objects that intersect ego footprints, dropping those leaving laterally.
+   * @details Objects with no overlapping footprint (expanded by `lat_margin`) are removed. Moving
+   * objects judged to be exiting the corridor (using lateral velocity and a short prediction
+   * horizon) are also removed. Polygons of retained objects are accumulated in `target_polygons`.
    * @param[in,out] objects Predicted objects to filter in place.
    * @param trajectory_points Reference path for time and geometry queries.
-   * @param target_area Multi-polygon region of interest (e.g. expanded path).
+   * @param trajectory_shape Ego footprint index used for overlap queries.
+   * @param lateral_margin_map Per-class lateral expansion of the ego footprint [m].
    * @param[out] target_polygons Footprints of objects that remain after filtering.
    */
   void filter_by_target_area(
-    PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+    TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-    const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons);
+    const TrajectoryShape & trajectory_shape, const LateralMarginMap & lateral_margin_map);
 
   /**
    * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
@@ -457,8 +529,7 @@ struct ObstacleTracker
    * @param now Current stamp used for track aging and activation timing
    */
   void update_objects(
-    const PredictedObjects & objects, PredictedObjects & persistent_objects,
-    const rclcpp::Time & now);
+    const PredictedObjects & objects, TargetObjects & persistent_objects, const rclcpp::Time & now);
 
   /**
    * @brief Update tracked points

--- a/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_processor/include/autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp
@@ -44,7 +44,8 @@ bool is_stop_trajectory(const TrajectoryPoints & trajectory, const double stoppe
 
 double clamp_stop_point_arc_length(
   const double stop_point_arc_length, const double max_length, const double ego_vel,
-  const double ego_accel, const double decel_limit, const double jerk_limit);
+  const double ego_accel, const double decel_limit, const double jerk_limit,
+  const double time_delay = 0.0);
 
 bool stop_point_exists(
   const TrajectoryPoints & traj_points, const double stop_point_arc_length,

--- a/planning/autoware_trajectory_processor/package.xml
+++ b/planning/autoware_trajectory_processor/package.xml
@@ -42,7 +42,6 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>pluginlib</depend>
-  <depend>range-v3</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rclpy</depend>

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -106,6 +106,13 @@ trajectory_processor_params:
       read_only: false
       validation:
         bounds<>: [0.0, 10.0]
+    delay_response_time:
+      type: double
+      default_value: 0.5
+      description: Delay response time used to estimate the minimum ego stopping distance [s]
+      read_only: false
+      validation:
+        bounds<>: [0.0, 10.0]
     arrived_distance_threshold:
       type: double
       default_value: 0.5

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -403,16 +403,9 @@ trajectory_processor_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-      reaction_time:
-        type: double
-        default_value: 0.2
-        description: Reaction time to consider for RSS calculation [s]
-        validation:
-          bounds<>: [0.0, 10.0]
-        read_only: false
       safety_margin:
         type: double
-        default_value: 2.0
+        default_value: 1.5
         description: Safety margin to consider for RSS calculation [m]
         validation:
           bounds<>: [0.0, 10.0]

--- a/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
+++ b/planning/autoware_trajectory_processor/param/trajectory_processor_parameter_struct.yaml
@@ -149,13 +149,6 @@ trajectory_processor_params:
       validation:
         bounds<>: [0.0, 100.0]
       read_only: false
-    lateral_margin:
-      type: double
-      default_value: 0.5
-      description: Lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
     duplicate_check_threshold:
       type: double
       default_value: 0.5
@@ -221,6 +214,11 @@ trajectory_processor_params:
           default_value: [car, truck, bus, trailer, pedestrian, hazard, unknown]
           description: Types of polygon shaped objects to consider for obstacle stop
           read_only: false
+        pointcloud:
+          type: string_array
+          default_value: [structure, vegetation]
+          description: Types of pointcloud to consider for obstacle stop
+          read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.25
@@ -242,26 +240,98 @@ trajectory_processor_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-    pointcloud:
-      target_types:
-        type: string_array
-        default_value: [hazard, structure, vegetation]
-        description: Pointcloud types to consider for obstacle stop
-        read_only: false
-      height_buffer:
+      pointcloud_height_buffer:
         type: double
-        default_value: 0.5
-        description: Height buffer to add above ego height [m]
+        default_value: 0.2
+        description: Height buffer to add above ego height for pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-      min_height:
+      pointcloud_min_height:
         type: double
         default_value: 0.2
         description: Minimum height of pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
+      lateral_margin:
+        car:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for car objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        truck:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for truck objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        bus:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for bus objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        trailer:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for trailer objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        motorcycle:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for motorcycle objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        bicycle:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for bicycle objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        pedestrian:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for pedestrian objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        hazard:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for hazard objects [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        structure:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for structure pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        vegetation:
+          type: double
+          default_value: 0.1
+          description: Lateral margin on top of ego width for vegetation pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
+        unknown:
+          type: double
+          default_value: 0.0
+          description: Lateral margin on top of ego width for unknown objects and unclassified pointcloud [m]
+          validation:
+            bounds<>: [0.0, 10.0]
+          read_only: false
 
     rss_params:
       enable:

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -161,12 +161,6 @@
               "default": 3.0,
               "minimum": 0.0
             },
-            "lateral_margin": {
-              "type": "number",
-              "description": "Lateral margin on top of ego width from trajectory to consider for obstacle stop [m]",
-              "default": 0.5,
-              "minimum": 0
-            },
             "duplicate_check_threshold": {
               "type": "number",
               "description": "Threshold to check if the stop point is already in the trajectory [m]",
@@ -255,6 +249,14 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "pointcloud": {
+                      "type": "array",
+                      "description": "Types of pointcloud to consider for obstacle stop",
+                      "default": ["structure", "vegetation"],
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [],
@@ -277,33 +279,92 @@
                   "description": "Safety buffer to expand object shape [m]",
                   "default": 0,
                   "minimum": 0
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            },
-            "pointcloud": {
-              "type": "object",
-              "properties": {
-                "target_types": {
-                  "type": "array",
-                  "description": "Pointcloud types to consider for obstacle stop",
-                  "default": ["hazard", "structure", "vegetation"],
-                  "items": {
-                    "type": "string"
-                  }
                 },
-                "height_buffer": {
+                "pointcloud_height_buffer": {
                   "type": "number",
-                  "description": "Height buffer to add above ego height [m]",
-                  "default": 0.5,
-                  "minimum": 0
+                  "description": "Height buffer to add above ego height for pointcloud [m]",
+                  "default": 0.2,
+                  "minimum": 0.0
                 },
-                "min_height": {
+                "pointcloud_min_height": {
                   "type": "number",
                   "description": "Minimum height of pointcloud [m]",
                   "default": 0.2,
-                  "minimum": 0
+                  "minimum": 0.0
+                },
+                "lateral_margin": {
+                  "type": "object",
+                  "description": "Lateral margin on top of ego width from trajectory, per object or pointcloud class [m]",
+                  "properties": {
+                    "car": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for car objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "truck": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for truck objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "bus": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for bus objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "trailer": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for trailer objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "motorcycle": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for motorcycle objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "bicycle": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for bicycle objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "pedestrian": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for pedestrian objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "hazard": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for hazard objects [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "structure": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for structure pointcloud [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "vegetation": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for vegetation pointcloud [m]",
+                      "default": 0.1,
+                      "minimum": 0.0
+                    },
+                    "unknown": {
+                      "type": "number",
+                      "description": "Lateral margin on top of ego width for unknown objects and unclassified pointcloud [m]",
+                      "default": 0.0,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
+++ b/planning/autoware_trajectory_processor/schema/trajectory_processor.schema.json
@@ -439,16 +439,10 @@
                   "default": 4,
                   "minimum": 0
                 },
-                "reaction_time": {
-                  "type": "number",
-                  "description": "Reaction time to consider for RSS calculation [s]",
-                  "default": 0.2,
-                  "minimum": 0
-                },
                 "safety_margin": {
                   "type": "number",
                   "description": "Safety margin to consider for RSS calculation [m]",
-                  "default": 2,
+                  "default": 1.5,
                   "minimum": 0
                 },
                 "lookahead_horizon": {

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -17,11 +17,8 @@
 #include "autoware/trajectory_processor/trajectory_modifier_utils/obstacle_stop_utils.hpp"
 #include "autoware/trajectory_processor/trajectory_modifier_utils/utils.hpp"
 
-#include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware/trajectory/trajectory_point.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
-#include <autoware_utils/transform/transforms.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/logging.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -35,11 +32,13 @@
 
 namespace autoware::trajectory_processor::plugin
 {
+using utils::obstacle_stop::build_trajectory_footprint_index;
 using utils::obstacle_stop::get_nearest_object_collision;
 using utils::obstacle_stop::get_nearest_pcd_collision;
-using utils::obstacle_stop::get_trajectory_shape;
 using utils::obstacle_stop::PointCloud;
 using utils::obstacle_stop::PointCloud2;
+using utils::obstacle_stop::TargetObject;
+using utils::obstacle_stop::TargetObjects;
 
 void ObstacleStop::on_initialize(const TrajectoryProcessorParams & params)
 {
@@ -62,15 +61,26 @@ void ObstacleStop::on_initialize(const TrajectoryProcessorParams & params)
   }
 
   {
-    const auto & p = params_.pointcloud;
-    pointcloud_filter_ = std::make_unique<utils::obstacle_stop::PointCloudFilter>(p.target_types);
-  }
-
-  {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
       p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
       p.max_lateral_velocity_th, p.safety_buffer);
+    pointcloud_filter_ =
+      std::make_unique<utils::obstacle_stop::PointCloudFilter>(p.target_objects.pointcloud);
+
+    lateral_margin_map_ = {
+      {utils::obstacle_stop::ObjectType::CAR, p.lateral_margin.car},
+      {utils::obstacle_stop::ObjectType::TRUCK, p.lateral_margin.truck},
+      {utils::obstacle_stop::ObjectType::BUS, p.lateral_margin.bus},
+      {utils::obstacle_stop::ObjectType::TRAILER, p.lateral_margin.trailer},
+      {utils::obstacle_stop::ObjectType::MOTORCYCLE, p.lateral_margin.motorcycle},
+      {utils::obstacle_stop::ObjectType::BICYCLE, p.lateral_margin.bicycle},
+      {utils::obstacle_stop::ObjectType::PEDESTRIAN, p.lateral_margin.pedestrian},
+      {utils::obstacle_stop::ObjectType::HAZARD, p.lateral_margin.hazard},
+      {utils::obstacle_stop::ObjectType::STRUCTURE, p.lateral_margin.structure},
+      {utils::obstacle_stop::ObjectType::VEGETATION, p.lateral_margin.vegetation},
+      {utils::obstacle_stop::ObjectType::UNKNOWN, p.lateral_margin.unknown},
+    };
   }
 
   {
@@ -108,15 +118,25 @@ void ObstacleStop::update_params(const TrajectoryProcessorParams & params)
   }
 
   {
-    const auto & p = params_.pointcloud;
-    pointcloud_filter_->set_params(p.target_types);
-  }
-
-  {
     const auto & p = params_.objects;
     object_filter_->set_params(
       p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
       p.max_lateral_velocity_th, p.safety_buffer);
+    pointcloud_filter_->set_params(p.target_objects.pointcloud);
+
+    lateral_margin_map_ = {
+      {utils::obstacle_stop::ObjectType::CAR, p.lateral_margin.car},
+      {utils::obstacle_stop::ObjectType::TRUCK, p.lateral_margin.truck},
+      {utils::obstacle_stop::ObjectType::BUS, p.lateral_margin.bus},
+      {utils::obstacle_stop::ObjectType::TRAILER, p.lateral_margin.trailer},
+      {utils::obstacle_stop::ObjectType::MOTORCYCLE, p.lateral_margin.motorcycle},
+      {utils::obstacle_stop::ObjectType::BICYCLE, p.lateral_margin.bicycle},
+      {utils::obstacle_stop::ObjectType::PEDESTRIAN, p.lateral_margin.pedestrian},
+      {utils::obstacle_stop::ObjectType::HAZARD, p.lateral_margin.hazard},
+      {utils::obstacle_stop::ObjectType::STRUCTURE, p.lateral_margin.structure},
+      {utils::obstacle_stop::ObjectType::VEGETATION, p.lateral_margin.vegetation},
+      {utils::obstacle_stop::ObjectType::UNKNOWN, p.lateral_margin.unknown},
+    };
   }
 
   {
@@ -153,19 +173,17 @@ bool ObstacleStop::is_trajectory_modification_required(
 
   {
     autoware_utils_debug::ScopedTimeTrack st(
-      "ObstacleStop::get_trajectory_shape", *get_time_keeper());
+      "ObstacleStop::build_trajectory_footprint_index", *get_time_keeper());
 
-    debug_data_.trajectory_shape = get_trajectory_shape(
+    debug_data_.trajectory_shape = build_trajectory_footprint_index(
       traj_points, input.current_odometry->pose.pose, context_->vehicle_info,
       input.current_odometry->twist.twist.linear.x,
       input.current_acceleration->accel.accel.linear.x, stopping_params_.nominal_deceleration,
-      stopping_params_.jerk_limit, params_.stop_margin, params_.lateral_margin);
+      stopping_params_.jerk_limit, params_.stop_margin);
   }
 
   check_obstacles(traj_points, input);
 
-  debug_data_.active_collision_point =
-    nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
   debug_data_.ego_z = input.current_odometry->pose.pose.position.z;
 
   const bool is_safe = nearest_collision_point_ == std::nullopt;
@@ -203,8 +221,10 @@ bool ObstacleStop::set_stop_point(
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::set_stop_point", *get_time_keeper());
 
+  const auto stop_margin =
+    nearest_collision_point_->is_dynamic ? params_.minimum_stop_margin : params_.stop_margin;
   const auto ego_longitudinal_offset = context_->vehicle_info.max_longitudinal_offset_m;
-  const auto target_stop_margin = params_.stop_margin + ego_longitudinal_offset;
+  const auto target_stop_margin = stop_margin + ego_longitudinal_offset;
   const auto target_stop_point_arc_length = utils::clamp_stop_point_arc_length(
     nearest_collision_point_->arc_length - target_stop_margin,
     debug_data_.trajectory_shape.trajectory_length, input.current_odometry->twist.twist.linear.x,
@@ -212,10 +232,10 @@ bool ObstacleStop::set_stop_point(
     stopping_params_.jerk_limit);
 
   // actual stop margin from ego front to collision point
-  const auto stop_margin =
+  const auto actual_stop_margin =
     nearest_collision_point_->arc_length - (target_stop_point_arc_length + ego_longitudinal_offset);
   const auto overlap_th =
-    stop_margin > params_.minimum_stop_margin ? params_.duplicate_check_threshold : 0.0;
+    actual_stop_margin > params_.minimum_stop_margin ? params_.duplicate_check_threshold : 0.0;
   if (utils::stop_point_exists(traj_points, target_stop_point_arc_length, overlap_th)) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 1000,
@@ -310,53 +330,41 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   object_filter_->filter_objects(debug_data_.filtered_objects);
 
-  PredictedObjects active_objects;
   obstacle_tracker_->update_objects(
-    debug_data_.filtered_objects, active_objects, get_clock()->now());
+    debug_data_.filtered_objects, debug_data_.target_objects, get_clock()->now());
 
   object_filter_->filter_by_target_area(
-    active_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape.polygon,
-    debug_data_.target_polygons);
+    debug_data_.target_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape,
+    lateral_margin_map_);
 
-  autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
-    traj_points, context_->vehicle_info, active_objects, object_decel_map_,
+    debug_data_.target_objects, traj_points, context_->vehicle_info, object_decel_map_,
     params_.rss_params.ego_decel, params_.rss_params.reaction_time,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
+    params_.rss_params.lookahead_horizon, params_.rss_params.enable);
 
-  if (collision_point) debug_data_.colliding_object = colliding_object;
+  if (collision_point) {
+    auto it = std::find_if(
+      debug_data_.target_objects.begin(), debug_data_.target_objects.end(),
+      [&](const TargetObject & object) { return !object.is_safe; });
+    if (it != debug_data_.target_objects.end()) {
+      debug_data_.colliding_object = it->object;
+    }
+  }
 
   return collision_point;
 }
 
 std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
-  const TrajectoryPoints & traj_points, const TrajectoryProcessorData & input)
+  [[maybe_unused]] const TrajectoryPoints & traj_points, const TrajectoryProcessorData & input)
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::check_pointcloud", *get_time_keeper());
   if (!params_.use_pointcloud || !input.obstacle_pointcloud) return std::nullopt;
 
   PointCloud::Ptr filtered_pointcloud(new PointCloud);
   pcl::fromROSMsg(*input.obstacle_pointcloud, *filtered_pointcloud);
-  {
-    autoware_utils_debug::ScopedTimeTrack stt(
-      "ObstacleStop::filter_pointcloud", *get_time_keeper());
-    const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
-    const auto rel_min_corner = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.min_corner().to_3d(), input.current_odometry->pose.pose);
-    const auto rel_max_corner = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.max_corner().to_3d(), input.current_odometry->pose.pose);
-    constexpr double buffer = 1.0;
-    const auto [min_x, max_x] = std::minmax(rel_min_corner.x(), rel_max_corner.x());
-    const auto [min_y, max_y] = std::minmax(rel_min_corner.y(), rel_max_corner.y());
-    const auto min_z = params_.pointcloud.min_height;
-    const auto max_z = context_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
-    pointcloud_filter_->filter_pointcloud(
-      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
-      max_z);
-  }
 
-  if (!filtered_pointcloud->empty()) {
+  {
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
       transform_stamped = context_->tf_buffer.lookupTransform(
@@ -373,6 +381,22 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
       p.y = q.y();
       p.z = q.z();
     }
+  }
+
+  {
+    autoware_utils_debug::ScopedTimeTrack stt(
+      "ObstacleStop::filter_pointcloud", *get_time_keeper());
+    const auto & bbox = debug_data_.trajectory_shape.bounding_box;
+    constexpr double buffer = 1.0;
+    const auto [min_x, max_x] = std::minmax(bbox.min_corner().x(), bbox.max_corner().x());
+    const auto [min_y, max_y] = std::minmax(bbox.min_corner().y(), bbox.max_corner().y());
+    const auto ego_z = input.current_odometry->pose.pose.position.z;
+    const auto min_z = ego_z + params_.objects.pointcloud_min_height;
+    const auto max_z =
+      ego_z + context_->vehicle_info.vehicle_height_m + params_.objects.pointcloud_height_buffer;
+    pointcloud_filter_->filter_pointcloud(
+      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
+      max_z);
   }
 
   {
@@ -397,7 +421,8 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
     autoware_utils_debug::ScopedTimeTrack stt(
       "ObstacleStop::get_nearest_pcd_collision", *get_time_keeper());
     collision_point = get_nearest_pcd_collision(
-      traj_points, debug_data_.trajectory_shape, active_points, debug_data_.target_pcd_points);
+      debug_data_.trajectory_shape, active_points, lateral_margin_map_,
+      debug_data_.target_pcd_points);
   }
 
   return collision_point;
@@ -435,6 +460,7 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
 
 void ObstacleStop::publish_debug_data(const std::string & ns) const
 {
+  autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::publish_debug_data", *get_time_keeper());
   if (debug_data_.filtered_points) pub_filtered_pointcloud_(*debug_data_.filtered_points);
 
   MarkerArray marker_array;
@@ -443,17 +469,46 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
   const auto yellow = autoware_utils::create_marker_color(1.0, 1.0, 0.0, 1.0);
   const auto magenta = autoware_utils::create_marker_color(1.0, 0.0, 1.0, 1.0);
 
-  auto add_point_marker = [&](
-                            const geometry_msgs::msg::Point & point, const std::string & ns,
-                            const int id, const std_msgs::msg::ColorRGBA & color,
-                            const double scale = 0.1) {
+  auto add_line_list_marker = [&](
+                                const std::vector<geometry_msgs::msg::Point> & segments,
+                                const std::string & ns, const int id,
+                                const std_msgs::msg::ColorRGBA & color) {
     Marker marker = autoware_utils::create_default_marker(
-      "map", get_clock()->now(), ns, id, Marker::SPHERE,
-      autoware_utils::create_marker_scale(scale, scale, scale), color);
+      "map", get_clock()->now(), ns, id, Marker::LINE_LIST,
+      autoware_utils::create_marker_scale(0.1, 0.1, 0.1), color);
     marker.lifetime = rclcpp::Duration::from_seconds(0.2);
-    marker.pose.position = point;
+    marker.points = segments;
     marker_array.markers.push_back(marker);
   };
+
+  int id = 0;
+  {
+    using autoware_utils_geometry::calc_offset_pose;
+    const auto & shape = debug_data_.trajectory_shape;
+    const auto half_width = shape.ego_half_width;
+    const auto front_offset = std::abs(shape.ego_front_offset);
+    const auto back_offset = std::abs(shape.ego_back_offset);
+    std::vector<geometry_msgs::msg::Point> segments;
+    auto dist = 0.0;
+    for (const auto & footprint : shape.footprints) {
+      if (footprint.arc_length - dist < 1.0) continue;
+      dist = footprint.arc_length;
+      auto front_left = calc_offset_pose(footprint.pose, front_offset, -half_width, 0.0).position;
+      auto front_right = calc_offset_pose(footprint.pose, front_offset, half_width, 0.0).position;
+      auto rear_right = calc_offset_pose(footprint.pose, -back_offset, half_width, 0.0).position;
+      auto rear_left = calc_offset_pose(footprint.pose, -back_offset, -half_width, 0.0).position;
+      segments.emplace_back(rear_left);
+      segments.emplace_back(front_left);
+      segments.emplace_back(front_left);
+      segments.emplace_back(front_right);
+      segments.emplace_back(front_right);
+      segments.emplace_back(rear_right);
+      segments.emplace_back(rear_right);
+      segments.emplace_back(rear_left);
+    }
+    add_line_list_marker(segments, ns + "/traj_polygon", id, yellow);
+    id++;
+  }
 
   auto add_polygon_marker = [&](
                               const autoware_utils_geometry::Polygon2d & polygon,
@@ -473,11 +528,19 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     marker_array.markers.push_back(marker);
   };
 
-  int id = 0;
-  for (const auto & traj_polygon : debug_data_.trajectory_shape.polygon) {
-    add_polygon_marker(traj_polygon, ns + "/traj_polygon", id, yellow);
-    id++;
-  }
+  auto add_text_marker = [&](
+                           const std::string & text, const geometry_msgs::msg::Pose & pose,
+                           const std::string & ns, const int id,
+                           const std_msgs::msg::ColorRGBA & color, const double scale = 0.4) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), ns, id, Marker::TEXT_VIEW_FACING,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose = pose;
+    marker.pose.position.z += 1.0;
+    marker.text = text;
+    marker_array.markers.push_back(marker);
+  };
 
   {
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
@@ -490,10 +553,31 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     id++;
   }
 
-  for (const auto & target_polygon : debug_data_.target_polygons) {
+  for (const auto & obj : debug_data_.target_objects) {
+    const auto & target_polygon = obj.polygon;
     add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(2);
+    ss << "safe: " << (obj.is_safe ? "true" : "false") << "\n";
+    ss << "rss_safe_dist: " << obj.safe_distance << " m" << "\n";
+    ss << "dist_from_ego: " << obj.distance_from_ego << " m";
+    add_text_marker(
+      ss.str(), obj.object.kinematics.initial_pose_with_covariance.pose,
+      ns + "/target_objects_text", id, white);
     id++;
   }
+
+  auto add_point_marker = [&](
+                            const geometry_msgs::msg::Point & point, const std::string & ns,
+                            const int id, const std_msgs::msg::ColorRGBA & color,
+                            const double scale = 0.1) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), ns, id, Marker::SPHERE,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose.position = point;
+    marker_array.markers.push_back(marker);
+  };
 
   for (const auto & target_pcd_point : debug_data_.target_pcd_points) {
     add_point_marker(target_pcd_point, ns + "/target_pcd", id, magenta, 0.25);

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -179,7 +179,7 @@ bool ObstacleStop::is_trajectory_modification_required(
       traj_points, input.current_odometry->pose.pose, context_->vehicle_info,
       input.current_odometry->twist.twist.linear.x,
       input.current_acceleration->accel.accel.linear.x, stopping_params_.nominal_deceleration,
-      stopping_params_.jerk_limit, params_.stop_margin);
+      stopping_params_.jerk_limit, params_.stop_margin, stopping_params_.delay_response_time);
   }
 
   check_obstacles(traj_points, input);
@@ -229,7 +229,7 @@ bool ObstacleStop::set_stop_point(
     nearest_collision_point_->arc_length - target_stop_margin,
     debug_data_.trajectory_shape.trajectory_length, input.current_odometry->twist.twist.linear.x,
     input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
-    stopping_params_.jerk_limit);
+    stopping_params_.jerk_limit, stopping_params_.delay_response_time);
 
   // actual stop margin from ego front to collision point
   const auto actual_stop_margin =
@@ -339,7 +339,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   auto collision_point = get_nearest_object_collision(
     debug_data_.target_objects, traj_points, context_->vehicle_info, object_decel_map_,
-    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.ego_decel, stopping_params_.delay_response_time, params_.stop_margin,
     params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
     params_.rss_params.lookahead_horizon, params_.rss_params.enable);
 
@@ -440,7 +440,7 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
      << "SAFE: " << is_safe << "\n";
   ss << "\t\t"
      << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
-     << debug_data_.target_polygons.size() << "\n";
+     << debug_data_.target_objects.size() << "\n";
   ss << "\t\t" << "POINTCLOUD: " << filtered_pcd_size << " --> "
      << debug_data_.target_pcd_points.size() << "\n";
   if (nearest_collision_point_) {
@@ -554,8 +554,7 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
   }
 
   for (const auto & obj : debug_data_.target_objects) {
-    const auto & target_polygon = obj.polygon;
-    add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
+    add_polygon_marker(obj.polygon, ns + "/target_objects", id, magenta);
     std::stringstream ss;
     ss << std::fixed << std::setprecision(2);
     ss << "safe: " << (obj.is_safe ? "true" : "false") << "\n";
@@ -564,6 +563,8 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
     add_text_marker(
       ss.str(), obj.object.kinematics.initial_pose_with_covariance.pose,
       ns + "/target_objects_text", id, white);
+    if (!obj.is_safe)
+      add_polygon_marker(obj.ego_footprint, ns + "/overlapping_ego_footprint", id, magenta);
     id++;
   }
 

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <iterator>
 #include <limits>
+#include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -55,11 +56,10 @@ void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points)
 
 double get_detection_length(
   const double forward_traj_length, const double current_vel, const double current_accel,
-  const double decel, const double jerk, const double stop_margin)
+  const double decel, const double jerk, const double stop_margin, const double time_delay)
 {
   // add a buffer length to account for the reaction time of the vehicle
   constexpr double buffer_length = 1.0;
-  constexpr double time_delay = 0.3;
   const auto margin = stop_margin + buffer_length;
   auto nominal_stopping_distance = autoware::motion_utils::calculate_stop_distance(
     current_vel, current_accel, decel, jerk, time_delay);
@@ -142,7 +142,8 @@ TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, c
 TrajectoryShape build_trajectory_footprint_index(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
-  const double ego_accel, const double decel, const double jerk, const double stop_margin)
+  const double ego_accel, const double decel, const double jerk, const double stop_margin,
+  const double time_delay)
 {
   TrajectoryShape shape;
   shape.trajectory_length = 0.0;
@@ -164,8 +165,8 @@ TrajectoryShape build_trajectory_footprint_index(
   shape.trajectory_length = traj_length;
   shape.forward_traj_length = forward_traj_length;
 
-  const auto detection_length =
-    get_detection_length(forward_traj_length, ego_vel, ego_accel, decel, jerk, stop_margin);
+  const auto detection_length = get_detection_length(
+    forward_traj_length, ego_vel, ego_accel, decel, jerk, stop_margin, time_delay);
 
   const auto detection_traj = std::invoke([&]() -> TrajectoryPoints {
     if (detection_length < forward_traj_length) {
@@ -255,13 +256,11 @@ std::vector<FootprintNode> query_rtree_candidates(
   return candidates;
 }
 
-std::vector<size_t> sort_hits_by_arc_length(
-  const TrajectoryShape & shape, std::vector<size_t> && hits)
+void sort_hits_by_arc_length(const TrajectoryShape & shape, std::vector<size_t> & hits)
 {
   std::sort(hits.begin(), hits.end(), [&](const size_t a, const size_t b) {
     return shape.footprints[a].arc_length < shape.footprints[b].arc_length;
   });
-  return hits;
 }
 
 bool is_point_within_footprint(
@@ -285,23 +284,26 @@ Polygon2d make_local_ego_polygon(const TrajectoryShape & shape, const double lat
   return ego;
 }
 
-Polygon2d transform_polygon_to_pose_frame(
-  const Polygon2d & polygon, const geometry_msgs::msg::Pose & pose)
+Polygon2d transform_polygon(
+  const Polygon2d & polygon, const geometry_msgs::msg::Pose & pose, bool inverse = false)
 {
+  auto pose_2d = pose;
+  pose_2d.orientation = autoware_utils::create_quaternion_from_yaw(tf2::getYaw(pose.orientation));
   Polygon2d local;
   local.outer().reserve(polygon.outer().size());
   for (const auto & p : polygon.outer()) {
-    const auto rel = autoware_utils::inverse_transform_point(p.to_3d(), pose);
+    const auto rel = inverse ? autoware_utils::inverse_transform_point(p.to_3d(), pose_2d)
+                             : autoware_utils::transform_point(p.to_3d(), pose_2d);
     local.outer().emplace_back(rel.x(), rel.y());
   }
   return local;
 }
 }  // namespace
 
-std::vector<size_t> query_overlapping_footprints(
+std::optional<QueryResult> query_overlapping_footprint(
   const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin)
 {
-  if (polygon.outer().empty()) return {};
+  if (polygon.outer().empty()) return std::nullopt;
 
   const auto query_box = inflate_box(
     boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(polygon), lat_margin);
@@ -311,16 +313,19 @@ std::vector<size_t> query_overlapping_footprints(
   std::vector<size_t> hits;
   hits.reserve(candidates.size());
   for (const auto & node : candidates) {
-    const auto object_local =
-      transform_polygon_to_pose_frame(polygon, shape.footprints[node.second].pose);
+    const auto object_local = transform_polygon(polygon, shape.footprints[node.second].pose, true);
     if (autoware_utils_geometry::sat::intersects(ego_local, object_local)) {
       hits.push_back(node.second);
     }
   }
-  return sort_hits_by_arc_length(shape, std::move(hits));
+
+  if (hits.empty()) return std::nullopt;
+  sort_hits_by_arc_length(shape, hits);
+  const auto overlap_polygon = transform_polygon(ego_local, shape.footprints[hits.front()].pose);
+  return QueryResult(hits.front(), overlap_polygon);
 }
 
-std::vector<size_t> query_overlapping_footprints(
+std::optional<QueryResult> query_overlapping_footprint(
   const TrajectoryShape & shape, const Point2d & point, const double lat_margin)
 {
   const autoware_utils_geometry::Box2d query_box{
@@ -335,7 +340,12 @@ std::vector<size_t> query_overlapping_footprints(
       hits.push_back(node.second);
     }
   }
-  return sort_hits_by_arc_length(shape, std::move(hits));
+
+  if (hits.empty()) return std::nullopt;
+  sort_hits_by_arc_length(shape, hits);
+  const auto overlap_polygon = transform_polygon(
+    make_local_ego_polygon(shape, lat_margin), shape.footprints[hits.front()].pose);
+  return QueryResult(hits.front(), overlap_polygon);
 }
 
 std::optional<CollisionPoint> get_nearest_pcd_collision(
@@ -353,10 +363,11 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
     const auto classification = static_cast<PointCloudClassification>(point.class_id);
     const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(classification));
     const Point2d query_point{point.x, point.y};
-    const auto hits = query_overlapping_footprints(trajectory_shape, query_point, lat_margin);
-    if (hits.empty()) continue;
+    const auto result = query_overlapping_footprint(trajectory_shape, query_point, lat_margin);
+    if (!result) continue;
 
-    const auto & footprint = trajectory_shape.footprints[hits.front()];
+    const auto & [index, overlap_polygon] = result.value();
+    const auto & footprint = trajectory_shape.footprints[index];
     const auto rel = autoware_utils::inverse_transform_point(query_point.to_3d(), footprint.pose);
     const auto arc_length = footprint.arc_length + rel.x();
 
@@ -465,7 +476,7 @@ double get_safe_distance(
   const auto ego_stopping_distance = ego_vel * ego_vel / (2 * ego_decel_mag);
   const auto safe_distance =
     reaction_distance + ego_stopping_distance - object_stopping_distance + safety_margin;
-  return std::max(safe_distance, safety_margin);
+  return safe_distance;
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
@@ -501,8 +512,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
-  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  const bool use_rss_check)
+  const double min_safe_distance, const double rss_safety_buffer, const double stopped_vel_th,
+  const double lookahead_horizon, const bool use_rss_check)
 {
   if (target_objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
@@ -536,8 +547,10 @@ std::optional<CollisionPoint> get_nearest_object_collision(
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
     if (obj_stopping_distance <= eps)
       return std::make_tuple(false, relative_arc_length, relative_arc_length);
-    const auto safe_dist =
-      get_safe_distance(ego_vel, ego_decel, obj_stopping_distance, reaction_time, safety_margin);
+    const auto safe_dist = std::max(
+      min_safe_distance,
+      get_safe_distance(
+        ego_vel, ego_decel, obj_stopping_distance, reaction_time, rss_safety_buffer));
     return std::make_tuple(relative_arc_length - safe_dist > 1e-3, safe_dist, relative_arc_length);
   };
 
@@ -549,7 +562,6 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   for (auto & object : target_objects) {
     auto last_p = trajectory_points.front().pose.position;
     auto curr_arc_length = 0.0;
-    bool is_first = true;
     for (const auto & traj_p : trajectory_points) {
       const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
       if (t > lookahead_horizon) break;
@@ -559,14 +571,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
       const auto obj_state = get_object_state_at_time(trajectory_points, object.object, t);
       const auto obj_stopping_distance =
         get_object_stopping_distance(object.object, obj_state.lon_vel);
-      const auto [safe, safe_distance, distance_from_ego] =
+      std::tie(object.is_safe, object.safe_distance, object.distance_from_ego) =
         is_safe(obj_state.arc_length, obj_stopping_distance, curr_arc_length, target_ego_vel);
-      object.is_safe = safe;
-      if (is_first) {
-        is_first = false;
-        object.safe_distance = safe_distance;
-        object.distance_from_ego = distance_from_ego;
-      }
       if (object.is_safe) continue;
       found_collision = true;
       auto collision_arc_length = obj_state.arc_length + obj_stopping_distance;
@@ -682,10 +688,6 @@ void ObjectFilter::filter_by_target_area(
     return autoware_utils::expand_polygon(polygon, safety_buffer_);
   };
 
-  auto overlaps_ego_footprints = [&](const Polygon2d & polygon, const double lat_margin) {
-    return !query_overlapping_footprints(trajectory_shape, polygon, lat_margin).empty();
-  };
-
   auto is_exiting = [&](const auto & object, const double lat_margin) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
@@ -705,7 +707,8 @@ void ObjectFilter::filter_by_target_area(
     if (!t_to_obj_current_pos) return true;
     const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos.value());
     const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);
-    return !overlaps_ego_footprints(obj_pred_polygon, lat_margin);
+    return query_overlapping_footprint(trajectory_shape, obj_pred_polygon, lat_margin) ==
+           std::nullopt;
   };
 
   target_objects.erase(
@@ -716,9 +719,12 @@ void ObjectFilter::filter_by_target_area(
         const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(object));
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
         const auto object_polygon = get_object_polygon(object_pose, object.shape);
-        if (!overlaps_ego_footprints(object_polygon, lat_margin)) return true;
+        const auto query_result =
+          query_overlapping_footprint(trajectory_shape, object_polygon, lat_margin);
+        if (!query_result) return true;
         if (is_exiting(object, lat_margin)) return true;
         obj.polygon = object_polygon;
+        obj.ego_footprint = query_result.value().second;
         return false;
       }),
     target_objects.end());

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -436,7 +436,7 @@ ObjectState get_object_state_at_time(
     const Eigen::Rotation2Dd obj_rot(tf2::getYaw(predicted_obj_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
     const auto obj_vel_vector = obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y);
-    return std::max(0.0, obj_vel_vector.dot(traj_dir));
+    return obj_vel_vector.dot(traj_dir);
   }();
 
   const auto obj_polygon = autoware_utils::to_polygon2d(predicted_obj_pose, object.shape);
@@ -544,7 +544,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   auto min_collision_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
-  bool is_dynamic_collision = false;
+  double obstacle_lon_vel = 0.0;
 
   for (auto & object : target_objects) {
     auto last_p = trajectory_points.front().pose.position;
@@ -576,14 +576,16 @@ std::optional<CollisionPoint> get_nearest_object_collision(
           trajectory_points, obj_state.nearest_point, obj_stopping_distance);
         nearest_collision_point =
           collision_point.has_value() ? collision_point.value().position : obj_state.nearest_point;
-        is_dynamic_collision = dynamic;
+        obstacle_lon_vel = obj_state.lon_vel;
       }
       break;
     }
   }
 
   if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_collision_arc_length, is_dynamic_collision);
+  return CollisionPoint(
+    nearest_collision_point, min_collision_arc_length, obstacle_lon_vel,
+    std::abs(obstacle_lon_vel) > stopped_vel_th);
 }
 
 void PointCloudFilter::filter_pointcloud(

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -19,16 +19,17 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/object_recognition_utils/predicted_path_utils.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware_utils/geometry/sat_2d.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
-#include <range/v3/view.hpp>
 
 #include <boost/geometry.hpp>
 
 #include <algorithm>
 #include <cmath>
+#include <iterator>
 #include <limits>
-#include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -138,12 +139,20 @@ TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, c
   return extended_trajectory;
 }
 
-TrajectoryShape get_trajectory_shape(
+TrajectoryShape build_trajectory_footprint_index(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
-  const double ego_accel, const double decel, const double jerk, const double stop_margin,
-  const double lateral_margin, const double longitudinal_margin)
+  const double ego_accel, const double decel, const double jerk, const double stop_margin)
 {
+  TrajectoryShape shape;
+  shape.trajectory_length = 0.0;
+  shape.forward_traj_length = 0.0;
+  shape.ego_half_width = vehicle_info.vehicle_width_m / 2.0;
+  shape.ego_front_offset = vehicle_info.max_longitudinal_offset_m;
+  shape.ego_back_offset = -vehicle_info.min_longitudinal_offset_m;
+
+  if (trajectory_points.empty()) return shape;
+
   const auto offset_pose =
     autoware_utils::calc_offset_pose(ego_pose, vehicle_info.max_longitudinal_offset_m, 0, 0);
   auto start_idx = motion_utils::findNearestSegmentIndex(trajectory_points, offset_pose.position);
@@ -152,6 +161,8 @@ TrajectoryShape get_trajectory_shape(
   const auto ego_arc_length =
     motion_utils::calcSignedArcLength(trajectory_points, 0, ego_pose.position);
   const auto forward_traj_length = traj_length - ego_arc_length;
+  shape.trajectory_length = traj_length;
+  shape.forward_traj_length = forward_traj_length;
 
   const auto detection_length =
     get_detection_length(forward_traj_length, ego_vel, ego_accel, decel, jerk, stop_margin);
@@ -164,131 +175,204 @@ TrajectoryShape get_trajectory_shape(
     return extend_trajectory(trajectory_points, stop_margin);
   });
 
-  autoware_utils_geometry::LineString2d ls_front_right;
-  autoware_utils_geometry::LineString2d ls_front_left;
-  autoware_utils_geometry::LineString2d ls_rear_right;
-  autoware_utils_geometry::LineString2d ls_rear_left;
-  ls_front_right.reserve(detection_traj.size());
-  ls_front_left.reserve(detection_traj.size());
-  ls_rear_right.reserve(detection_traj.size());
-  ls_rear_left.reserve(detection_traj.size());
+  if (detection_traj.empty()) return shape;
 
-  autoware_utils_geometry::Polygon2d polygon_front;
-  autoware_utils_geometry::Polygon2d polygon_rear;
+  constexpr double min_ds = 0.1;
+  constexpr double max_ds = 1.0;
 
-  constexpr double min_resolution = 0.1;
+  auto add_sample =
+    [&](const geometry_msgs::msg::Pose & pose, const size_t traj_index, const double arc_length) {
+      shape.footprints.push_back(EgoFootprint{pose, traj_index, arc_length});
+    };
 
-  const auto base_footprint = vehicle_info.createFootprint(lateral_margin, longitudinal_margin);
-  for (const auto & [idx, p] : detection_traj | ranges::views::enumerate) {
-    if (idx > 0) {
-      const auto & prev_p = detection_traj[idx - 1];
-      const auto dist = autoware_utils::calc_distance2d(prev_p, p);
-      if (dist < min_resolution) continue;
+  const auto to_original_index = [&](const size_t detection_idx) {
+    return std::min(detection_idx, trajectory_points.size() - 1);
+  };
+
+  auto prev_pose = detection_traj.front().pose;
+  double prev_s = 0.0;
+  size_t prev_idx = 0;
+  add_sample(prev_pose, prev_idx, prev_s);
+
+  for (size_t i = 1; i < detection_traj.size(); ++i) {
+    const auto & curr_pose = detection_traj[i].pose;
+    const auto dist = autoware_utils::calc_distance2d(prev_pose, curr_pose);
+    const bool is_last = (i + 1 == detection_traj.size());
+    if (!is_last && dist < min_ds) continue;
+
+    const auto traj_index = to_original_index(i);
+    if (dist > max_ds) {
+      const auto n_steps = static_cast<size_t>(std::ceil(dist / max_ds));
+      for (size_t k = 1; k < n_steps; ++k) {
+        const auto ratio = static_cast<double>(k) / static_cast<double>(n_steps);
+        const auto interp_pose =
+          autoware_utils_geometry::calc_interpolated_pose(prev_pose, curr_pose, ratio, false);
+        add_sample(interp_pose, prev_idx, prev_s + ratio * dist);
+      }
     }
-    const autoware_utils_geometry::Point2d base_link(p.pose.position.x, p.pose.position.y);
-    const auto angle = tf2::getYaw(p.pose.orientation);
-    const Eigen::Rotation2Dd rotation(angle);
-    const auto front_left_offset =
-      rotation * base_footprint[vehicle_info_utils::VehicleInfo::FrontLeftIndex];
-    const auto front_right_offset =
-      rotation * base_footprint[vehicle_info_utils::VehicleInfo::FrontRightIndex];
-    const auto rear_right_offset =
-      rotation * base_footprint[vehicle_info_utils::VehicleInfo::RearRightIndex];
-    const auto rear_left_offset =
-      rotation * base_footprint[vehicle_info_utils::VehicleInfo::RearLeftIndex];
-    ls_front_left.emplace_back(
-      base_link.x() + front_left_offset.x(), base_link.y() + front_left_offset.y());
-    ls_front_right.emplace_back(
-      base_link.x() + front_right_offset.x(), base_link.y() + front_right_offset.y());
-    ls_rear_right.emplace_back(
-      base_link.x() + rear_right_offset.x(), base_link.y() + rear_right_offset.y());
-    ls_rear_left.emplace_back(
-      base_link.x() + rear_left_offset.x(), base_link.y() + rear_left_offset.y());
+
+    const auto curr_s = prev_s + dist;
+    add_sample(curr_pose, traj_index, curr_s);
+    prev_pose = curr_pose;
+    prev_s = curr_s;
+    prev_idx = traj_index;
   }
-  ls_rear_left.emplace_back(ls_front_left.back());
-  ls_rear_right.emplace_back(ls_front_right.back());
-  ls_front_left.insert(ls_front_left.begin(), ls_rear_left.front());
-  ls_front_right.insert(ls_front_right.begin(), ls_rear_right.front());
 
-  boost::geometry::reverse(ls_front_right);
-  boost::geometry::reverse(ls_rear_right);
+  std::vector<FootprintNode> nodes;
+  nodes.reserve(shape.footprints.size());
+  for (size_t i = 0; i < shape.footprints.size(); ++i) {
+    const auto poly = autoware_utils::to_footprint(
+      shape.footprints[i].pose, shape.ego_front_offset, shape.ego_back_offset,
+      2.0 * shape.ego_half_width);
+    const auto box = boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(poly);
+    nodes.emplace_back(box, i);
+    if (i == 0) {
+      shape.bounding_box = box;
+    } else {
+      boost::geometry::expand(shape.bounding_box, box);
+    }
+  }
+  shape.rtree = FootprintRtree(nodes.begin(), nodes.end());
+  return shape;
+}
 
-  boost::geometry::append(polygon_front, ls_front_left);
-  boost::geometry::append(polygon_front, ls_front_right);
-  boost::geometry::append(polygon_rear, ls_rear_left);
-  boost::geometry::append(polygon_rear, ls_rear_right);
+namespace
+{
+autoware_utils_geometry::Box2d inflate_box(
+  const autoware_utils_geometry::Box2d & box, const double margin)
+{
+  return {
+    {box.min_corner().x() - margin, box.min_corner().y() - margin},
+    {box.max_corner().x() + margin, box.max_corner().y() + margin}};
+}
 
-  boost::geometry::correct(polygon_front);
-  boost::geometry::correct(polygon_rear);
+std::vector<FootprintNode> query_rtree_candidates(
+  const TrajectoryShape & shape, const autoware_utils_geometry::Box2d & query_box)
+{
+  std::vector<FootprintNode> candidates;
+  if (shape.rtree.empty()) return candidates;
+  shape.rtree.query(boost::geometry::index::intersects(query_box), std::back_inserter(candidates));
+  return candidates;
+}
 
-  autoware_utils_geometry::MultiPolygon2d trajectory_polygon;
-  boost::geometry::union_(polygon_front, polygon_rear, trajectory_polygon);
+std::vector<size_t> sort_hits_by_arc_length(
+  const TrajectoryShape & shape, std::vector<size_t> && hits)
+{
+  std::sort(hits.begin(), hits.end(), [&](const size_t a, const size_t b) {
+    return shape.footprints[a].arc_length < shape.footprints[b].arc_length;
+  });
+  return hits;
+}
 
-  autoware_utils_geometry::Box2d envelope;
-  boost::geometry::envelope(trajectory_polygon, envelope);
+bool is_point_within_footprint(
+  const TrajectoryShape & shape, const EgoFootprint & footprint, const Point2d & point,
+  const double lat_margin)
+{
+  const auto rel = autoware_utils::inverse_transform_point(point.to_3d(), footprint.pose);
+  return rel.x() >= -shape.ego_back_offset && rel.x() <= shape.ego_front_offset &&
+         std::abs(rel.y()) <= shape.ego_half_width + lat_margin;
+}
 
-  return TrajectoryShape{trajectory_polygon, envelope, traj_length, forward_traj_length};
+Polygon2d make_local_ego_polygon(const TrajectoryShape & shape, const double lat_margin)
+{
+  const double half_width = shape.ego_half_width + lat_margin;
+  Polygon2d ego;
+  ego.outer() = {
+    {shape.ego_front_offset, half_width},  {shape.ego_front_offset, -half_width},
+    {-shape.ego_back_offset, -half_width}, {-shape.ego_back_offset, half_width},
+    {shape.ego_front_offset, half_width},
+  };
+  return ego;
+}
+
+Polygon2d transform_polygon_to_pose_frame(
+  const Polygon2d & polygon, const geometry_msgs::msg::Pose & pose)
+{
+  Polygon2d local;
+  local.outer().reserve(polygon.outer().size());
+  for (const auto & p : polygon.outer()) {
+    const auto rel = autoware_utils::inverse_transform_point(p.to_3d(), pose);
+    local.outer().emplace_back(rel.x(), rel.y());
+  }
+  return local;
+}
+}  // namespace
+
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Polygon2d & polygon, const double lat_margin)
+{
+  if (polygon.outer().empty()) return {};
+
+  const auto query_box = inflate_box(
+    boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(polygon), lat_margin);
+  const auto candidates = query_rtree_candidates(shape, query_box);
+  const auto ego_local = make_local_ego_polygon(shape, lat_margin);
+
+  std::vector<size_t> hits;
+  hits.reserve(candidates.size());
+  for (const auto & node : candidates) {
+    const auto object_local =
+      transform_polygon_to_pose_frame(polygon, shape.footprints[node.second].pose);
+    if (autoware_utils_geometry::sat::intersects(ego_local, object_local)) {
+      hits.push_back(node.second);
+    }
+  }
+  return sort_hits_by_arc_length(shape, std::move(hits));
+}
+
+std::vector<size_t> query_overlapping_footprints(
+  const TrajectoryShape & shape, const Point2d & point, const double lat_margin)
+{
+  const autoware_utils_geometry::Box2d query_box{
+    {point.x() - lat_margin, point.y() - lat_margin},
+    {point.x() + lat_margin, point.y() + lat_margin}};
+  const auto candidates = query_rtree_candidates(shape, query_box);
+
+  std::vector<size_t> hits;
+  hits.reserve(candidates.size());
+  for (const auto & node : candidates) {
+    if (is_point_within_footprint(shape, shape.footprints[node.second], point, lat_margin)) {
+      hits.push_back(node.second);
+    }
+  }
+  return sort_hits_by_arc_length(shape, std::move(hits));
 }
 
 std::optional<CollisionPoint> get_nearest_pcd_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points)
+  const TrajectoryShape & trajectory_shape, const PointCloud::Ptr & pointcloud,
+  const LateralMarginMap & lateral_margin_map,
+  std::vector<geometry_msgs::msg::Point> & target_pcd_points)
 {
-  if (pointcloud->empty() || trajectory_points.size() < 2) return std::nullopt;
-
-  PointCloud::Ptr pointcloud_in_polygon(new PointCloud);
-  for (const auto & point : *pointcloud) {
-    if (
-      boost::geometry::within(
-        autoware_utils::Point2d{point.x, point.y}, trajectory_shape.polygon)) {
-      pointcloud_in_polygon->push_back(point);
-    }
-  }
-
-  if (pointcloud_in_polygon->empty()) return std::nullopt;
-
-  auto min_arc_length = std::numeric_limits<double>::max();
-  geometry_msgs::msg::Point nearest_collision_point;
-  for (const auto & point : *pointcloud_in_polygon) {
-    geometry_msgs::msg::Point p =
-      geometry_msgs::msg::Point().set__x(point.x).set__y(point.y).set__z(point.z);
-    auto arc_length = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
-    if (arc_length < min_arc_length) {
-      min_arc_length = arc_length;
-      nearest_collision_point = p;
-    }
-    target_pcd_points.emplace_back(p);
-  }
-
-  return CollisionPoint(nearest_collision_point, min_arc_length);
-}
-
-std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
-  PredictedObject & colliding_object)
-{
-  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+  if (pointcloud->empty() || trajectory_shape.footprints.empty()) return std::nullopt;
 
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
-  for (const auto & object : target_objects.objects) {
-    const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
-    const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
-    found_collision = true;
-    for (const auto & point : object_polygon.outer()) {
-      geometry_msgs::msg::Point p = geometry_msgs::msg::Point().set__x(point.x()).set__y(point.y());
-      auto arc_length = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
-      if (arc_length < min_arc_length) {
-        min_arc_length = arc_length;
-        nearest_collision_point = p;
-        colliding_object = object;
-      }
+
+  for (const auto & point : *pointcloud) {
+    const auto classification = static_cast<PointCloudClassification>(point.class_id);
+    const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(classification));
+    const Point2d query_point{point.x, point.y};
+    const auto hits = query_overlapping_footprints(trajectory_shape, query_point, lat_margin);
+    if (hits.empty()) continue;
+
+    const auto & footprint = trajectory_shape.footprints[hits.front()];
+    const auto rel = autoware_utils::inverse_transform_point(query_point.to_3d(), footprint.pose);
+    const auto arc_length = footprint.arc_length + rel.x();
+
+    geometry_msgs::msg::Point p =
+      geometry_msgs::msg::Point().set__x(point.x).set__y(point.y).set__z(point.z);
+    target_pcd_points.emplace_back(p);
+
+    if (arc_length < min_arc_length) {
+      min_arc_length = arc_length;
+      nearest_collision_point = p;
+      found_collision = true;
     }
   }
 
   if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_arc_length);
+  return CollisionPoint(nearest_collision_point, min_arc_length, 0.0);
 }
 
 geometry_msgs::msg::Pose extrapolate_object_pose_from_kinematics(
@@ -385,18 +469,46 @@ double get_safe_distance(
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points,
+  TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
+  const double stopped_vel_th)
+{
+  if (target_objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+
+  auto min_arc_length = std::numeric_limits<double>::max();
+  geometry_msgs::msg::Point nearest_collision_point;
+  bool found_collision = false;
+  double obstacle_lon_vel = 0.0;
+  for (auto & object : target_objects) {
+    const auto obj_state = get_object_state_at_time(trajectory_points, object.object, 0.0);
+    object.is_safe = false;
+    object.safe_distance = obj_state.arc_length;
+    object.distance_from_ego = obj_state.arc_length;
+    found_collision = true;
+    if (obj_state.arc_length < min_arc_length) {
+      min_arc_length = obj_state.arc_length;
+      nearest_collision_point = obj_state.nearest_point;
+      obstacle_lon_vel = obj_state.lon_vel;
+    }
+  }
+
+  if (!found_collision) return std::nullopt;
+  return CollisionPoint(
+    nearest_collision_point, min_arc_length, obstacle_lon_vel,
+    std::abs(obstacle_lon_vel) > stopped_vel_th);
+}
+
+std::optional<CollisionPoint> get_nearest_object_collision(
+  TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
-  const double ego_decel, const double reaction_time, const double safety_margin,
-  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object,
+  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
+  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   const bool use_rss_check)
 {
-  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+  if (target_objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   // If RSS check is disabled, get the nearest object collision by pure geometric overlap.
   if (!use_rss_check) {
-    return get_nearest_object_collision(trajectory_points, target_objects, colliding_object);
+    return get_nearest_object_collision(target_objects, trajectory_points, stopped_vel_th);
   }
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
@@ -418,13 +530,15 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 
   auto is_safe = [&](
                    const double obj_arc_length, const double obj_stopping_distance,
-                   const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
-    if (obj_stopping_distance <= eps) return {false, false};
-    const auto safe_dist =
-      get_safe_distance(ego_vel, ego_decel, obj_stopping_distance, reaction_time, safety_margin);
+                   const double ego_arc_length,
+                   const double ego_vel) -> std::tuple<bool, double, double> {
     const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
-    return {relative_arc_length - safe_dist > 1e-3, true};
+    if (obj_stopping_distance <= eps)
+      return std::make_tuple(false, relative_arc_length, relative_arc_length);
+    const auto safe_dist =
+      get_safe_distance(ego_vel, ego_decel, obj_stopping_distance, reaction_time, safety_margin);
+    return std::make_tuple(relative_arc_length - safe_dist > 1e-3, safe_dist, relative_arc_length);
   };
 
   auto min_collision_arc_length = std::numeric_limits<double>::max();
@@ -432,25 +546,32 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   bool found_collision = false;
   bool is_dynamic_collision = false;
 
-  for (const auto & object : target_objects.objects) {
+  for (auto & object : target_objects) {
     auto last_p = trajectory_points.front().pose.position;
     auto curr_arc_length = 0.0;
+    bool is_first = true;
     for (const auto & traj_p : trajectory_points) {
       const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
       if (t > lookahead_horizon) break;
       curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
       last_p = traj_p.pose.position;
       const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
-      const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
-      const auto obj_stopping_distance = get_object_stopping_distance(object, obj_state.lon_vel);
-      const auto [safe, dynamic] =
+      const auto obj_state = get_object_state_at_time(trajectory_points, object.object, t);
+      const auto obj_stopping_distance =
+        get_object_stopping_distance(object.object, obj_state.lon_vel);
+      const auto [safe, safe_distance, distance_from_ego] =
         is_safe(obj_state.arc_length, obj_stopping_distance, curr_arc_length, target_ego_vel);
-      if (safe) continue;
+      object.is_safe = safe;
+      if (is_first) {
+        is_first = false;
+        object.safe_distance = safe_distance;
+        object.distance_from_ego = distance_from_ego;
+      }
+      if (object.is_safe) continue;
       found_collision = true;
       auto collision_arc_length = obj_state.arc_length + obj_stopping_distance;
       if (collision_arc_length < min_collision_arc_length) {
         min_collision_arc_length = collision_arc_length;
-        colliding_object = object;
         const auto collision_point = motion_utils::calcLongitudinalOffsetPose(
           trajectory_points, obj_state.nearest_point, obj_stopping_distance);
         nearest_collision_point =
@@ -525,20 +646,23 @@ void PointCloudFilter::filter_pointcloud_by_object(
 }
 
 void ObjectFilter::filter_by_target_area(
-  PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+  TargetObjects & target_objects, const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
+  const TrajectoryShape & trajectory_shape, const LateralMarginMap & lateral_margin_map)
 {
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
   constexpr double time_buffer = 0.5;
   auto time_to_obj_current_pos =
-    [&](const auto & object_pose, const size_t nearest_seg_idx) -> double {
+    [&](const auto & object_pose, const size_t nearest_seg_idx) -> std::optional<double> {
     const auto t_to_nearest_seg =
       rclcpp::Duration(trajectory_points.at(nearest_seg_idx).time_from_start).seconds();
     const auto lon_offset_dist =
       motion_utils::calcSignedArcLength(trajectory_points, nearest_seg_idx, object_pose.position);
-    const auto nearest_seg_vel =
-      std::max<double>(trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps, 1e-3);
+    const auto nearest_seg_vel = trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps;
+    if (nearest_seg_vel < 1e-3) {
+      if (lon_offset_dist > ego_front_offset) return std::nullopt;
+      return std::max(0.0, t_to_nearest_seg - time_buffer);
+    }
     const auto ego_front_time_offset = ego_front_offset / nearest_seg_vel;
     const auto t_to_obj =
       t_to_nearest_seg + (lon_offset_dist / nearest_seg_vel) - ego_front_time_offset - time_buffer;
@@ -556,7 +680,11 @@ void ObjectFilter::filter_by_target_area(
     return autoware_utils::expand_polygon(polygon, safety_buffer_);
   };
 
-  auto is_exiting = [&](const auto & object) -> bool {
+  auto overlaps_ego_footprints = [&](const Polygon2d & polygon, const double lat_margin) {
+    return !query_overlapping_footprints(trajectory_shape, polygon, lat_margin).empty();
+  };
+
+  auto is_exiting = [&](const auto & object, const double lat_margin) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
@@ -572,27 +700,30 @@ void ObjectFilter::filter_by_target_area(
     const auto obj_lat_vel = std::abs(obj_vel_vector.dot(traj_lat_dir));
     if (obj_lat_vel < max_lateral_velocity_th_ && obj_lat_vel < obj_lon_vel) return false;
     const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
-    const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
+    if (!t_to_obj_current_pos) return true;
+    const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos.value());
     const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);
-    return boost::geometry::disjoint(obj_pred_polygon, target_area);
+    return !overlaps_ego_footprints(obj_pred_polygon, lat_margin);
   };
 
-  objects.objects.erase(
+  target_objects.erase(
     std::remove_if(
-      objects.objects.begin(), objects.objects.end(),
-      [&](const auto & object) {
+      target_objects.begin(), target_objects.end(),
+      [&](auto & obj) {
+        const auto & object = obj.object;
+        const auto lat_margin = get_lateral_margin(lateral_margin_map, to_object_type(object));
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
         const auto object_polygon = get_object_polygon(object_pose, object.shape);
-        if (boost::geometry::disjoint(object_polygon, target_area)) return true;
-        if (is_exiting(object)) return true;
-        target_polygons.emplace_back(object_polygon);
+        if (!overlaps_ego_footprints(object_polygon, lat_margin)) return true;
+        if (is_exiting(object, lat_margin)) return true;
+        obj.polygon = object_polygon;
         return false;
       }),
-    objects.objects.end());
+    target_objects.end());
 }
 
 void ObstacleTracker::update_objects(
-  const PredictedObjects & objects, PredictedObjects & persistent_objects, const rclcpp::Time & now)
+  const PredictedObjects & objects, TargetObjects & persistent_objects, const rclcpp::Time & now)
 {
   for (auto it = persistent_objects_map_.begin(); it != persistent_objects_map_.end();) {
     const auto idle_time = (now - it->second.last_seen_time).seconds();
@@ -603,6 +734,15 @@ void ObstacleTracker::update_objects(
     else
       it++;
   }
+
+  auto estimate_pose = [&](const PersistentObject & object) -> geometry_msgs::msg::Pose {
+    const auto & pose = object.object.kinematics.initial_pose_with_covariance.pose;
+    const auto & twist = object.object.kinematics.initial_twist_with_covariance.twist.linear;
+    const auto dt = (now - object.last_seen_time).seconds();
+    const auto dx = twist.x * dt;
+    const auto dy = twist.y * dt;
+    return autoware_utils::calc_offset_pose(pose, dx, dy, 0.0);
+  };
 
   auto get_closest_object_uuid =
     [&](const PredictedObject & object) -> std::optional<boost::uuids::uuid> {
@@ -621,9 +761,9 @@ void ObstacleTracker::update_objects(
       if (existing_obj_label != obj_label) continue;
       const auto distance = autoware_utils::calc_distance2d(
         object.kinematics.initial_pose_with_covariance.pose.position,
-        existing_object.object.kinematics.initial_pose_with_covariance.pose.position);
+        estimate_pose(existing_object).position);
       if (distance > min_distance) continue;
-      // ignore orientation difference for cylinder objects
+      // ignore orientation difference for symmetric objects
       const bool is_symmetric =
         std::abs(object.shape.dimensions.x - object.shape.dimensions.y) < 0.1;
       const auto yaw_diff =
@@ -654,7 +794,7 @@ void ObstacleTracker::update_objects(
 
   for (const auto & [uuid, entry] : persistent_objects_map_) {
     if (entry.is_active) {
-      persistent_objects.objects.push_back(entry.object);
+      persistent_objects.emplace_back(entry.object);
     }
   }
 }

--- a/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_processor/src/trajectory_modifier_utils/utils.cpp
@@ -88,10 +88,11 @@ bool is_stop_trajectory(const TrajectoryPoints & traj_points, const double stopp
 
 double clamp_stop_point_arc_length(
   const double stop_point_arc_length, const double max_length, const double ego_vel,
-  const double ego_accel, const double decel_limit, const double jerk_limit)
+  const double ego_accel, const double decel_limit, const double jerk_limit,
+  const double time_delay)
 {
   auto min_stopping_distance =
-    motion_utils::calculate_stop_distance(ego_vel, ego_accel, decel_limit, jerk_limit, 0.0);
+    motion_utils::calculate_stop_distance(ego_vel, ego_accel, decel_limit, jerk_limit, time_delay);
   if (!min_stopping_distance) min_stopping_distance = 0.0;
   return std::clamp(stop_point_arc_length, min_stopping_distance.value(), max_length);
 }

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -249,7 +249,6 @@ protected:
 
     p.rss_params.enable = true;
     p.rss_params.object_decel.car = 1.5;
-    p.rss_params.reaction_time = 0.2;
     p.rss_params.safety_margin = 2.0;
     p.rss_params.ego_decel = 4.0;
     p.rss_params.lookahead_horizon = 1.5;

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -225,6 +225,7 @@ protected:
     params_.stopping_constraints.nominal_deceleration = 1.0;
     params_.stopping_constraints.maximum_deceleration = 4.0;
     params_.stopping_constraints.jerk_limit = 3.0;
+    params_.stopping_constraints.delay_response_time = 0.0;
     params_.stopping_constraints.arrived_distance_threshold = 0.5;
 
     auto & p = params_.obstacle_stop;

--- a/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_processor/tests/test_obstacle_stop_integration.cpp
@@ -233,7 +233,8 @@ protected:
     p.enable_stop_for_objects = true;
     p.enable_stop_for_pointcloud = true;
     p.stop_margin = 6.0;
-    p.lateral_margin = 0.5;
+    p.objects.lateral_margin.car = 0.5;
+    p.objects.lateral_margin.unknown = 0.5;
 
     p.obstacle_tracking.on_time_buffer = 0.01;
     p.obstacle_tracking.off_time_buffer = 1.0;
@@ -244,10 +245,7 @@ protected:
 
     p.objects.target_objects.bbox = {"car"};
     p.objects.target_objects.polygon = {"car"};
-
-    p.pointcloud.target_types = {"unknown"};
-    p.pointcloud.height_buffer = 0.5;
-    p.pointcloud.min_height = 0.2;
+    p.objects.target_objects.pointcloud = {"unknown"};
 
     p.rss_params.enable = true;
     p.rss_params.object_decel.car = 1.5;


### PR DESCRIPTION
## Description
This is a cherry-pick PR to synch changes from private TIER IV fork:
- https://github.com/tier4/autoware_universe/pull/3334
- https://github.com/tier4/autoware_universe/pull/3354
- https://github.com/tier4/autoware_universe/pull/3393

The PR applies several improvements to `obstacle_stop` module and related packages:
- modifies `obstacle_stop` logic to use an ego-footprint R-tree and apply a per-class lateral margin at query time, instead of a single swept-union polygon with one global margin. The same filtering and parameter layout is used in both autoware_trajectory_modifier and the backup planner (autoware_minimum_rule_based_planner).
- Improves obstacle-stop collision tracking in the `minimum_rule_based_planner` so moving (including oncoming) obstacles stay correctly associated across frames. Collision points now carry path-projected longitudinal speed and first/last-seen timestamps, and buffer association uses a speed-aware expected arc-length gate instead of a fixed distance check.
- Improves rss logic by using 2 separate parameters for safe_distance lower margin and rss distanc buffer:
  - The existing obstacle_stop.stop_margin [6.0 m] is used as a lower limit for the computed rss safe distance to control how close ego can safely get to the front target
  - rss_params.safety_margin is used as a distance buffer added to the raw safe distance, the value is reduced from 3.0 m to 1.5 m to relax ego behavior with respect to further moving targets

### Changes
Ego-footprint R-tree and per-class lateral margins:
- Build an R-tree of ego footprints along the detection range. Vehicle extents are stored without extra lateral margin; class-specific expansion is applied only when querying.
- Filter predicted objects and pointcloud points against that index: coarse AABB lookup, then a precise overlap test with the class’s lateral_margin.
- Replace boost::geometry::disjoint polygon checks with 2d SAT in the footprint frame.
- Point queries use a vehicle-frame OBB test (x in bumper range, `|y| <= half_width + lat_margin`).
- Pointcloud collisions use the class of each point so structure, vegetation, and unknown can have different margins.
- Drop the single `obstacle_stop.lateral_margin` and look up `objects.lateral_margin.<class>` .

MRBP collision tracking:
- Replace `CollisionPoint::start_time` with `first_seen` / `last_seen`, and store path-projected `obstacle_lon_vel` on each collision
- Modify geometric collision check to utilize `get_object_state_at_time` at `t=0`
- Preserve signed longitudinal velocity so oncoming obstacles associate and track correctly
- Refactor `update_collision_points_buffer()`: prune by `last_seen` / presence, associate with `estimated_shift = |vel| * dt`, activate after `on_time_buffer`, and always refresh pose / velocity / dynamic flag on match
- Use `maximum_stopping_decel` when clamping the stop-point arc length

RSS check improvement:
- update `get_nearest_object_collision()` function interface to take `min_safe_distance` and `rss_safety_buffer` as arguments
- use common parameter `delay_response_time` for stopping distance calculation
- update `build_trajectory_footprint_index()` function interface to take `time_delay` as argument
- update `clamp_stop_point_arc_length()` function interface to take `time_delay` as argument
- add overlapping ego footprint data to `TargetObject` struct
- visualize overlapping ego footprint for unsafe target objects

## How was this PR tested?
- Successful build
- Pass unit tests
- PSIM