### PR TITLE
feat(autoware_default_adapi_universe): move the mechanical component_interface_utils nodes to agnocast_wrapper::Node

### DIFF
--- a/system/autoware_default_adapi_universe/CMakeLists.txt
+++ b/system/autoware_default_adapi_universe/CMakeLists.txt
@@ -25,24 +25,15 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 
 rclcpp_components_register_nodes(${PROJECT_NAME}
   "autoware::default_adapi::AutowareStateNode"
-  "autoware::default_adapi::FailSafeNode"
-  "autoware::default_adapi::HeartbeatNode"
   "autoware::default_adapi::MotionNode"
   "autoware::default_adapi::MrmRequestNode"
   "autoware::default_adapi::OperationModeNode"
-  "autoware::default_adapi::PerceptionNode"
   "autoware::default_adapi::PlanningNode"
-  "autoware::default_adapi::VehicleStatusNode"
-  "autoware::default_adapi::VehicleCommandNode"
-  "autoware::default_adapi::VehicleMetricsNode"
-  "autoware::default_adapi::VehicleInfoNode"
   "autoware::default_adapi::VehicleDoorNode"
 )
 
-# DiagnosticsNode derives from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
-# executor, so it also gets a standalone executable. on_reset() blocks on the reset client from
-# inside a service callback, so the executor has to serve the client's callback group on another
-# thread.
+# These nodes derive from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
+# executor, so they also get standalone executables.
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::default_adapi::DiagnosticsNode"
   EXECUTABLE diagnostics_node
@@ -51,8 +42,57 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
 )
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::FailSafeNode"
+  EXECUTABLE fail_safe_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::HeartbeatNode"
+  EXECUTABLE heartbeat_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::default_adapi::ManualControlNode"
   EXECUTABLE manual_control_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::PerceptionNode"
+  EXECUTABLE perception_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::VehicleCommandNode"
+  EXECUTABLE vehicle_command_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::VehicleInfoNode"
+  EXECUTABLE vehicle_info_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::VehicleMetricsNode"
+  EXECUTABLE vehicle_metrics_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::VehicleStatusNode"
+  EXECUTABLE vehicle_status_node
   ROS2_EXECUTOR MultiThreadedExecutor
   AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )

--- a/system/autoware_default_adapi_universe/launch/default_adapi.launch.py
+++ b/system/autoware_default_adapi_universe/launch/default_adapi.launch.py
@@ -39,8 +39,15 @@ AGNOCAST_WRAPPER_NODES = [
     (CORE, "localization", "LocalizationNode", "localization_node"),
     (CORE, "routing", "RoutingNode", "routing_node"),
     (UNIVERSE, "diagnostics", "DiagnosticsNode", "diagnostics_node"),
+    (UNIVERSE, "fail_safe", "FailSafeNode", "fail_safe_node"),
+    (UNIVERSE, "heartbeat", "HeartbeatNode", "heartbeat_node"),
     (UNIVERSE, "manual/local", "ManualControlNode", "manual_control_node"),
     (UNIVERSE, "manual/remote", "ManualControlNode", "manual_control_node"),
+    (UNIVERSE, "perception", "PerceptionNode", "perception_node"),
+    (UNIVERSE, "vehicle_command", "VehicleCommandNode", "vehicle_command_node"),
+    (UNIVERSE, "vehicle_info", "VehicleInfoNode", "vehicle_info_node"),
+    (UNIVERSE, "vehicle_metrics", "VehicleMetricsNode", "vehicle_metrics_node"),
+    (UNIVERSE, "vehicle_status", "VehicleStatusNode", "vehicle_status_node"),
 ]
 
 
@@ -98,17 +105,10 @@ def launch_setup(context, *args, **kwargs):
 
     components = [
         create_api_node("autoware_default_adapi_universe", "autoware_state", "AutowareStateNode"),
-        create_api_node("autoware_default_adapi_universe", "fail_safe", "FailSafeNode"),
-        create_api_node("autoware_default_adapi_universe", "heartbeat", "HeartbeatNode"),
         create_api_node("autoware_default_adapi_universe", "motion", "MotionNode"),
         create_api_node("autoware_default_adapi_universe", "mrm_request", "MrmRequestNode"),
         create_api_node("autoware_default_adapi_universe", "operation_mode", "OperationModeNode"),
-        create_api_node("autoware_default_adapi_universe", "perception", "PerceptionNode"),
         create_api_node("autoware_default_adapi_universe", "planning", "PlanningNode"),
-        create_api_node("autoware_default_adapi_universe", "vehicle_status", "VehicleStatusNode"),
-        create_api_node("autoware_default_adapi_universe", "vehicle_command", "VehicleCommandNode"),
-        create_api_node("autoware_default_adapi_universe", "vehicle_metrics", "VehicleMetricsNode"),
-        create_api_node("autoware_default_adapi_universe", "vehicle_info", "VehicleInfoNode"),
         create_api_node("autoware_default_adapi_universe", "vehicle_door", "VehicleDoorNode"),
     ]
     nodes = []

--- a/system/autoware_default_adapi_universe/src/fail_safe.cpp
+++ b/system/autoware_default_adapi_universe/src/fail_safe.cpp
@@ -29,9 +29,9 @@ auto allow_dynamic_params(const rclcpp::NodeOptions & original_options)
 }
 
 FailSafeNode::FailSafeNode(const rclcpp::NodeOptions & options)
-: Node("fail_safe", allow_dynamic_params(options))
+: autoware::agnocast_wrapper::Node("fail_safe", allow_dynamic_params(options))
 {
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_pub(pub_mrm_state_);
   adaptor.init_sub(sub_mrm_state_, this, &FailSafeNode::on_state);
   adaptor.init_srv(srv_mrm_description_, this, &FailSafeNode::on_mrm_description);

--- a/system/autoware_default_adapi_universe/src/fail_safe.hpp
+++ b/system/autoware_default_adapi_universe/src/fail_safe.hpp
@@ -16,6 +16,7 @@
 #define FAIL_SAFE_HPP_
 
 #include <autoware/adapi_specs/fail_safe.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/system.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -28,7 +29,7 @@
 namespace autoware::default_adapi
 {
 
-class FailSafeNode : public rclcpp::Node
+class FailSafeNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit FailSafeNode(const rclcpp::NodeOptions & options);
@@ -36,9 +37,9 @@ public:
 private:
   using MrmDescription = autoware::adapi_specs::fail_safe::MrmDescription::Service;
   using MrmState = autoware::adapi_specs::fail_safe::MrmState::Message;
-  Srv<autoware::adapi_specs::fail_safe::MrmDescription> srv_mrm_description_;
-  Pub<autoware::adapi_specs::fail_safe::MrmState> pub_mrm_state_;
-  Sub<autoware::component_interface_specs_universe::system::MrmState> sub_mrm_state_;
+  Srv<autoware::adapi_specs::fail_safe::MrmDescription, NodeT> srv_mrm_description_;
+  Pub<autoware::adapi_specs::fail_safe::MrmState, NodeT> pub_mrm_state_;
+  Sub<autoware::component_interface_specs_universe::system::MrmState, NodeT> sub_mrm_state_;
   MrmState prev_state_;
   void on_state(const MrmState::ConstSharedPtr msg);
   void on_mrm_description(

--- a/system/autoware_default_adapi_universe/src/heartbeat.cpp
+++ b/system/autoware_default_adapi_universe/src/heartbeat.cpp
@@ -19,7 +19,8 @@
 namespace autoware::default_adapi
 {
 
-HeartbeatNode::HeartbeatNode(const rclcpp::NodeOptions & options) : Node("heartbeat", options)
+HeartbeatNode::HeartbeatNode(const rclcpp::NodeOptions & options)
+: autoware::agnocast_wrapper::Node("heartbeat", options)
 {
   // Move this function so that the timer no longer holds it as a reference.
   const auto on_timer = [this]() {
@@ -29,11 +30,11 @@ HeartbeatNode::HeartbeatNode(const rclcpp::NodeOptions & options) : Node("heartb
     pub_->publish(heartbeat);
   };
 
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_pub(pub_);
 
   const auto period = rclcpp::Rate(10.0).period();
-  timer_ = rclcpp::create_timer(this, get_clock(), period, std::move(on_timer));
+  timer_ = autoware::agnocast_wrapper::create_timer(this, get_clock(), period, std::move(on_timer));
 }
 
 }  // namespace autoware::default_adapi

--- a/system/autoware_default_adapi_universe/src/heartbeat.hpp
+++ b/system/autoware_default_adapi_universe/src/heartbeat.hpp
@@ -16,6 +16,8 @@
 #define HEARTBEAT_HPP_
 
 #include <autoware/adapi_specs/system.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 // This file should be included after messages.
@@ -24,14 +26,14 @@
 namespace autoware::default_adapi
 {
 
-class HeartbeatNode : public rclcpp::Node
+class HeartbeatNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit HeartbeatNode(const rclcpp::NodeOptions & options);
 
 private:
-  rclcpp::TimerBase::SharedPtr timer_;
-  Pub<autoware::adapi_specs::system::Heartbeat> pub_;
+  AUTOWARE_TIMER_PTR timer_;
+  Pub<autoware::adapi_specs::system::Heartbeat, NodeT> pub_;
   uint16_t sequence_ = 0;
 };
 

--- a/system/autoware_default_adapi_universe/src/perception.cpp
+++ b/system/autoware_default_adapi_universe/src/perception.cpp
@@ -33,9 +33,10 @@ std::unordered_map<uint8_t, uint8_t> shape_type_ = {
   {Shape::POLYGON, API_Shape::PRISM},
 };
 
-PerceptionNode::PerceptionNode(const rclcpp::NodeOptions & options) : Node("perception", options)
+PerceptionNode::PerceptionNode(const rclcpp::NodeOptions & options)
+: autoware::agnocast_wrapper::Node("perception", options)
 {
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_pub(pub_object_recognized_);
   adaptor.init_sub(sub_object_recognized_, this, &PerceptionNode::object_recognize);
 }

--- a/system/autoware_default_adapi_universe/src/perception.hpp
+++ b/system/autoware_default_adapi_universe/src/perception.hpp
@@ -16,6 +16,7 @@
 #define PERCEPTION_HPP_
 
 #include <autoware/adapi_specs/perception.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/perception.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -34,14 +35,14 @@
 namespace autoware::default_adapi
 {
 
-class PerceptionNode : public rclcpp::Node
+class PerceptionNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit PerceptionNode(const rclcpp::NodeOptions & options);
 
 private:
-  Pub<autoware::adapi_specs::perception::DynamicObjectArray> pub_object_recognized_;
-  Sub<autoware::component_interface_specs_universe::perception::ObjectRecognition>
+  Pub<autoware::adapi_specs::perception::DynamicObjectArray, NodeT> pub_object_recognized_;
+  Sub<autoware::component_interface_specs_universe::perception::ObjectRecognition, NodeT>
     sub_object_recognized_;
   void object_recognize(
     const autoware::component_interface_specs_universe::perception::ObjectRecognition::Message::

--- a/system/autoware_default_adapi_universe/src/utils/types.hpp
+++ b/system/autoware_default_adapi_universe/src/utils/types.hpp
@@ -15,19 +15,22 @@
 #ifndef UTILS__TYPES_HPP_
 #define UTILS__TYPES_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 
 namespace autoware::default_adapi
 {
 
-template <class T>
-using Pub = typename autoware::component_interface_utils::Publisher<T>::SharedPtr;
-template <class T>
-using Sub = typename autoware::component_interface_utils::Subscription<T>::SharedPtr;
-template <class T>
-using Cli = typename autoware::component_interface_utils::Client<T>::SharedPtr;
-template <class T>
-using Srv = typename autoware::component_interface_utils::Service<T>::SharedPtr;
+using NodeT = autoware::agnocast_wrapper::Node;
+
+template <class T, class N = rclcpp::Node>
+using Pub = typename autoware::component_interface_utils::Publisher<T, N>::SharedPtr;
+template <class T, class N = rclcpp::Node>
+using Sub = typename autoware::component_interface_utils::Subscription<T, N>::SharedPtr;
+template <class T, class N = rclcpp::Node>
+using Cli = typename autoware::component_interface_utils::Client<T, N>::SharedPtr;
+template <class T, class N = rclcpp::Node>
+using Srv = typename autoware::component_interface_utils::Service<T, N>::SharedPtr;
 
 }  // namespace autoware::default_adapi
 

--- a/system/autoware_default_adapi_universe/src/vehicle_command.cpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_command.cpp
@@ -18,9 +18,9 @@ namespace autoware::default_adapi
 {
 
 VehicleCommandNode::VehicleCommandNode(const rclcpp::NodeOptions & options)
-: Node("vehicle_command", options)
+: autoware::agnocast_wrapper::Node("vehicle_command", options)
 {
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_pub(pub_pedals_);
   adaptor.init_pub(pub_acceleration_);
   adaptor.init_pub(pub_velocity_);

--- a/system/autoware_default_adapi_universe/src/vehicle_command.hpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_command.hpp
@@ -16,6 +16,7 @@
 #define VEHICLE_COMMAND_HPP_
 
 #include <autoware/adapi_specs/control.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs/control.hpp>
 #include <autoware/component_interface_specs_universe/control.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -26,7 +27,7 @@
 namespace autoware::default_adapi
 {
 
-class VehicleCommandNode : public rclcpp::Node
+class VehicleCommandNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit VehicleCommandNode(const rclcpp::NodeOptions & options);
@@ -42,12 +43,12 @@ private:
   void on_control(const InternalControl::Message & msg);
   void on_actuation(const InternalActuation::Message & msg);
 
-  Pub<ExternalPedals> pub_pedals_;
-  Pub<ExternalAcceleration> pub_acceleration_;
-  Pub<ExternalVelocity> pub_velocity_;
-  Pub<ExternalSteering> pub_steering_;
-  Sub<InternalControl> sub_control_;
-  Sub<InternalActuation> sub_actuation_;
+  Pub<ExternalPedals, NodeT> pub_pedals_;
+  Pub<ExternalAcceleration, NodeT> pub_acceleration_;
+  Pub<ExternalVelocity, NodeT> pub_velocity_;
+  Pub<ExternalSteering, NodeT> pub_steering_;
+  Sub<InternalControl, NodeT> sub_control_;
+  Sub<InternalActuation, NodeT> sub_actuation_;
 };
 
 }  // namespace autoware::default_adapi

--- a/system/autoware_default_adapi_universe/src/vehicle_info.cpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_info.cpp
@@ -34,7 +34,7 @@ namespace autoware::default_adapi
 {
 
 VehicleInfoNode::VehicleInfoNode(const rclcpp::NodeOptions & options)
-: Node("vehicle_info", options)
+: autoware::agnocast_wrapper::Node("vehicle_info", options)
 {
   const auto on_vehicle_dimensions = [this](auto, auto res) {
     res->status.success = true;
@@ -61,7 +61,7 @@ VehicleInfoNode::VehicleInfoNode(const rclcpp::NodeOptions & options)
   dimensions_.footprint.points.push_back(create_point(-b, -l));
   dimensions_.footprint.points.push_back(create_point(-b, +r));
 
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_srv(srv_dimensions_, on_vehicle_dimensions);
 }
 

--- a/system/autoware_default_adapi_universe/src/vehicle_info.hpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_info.hpp
@@ -16,6 +16,7 @@
 #define VEHICLE_INFO_HPP_
 
 #include <autoware/adapi_specs/vehicle.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 // This file should be included after messages.
@@ -24,13 +25,13 @@
 namespace autoware::default_adapi
 {
 
-class VehicleInfoNode : public rclcpp::Node
+class VehicleInfoNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit VehicleInfoNode(const rclcpp::NodeOptions & options);
 
 private:
-  Srv<autoware::adapi_specs::vehicle::Dimensions> srv_dimensions_;
+  Srv<autoware::adapi_specs::vehicle::Dimensions, NodeT> srv_dimensions_;
   autoware_adapi_v1_msgs::msg::VehicleDimensions dimensions_;
 };
 

--- a/system/autoware_default_adapi_universe/src/vehicle_metrics.cpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_metrics.cpp
@@ -20,17 +20,18 @@ namespace autoware::default_adapi
 {
 
 VehicleMetricsNode::VehicleMetricsNode(const rclcpp::NodeOptions & options)
-: Node("vehicle_metrics", options)
+: autoware::agnocast_wrapper::Node("vehicle_metrics", options)
 {
   max_energy_level_ = declare_parameter<float>("max_energy_level");
 
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_pub(pub_metrics_);
   adaptor.init_sub(
     sub_energy_, [this](const EnergyStatus::Message::ConstSharedPtr msg) { energy_ = msg; });
 
   const auto period = rclcpp::Rate(declare_parameter<double>("update_rate")).period();
-  timer_ = rclcpp::create_timer(this, get_clock(), period, [this]() { on_timer(); });
+  timer_ =
+    autoware::agnocast_wrapper::create_timer(this, get_clock(), period, [this]() { on_timer(); });
 }
 
 void VehicleMetricsNode::on_timer()

--- a/system/autoware_default_adapi_universe/src/vehicle_metrics.hpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_metrics.hpp
@@ -16,6 +16,8 @@
 #define VEHICLE_METRICS_HPP_
 
 #include <autoware/adapi_specs/vehicle.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/vehicle.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -25,7 +27,7 @@
 namespace autoware::default_adapi
 {
 
-class VehicleMetricsNode : public rclcpp::Node
+class VehicleMetricsNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit VehicleMetricsNode(const rclcpp::NodeOptions & options);
@@ -35,9 +37,9 @@ private:
   using EnergyStatus = autoware::component_interface_specs_universe::vehicle::EnergyStatus;
   void on_timer();
 
-  rclcpp::TimerBase::SharedPtr timer_;
-  Pub<VehicleMetrics> pub_metrics_;
-  Sub<EnergyStatus> sub_energy_;
+  AUTOWARE_TIMER_PTR timer_;
+  Pub<VehicleMetrics, NodeT> pub_metrics_;
+  Sub<EnergyStatus, NodeT> sub_energy_;
   EnergyStatus::Message::ConstSharedPtr energy_;
 
   float max_energy_level_;

--- a/system/autoware_default_adapi_universe/src/vehicle_status.cpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_status.cpp
@@ -64,9 +64,9 @@ std::unordered_map<uint8_t, uint8_t> hazard_light_type_ = {
 };
 
 VehicleStatusNode::VehicleStatusNode(const rclcpp::NodeOptions & options)
-: Node("vehicle_status", options)
+: autoware::agnocast_wrapper::Node("vehicle_status", options)
 {
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_pub(pub_kinematics_);
   adaptor.init_pub(pub_status_);
@@ -80,7 +80,8 @@ VehicleStatusNode::VehicleStatusNode(const rclcpp::NodeOptions & options)
   adaptor.init_sub(sub_energy_level_, nullptr);
 
   const auto rate = rclcpp::Rate(10);
-  timer_ = rclcpp::create_timer(this, get_clock(), rate.period(), [this]() { on_timer(); });
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), rate.period(), [this]() { on_timer(); });
 }
 
 uint8_t VehicleStatusNode::mapping(

--- a/system/autoware_default_adapi_universe/src/vehicle_status.hpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_status.hpp
@@ -16,6 +16,8 @@
 #define VEHICLE_STATUS_HPP_
 
 #include <autoware/adapi_specs/vehicle.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/localization.hpp>
 #include <autoware/component_interface_specs_universe/map.hpp>
 #include <autoware/component_interface_specs_universe/vehicle.hpp>
@@ -33,26 +35,29 @@
 namespace autoware::default_adapi
 {
 
-class VehicleStatusNode : public rclcpp::Node
+class VehicleStatusNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit VehicleStatusNode(const rclcpp::NodeOptions & options);
 
 private:
   rclcpp::CallbackGroup::SharedPtr group_cli_;
-  Pub<autoware::adapi_specs::vehicle::VehicleKinematics> pub_kinematics_;
-  Pub<autoware::adapi_specs::vehicle::VehicleStatus> pub_status_;
-  Sub<autoware::component_interface_specs_universe::localization::KinematicState>
+  Pub<autoware::adapi_specs::vehicle::VehicleKinematics, NodeT> pub_kinematics_;
+  Pub<autoware::adapi_specs::vehicle::VehicleStatus, NodeT> pub_status_;
+  Sub<autoware::component_interface_specs_universe::localization::KinematicState, NodeT>
     sub_kinematic_state_;
-  Sub<autoware::component_interface_specs_universe::localization::Acceleration> sub_acceleration_;
-  Sub<autoware::component_interface_specs_universe::vehicle::SteeringStatus> sub_steering_;
-  Sub<autoware::component_interface_specs_universe::vehicle::GearStatus> sub_gear_state_;
-  Sub<autoware::component_interface_specs_universe::vehicle::TurnIndicatorStatus>
+  Sub<autoware::component_interface_specs_universe::localization::Acceleration, NodeT>
+    sub_acceleration_;
+  Sub<autoware::component_interface_specs_universe::vehicle::SteeringStatus, NodeT> sub_steering_;
+  Sub<autoware::component_interface_specs_universe::vehicle::GearStatus, NodeT> sub_gear_state_;
+  Sub<autoware::component_interface_specs_universe::vehicle::TurnIndicatorStatus, NodeT>
     sub_turn_indicator_;
-  Sub<autoware::component_interface_specs_universe::vehicle::HazardLightStatus> sub_hazard_light_;
-  Sub<autoware::component_interface_specs_universe::vehicle::EnergyStatus> sub_energy_level_;
-  Sub<autoware::component_interface_specs_universe::map::MapProjectorInfo> sub_map_projector_info_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  Sub<autoware::component_interface_specs_universe::vehicle::HazardLightStatus, NodeT>
+    sub_hazard_light_;
+  Sub<autoware::component_interface_specs_universe::vehicle::EnergyStatus, NodeT> sub_energy_level_;
+  Sub<autoware::component_interface_specs_universe::map::MapProjectorInfo, NodeT>
+    sub_map_projector_info_;
+  AUTOWARE_TIMER_PTR timer_;
 
   autoware::component_interface_specs_universe::localization::KinematicState::Message::
     ConstSharedPtr kinematic_state_msgs_;


### PR DESCRIPTION
## Description

Move seven of the thirteen nodes in this package that reach the middleware through `component_interface_utils` from `rclcpp::Node` to `autoware::agnocast_wrapper::Node`: `FailSafeNode`, `HeartbeatNode`, `PerceptionNode`, `VehicleCommandNode`, `VehicleInfoNode`, `VehicleMetricsNode` and `VehicleStatusNode`.

`component_interface_utils` is already templated on the node type (autoware_core#1362), so these seven need nothing beyond naming it: the base class, `NodeAdaptor<NodeT>` instead of CTAD( Class Template Argument Deduction: the feature that deduces std::vector<int> from the constructor arguments, without writing the template argument), and the wrapper's `create_timer`.

The endpoint aliases in `utils/types.hpp` take the node type as a second parameter defaulting to `rclcpp::Node`, so the six nodes that have not moved yet keep compiling untouched. The default is needed because `NodeAdaptor` deduces its constructor argument separately from its node type, so `NodeAdaptor(this)` would otherwise hand a node one endpoint type and declare another. It disappears in the last PR of this series.

First of three PRs; the remaining six nodes follow.

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

Built and run on `planning_simulator.launch.xml` / `sample-map-planning` with `ENABLE_AGNOCAST=1` and `=0`, driving the same route through the AD API alone. Both drive it; all 19 AD API services stay reachable from the ROS side and every API topic these seven publish is received.

## Interface changes

None.

## Effects on system behavior

None under `ENABLE_AGNOCAST=0`.

Under `=1` these seven nodes move out of `/adapi/container` into their own processes, and their endpoints are carried by Agnocast rather than DDS. Peers still on `rclcpp` reach them through the Agnocast bridge.
