### PR TITLE
feat(autoware_default_adapi_universe): move the nodes that build endpoints outside the adaptor to agnocast_wrapper::Node

### DIFF
--- a/system/autoware_default_adapi_universe/CMakeLists.txt
+++ b/system/autoware_default_adapi_universe/CMakeLists.txt
@@ -24,16 +24,20 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 rclcpp_components_register_nodes(${PROJECT_NAME}
-  "autoware::default_adapi::AutowareStateNode"
   "autoware::default_adapi::MotionNode"
   "autoware::default_adapi::MrmRequestNode"
-  "autoware::default_adapi::OperationModeNode"
-  "autoware::default_adapi::PlanningNode"
   "autoware::default_adapi::VehicleDoorNode"
 )
 
 # These nodes derive from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
 # executor, so they also get standalone executables.
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::AutowareStateNode"
+  EXECUTABLE autoware_state_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::default_adapi::DiagnosticsNode"
   EXECUTABLE diagnostics_node
@@ -63,8 +67,22 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
 )
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::OperationModeNode"
+  EXECUTABLE operation_mode_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::default_adapi::PerceptionNode"
   EXECUTABLE perception_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::PlanningNode"
+  EXECUTABLE planning_node
   ROS2_EXECUTOR MultiThreadedExecutor
   AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )

--- a/system/autoware_default_adapi_universe/launch/default_adapi.launch.py
+++ b/system/autoware_default_adapi_universe/launch/default_adapi.launch.py
@@ -38,12 +38,15 @@ AGNOCAST_WRAPPER_NODES = [
     (CORE, "interface", "InterfaceNode", "interface_node"),
     (CORE, "localization", "LocalizationNode", "localization_node"),
     (CORE, "routing", "RoutingNode", "routing_node"),
+    (UNIVERSE, "autoware_state", "AutowareStateNode", "autoware_state_node"),
     (UNIVERSE, "diagnostics", "DiagnosticsNode", "diagnostics_node"),
     (UNIVERSE, "fail_safe", "FailSafeNode", "fail_safe_node"),
     (UNIVERSE, "heartbeat", "HeartbeatNode", "heartbeat_node"),
     (UNIVERSE, "manual/local", "ManualControlNode", "manual_control_node"),
     (UNIVERSE, "manual/remote", "ManualControlNode", "manual_control_node"),
+    (UNIVERSE, "operation_mode", "OperationModeNode", "operation_mode_node"),
     (UNIVERSE, "perception", "PerceptionNode", "perception_node"),
+    (UNIVERSE, "planning", "PlanningNode", "planning_node"),
     (UNIVERSE, "vehicle_command", "VehicleCommandNode", "vehicle_command_node"),
     (UNIVERSE, "vehicle_info", "VehicleInfoNode", "vehicle_info_node"),
     (UNIVERSE, "vehicle_metrics", "VehicleMetricsNode", "vehicle_metrics_node"),
@@ -104,11 +107,8 @@ def launch_setup(context, *args, **kwargs):
     use_agnocast = context.perform_substitution(LaunchConfiguration("use_agnocast")) == "1"
 
     components = [
-        create_api_node("autoware_default_adapi_universe", "autoware_state", "AutowareStateNode"),
         create_api_node("autoware_default_adapi_universe", "motion", "MotionNode"),
         create_api_node("autoware_default_adapi_universe", "mrm_request", "MrmRequestNode"),
-        create_api_node("autoware_default_adapi_universe", "operation_mode", "OperationModeNode"),
-        create_api_node("autoware_default_adapi_universe", "planning", "PlanningNode"),
         create_api_node("autoware_default_adapi_universe", "vehicle_door", "VehicleDoorNode"),
     ]
     nodes = []

--- a/system/autoware_default_adapi_universe/src/compatibility/autoware_state.cpp
+++ b/system/autoware_default_adapi_universe/src/compatibility/autoware_state.cpp
@@ -15,13 +15,14 @@
 #include "autoware_state.hpp"
 
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::default_adapi
 {
 
 AutowareStateNode::AutowareStateNode(const rclcpp::NodeOptions & options)
-: Node("autoware_state", options)
+: autoware::agnocast_wrapper::Node("autoware_state", options)
 {
   const std::vector<std::string> module_names = {
     "sensing", "perception", "map", "localization", "planning", "control", "vehicle", "system",
@@ -41,13 +42,14 @@ AutowareStateNode::AutowareStateNode(const rclcpp::NodeOptions & options)
     "/autoware/shutdown",
     std::bind(&AutowareStateNode::on_shutdown, this, std::placeholders::_1, std::placeholders::_2));
 
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_sub(sub_localization_, nullptr);
   adaptor.init_sub(sub_routing_, nullptr);
   adaptor.init_sub(sub_operation_mode_, nullptr);
 
   const auto rate = rclcpp::Rate(declare_parameter<double>("update_rate"));
-  timer_ = rclcpp::create_timer(this, get_clock(), rate.period(), [this]() { on_timer(); });
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), rate.period(), [this]() { on_timer(); });
 
   component_states_.resize(module_names.size());
   launch_state_ = LaunchState::Initializing;
@@ -150,10 +152,10 @@ void AutowareStateNode::on_timer()
     RCLCPP_INFO_STREAM(get_logger(), "AutowareState: " << prev_name << " => " << curr_name);
   }
 
-  AutowareState msg;
-  msg.stamp = now();
-  msg.state = state;
-  pub_autoware_state_->publish(msg);
+  auto msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_autoware_state_);
+  msg->stamp = now();
+  msg->state = state;
+  pub_autoware_state_->publish(std::move(msg));
 }
 
 }  // namespace autoware::default_adapi

--- a/system/autoware_default_adapi_universe/src/compatibility/autoware_state.hpp
+++ b/system/autoware_default_adapi_universe/src/compatibility/autoware_state.hpp
@@ -18,6 +18,8 @@
 #include <autoware/adapi_specs/localization.hpp>
 #include <autoware/adapi_specs/operation_mode.hpp>
 #include <autoware/adapi_specs/routing.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 
 #include <autoware_system_msgs/msg/autoware_state.hpp>
 #include <std_srvs/srv/trigger.hpp>
@@ -31,18 +33,18 @@
 namespace autoware::default_adapi
 {
 
-class AutowareStateNode : public rclcpp::Node
+class AutowareStateNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit AutowareStateNode(const rclcpp::NodeOptions & options);
 
 private:
   using ModeChangeAvailable = tier4_system_msgs::msg::ModeChangeAvailable;
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
   // emergency
-  Sub<autoware::adapi_specs::localization::InitializationState> sub_localization_;
-  Sub<autoware::adapi_specs::routing::RouteState> sub_routing_;
-  Sub<autoware::adapi_specs::operation_mode::OperationModeState> sub_operation_mode_;
+  Sub<autoware::adapi_specs::localization::InitializationState, NodeT> sub_localization_;
+  Sub<autoware::adapi_specs::routing::RouteState, NodeT> sub_routing_;
+  Sub<autoware::adapi_specs::operation_mode::OperationModeState, NodeT> sub_operation_mode_;
 
   using AutowareState = autoware_system_msgs::msg::AutowareState;
   using LocalizationState = autoware::adapi_specs::localization::InitializationState::Message;
@@ -50,9 +52,9 @@ private:
   using OperationModeState = autoware::adapi_specs::operation_mode::OperationModeState::Message;
   using Trigger = std_srvs::srv::Trigger;
   std::vector<bool> component_states_;
-  std::vector<rclcpp::Subscription<ModeChangeAvailable>::SharedPtr> sub_component_states_;
-  rclcpp::Publisher<AutowareState>::SharedPtr pub_autoware_state_;
-  rclcpp::Service<Trigger>::SharedPtr srv_autoware_shutdown_;
+  std::vector<AUTOWARE_SUBSCRIPTION_PTR(ModeChangeAvailable)> sub_component_states_;
+  AUTOWARE_PUBLISHER_PTR(AutowareState) pub_autoware_state_;
+  AUTOWARE_SERVICE_PTR(Trigger) srv_autoware_shutdown_;
 
   enum class LaunchState { Initializing, Running, Finalizing };
   LaunchState launch_state_;

--- a/system/autoware_default_adapi_universe/src/operation_mode.cpp
+++ b/system/autoware_default_adapi_universe/src/operation_mode.cpp
@@ -24,9 +24,9 @@ namespace autoware::default_adapi
 using ServiceResponse = autoware_adapi_v1_msgs::srv::ChangeOperationMode::Response;
 
 OperationModeNode::OperationModeNode(const rclcpp::NodeOptions & options)
-: Node("operation_mode", options)
+: autoware::agnocast_wrapper::Node("operation_mode", options)
 {
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_sub(sub_state_, this, &OperationModeNode::on_state);
   adaptor.init_pub(pub_state_);
@@ -49,7 +49,7 @@ OperationModeNode::OperationModeNode(const rclcpp::NodeOptions & options)
   };
   sub_availability_ = create_subscription<OperationModeAvailability>(name, qos, callback);
 
-  timer_ = rclcpp::create_timer(
+  timer_ = autoware::agnocast_wrapper::create_timer(
     this, get_clock(), rclcpp::Rate(5.0).period(), std::bind(&OperationModeNode::on_timer, this));
 
   curr_state_.mode = OperationModeState::Message::UNKNOWN;

--- a/system/autoware_default_adapi_universe/src/operation_mode.hpp
+++ b/system/autoware_default_adapi_universe/src/operation_mode.hpp
@@ -16,6 +16,8 @@
 #define OPERATION_MODE_HPP_
 
 #include <autoware/adapi_specs/operation_mode.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/system.hpp>
 #include <autoware/component_interface_utils/status.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -32,7 +34,7 @@
 
 namespace autoware::default_adapi
 {
-class OperationModeNode : public rclcpp::Node
+class OperationModeNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit OperationModeNode(const rclcpp::NodeOptions & options);
@@ -56,18 +58,19 @@ private:
   std::unordered_map<OperationModeState::Message::_mode_type, bool> mode_available_;
 
   rclcpp::CallbackGroup::SharedPtr group_cli_;
-  rclcpp::TimerBase::SharedPtr timer_;
-  Pub<autoware::adapi_specs::operation_mode::OperationModeState> pub_state_;
-  Srv<autoware::adapi_specs::operation_mode::ChangeToStop> srv_stop_mode_;
-  Srv<autoware::adapi_specs::operation_mode::ChangeToAutonomous> srv_autonomous_mode_;
-  Srv<autoware::adapi_specs::operation_mode::ChangeToLocal> srv_local_mode_;
-  Srv<autoware::adapi_specs::operation_mode::ChangeToRemote> srv_remote_mode_;
-  Srv<autoware::adapi_specs::operation_mode::EnableAutowareControl> srv_enable_control_;
-  Srv<autoware::adapi_specs::operation_mode::DisableAutowareControl> srv_disable_control_;
-  Sub<autoware::component_interface_specs_universe::system::OperationModeState> sub_state_;
-  Cli<autoware::component_interface_specs_universe::system::ChangeOperationMode> cli_mode_;
-  Cli<autoware::component_interface_specs_universe::system::ChangeAutowareControl> cli_control_;
-  rclcpp::Subscription<OperationModeAvailability>::SharedPtr sub_availability_;
+  AUTOWARE_TIMER_PTR timer_;
+  Pub<autoware::adapi_specs::operation_mode::OperationModeState, NodeT> pub_state_;
+  Srv<autoware::adapi_specs::operation_mode::ChangeToStop, NodeT> srv_stop_mode_;
+  Srv<autoware::adapi_specs::operation_mode::ChangeToAutonomous, NodeT> srv_autonomous_mode_;
+  Srv<autoware::adapi_specs::operation_mode::ChangeToLocal, NodeT> srv_local_mode_;
+  Srv<autoware::adapi_specs::operation_mode::ChangeToRemote, NodeT> srv_remote_mode_;
+  Srv<autoware::adapi_specs::operation_mode::EnableAutowareControl, NodeT> srv_enable_control_;
+  Srv<autoware::adapi_specs::operation_mode::DisableAutowareControl, NodeT> srv_disable_control_;
+  Sub<autoware::component_interface_specs_universe::system::OperationModeState, NodeT> sub_state_;
+  Cli<autoware::component_interface_specs_universe::system::ChangeOperationMode, NodeT> cli_mode_;
+  Cli<autoware::component_interface_specs_universe::system::ChangeAutowareControl, NodeT>
+    cli_control_;
+  AUTOWARE_SUBSCRIPTION_PTR(OperationModeAvailability) sub_availability_;
 
   void on_change_to_stop(
     const ChangeToStop::Service::Request::SharedPtr req,

--- a/system/autoware_default_adapi_universe/src/planning.cpp
+++ b/system/autoware_default_adapi_universe/src/planning.cpp
@@ -65,18 +65,19 @@ void concat(std::vector<T> & v1, const std::vector<T> & v2)
   v1.insert(v1.end(), v2.begin(), v2.end());
 }
 
-template <class T>
-std::vector<typename rclcpp::Subscription<T>::SharedPtr> init_factors(
-  rclcpp::Node * node, std::vector<typename T::ConstSharedPtr> & factors,
+template <class T, class NodeT>
+auto init_factors(
+  NodeT * node, std::vector<typename T::ConstSharedPtr> & factors,
   const std::vector<std::string> & topics)
 {
   const auto callback = [&factors](const int index) {
     return [&factors, index](const typename T::ConstSharedPtr msg) { factors[index] = msg; };
   };
 
-  std::vector<typename rclcpp::Subscription<T>::SharedPtr> subs;
+  std::vector<AUTOWARE_SUBSCRIPTION_PTR(T)> subs;
   for (size_t index = 0; index < topics.size(); ++index) {
-    subs.push_back(node->create_subscription<T>(topics[index], rclcpp::QoS(1), callback(index)));
+    subs.push_back(
+      node->template create_subscription<T>(topics[index], rclcpp::QoS(1), callback(index)));
   }
   factors.resize(topics.size());
   return subs;
@@ -203,7 +204,8 @@ SteeringFactorArray merge_factors(
   return message;
 }
 
-PlanningNode::PlanningNode(const rclcpp::NodeOptions & options) : Node("planning", options)
+PlanningNode::PlanningNode(const rclcpp::NodeOptions & options)
+: autoware::agnocast_wrapper::Node("planning", options)
 {
   // TODO(Takagi, Isamu): remove default value
   stop_distance_ = declare_parameter<double>("stop_distance", 1.0);
@@ -243,14 +245,15 @@ PlanningNode::PlanningNode(const rclcpp::NodeOptions & options) : Node("planning
 
   sub_factors_ = init_factors<PlanningFactorArray>(this, factors_, factor_topics);
 
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_pub(pub_velocity_factors_);
   adaptor.init_pub(pub_steering_factors_);
   adaptor.init_sub(sub_kinematic_state_, this, &PlanningNode::on_kinematic_state);
   adaptor.init_sub(sub_trajectory_, nullptr);
 
   const auto rate = rclcpp::Rate(5);
-  timer_ = rclcpp::create_timer(this, get_clock(), rate.period(), [this]() { on_timer(); });
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), rate.period(), [this]() { on_timer(); });
 }
 
 void PlanningNode::on_kinematic_state(const KinematicState::ConstSharedPtr msg)

--- a/system/autoware_default_adapi_universe/src/planning.hpp
+++ b/system/autoware_default_adapi_universe/src/planning.hpp
@@ -16,6 +16,8 @@
 #define PLANNING_HPP_
 
 #include <autoware/adapi_specs/planning.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/localization.hpp>
 #include <autoware/component_interface_specs_universe/planning.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
@@ -42,20 +44,20 @@ using autoware_adapi_v1_msgs::msg::VelocityFactorArray;
 using autoware_internal_planning_msgs::msg::PlanningFactor;
 using autoware_internal_planning_msgs::msg::PlanningFactorArray;
 
-class PlanningNode : public rclcpp::Node
+class PlanningNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit PlanningNode(const rclcpp::NodeOptions & options);
 
 private:
-  Pub<autoware::adapi_specs::planning::VelocityFactors> pub_velocity_factors_;
-  Pub<autoware::adapi_specs::planning::SteeringFactors> pub_steering_factors_;
-  Sub<autoware::component_interface_specs_universe::planning::Trajectory> sub_trajectory_;
-  Sub<autoware::component_interface_specs_universe::localization::KinematicState>
+  Pub<autoware::adapi_specs::planning::VelocityFactors, NodeT> pub_velocity_factors_;
+  Pub<autoware::adapi_specs::planning::SteeringFactors, NodeT> pub_steering_factors_;
+  Sub<autoware::component_interface_specs_universe::planning::Trajectory, NodeT> sub_trajectory_;
+  Sub<autoware::component_interface_specs_universe::localization::KinematicState, NodeT>
     sub_kinematic_state_;
-  std::vector<rclcpp::Subscription<PlanningFactorArray>::SharedPtr> sub_factors_;
+  std::vector<AUTOWARE_SUBSCRIPTION_PTR(PlanningFactorArray)> sub_factors_;
   std::vector<PlanningFactorArray::ConstSharedPtr> factors_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
 
   using VehicleStopChecker = autoware::motion_utils::VehicleStopCheckerBase;
   using Trajectory = autoware::component_interface_specs_universe::planning::Trajectory::Message;


### PR DESCRIPTION
## Description

Move the three nodes in this package that build endpoints `NodeAdaptor` does not cover: `AutowareStateNode`, `OperationModeNode` and `PlanningNode`. Because those endpoints are created by hand, they name the wrapper types instead of the rclcpp handle types — `autoware_state`'s component-state subscriptions, its state publisher and its shutdown service, `operation_mode`'s availability subscription, and `planning`'s factor subscriptions, whose `init_factors()` now deduces the node type rather than naming `rclcpp::Node`.

Second of three PRs. #13376, now merged, explains why the endpoint aliases carry the node type as a second argument.

## Related links

**Parent Issue:**

- None.

Follows #13376.

## How was this PR tested?

Built and run on `planning_simulator.launch.xml` / `sample-map-planning` with `ENABLE_AGNOCAST=1` and `=0`, driving the same route through the AD API alone. Both drive it; `/autoware/state` reaches `DRIVING` (`AutowareStateNode`'s own output, published through the loaned message), `change_to_autonomous` returns success (`operation_mode`'s client-inside-a-service-callback path), the planning factor topics are received throughout, and all 19 AD API services stay reachable from the ROS side.

## Interface changes

None.

## Effects on system behavior

None under `ENABLE_AGNOCAST=0`.

Under `=1` these three nodes move out of `/adapi/container` into their own processes, and their endpoints are carried by Agnocast rather than DDS.
