### PR TITLE
feat(autoware_default_adapi_universe): move the last component_interface_utils nodes to agnocast_wrapper::Node

### DIFF
--- a/system/autoware_default_adapi_universe/CMakeLists.txt
+++ b/system/autoware_default_adapi_universe/CMakeLists.txt
@@ -23,12 +23,6 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/compatibility/autoware_state.cpp
 )
 
-rclcpp_components_register_nodes(${PROJECT_NAME}
-  "autoware::default_adapi::MotionNode"
-  "autoware::default_adapi::MrmRequestNode"
-  "autoware::default_adapi::VehicleDoorNode"
-)
-
 # These nodes derive from autoware::agnocast_wrapper::Node, which requires an AgnocastOnly
 # executor, so they also get standalone executables.
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
@@ -67,6 +61,20 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
 )
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::MotionNode"
+  EXECUTABLE motion_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::MrmRequestNode"
+  EXECUTABLE mrm_request_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::default_adapi::OperationModeNode"
   EXECUTABLE operation_mode_node
   ROS2_EXECUTOR MultiThreadedExecutor
@@ -90,6 +98,13 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::default_adapi::VehicleCommandNode"
   EXECUTABLE vehicle_command_node
+  ROS2_EXECUTOR MultiThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+)
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::default_adapi::VehicleDoorNode"
+  EXECUTABLE vehicle_door_node
   ROS2_EXECUTOR MultiThreadedExecutor
   AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )

--- a/system/autoware_default_adapi_universe/launch/default_adapi.launch.py
+++ b/system/autoware_default_adapi_universe/launch/default_adapi.launch.py
@@ -44,10 +44,13 @@ AGNOCAST_WRAPPER_NODES = [
     (UNIVERSE, "heartbeat", "HeartbeatNode", "heartbeat_node"),
     (UNIVERSE, "manual/local", "ManualControlNode", "manual_control_node"),
     (UNIVERSE, "manual/remote", "ManualControlNode", "manual_control_node"),
+    (UNIVERSE, "motion", "MotionNode", "motion_node"),
+    (UNIVERSE, "mrm_request", "MrmRequestNode", "mrm_request_node"),
     (UNIVERSE, "operation_mode", "OperationModeNode", "operation_mode_node"),
     (UNIVERSE, "perception", "PerceptionNode", "perception_node"),
     (UNIVERSE, "planning", "PlanningNode", "planning_node"),
     (UNIVERSE, "vehicle_command", "VehicleCommandNode", "vehicle_command_node"),
+    (UNIVERSE, "vehicle_door", "VehicleDoorNode", "vehicle_door_node"),
     (UNIVERSE, "vehicle_info", "VehicleInfoNode", "vehicle_info_node"),
     (UNIVERSE, "vehicle_metrics", "VehicleMetricsNode", "vehicle_metrics_node"),
     (UNIVERSE, "vehicle_status", "VehicleStatusNode", "vehicle_status_node"),
@@ -106,18 +109,16 @@ def get_default_config():
 def launch_setup(context, *args, **kwargs):
     use_agnocast = context.perform_substitution(LaunchConfiguration("use_agnocast")) == "1"
 
-    components = [
-        create_api_node("autoware_default_adapi_universe", "motion", "MotionNode"),
-        create_api_node("autoware_default_adapi_universe", "mrm_request", "MrmRequestNode"),
-        create_api_node("autoware_default_adapi_universe", "vehicle_door", "VehicleDoorNode"),
-    ]
-    nodes = []
-    for package_name, node_name, class_name, executable in AGNOCAST_WRAPPER_NODES:
-        if use_agnocast:
-            nodes.append(create_standalone_api_node(package_name, node_name, executable))
-        else:
-            components.append(create_api_node(package_name, node_name, class_name))
+    if use_agnocast:
+        return [
+            create_standalone_api_node(package_name, node_name, executable)
+            for package_name, node_name, _, executable in AGNOCAST_WRAPPER_NODES
+        ]
 
+    components = [
+        create_api_node(package_name, node_name, class_name)
+        for package_name, node_name, class_name, _ in AGNOCAST_WRAPPER_NODES
+    ]
     container = ComposableNodeContainer(
         namespace="adapi",
         name="container",
@@ -126,7 +127,7 @@ def launch_setup(context, *args, **kwargs):
         ros_arguments=["--log-level", "adapi.container:=WARN"],
         composable_node_descriptions=components,
     )
-    return [container, *nodes]
+    return [container]
 
 
 def generate_launch_description():

--- a/system/autoware_default_adapi_universe/src/motion.cpp
+++ b/system/autoware_default_adapi_universe/src/motion.cpp
@@ -20,23 +20,29 @@
 namespace autoware::default_adapi
 {
 
+// The buffer VehicleStopChecker keeps, reproduced here because its base takes it as an argument.
+constexpr double velocity_buffer_time_sec = 10.0;
+
 MotionNode::MotionNode(const rclcpp::NodeOptions & options)
-: Node("motion", options), vehicle_stop_checker_(this)
+: autoware::agnocast_wrapper::Node("motion", options),
+  vehicle_stop_checker_(this, velocity_buffer_time_sec)
 {
   stop_check_duration_ = declare_parameter<double>("stop_check_duration");
   require_accept_start_ = declare_parameter<bool>("require_accept_start");
   is_calling_set_pause_ = false;
 
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.init_srv(srv_accept_, this, &MotionNode::on_accept);
   adaptor.init_pub(pub_state_);
   adaptor.init_cli(cli_set_pause_, group_cli_);
   adaptor.init_sub(sub_is_paused_, this, &MotionNode::on_is_paused);
   adaptor.init_sub(sub_is_start_requested_, this, &MotionNode::on_is_start_requested);
+  adaptor.init_sub(sub_kinematic_state_, this, &MotionNode::on_kinematic_state);
 
   rclcpp::Rate rate(10);
-  timer_ = rclcpp::create_timer(this, get_clock(), rate.period(), [this]() { on_timer(); });
+  timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), rate.period(), [this]() { on_timer(); });
   state_ = State::Unknown;
 }
 
@@ -148,6 +154,16 @@ void MotionNode::on_is_start_requested(
 {
   is_start_requested_ = msg->data;
   update_state();
+}
+
+void MotionNode::on_kinematic_state(
+  const autoware::component_interface_specs_universe::localization::KinematicState::Message::
+    ConstSharedPtr msg)
+{
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header = msg->header;
+  twist.twist = msg->twist.twist;
+  vehicle_stop_checker_.addTwist(twist);
 }
 
 void MotionNode::on_accept(

--- a/system/autoware_default_adapi_universe/src/motion.cpp
+++ b/system/autoware_default_adapi_universe/src/motion.cpp
@@ -21,6 +21,7 @@ namespace autoware::default_adapi
 {
 
 // The buffer VehicleStopChecker keeps, reproduced here because its base takes it as an argument.
+// Ref. https://github.com/autowarefoundation/autoware_core/blob/758b6c65b276447b2784275b37054c57ed8061cc/common/autoware_motion_utils/include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp#L64
 constexpr double velocity_buffer_time_sec = 10.0;
 
 MotionNode::MotionNode(const rclcpp::NodeOptions & options)

--- a/system/autoware_default_adapi_universe/src/motion.cpp
+++ b/system/autoware_default_adapi_universe/src/motion.cpp
@@ -21,7 +21,8 @@ namespace autoware::default_adapi
 {
 
 // The buffer VehicleStopChecker keeps, reproduced here because its base takes it as an argument.
-// Ref. https://github.com/autowarefoundation/autoware_core/blob/758b6c65b276447b2784275b37054c57ed8061cc/common/autoware_motion_utils/include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp#L64
+// Ref.
+// https://github.com/autowarefoundation/autoware_core/blob/758b6c65b276447b2784275b37054c57ed8061cc/common/autoware_motion_utils/include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp#L64
 constexpr double velocity_buffer_time_sec = 10.0;
 
 MotionNode::MotionNode(const rclcpp::NodeOptions & options)

--- a/system/autoware_default_adapi_universe/src/motion.hpp
+++ b/system/autoware_default_adapi_universe/src/motion.hpp
@@ -16,7 +16,10 @@
 #define MOTION_HPP_
 
 #include <autoware/adapi_specs/motion.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/control.hpp>
+#include <autoware/component_interface_specs_universe/localization.hpp>
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/component_interface_utils/status.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
@@ -28,21 +31,25 @@
 namespace autoware::default_adapi
 {
 
-class MotionNode : public rclcpp::Node
+class MotionNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit MotionNode(const rclcpp::NodeOptions & options);
 
 private:
-  autoware::motion_utils::VehicleStopChecker vehicle_stop_checker_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  // VehicleStopChecker owns an rclcpp subscription, so only its node-agnostic base is used here
+  // and the odometry is fed from the subscription below, which covers the same topic and QoS.
+  autoware::motion_utils::VehicleStopCheckerBase vehicle_stop_checker_;
+  AUTOWARE_TIMER_PTR timer_;
   rclcpp::CallbackGroup::SharedPtr group_cli_;
-  Srv<autoware::adapi_specs::motion::AcceptStart> srv_accept_;
-  Pub<autoware::adapi_specs::motion::State> pub_state_;
-  Cli<autoware::component_interface_specs_universe::control::SetPause> cli_set_pause_;
-  Sub<autoware::component_interface_specs_universe::control::IsPaused> sub_is_paused_;
-  Sub<autoware::component_interface_specs_universe::control::IsStartRequested>
+  Srv<autoware::adapi_specs::motion::AcceptStart, NodeT> srv_accept_;
+  Pub<autoware::adapi_specs::motion::State, NodeT> pub_state_;
+  Cli<autoware::component_interface_specs_universe::control::SetPause, NodeT> cli_set_pause_;
+  Sub<autoware::component_interface_specs_universe::control::IsPaused, NodeT> sub_is_paused_;
+  Sub<autoware::component_interface_specs_universe::control::IsStartRequested, NodeT>
     sub_is_start_requested_;
+  Sub<autoware::component_interface_specs_universe::localization::KinematicState, NodeT>
+    sub_kinematic_state_;
 
   enum class State { Unknown, Pausing, Paused, Starting, Resuming, Resumed, Moving };
   State state_;
@@ -63,6 +70,9 @@ private:
       msg);
   void on_is_start_requested(
     const autoware::component_interface_specs_universe::control::IsStartRequested::Message::
+      ConstSharedPtr msg);
+  void on_kinematic_state(
+    const autoware::component_interface_specs_universe::localization::KinematicState::Message::
       ConstSharedPtr msg);
   void on_accept(
     const autoware::adapi_specs::motion::AcceptStart::Service::Request::SharedPtr req,

--- a/system/autoware_default_adapi_universe/src/mrm_request.cpp
+++ b/system/autoware_default_adapi_universe/src/mrm_request.cpp
@@ -18,12 +18,12 @@ namespace autoware::default_adapi
 {
 
 MrmRequestNode::MrmRequestNode(const rclcpp::NodeOptions & options)
-: Node("mrm_request", options), diagnostics_(this)
+: autoware::agnocast_wrapper::Node("mrm_request", options), diagnostics_(this)
 {
   diagnostics_.setHardwareID("none");
   diagnostics_.add("delegate", this, &MrmRequestNode::diagnose_delegate);
 
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   adaptor.init_pub(pub_mrm_request_list_);
   adaptor.init_srv(srv_send_mrm_request_, this, &MrmRequestNode::on_send_mrm_request);
 

--- a/system/autoware_default_adapi_universe/src/mrm_request.hpp
+++ b/system/autoware_default_adapi_universe/src/mrm_request.hpp
@@ -16,7 +16,8 @@
 #define MRM_REQUEST_HPP_
 
 #include <autoware/adapi_specs/fail_safe.hpp>
-#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <string>
@@ -28,7 +29,7 @@
 namespace autoware::default_adapi
 {
 
-class MrmRequestNode : public rclcpp::Node
+class MrmRequestNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit MrmRequestNode(const rclcpp::NodeOptions & options);
@@ -38,8 +39,8 @@ private:
   using MrmRequestList = autoware::adapi_specs::fail_safe::MrmRequestList;
   using MrmRequestItem = autoware_adapi_v1_msgs::msg::MrmRequest;
 
-  Srv<SendMrmRequest> srv_send_mrm_request_;
-  Pub<MrmRequestList> pub_mrm_request_list_;
+  Srv<SendMrmRequest, NodeT> srv_send_mrm_request_;
+  Pub<MrmRequestList, NodeT> pub_mrm_request_list_;
 
   void diagnose_delegate(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void publish_mrm_request_list();
@@ -47,7 +48,7 @@ private:
     const SendMrmRequest::Service::Request::SharedPtr req,
     const SendMrmRequest::Service::Response::SharedPtr res);
 
-  diagnostic_updater::Updater diagnostics_;
+  autoware::agnocast_wrapper::diagnostic_updater::Updater diagnostics_;
   std::unordered_map<std::string, MrmRequestItem> mrm_requests_;
 };
 

--- a/system/autoware_default_adapi_universe/src/utils/types.hpp
+++ b/system/autoware_default_adapi_universe/src/utils/types.hpp
@@ -23,13 +23,13 @@ namespace autoware::default_adapi
 
 using NodeT = autoware::agnocast_wrapper::Node;
 
-template <class T, class N = rclcpp::Node>
+template <class T, class N>
 using Pub = typename autoware::component_interface_utils::Publisher<T, N>::SharedPtr;
-template <class T, class N = rclcpp::Node>
+template <class T, class N>
 using Sub = typename autoware::component_interface_utils::Subscription<T, N>::SharedPtr;
-template <class T, class N = rclcpp::Node>
+template <class T, class N>
 using Cli = typename autoware::component_interface_utils::Client<T, N>::SharedPtr;
-template <class T, class N = rclcpp::Node>
+template <class T, class N>
 using Srv = typename autoware::component_interface_utils::Service<T, N>::SharedPtr;
 
 }  // namespace autoware::default_adapi

--- a/system/autoware_default_adapi_universe/src/vehicle_door.cpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_door.cpp
@@ -20,12 +20,12 @@ namespace autoware::default_adapi
 {
 
 VehicleDoorNode::VehicleDoorNode(const rclcpp::NodeOptions & options)
-: Node("vehicle_door", options), diagnostics_(this)
+: autoware::agnocast_wrapper::Node("vehicle_door", options), diagnostics_(this)
 {
   diagnostics_.setHardwareID("none");
   diagnostics_.add("state", this, &VehicleDoorNode::diagnose_state);
 
-  const auto adaptor = autoware::component_interface_utils::NodeAdaptor(this);
+  const auto adaptor = autoware::component_interface_utils::NodeAdaptor<NodeT>(this);
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   adaptor.relay_service(cli_layout_, srv_layout_, group_cli_);
   adaptor.init_cli(cli_command_, group_cli_);

--- a/system/autoware_default_adapi_universe/src/vehicle_door.hpp
+++ b/system/autoware_default_adapi_universe/src/vehicle_door.hpp
@@ -16,10 +16,11 @@
 #define VEHICLE_DOOR_HPP_
 
 #include <autoware/adapi_specs/vehicle.hpp>
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs_universe/system.hpp>
 #include <autoware/component_interface_specs_universe/vehicle.hpp>
 #include <autoware/component_interface_utils/status.hpp>
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <optional>
@@ -30,7 +31,7 @@
 namespace autoware::default_adapi
 {
 
-class VehicleDoorNode : public rclcpp::Node
+class VehicleDoorNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit VehicleDoorNode(const rclcpp::NodeOptions & options);
@@ -52,20 +53,20 @@ private:
     const ExternalDoorCommand::Service::Request::SharedPtr req,
     const ExternalDoorCommand::Service::Response::SharedPtr res);
 
-  diagnostic_updater::Updater diagnostics_;
+  autoware::agnocast_wrapper::diagnostic_updater::Updater diagnostics_;
   rclcpp::CallbackGroup::SharedPtr group_cli_;
-  Srv<ExternalDoorCommand> srv_command_;
-  Srv<ExternalDoorLayout> srv_layout_;
-  Pub<ExternalDoorStatus> pub_status_;
-  Cli<InternalDoorCommand> cli_command_;
-  Cli<InternalDoorLayout> cli_layout_;
-  Sub<InternalDoorStatus> sub_status_;
+  Srv<ExternalDoorCommand, NodeT> srv_command_;
+  Srv<ExternalDoorLayout, NodeT> srv_layout_;
+  Pub<ExternalDoorStatus, NodeT> pub_status_;
+  Cli<InternalDoorCommand, NodeT> cli_command_;
+  Cli<InternalDoorLayout, NodeT> cli_layout_;
+  Sub<InternalDoorStatus, NodeT> sub_status_;
   std::optional<InternalDoorStatus::Message> status_;
 
   bool check_autoware_control_;
   bool is_autoware_control_;
   bool is_stop_mode_;
-  Sub<OperationModeState> sub_operation_mode_;
+  Sub<OperationModeState, NodeT> sub_operation_mode_;
 };
 
 }  // namespace autoware::default_adapi


### PR DESCRIPTION
## Description
Move the last three nodes in this package — `MotionNode`, `MrmRequestNode` and `VehicleDoorNode`.

`motion` held a `VehicleStopChecker`, which owns an rclcpp subscription. Only the node-agnostic `VehicleStopCheckerBase` is kept, fed from a `KinematicState` subscription; that spec is the topic the checker subscribed to with the same depth and QoS, so only the owner of the subscription changes.

With no node left on `rclcpp`, three things get cleaned up:
- `utils/types.hpp` drops the `rclcpp::Node` default from the endpoint aliases,
- the package registers no rclcpp components any more, so `rclcpp_components_register_nodes()` goes away,
- the launch file starts the whole set as separate processes under `=1` instead of an empty `/adapi/container` beside them.

## Related links

**Parent Issue:**

- None.

Depends on #13377.

## How was this PR tested?

Built and run on `planning_simulator.launch.xml` / `sample-map-planning` with `ENABLE_AGNOCAST=1` and `=0`, driving the same route through the AD API alone. Both drive it; all 19 AD API services stay reachable and every API topic the package publishes is received, with `/api/motion/state` reaching `MOVING`. Under `=1` all 19 nodes run standalone with no `/adapi/container`, and `ros2 topic list_agnocast` reports every endpoint of this package as `(Agnocast enabled)`.

## Interface changes

None.

## Effects on system behavior

None under `ENABLE_AGNOCAST=0`.

Under `=1` the remaining three nodes move out of `/adapi/container` into their own processes, and `/adapi/container` is no longer started at all, because every node in the list now runs standalone. `motion` keeps deriving its stop state from the same topic at the same rate and QoS as before.
