### PR TITLE
feat(tier4_api_utils): let non-rclcpp node types supply the service and client handles

### DIFF
--- a/common/tier4_api_utils/include/tier4_api_utils/rclcpp/client.hpp
+++ b/common/tier4_api_utils/include/tier4_api_utils/rclcpp/client.hpp
@@ -15,27 +15,45 @@
 #ifndef TIER4_API_UTILS__RCLCPP__CLIENT_HPP_
 #define TIER4_API_UTILS__RCLCPP__CLIENT_HPP_
 
+#include "rclcpp/callback_group.hpp"
 #include "rclcpp/client.hpp"
 #include "tier4_api_utils/types/response.hpp"
 
 #include <chrono>
+#include <string>
 #include <utility>
 
 namespace tier4_api_utils
 {
-template <typename ServiceT>
+
+/// Create the underlying client handle. Kept as a free function because Client deduces its handle
+/// type from this call, which is what lets node types other than rclcpp::Node supply their own.
+template <typename ServiceT, class NodeT>
+auto create_client_handle(
+  NodeT * node, const std::string & service_name, const rmw_qos_profile_t & qos_profile,
+  rclcpp::CallbackGroup::SharedPtr group)
+{
+  return node->template create_client<ServiceT>(service_name, qos_profile, group);
+}
+
+template <typename ServiceT, class NodeT = rclcpp::Node>
 class Client
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Client)
 
-  using ResponseStatus = tier4_external_api_msgs::msg::ResponseStatus;
-  using AutowareServiceResult = std::pair<ResponseStatus, typename ServiceT::Response::SharedPtr>;
+  using ClientHandle = decltype(create_client_handle<ServiceT>(
+    std::declval<NodeT *>(), std::declval<const std::string &>(),
+    std::declval<const rmw_qos_profile_t &>(), nullptr));
 
-  Client(typename rclcpp::Client<ServiceT>::SharedPtr client, const rclcpp::Logger & logger)
-  : client_(client), logger_(logger)
-  {
-  }
+  /// Taken from the handle rather than spelled as ServiceT::Response::SharedPtr: a node type may
+  /// hand the response over as a pointer to const.
+  using SharedResponse = typename ClientHandle::element_type::SharedResponse;
+
+  using ResponseStatus = tier4_external_api_msgs::msg::ResponseStatus;
+  using AutowareServiceResult = std::pair<ResponseStatus, SharedResponse>;
+
+  Client(ClientHandle client, const rclcpp::Logger & logger) : client_(client), logger_(logger) {}
 
   AutowareServiceResult call(
     const typename ServiceT::Request::SharedPtr & request,
@@ -45,13 +63,13 @@ public:
 
     if (!client_->service_is_ready()) {
       RCLCPP_DEBUG(logger_, "client available");
-      return {response_error("Internal service is not available."), nullptr};
+      return {response_error("Internal service is not available."), {}};
     }
 
     auto future = client_->async_send_request(request);
     if (future.wait_for(timeout) != std::future_status::ready) {
       RCLCPP_DEBUG(logger_, "client timeout");
-      return {response_error("Internal service has timed out."), nullptr};
+      return {response_error("Internal service has timed out."), {}};
     }
 
     RCLCPP_DEBUG(logger_, "client response");
@@ -61,7 +79,7 @@ public:
 private:
   RCLCPP_DISABLE_COPY(Client)
 
-  typename rclcpp::Client<ServiceT>::SharedPtr client_;
+  ClientHandle client_;
   rclcpp::Logger logger_;
 };
 

--- a/common/tier4_api_utils/include/tier4_api_utils/rclcpp/proxy.hpp
+++ b/common/tier4_api_utils/include/tier4_api_utils/rclcpp/proxy.hpp
@@ -24,34 +24,40 @@
 
 namespace tier4_api_utils
 {
-template <class NodeT>
+template <class NodeT = rclcpp::Node>
 class ServiceProxyNodeInterface
 {
 public:
-  // Use a raw pointer because shared_from_this cannot be used in constructor.
-  explicit ServiceProxyNodeInterface(NodeT * node) { node_ = node; }
+  /// Use a raw pointer because shared_from_this cannot be used in constructor.
+  /// D is deduced separately from NodeT so that ServiceProxyNodeInterface(this) on a node derived
+  /// from rclcpp::Node keeps NodeT at its default instead of deducing the derived type.
+  template <class D>
+  explicit ServiceProxyNodeInterface(D * node)
+  {
+    node_ = node;
+  }
 
   template <typename ServiceT, typename CallbackT>
-  typename Service<ServiceT>::SharedPtr create_service(
+  typename Service<ServiceT, NodeT>::SharedPtr create_service(
     const std::string & service_name, CallbackT && callback,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
-    auto wrapped_callback = Service<ServiceT>::template wrap<CallbackT>(
+    auto wrapped_callback = Service<ServiceT, NodeT>::template wrap<CallbackT>(
       std::forward<CallbackT>(callback), node_->get_logger());
-    return Service<ServiceT>::make_shared(node_->template create_service<ServiceT>(
-      service_name, std::move(wrapped_callback), qos_profile, group));
+    return Service<ServiceT, NodeT>::make_shared(
+      create_service_handle<ServiceT>(
+        node_, service_name, std::move(wrapped_callback), qos_profile, group));
   }
 
   template <typename ServiceT>
-  typename Client<ServiceT>::SharedPtr create_client(
+  typename Client<ServiceT, NodeT>::SharedPtr create_client(
     const std::string & service_name,
     const rmw_qos_profile_t & qos_profile = rmw_qos_profile_services_default,
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
-    return Client<ServiceT>::make_shared(
-      node_->template create_client<ServiceT>(service_name, qos_profile, group),
-      node_->get_logger());
+    return Client<ServiceT, NodeT>::make_shared(
+      create_client_handle<ServiceT>(node_, service_name, qos_profile, group), node_->get_logger());
   }
 
 private:

--- a/common/tier4_api_utils/include/tier4_api_utils/rclcpp/service.hpp
+++ b/common/tier4_api_utils/include/tier4_api_utils/rclcpp/service.hpp
@@ -15,17 +15,46 @@
 #ifndef TIER4_API_UTILS__RCLCPP__SERVICE_HPP_
 #define TIER4_API_UTILS__RCLCPP__SERVICE_HPP_
 
+#include "rclcpp/callback_group.hpp"
+#include "rclcpp/logger.hpp"
 #include "rclcpp/service.hpp"
+
+#include <functional>
+#include <string>
+#include <utility>
 
 namespace tier4_api_utils
 {
+
+/// The callback shape wrap() produces, named so that the service handle type below is deduced
+/// from it rather than from the caller's lambda type.
 template <typename ServiceT>
+using ServiceCallback = std::function<void(
+  typename ServiceT::Request::SharedPtr, typename ServiceT::Response::SharedPtr)>;
+
+/// Create the underlying service handle. Kept as a free function because Service deduces its
+/// handle type from this call, which is what lets node types other than rclcpp::Node supply
+/// their own handle.
+template <typename ServiceT, class NodeT>
+auto create_service_handle(
+  NodeT * node, const std::string & service_name, ServiceCallback<ServiceT> callback,
+  const rmw_qos_profile_t & qos_profile, rclcpp::CallbackGroup::SharedPtr group)
+{
+  return node->template create_service<ServiceT>(
+    service_name, std::move(callback), qos_profile, group);
+}
+
+template <typename ServiceT, class NodeT = rclcpp::Node>
 class Service
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Service)
 
-  explicit Service(typename rclcpp::Service<ServiceT>::SharedPtr service) : service_(service) {}
+  using ServiceHandle = decltype(create_service_handle<ServiceT>(
+    std::declval<NodeT *>(), std::declval<const std::string &>(),
+    std::declval<ServiceCallback<ServiceT>>(), std::declval<const rmw_qos_profile_t &>(), nullptr));
+
+  explicit Service(ServiceHandle service) : service_(service) {}
 
   template <typename CallbackT>
   static auto wrap(CallbackT && callback, const rclcpp::Logger & logger)
@@ -43,7 +72,7 @@ public:
 private:
   RCLCPP_DISABLE_COPY(Service)
 
-  typename rclcpp::Service<ServiceT>::SharedPtr service_;
+  ServiceHandle service_;
 };
 
 }  // namespace tier4_api_utils


### PR DESCRIPTION
## Description

`Service` and `Client` fixed their handles to `rclcpp::Service` and `rclcpp::Client`, so a node that is not an `rclcpp::Node` could not use the proxy even though `ServiceProxyNodeInterface` was already templated on the node type. Both now take the node type as a second parameter and deduce the handle from the create call, and the client's response type follows the handle.

Callers are unchanged. The node type defaults to `rclcpp::Node`, and the constructor deduces its argument separately, so `ServiceProxyNodeInterface proxy(this)` on a derived node keeps the default.

## Related links

None.

## How was this PR tested?

Built the 18 proxy-using classes in `tier4/tier4_ad_api_adaptor` unchanged (`ENABLE_AGNOCAST=0` and `=1`). The existing test in this package also passes unchanged. A compile probe with the `agnocast_wrapper::Node` spelling and the legacy one in the same translation unit was checked in both modes.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.