### PR TITLE
feat(autoware_topic_state_monitor): apply `agnocast_wrapper::Node` to `topic_state_monitor`

### DIFF
--- a/system/autoware_component_state_monitor/launch/component_state_monitor.launch.py
+++ b/system/autoware_component_state_monitor/launch/component_state_monitor.launch.py
@@ -21,6 +21,7 @@ from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
@@ -40,20 +41,30 @@ def create_topic_monitor_name(row):
     return "topic_state_monitor_{}: {}".format(row["args"]["node_name_suffix"], diag_name)
 
 
-def create_topic_monitor_node(row, target_container):
+def create_topic_monitor_node(row, target_container, use_agnocast):
     tf_mode = "" if "topic_type" in row["args"] else "_tf"
     package = FindPackageShare("autoware_topic_state_monitor")
-    include = PathJoinSubstitution(
-        [package, f"launch/load_topic_state_monitor{tf_mode}.launch.xml"]
-    )
+    # ENABLE_AGNOCAST=1 runs the monitors as standalone processes.
+    if use_agnocast:
+        launch_file = f"launch/topic_state_monitor{tf_mode}.launch.xml"
+        placement = [("ld_preload", LaunchConfiguration("ld_preload_value"))]
+    else:
+        launch_file = f"launch/load_topic_state_monitor{tf_mode}.launch.xml"
+        placement = [("target_container", target_container)]
+    include = PathJoinSubstitution([package, launch_file])
     diag_name = create_diagnostic_name(row)
-    arguments = [("diag_name", diag_name), ("target_container", target_container)] + [
-        (k, str(v)) for k, v in row["args"].items()
-    ]
+    arguments = (
+        [("diag_name", diag_name)] + placement + [(k, str(v)) for k, v in row["args"].items()]
+    )
     return IncludeLaunchDescription(include, launch_arguments=arguments)
 
 
 def launch_setup(context, *args, **kwargs):
+    use_agnocast = (
+        context.perform_substitution(EnvironmentVariable("ENABLE_AGNOCAST", default_value="0"))
+        == "1"
+    )
+
     # create container name based on current ros namespace
     target_namespace = context.launch_configurations.get("ros_namespace", None)
     target_container = make_namespace_absolute(
@@ -64,7 +75,9 @@ def launch_setup(context, *args, **kwargs):
     mode = LaunchConfiguration("mode").perform(context)
     rows = yaml.safe_load(Path(LaunchConfiguration("file").perform(context)).read_text())
     rows = [row for row in rows if mode in row["mode"]]
-    topic_monitor_nodes = [create_topic_monitor_node(row, target_container) for row in rows]
+    topic_monitor_nodes = [
+        create_topic_monitor_node(row, target_container, use_agnocast) for row in rows
+    ]
     topic_monitor_names = [create_topic_monitor_name(row) for row in rows]
     topic_monitor_param = defaultdict(lambda: defaultdict(list))
     for row in rows:
@@ -91,15 +104,19 @@ def launch_setup(context, *args, **kwargs):
         additional_env={"LD_PRELOAD": LaunchConfiguration("ld_preload_value")},
         output="screen",
     )
-    # The topic_state_monitor nodes remain composable nodes loaded into this container by name.
-    container = ComposableNodeContainer(
-        namespace="component_state_monitor",
-        name="container",
-        package="rclcpp_components",
-        executable="component_container",
-        composable_node_descriptions=[],
-    )
-    return [agnocast_env, state_monitor_node, container, *topic_monitor_nodes]
+    actions = [agnocast_env, state_monitor_node]
+    if not use_agnocast:
+        # The topic_state_monitor nodes remain composable nodes loaded into this container by name.
+        actions.append(
+            ComposableNodeContainer(
+                namespace="component_state_monitor",
+                name="container",
+                package="rclcpp_components",
+                executable="component_container",
+                composable_node_descriptions=[],
+            )
+        )
+    return [*actions, *topic_monitor_nodes]
 
 
 def generate_launch_description():

--- a/system/autoware_topic_state_monitor/CMakeLists.txt
+++ b/system/autoware_topic_state_monitor/CMakeLists.txt
@@ -9,9 +9,13 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/topic_state_monitor_core.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_setup(${PROJECT_NAME})
+
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::topic_state_monitor::TopicStateMonitorNode"
   EXECUTABLE ${PROJECT_NAME}_node
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/system/autoware_topic_state_monitor/launch/topic_state_monitor.launch.xml
+++ b/system/autoware_topic_state_monitor/launch/topic_state_monitor.launch.xml
@@ -10,8 +10,10 @@
   <arg name="timeout" description="timeout period[s]"/>
   <arg name="window_size" default="10" description="window size"/>
   <arg name="pub_topic_name" default="/diagnostics" description="topic name to publish diagnostics"/>
+  <arg name="ld_preload" default="$(env LD_PRELOAD '')" description="LD_PRELOAD for the node process; set to the Agnocast heaphook when ENABLE_AGNOCAST=1"/>
 
-  <node pkg="autoware_topic_state_monitor" exec="autoware_topic_state_monitor_node" name="topic_state_monitor_$(var node_name_suffix)" output="screen">
+  <node pkg="autoware_topic_state_monitor" exec="autoware_topic_state_monitor_node" name="topic_state_monitor_$(var node_name_suffix)" namespace="" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload)"/>
     <remap from="/diagnostics" to="$(var pub_topic_name)"/>
     <param name="topic" value="$(var topic)"/>
     <param name="topic_type" value="$(var topic_type)"/>

--- a/system/autoware_topic_state_monitor/launch/topic_state_monitor_tf.launch.xml
+++ b/system/autoware_topic_state_monitor/launch/topic_state_monitor_tf.launch.xml
@@ -11,8 +11,10 @@
   <arg name="timeout" description="timeout period[s]"/>
   <arg name="window_size" default="10" description="window size"/>
   <arg name="pub_topic_name" default="/diagnostics" description="topic name to publish diagnostics"/>
+  <arg name="ld_preload" default="$(env LD_PRELOAD '')" description="LD_PRELOAD for the node process; set to the Agnocast heaphook when ENABLE_AGNOCAST=1"/>
 
-  <node pkg="autoware_topic_state_monitor" exec="autoware_topic_state_monitor_node" name="topic_state_monitor_$(var node_name_suffix)" output="screen">
+  <node pkg="autoware_topic_state_monitor" exec="autoware_topic_state_monitor_node" name="topic_state_monitor_$(var node_name_suffix)" namespace="" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload)"/>
     <remap from="/diagnostics" to="$(var pub_topic_name)"/>
     <param name="topic" value="$(var topic)"/>
     <param name="frame_id" value="$(var frame_id)"/>

--- a/system/autoware_topic_state_monitor/package.xml
+++ b/system/autoware_topic_state_monitor/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>rcl_interfaces</depend>

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor.cpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor.cpp
@@ -14,10 +14,13 @@
 
 #include "topic_state_monitor.hpp"
 
+#include <memory>
+#include <utility>
+
 namespace autoware::topic_state_monitor
 {
-TopicStateMonitor::TopicStateMonitor(rclcpp::Node & node, const Param & param)
-: clock_(node.get_clock())
+TopicStateMonitor::TopicStateMonitor(rclcpp::Clock::SharedPtr clock, const Param & param)
+: clock_(std::move(clock))
 {
   param_ = param;
 }

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor.hpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <deque>
+#include <memory>
 #include <string>
 
 namespace autoware::topic_state_monitor
@@ -41,7 +42,7 @@ enum class TopicStatus : int8_t {
 class TopicStateMonitor
 {
 public:
-  explicit TopicStateMonitor(rclcpp::Node & node, const Param & param);
+  explicit TopicStateMonitor(rclcpp::Clock::SharedPtr clock, const Param & param);
 
   void setParam(const Param & param) { param_ = param; }
 

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -66,7 +66,7 @@ TopicStateMonitorNode::TopicStateMonitorNode(const rclcpp::NodeOptions & node_op
     this->add_on_set_parameters_callback(std::bind(&TopicStateMonitorNode::onParameter, this, _1));
 
   // Core
-  topic_state_monitor_ = std::make_unique<TopicStateMonitor>(*this, param_);
+  topic_state_monitor_ = std::make_unique<TopicStateMonitor>(get_clock(), param_);
 
   // Subscriber
   rclcpp::QoS qos = rclcpp::QoS{1};
@@ -79,8 +79,8 @@ TopicStateMonitorNode::TopicStateMonitorNode(const rclcpp::NodeOptions & node_op
 
   if (node_param_.is_transform) {
     sub_transform_ = this->create_subscription<tf2_msgs::msg::TFMessage>(
-      node_param_.topic, qos, [this](tf2_msgs::msg::TFMessage::ConstSharedPtr msg) {
-        for (const auto & transform : msg->transforms) {
+      node_param_.topic, qos, [this](const tf2_msgs::msg::TFMessage & msg) {
+        for (const auto & transform : msg.transforms) {
           if (
             transform.header.frame_id == node_param_.frame_id &&
             transform.child_frame_id == node_param_.child_frame_id) {
@@ -91,7 +91,7 @@ TopicStateMonitorNode::TopicStateMonitorNode(const rclcpp::NodeOptions & node_op
   } else {
     sub_topic_ = this->create_generic_subscription(
       node_param_.topic, node_param_.topic_type, qos,
-      [this]([[maybe_unused]] std::shared_ptr<rclcpp::SerializedMessage> msg) {
+      [this]([[maybe_unused]] std::shared_ptr<const rclcpp::SerializedMessage> msg) {
         topic_state_monitor_->update();
       });
   }

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp
@@ -17,6 +17,8 @@
 
 #include "topic_state_monitor.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -43,7 +45,7 @@ struct NodeParam
   bool is_transform;
 };
 
-class TopicStateMonitorNode : public rclcpp::Node
+class TopicStateMonitorNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit TopicStateMonitorNode(const rclcpp::NodeOptions & node_options);
@@ -54,7 +56,7 @@ private:
   Param param_;
 
   // Parameter Reconfigure
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
   rcl_interfaces::msg::SetParametersResult onParameter(
     const std::vector<rclcpp::Parameter> & parameters);
 
@@ -62,11 +64,11 @@ private:
   std::unique_ptr<TopicStateMonitor> topic_state_monitor_;
 
   // Subscriber
-  rclcpp::GenericSubscription::SharedPtr sub_topic_;
-  rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr sub_transform_;
+  AUTOWARE_GENERIC_SUBSCRIPTION_PTR sub_topic_;
+  AUTOWARE_SUBSCRIPTION_PTR(tf2_msgs::msg::TFMessage) sub_transform_;
 
   // Diagnostic Updater
-  diagnostic_updater::Updater updater_;
+  autoware::agnocast_wrapper::diagnostic_updater::Updater updater_;
 
   void checkTopicStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
 };


### PR DESCRIPTION
## Description

Moves `TopicStateMonitorNode` to `agnocast_wrapper::Node` so the monitored topics can be taken over Agnocast.

At `ENABLE_AGNOCAST=1` the monitors no longer run as composable nodes: `component_state_monitor.launch.py` starts them as standalone processes so each one gets the heaphook preloaded.

## Related links

None.

## How was this PR tested?

Built and ran planning_simulator (sample-map-planning) and logging_simulator (sample-map-rosbag + sample-rosbag) with `ENABLE_AGNOCAST=0` and `=1`, and compared what every `topic_state_monitor` reports.

- planning_simulator, driven through the AD API (initialize -> set_route_points -> change_to_autonomous): all 10 monitors of that mode report `OK` in both builds.
- logging_simulator: all 14 monitors report the same level in both builds - the 7 whose topic is published are `OK` with matching rates, the 7 without a publisher are `Error` in both.

Also fed a single monitor a 10 Hz topic and confirmed `/diagnostics` reports `OK` with `measured_rate=10.00 [Hz]` in both builds, and switches to `Timeout` once the publisher stops.

## Notes for reviewers

None.

## Interface changes

`topic_state_monitor.launch.xml` and `topic_state_monitor_tf.launch.xml` take a new `ld_preload` argument, defaulting to the ambient `LD_PRELOAD`.

## Effects on system behavior

None at `ENABLE_AGNOCAST=0`. At `ENABLE_AGNOCAST=1` the topic state monitors run as standalone processes instead of composable nodes in `component_state_monitor/container`.

