### PR TITLE
feat(probabilistic_occupancy_grid_map): apply `agnocast_wrapper::Node` to `pointcloud_based_occupancy_grid_map`

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/CMakeLists.txt
+++ b/perception/autoware_probabilistic_occupancy_grid_map/CMakeLists.txt
@@ -84,9 +84,13 @@ if(${CUDA_FOUND})
     ${PROJECT_NAME}_cuda
   )
 
-  rclcpp_components_register_node(pointcloud_based_occupancy_grid_map
+  autoware_agnocast_wrapper_setup(pointcloud_based_occupancy_grid_map)
+
+  autoware_agnocast_wrapper_register_node(pointcloud_based_occupancy_grid_map
     PLUGIN "autoware::occupancy_grid_map::PointcloudBasedOccupancyGridMapNode"
     EXECUTABLE pointcloud_based_occupancy_grid_map_node
+    AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+    ROS2_EXECUTOR SingleThreadedExecutor
   )
 
   # GridMapFusionNode

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map.hpp
@@ -86,7 +86,10 @@ private:
 
   bool worldToMap(double wx, double wy, unsigned int & mx, unsigned int & my) const;
 
-  void initRosParam([[maybe_unused]] rclcpp::Node & node) override {}
+  void initRosParam(
+    [[maybe_unused]] rclcpp::node_interfaces::NodeParametersInterface & parameters) override
+  {
+  }
 
   rclcpp::Logger logger_{rclcpp::get_logger("laserscan_based_occupancy_grid_map")};
   rclcpp::Clock clock_{RCL_ROS_TIME};

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_base.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_base.hpp
@@ -92,7 +92,7 @@ public:
 
   void resetMaps() override;
 
-  virtual void initRosParam(rclcpp::Node & node) = 0;
+  virtual void initRosParam(rclcpp::node_interfaces::NodeParametersInterface & parameters) = 0;
 
   void setHeightLimit(const double min_height, const double max_height);
 

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_fixed.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_fixed.hpp
@@ -36,7 +36,7 @@ public:
     const CudaPointCloud2 & raw_pointcloud, const CudaPointCloud2 & obstacle_pointcloud,
     const Pose & robot_pose, const Pose & scan_origin) override;
 
-  void initRosParam(rclcpp::Node & node) override;
+  void initRosParam(rclcpp::node_interfaces::NodeParametersInterface & parameters) override;
 
 protected:
   double distance_margin_;

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_projective.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_projective.hpp
@@ -39,7 +39,7 @@ public:
     const CudaPointCloud2 & raw_pointcloud, const CudaPointCloud2 & obstacle_pointcloud,
     const Pose & robot_pose, const Pose & scan_origin) override;
 
-  void initRosParam(rclcpp::Node & node) override;
+  void initRosParam(rclcpp::node_interfaces::NodeParametersInterface & parameters) override;
 
 private:
   float projection_dz_threshold_;

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/updater/binary_bayes_filter_updater.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/updater/binary_bayes_filter_updater.hpp
@@ -36,7 +36,7 @@ public:
     const bool use_cuda, const unsigned int cells_size_x, const unsigned int cells_size_y,
     const float resolution);
   bool update(const OccupancyGridMapInterface & single_frame_occupancy_grid_map) override;
-  void initRosParam(rclcpp::Node & node) override;
+  void initRosParam(rclcpp::node_interfaces::NodeParametersInterface & parameters) override;
 
 private:
   inline unsigned char applyBBF(const unsigned char & z, const unsigned char & o);

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/updater/log_odds_bayes_filter_updater.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/updater/log_odds_bayes_filter_updater.hpp
@@ -40,7 +40,7 @@ public:
   {
   }
   bool update(const OccupancyGridMapInterface & single_frame_occupancy_grid_map) override;
-  void initRosParam(rclcpp::Node & node) override;
+  void initRosParam(rclcpp::node_interfaces::NodeParametersInterface & parameters) override;
 
 private:
   inline unsigned char applyLOBF(const unsigned char & z, const unsigned char & o);

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/updater/ogm_updater_interface.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/updater/ogm_updater_interface.hpp
@@ -39,7 +39,7 @@ public:
   }
   virtual ~OccupancyGridMapUpdaterInterface() = default;
   virtual bool update(const OccupancyGridMapInterface & single_frame_occupancy_grid_map) = 0;
-  virtual void initRosParam(rclcpp::Node & node) = 0;
+  virtual void initRosParam(rclcpp::node_interfaces::NodeParametersInterface & parameters) = 0;
 };
 
 }  // namespace costmap_2d

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/utils.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/utils.hpp
@@ -38,11 +38,11 @@
 
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer_interface.h>
 
 #include <algorithm>
 #include <cmath>
+#include <string>
 #include <vector>
 
 namespace autoware::occupancy_grid_map
@@ -51,12 +51,12 @@ namespace utils
 {
 
 bool transformPointcloud(
-  const sensor_msgs::msg::PointCloud2 & input, const tf2_ros::Buffer & tf2,
+  const sensor_msgs::msg::PointCloud2 & input, const tf2_ros::BufferInterface & tf2,
   const std::string & target_frame, sensor_msgs::msg::PointCloud2 & output);
 
 #ifdef USE_CUDA
 bool transformPointcloudAsync(
-  CudaPointCloud2 & input, const tf2_ros::Buffer & tf2, const std::string & target_frame,
+  CudaPointCloud2 & input, const tf2_ros::BufferInterface & tf2, const std::string & target_frame,
   autoware::cuda_utils::CudaUniquePtr<Eigen::Matrix3f> & device_rotation,
   autoware::cuda_utils::CudaUniquePtr<Eigen::Vector3f> & device_translation);
 #endif
@@ -64,21 +64,33 @@ bool transformPointcloudAsync(
 Eigen::Matrix4f getTransformMatrix(const geometry_msgs::msg::Pose & pose);
 
 bool cropPointcloudByHeight(
-  const sensor_msgs::msg::PointCloud2 & input, const tf2_ros::Buffer & tf2,
+  const sensor_msgs::msg::PointCloud2 & input, const tf2_ros::BufferInterface & tf2,
   const std::string & target_frame, const float min_height, const float max_height,
   sensor_msgs::msg::PointCloud2 & output);
 
 // get pose from tf2
 geometry_msgs::msg::Pose getPose(
-  const std_msgs::msg::Header & source_header, const tf2_ros::Buffer & tf2,
+  const std_msgs::msg::Header & source_header, const tf2_ros::BufferInterface & tf2,
   const std::string & target_frame);
 
 geometry_msgs::msg::Pose getPose(
-  const builtin_interfaces::msg::Time & stamp, const tf2_ros::Buffer & tf2,
+  const builtin_interfaces::msg::Time & stamp, const tf2_ros::BufferInterface & tf2,
   const std::string & source_frame, const std::string & target_frame);
 
 // get inverted pose
 geometry_msgs::msg::Pose getInversePose(const geometry_msgs::msg::Pose & pose);
+
+// Declare a parameter that has no default, through the node parameters interface rather than the
+// node itself, so that initRosParam() works with any node type that exposes the interface.
+template <typename T>
+T declareParameter(
+  rclcpp::node_interfaces::NodeParametersInterface & parameters, const std::string & name)
+{
+  const rclcpp::ParameterValue value{T{}};
+  return parameters
+    .declare_parameter(name, value.get_type(), rcl_interfaces::msg::ParameterDescriptor{}, false)
+    .get<T>();
+}
 
 }  // namespace utils
 }  // namespace autoware::occupancy_grid_map

--- a/perception/autoware_probabilistic_occupancy_grid_map/launch/multi_lidar_pointcloud_based_occupancy_grid_map.launch.py
+++ b/perception/autoware_probabilistic_occupancy_grid_map/launch/multi_lidar_pointcloud_based_occupancy_grid_map.launch.py
@@ -15,19 +15,38 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import GroupAction
+from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
-from launch.actions import SetLaunchConfiguration
+from launch.actions import SetEnvironmentVariable
 from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
 
 # In this file, we use "ogm" as a meaning of occupancy grid map
+
+
+def get_agnocast_env():
+    return IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("autoware_agnocast_wrapper"),
+                    "launch",
+                    "agnocast_env.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={"use_multithread": LaunchConfiguration("use_multithread")}.items(),
+    )
 
 
 # overwrite parameter
@@ -160,7 +179,9 @@ def launch_setup(context, *args, **kwargs):
     updater_config = load_config_file(context, "updater_param_file")
 
     # pointcloud based occupancy grid map nodes
+    use_agnocast = context.perform_substitution(LaunchConfiguration("use_agnocast")) == "1"
     gridmap_generation_composable_nodes = []
+    gridmap_generation_standalone_nodes = []
 
     number_of_nodes = len(fusion_config["raw_pointcloud_topics"])
     print(
@@ -194,21 +215,39 @@ def launch_setup(context, *args, **kwargs):
         if downsample_input_pointcloud:
             raw_pointcloud_topic = "raw/downsample/pointcloud"
 
-        # generate composable node
-        node = ComposableNode(
-            package="autoware_probabilistic_occupancy_grid_map",
-            plugin="autoware::occupancy_grid_map::PointcloudBasedOccupancyGridMapNode",
-            name="occupancy_grid_map_node",
-            namespace=frame_name,
-            remappings=[
-                ("~/input/obstacle_pointcloud", obstacle_pointcloud_topic),
-                ("~/input/raw_pointcloud", raw_pointcloud_topic),
-                ("~/output/occupancy_grid_map", fusion_config["fusion_input_ogm_topics"][i]),
-            ],
-            parameters=[ogm_creation_config],
-            extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
-        )
-        gridmap_generation_composable_nodes.append(node)
+        remappings = [
+            ("~/input/obstacle_pointcloud", obstacle_pointcloud_topic),
+            ("~/input/raw_pointcloud", raw_pointcloud_topic),
+            ("~/output/occupancy_grid_map", fusion_config["fusion_input_ogm_topics"][i]),
+        ]
+        if use_agnocast:
+            # The node runs as a standalone process when Agnocast is enabled.
+            gridmap_generation_standalone_nodes.append(
+                Node(
+                    package="autoware_probabilistic_occupancy_grid_map",
+                    executable="pointcloud_based_occupancy_grid_map_node",
+                    name="occupancy_grid_map_node",
+                    namespace=frame_name,
+                    remappings=remappings,
+                    parameters=[ogm_creation_config],
+                    additional_env={"LD_PRELOAD": LaunchConfiguration("ld_preload_value")},
+                    output="screen",
+                )
+            )
+        else:
+            gridmap_generation_composable_nodes.append(
+                ComposableNode(
+                    package="autoware_probabilistic_occupancy_grid_map",
+                    plugin="autoware::occupancy_grid_map::PointcloudBasedOccupancyGridMapNode",
+                    name="occupancy_grid_map_node",
+                    namespace=frame_name,
+                    remappings=remappings,
+                    parameters=[ogm_creation_config],
+                    extra_arguments=[
+                        {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
+                    ],
+                )
+            )
 
     if downsample_input_pointcloud:
         downsample_nodes = get_downsample_preprocess_nodes(
@@ -231,40 +270,42 @@ def launch_setup(context, *args, **kwargs):
     ]
 
     # 3. launch setting
+    composable_nodes = gridmap_generation_composable_nodes + gridmap_fusion_node
+
     occupancy_grid_map_container = ComposableNodeContainer(
         name=LaunchConfiguration("pointcloud_container_name"),
         namespace="",
-        package="rclcpp_components",
+        package=LaunchConfiguration("container_package"),
         executable=LaunchConfiguration("container_executable"),
-        composable_node_descriptions=gridmap_generation_composable_nodes + gridmap_fusion_node,
+        composable_node_descriptions=composable_nodes,
         condition=UnlessCondition(LaunchConfiguration("use_pointcloud_container")),
         output="screen",
     )
 
     load_composable_nodes = LoadComposableNodes(
-        composable_node_descriptions=gridmap_generation_composable_nodes + gridmap_fusion_node,
+        composable_node_descriptions=composable_nodes,
         target_container=LaunchConfiguration("pointcloud_container_name"),
         condition=IfCondition(LaunchConfiguration("use_pointcloud_container")),
     )
 
-    return [occupancy_grid_map_container, load_composable_nodes]
+    return gridmap_generation_standalone_nodes + [
+        GroupAction(
+            [
+                SetEnvironmentVariable(
+                    name="LD_PRELOAD",
+                    value=LaunchConfiguration("ld_preload_value"),
+                    condition=IfCondition(LaunchConfiguration("use_agnocast")),
+                ),
+                occupancy_grid_map_container,
+            ]
+        ),
+        load_composable_nodes,
+    ]
 
 
 def generate_launch_description():
     def add_launch_arg(name: str, default_value=None):
         return DeclareLaunchArgument(name, default_value=default_value)
-
-    set_container_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container",
-        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
-    )
-
-    set_container_mt_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container_mt",
-        condition=IfCondition(LaunchConfiguration("use_multithread")),
-    )
 
     return LaunchDescription(
         [
@@ -295,8 +336,7 @@ def generate_launch_description():
                     ]
                 ),
             ),
-            set_container_executable,
-            set_container_mt_executable,
+            get_agnocast_env(),
         ]
         + [OpaqueFunction(function=launch_setup)]
     )

--- a/perception/autoware_probabilistic_occupancy_grid_map/launch/pointcloud_based_occupancy_grid_map.launch.py
+++ b/perception/autoware_probabilistic_occupancy_grid_map/launch/pointcloud_based_occupancy_grid_map.launch.py
@@ -14,17 +14,36 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import GroupAction
+from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
-from launch.actions import SetLaunchConfiguration
+from launch.actions import SetEnvironmentVariable
 from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
+
+
+def get_agnocast_env():
+    return IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("autoware_agnocast_wrapper"),
+                    "launch",
+                    "agnocast_env.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={"use_multithread": LaunchConfiguration("use_multithread")}.items(),
+    )
 
 
 def get_downsample_filter_node(setting: dict) -> ComposableNode:
@@ -94,43 +113,66 @@ def launch_setup(context, *args, **kwargs):
         downsample_preprocess_nodes = get_downsample_preprocess_nodes(voxel_grid_size)
         composable_nodes.extend(downsample_preprocess_nodes)
 
-    composable_nodes.append(
-        ComposableNode(
-            package="autoware_probabilistic_occupancy_grid_map",
-            plugin="autoware::occupancy_grid_map::PointcloudBasedOccupancyGridMapNode",
-            name="occupancy_grid_map_node",
-            remappings=[
-                (
-                    "~/input/obstacle_pointcloud",
-                    (
-                        LaunchConfiguration("input/obstacle_pointcloud")
-                        if not downsample_input_pointcloud
-                        else "obstacle/downsample/pointcloud"
-                    ),
-                ),
-                (
-                    "~/input/raw_pointcloud",
-                    (
-                        LaunchConfiguration("input/raw_pointcloud")
-                        if not downsample_input_pointcloud
-                        else "raw/downsample/pointcloud"
-                    ),
-                ),
-                ("~/output/occupancy_grid_map", LaunchConfiguration("output")),
-            ],
-            parameters=[
-                pointcloud_based_occupancy_grid_map_node_params,
-                occupancy_grid_map_updater_params,
-                {"updater_type": LaunchConfiguration("updater_type")},
-            ],
-            extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+    occupancy_grid_map_remappings = [
+        (
+            "~/input/obstacle_pointcloud",
+            (
+                LaunchConfiguration("input/obstacle_pointcloud")
+                if not downsample_input_pointcloud
+                else "obstacle/downsample/pointcloud"
+            ),
+        ),
+        (
+            "~/input/raw_pointcloud",
+            (
+                LaunchConfiguration("input/raw_pointcloud")
+                if not downsample_input_pointcloud
+                else "raw/downsample/pointcloud"
+            ),
+        ),
+        ("~/output/occupancy_grid_map", LaunchConfiguration("output")),
+    ]
+    occupancy_grid_map_parameters = [
+        pointcloud_based_occupancy_grid_map_node_params,
+        occupancy_grid_map_updater_params,
+        {"updater_type": LaunchConfiguration("updater_type")},
+    ]
+
+    standalone_nodes = []
+    if context.perform_substitution(LaunchConfiguration("use_agnocast")) == "1":
+        # The node runs as a standalone process when Agnocast is enabled.
+        standalone_nodes.append(
+            Node(
+                package="autoware_probabilistic_occupancy_grid_map",
+                executable="pointcloud_based_occupancy_grid_map_node",
+                name="occupancy_grid_map_node",
+                remappings=occupancy_grid_map_remappings,
+                parameters=occupancy_grid_map_parameters,
+                additional_env={"LD_PRELOAD": LaunchConfiguration("ld_preload_value")},
+                output="screen",
+            )
         )
-    )
+    else:
+        composable_nodes.append(
+            ComposableNode(
+                package="autoware_probabilistic_occupancy_grid_map",
+                plugin="autoware::occupancy_grid_map::PointcloudBasedOccupancyGridMapNode",
+                name="occupancy_grid_map_node",
+                remappings=occupancy_grid_map_remappings,
+                parameters=occupancy_grid_map_parameters,
+                extra_arguments=[
+                    {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
+                ],
+            )
+        )
+
+    if not composable_nodes:
+        return standalone_nodes
 
     occupancy_grid_map_container = ComposableNodeContainer(
         name=LaunchConfiguration("individual_container_name"),
         namespace="",
-        package="rclcpp_components",
+        package=LaunchConfiguration("container_package"),
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=composable_nodes,
         condition=UnlessCondition(LaunchConfiguration("use_pointcloud_container")),
@@ -143,24 +185,24 @@ def launch_setup(context, *args, **kwargs):
         condition=IfCondition(LaunchConfiguration("use_pointcloud_container")),
     )
 
-    return [occupancy_grid_map_container, load_composable_nodes]
+    return standalone_nodes + [
+        GroupAction(
+            [
+                SetEnvironmentVariable(
+                    name="LD_PRELOAD",
+                    value=LaunchConfiguration("ld_preload_value"),
+                    condition=IfCondition(LaunchConfiguration("use_agnocast")),
+                ),
+                occupancy_grid_map_container,
+            ]
+        ),
+        load_composable_nodes,
+    ]
 
 
 def generate_launch_description():
     def add_launch_arg(name: str, default_value=None):
         return DeclareLaunchArgument(name, default_value=default_value)
-
-    set_container_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container",
-        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
-    )
-
-    set_container_mt_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container_mt",
-        condition=IfCondition(LaunchConfiguration("use_multithread")),
-    )
 
     return LaunchDescription(
         [
@@ -193,8 +235,7 @@ def generate_launch_description():
                     ]
                 ),
             ),
-            set_container_executable,
-            set_container_mt_executable,
+            get_agnocast_env(),
         ]
         + [OpaqueFunction(function=launch_setup)]
     )

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
@@ -151,10 +151,11 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
     cost_value::LETHAL_OBSTACLE, device_costmap_.get(), stream_);
 }
 
-void OccupancyGridMapFixedBlindSpot::initRosParam(rclcpp::Node & node)
+void OccupancyGridMapFixedBlindSpot::initRosParam(
+  rclcpp::node_interfaces::NodeParametersInterface & parameters)
 {
   distance_margin_ =
-    node.declare_parameter<double>("OccupancyGridMapFixedBlindSpot.distance_margin");
+    utils::declareParameter<double>(parameters, "OccupancyGridMapFixedBlindSpot.distance_margin");
 }
 
 }  // namespace costmap_2d

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
@@ -161,12 +161,13 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
   cudaStreamSynchronize(stream_);
 }
 
-void OccupancyGridMapProjectiveBlindSpot::initRosParam(rclcpp::Node & node)
+void OccupancyGridMapProjectiveBlindSpot::initRosParam(
+  rclcpp::node_interfaces::NodeParametersInterface & parameters)
 {
-  projection_dz_threshold_ =
-    node.declare_parameter<float>("OccupancyGridMapProjectiveBlindSpot.projection_dz_threshold");
-  obstacle_separation_threshold_ = node.declare_parameter<float>(
-    "OccupancyGridMapProjectiveBlindSpot.obstacle_separation_threshold");
+  projection_dz_threshold_ = utils::declareParameter<float>(
+    parameters, "OccupancyGridMapProjectiveBlindSpot.projection_dz_threshold");
+  obstacle_separation_threshold_ = utils::declareParameter<float>(
+    parameters, "OccupancyGridMapProjectiveBlindSpot.obstacle_separation_threshold");
 }
 
 }  // namespace costmap_2d

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp
@@ -15,6 +15,7 @@
 #include "autoware/probabilistic_occupancy_grid_map/updater/binary_bayes_filter_updater.hpp"
 
 #include "autoware/probabilistic_occupancy_grid_map/cost_value/cost_value.hpp"
+#include "autoware/probabilistic_occupancy_grid_map/utils/utils.hpp"
 
 #ifdef USE_CUDA
 #include "autoware/probabilistic_occupancy_grid_map/updater/binary_bayes_filter_updater_kernel.hpp"
@@ -35,17 +36,18 @@ OccupancyGridMapBBFUpdater::OccupancyGridMapBBFUpdater(
 {
 }
 
-void OccupancyGridMapBBFUpdater::initRosParam(rclcpp::Node & node)
+void OccupancyGridMapBBFUpdater::initRosParam(
+  rclcpp::node_interfaces::NodeParametersInterface & parameters)
 {
   probability_matrix_(Index::OCCUPIED, Index::OCCUPIED) =
-    node.declare_parameter<double>("probability_matrix.occupied_to_occupied");
+    utils::declareParameter<double>(parameters, "probability_matrix.occupied_to_occupied");
   probability_matrix_(Index::FREE, Index::OCCUPIED) =
-    node.declare_parameter<double>("probability_matrix.occupied_to_free");
+    utils::declareParameter<double>(parameters, "probability_matrix.occupied_to_free");
   probability_matrix_(Index::FREE, Index::FREE) =
-    node.declare_parameter<double>("probability_matrix.free_to_free");
+    utils::declareParameter<double>(parameters, "probability_matrix.free_to_free");
   probability_matrix_(Index::OCCUPIED, Index::FREE) =
-    node.declare_parameter<double>("probability_matrix.free_to_occupied");
-  v_ratio_ = node.declare_parameter<double>("v_ratio");
+    utils::declareParameter<double>(parameters, "probability_matrix.free_to_occupied");
+  v_ratio_ = utils::declareParameter<double>(parameters, "v_ratio");
 
 #ifdef USE_CUDA
   if (use_cuda_) {

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/log_odds_bayes_filter_updater.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/log_odds_bayes_filter_updater.cpp
@@ -29,7 +29,8 @@ namespace autoware::occupancy_grid_map
 namespace costmap_2d
 {
 
-void OccupancyGridMapLOBFUpdater::initRosParam(rclcpp::Node & /*node*/)
+void OccupancyGridMapLOBFUpdater::initRosParam(
+  rclcpp::node_interfaces::NodeParametersInterface & /*parameters*/)
 {
   // nothing to load
 }

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/utils/utils.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/utils/utils.cpp
@@ -29,14 +29,15 @@ namespace utils
 
 // used in laserscan based occupancy grid map
 bool transformPointcloud(
-  const sensor_msgs::msg::PointCloud2 & input, const tf2_ros::Buffer & tf2,
+  const sensor_msgs::msg::PointCloud2 & input, const tf2_ros::BufferInterface & tf2,
   const std::string & target_frame, sensor_msgs::msg::PointCloud2 & output)
 {
   geometry_msgs::msg::TransformStamped tf_stamped;
   // lookup transform
   try {
     tf_stamped = tf2.lookupTransform(
-      target_frame, input.header.frame_id, input.header.stamp, rclcpp::Duration::from_seconds(0.5));
+      target_frame, input.header.frame_id, tf2_ros::fromMsg(input.header.stamp),
+      tf2::durationFromSec(0.5));
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(
       rclcpp::get_logger("probabilistic_occupancy_grid_map"), "Failed to lookup transform: %s",
@@ -53,7 +54,7 @@ bool transformPointcloud(
 
 #ifdef USE_CUDA
 bool transformPointcloudAsync(
-  CudaPointCloud2 & input, const tf2_ros::Buffer & tf2, const std::string & target_frame,
+  CudaPointCloud2 & input, const tf2_ros::BufferInterface & tf2, const std::string & target_frame,
   autoware::cuda_utils::CudaUniquePtr<Eigen::Matrix3f> & device_rotation,
   autoware::cuda_utils::CudaUniquePtr<Eigen::Vector3f> & device_translation)
 {
@@ -61,7 +62,8 @@ bool transformPointcloudAsync(
   // lookup transform
   try {
     tf_stamped = tf2.lookupTransform(
-      target_frame, input.header.frame_id, input.header.stamp, rclcpp::Duration::from_seconds(0.5));
+      target_frame, input.header.frame_id, tf2_ros::fromMsg(input.header.stamp),
+      tf2::durationFromSec(0.5));
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(
       rclcpp::get_logger("probabilistic_occupancy_grid_map"), "Failed to lookup transform: %s",
@@ -97,7 +99,7 @@ Eigen::Matrix4f getTransformMatrix(const geometry_msgs::msg::Pose & pose)
 }
 
 bool cropPointcloudByHeight(
-  const sensor_msgs::msg::PointCloud2 & input, const tf2_ros::Buffer & tf2,
+  const sensor_msgs::msg::PointCloud2 & input, const tf2_ros::BufferInterface & tf2,
   const std::string & target_frame, const float min_height, const float max_height,
   sensor_msgs::msg::PointCloud2 & output)
 {
@@ -127,25 +129,26 @@ bool cropPointcloudByHeight(
 }
 
 geometry_msgs::msg::Pose getPose(
-  const std_msgs::msg::Header & source_header, const tf2_ros::Buffer & tf2,
+  const std_msgs::msg::Header & source_header, const tf2_ros::BufferInterface & tf2,
   const std::string & target_frame)
 {
   geometry_msgs::msg::Pose pose;
   geometry_msgs::msg::TransformStamped tf_stamped;
   tf_stamped = tf2.lookupTransform(
-    target_frame, source_header.frame_id, source_header.stamp, rclcpp::Duration::from_seconds(0.5));
+    target_frame, source_header.frame_id, tf2_ros::fromMsg(source_header.stamp),
+    tf2::durationFromSec(0.5));
   pose = autoware_utils::transform2pose(tf_stamped.transform);
   return pose;
 }
 
 geometry_msgs::msg::Pose getPose(
-  const builtin_interfaces::msg::Time & stamp, const tf2_ros::Buffer & tf2,
+  const builtin_interfaces::msg::Time & stamp, const tf2_ros::BufferInterface & tf2,
   const std::string & source_frame, const std::string & target_frame)
 {
   geometry_msgs::msg::Pose pose;
   geometry_msgs::msg::TransformStamped tf_stamped;
-  tf_stamped =
-    tf2.lookupTransform(target_frame, source_frame, stamp, rclcpp::Duration::from_seconds(0.5));
+  tf_stamped = tf2.lookupTransform(
+    target_frame, source_frame, tf2_ros::fromMsg(stamp), tf2::durationFromSec(0.5));
   pose = autoware_utils::transform2pose(tf_stamped.transform);
   return pose;
 }

--- a/perception/autoware_probabilistic_occupancy_grid_map/package.xml
+++ b/perception/autoware_probabilistic_occupancy_grid_map/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_cuda_dependency_meta</depend>
   <depend>autoware_cuda_utils</depend>
   <depend>autoware_utils</depend>

--- a/perception/autoware_probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
@@ -99,7 +99,7 @@ LaserscanBasedOccupancyGridMapNode::LaserscanBasedOccupancyGridMapNode(
     occupancy_grid_map_updater_ptr_ = std::make_shared<OccupancyGridMapBBFUpdater>(
       false, map_length / map_resolution, map_width / map_resolution, map_resolution);
   }
-  occupancy_grid_map_updater_ptr_->initRosParam(*this);
+  occupancy_grid_map_updater_ptr_->initRosParam(*this->get_node_parameters_interface());
 
   // time keeper setup
   bool use_time_keeper = declare_parameter<bool>("publish_processing_time_detail");

--- a/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -46,7 +46,7 @@ using geometry_msgs::msg::Pose;
 
 PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
   const rclcpp::NodeOptions & node_options)
-: Node("pointcloud_based_occupancy_grid_map_node", node_options)
+: autoware::agnocast_wrapper::Node("pointcloud_based_occupancy_grid_map_node", node_options)
 {
   using std::placeholders::_1;
   using std::placeholders::_2;
@@ -120,12 +120,12 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
   device_rotation_ = autoware::cuda_utils::make_unique<Eigen::Matrix3f>();
   device_translation_ = autoware::cuda_utils::make_unique<Eigen::Vector3f>();
 
-  occupancy_grid_map_ptr_->initRosParam(*this);
-  occupancy_grid_map_updater_ptr_->initRosParam(*this);
+  occupancy_grid_map_ptr_->initRosParam(*this->get_node_parameters_interface());
+  occupancy_grid_map_updater_ptr_->initRosParam(*this->get_node_parameters_interface());
 
   // initialize debug tool
   {
-    using autoware_utils::DebugPublisher;
+    using DebugPublisher = autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>;
     using autoware_utils::StopWatch;
     stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
     debug_publisher_ptr_ =
@@ -147,8 +147,9 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
   processing_time_tolerance_ms_ = this->declare_parameter<double>("processing_time_tolerance_ms");
   processing_time_consecutive_excess_tolerance_ms_ =
     this->declare_parameter<double>("processing_time_consecutive_excess_tolerance_ms");
-  diagnostics_interface_ptr_ = std::make_unique<autoware_utils::DiagnosticsInterface>(
-    this, "pointcloud_based_probabilistic_occupancy_grid_map");
+  diagnostics_interface_ptr_ =
+    std::make_unique<autoware_utils::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>(
+      this, "pointcloud_based_probabilistic_occupancy_grid_map");
 }
 
 void PointcloudBasedOccupancyGridMapNode::obstaclePointcloudCallback(
@@ -240,13 +241,13 @@ void PointcloudBasedOccupancyGridMapNode::onPointcloudWithObstacleAndRaw()
     // Make sure that the frame is base_link
     if (raw_pointcloud_.header.frame_id != base_link_frame_) {
       if (!utils::transformPointcloudAsync(
-            raw_pointcloud_, *tf2_, base_link_frame_, device_rotation_, device_translation_)) {
+            raw_pointcloud_, tf2_, base_link_frame_, device_rotation_, device_translation_)) {
         return;
       }
     }
     if (obstacle_pointcloud_.header.frame_id != base_link_frame_) {
       if (!utils::transformPointcloudAsync(
-            obstacle_pointcloud_, *tf2_, base_link_frame_, device_rotation_, device_translation_)) {
+            obstacle_pointcloud_, tf2_, base_link_frame_, device_rotation_, device_translation_)) {
         return;
       }
     }
@@ -261,11 +262,11 @@ void PointcloudBasedOccupancyGridMapNode::onPointcloudWithObstacleAndRaw()
   Pose gridmap_origin{};
   Pose scan_origin{};
   try {
-    robot_pose = utils::getPose(raw_pointcloud_.header.stamp, *tf2_, base_link_frame_, map_frame_);
+    robot_pose = utils::getPose(raw_pointcloud_.header.stamp, tf2_, base_link_frame_, map_frame_);
     gridmap_origin =
-      utils::getPose(raw_pointcloud_.header.stamp, *tf2_, gridmap_origin_frame_, map_frame_);
+      utils::getPose(raw_pointcloud_.header.stamp, tf2_, gridmap_origin_frame_, map_frame_);
     scan_origin =
-      utils::getPose(raw_pointcloud_.header.stamp, *tf2_, scan_origin_frame_, map_frame_);
+      utils::getPose(raw_pointcloud_.header.stamp, tf2_, scan_origin_frame_, map_frame_);
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN_STREAM(get_logger(), ex.what());
     return;
@@ -331,14 +332,15 @@ void PointcloudBasedOccupancyGridMapNode::onPointcloudWithObstacleAndRaw()
   }
 }
 
-OccupancyGrid::UniquePtr PointcloudBasedOccupancyGridMapNode::OccupancyGridMapToMsgPtr(
+AUTOWARE_MESSAGE_UNIQUE_PTR(OccupancyGrid)
+PointcloudBasedOccupancyGridMapNode::OccupancyGridMapToMsgPtr(
   const std::string & frame_id, const Time & stamp, const float & robot_pose_z,
   const Costmap2D & occupancy_grid_map)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
-  auto msg_ptr = std::make_unique<OccupancyGrid>();
+  auto msg_ptr = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(occupancy_grid_map_pub_);
 
   msg_ptr->header.frame_id = frame_id;
   msg_ptr->header.stamp = stamp;

--- a/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
@@ -20,6 +20,9 @@
 #include "autoware/probabilistic_occupancy_grid_map/updater/ogm_updater_interface.hpp"
 #include "autoware/probabilistic_occupancy_grid_map/utils/cuda_pointcloud.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
@@ -32,8 +35,6 @@
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <cuda_runtime.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <memory>
 #include <string>
@@ -48,10 +49,8 @@ using nav2_costmap_2d::Costmap2D;
 using nav_msgs::msg::OccupancyGrid;
 using sensor_msgs::msg::LaserScan;
 using sensor_msgs::msg::PointCloud2;
-using tf2_ros::Buffer;
-using tf2_ros::TransformListener;
 
-class PointcloudBasedOccupancyGridMapNode : public rclcpp::Node
+class PointcloudBasedOccupancyGridMapNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit PointcloudBasedOccupancyGridMapNode(const rclcpp::NodeOptions & node_options);
@@ -62,19 +61,21 @@ private:
   void onPointcloudWithObstacleAndRaw();
   void checkProcessingTime(double processing_time_ms);
 
-  OccupancyGrid::UniquePtr OccupancyGridMapToMsgPtr(
+  AUTOWARE_MESSAGE_UNIQUE_PTR(OccupancyGrid)
+  OccupancyGridMapToMsgPtr(
     const std::string & frame_id, const Time & stamp, const float & robot_pose_z,
     const Costmap2D & occupancy_grid_map);
 
 private:
-  rclcpp::Publisher<OccupancyGrid>::SharedPtr occupancy_grid_map_pub_;
-  rclcpp::Subscription<PointCloud2>::SharedPtr obstacle_pointcloud_sub_ptr_;
-  rclcpp::Subscription<PointCloud2>::SharedPtr raw_pointcloud_sub_ptr_;
+  AUTOWARE_PUBLISHER_PTR(OccupancyGrid) occupancy_grid_map_pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(PointCloud2) obstacle_pointcloud_sub_ptr_;
+  AUTOWARE_SUBSCRIPTION_PTR(PointCloud2) raw_pointcloud_sub_ptr_;
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{};
-  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_ptr_{};
+  std::unique_ptr<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    debug_publisher_ptr_{};
 
-  std::shared_ptr<Buffer> tf2_{std::make_shared<Buffer>(get_clock())};
-  std::shared_ptr<TransformListener> tf2_listener_{std::make_shared<TransformListener>(*tf2_)};
+  autoware::agnocast_wrapper::Buffer tf2_{get_clock()};
+  autoware::agnocast_wrapper::TransformListener tf2_listener_{tf2_};
 
   std::unique_ptr<OccupancyGridMapInterface> occupancy_grid_map_ptr_;
   std::unique_ptr<OccupancyGridMapUpdaterInterface> occupancy_grid_map_updater_ptr_;
@@ -98,11 +99,11 @@ private:
   bool filter_obstacle_pointcloud_by_raw_pointcloud_;
 
   // time keeper
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
-    detailed_processing_time_publisher_;
+  AUTOWARE_PUBLISHER_PTR(autoware_utils::ProcessingTimeDetail) detailed_processing_time_publisher_;
   std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
   // diagnostics
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
+  std::unique_ptr<autoware_utils::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>
+    diagnostics_interface_ptr_;
   double processing_time_tolerance_ms_;
   double processing_time_consecutive_excess_tolerance_ms_;
 };


### PR DESCRIPTION
## Description

Migrates `PointcloudBasedOccupancyGridMapNode` to `autoware::agnocast_wrapper::Node`, and publishes the output grid through `ALLOCATE_OUTPUT_MESSAGE_UNIQUE`. Under `ENABLE_AGNOCAST=1` the launch files start it as a standalone process instead of composing it.

Two shared interfaces had to stop naming a concrete node/buffer type, since the other two nodes in this package stay on `rclcpp::Node`:

- `initRosParam()` takes `rclcpp::node_interfaces::NodeParametersInterface &` instead of `rclcpp::Node &`.
- The `utils::` transform helpers take `tf2_ros::BufferInterface &` instead of `tf2_ros::Buffer &`, so both `tf2_ros::Buffer` and `agnocast::Buffer` fit.

The `TransformListener` keeps the buffer-only constructor on purpose: binding `/tf_static` to this node instead is rejected by rclcpp, which does not allow a transient-local subscription on a node composed with intra-process communication on.

## Related links

None.

## How was this PR tested?

Built with `ENABLE_AGNOCAST=0` and `=1`. Ran `logging_simulator` with `sample-rosbag` in both modes: `/perception/occupancy_grid_map/map` came out , with matching `OccupancyGrid` info for the same input frame.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior
None when `ENABLE_AGNOCAST=0`. `agnocast::Node` will be used when `ENABLE_AGNOCAST=1`.